### PR TITLE
BACK-447 - Add No milestone option to TUI milestone filters

### DIFF
--- a/backlog/tasks/back-447 - Add-No-milestone-option-to-TUI-milestone-filters.md
+++ b/backlog/tasks/back-447 - Add-No-milestone-option-to-TUI-milestone-filters.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-447
 title: Add No milestone option to TUI milestone filters
-status: To Do
+status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-04-26 08:41'
+updated_date: '2026-04-26 08:48'
 labels:
   - tui
   - milestone
@@ -12,6 +13,13 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/pull/81'
+modified_files:
+  - src/utils/milestone-filter.ts
+  - src/utils/task-search.ts
+  - src/ui/components/filter-header.ts
+  - src/ui/task-viewer-with-search.ts
+  - src/ui/board.ts
+  - src/test/unified-view-filters.test.ts
 priority: medium
 ---
 
@@ -23,16 +31,37 @@ Bring the TUI milestone filter UX in line with the Web UI by allowing users to f
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 TUI task-list milestone picker includes a No milestone option alongside All and active milestones.
-- [ ] #2 TUI Kanban/board milestone picker includes the same No milestone option and filters tasks consistently.
-- [ ] #3 No milestone filtering matches tasks with no milestone assignment without breaking existing milestone title/alias filtering.
-- [ ] #4 The refreshed PR title and task references use the current BACK task ID format.
-- [ ] #5 Focused automated coverage verifies the filter model and shared TUI filtering behavior.
+- [x] #1 TUI task-list milestone picker includes a No milestone option alongside All and active milestones.
+- [x] #2 TUI Kanban/board milestone picker includes the same No milestone option and filters tasks consistently.
+- [x] #3 No milestone filtering matches tasks with no milestone assignment without breaking existing milestone title/alias filtering.
+- [x] #4 The refreshed PR title and task references use the current BACK task ID format.
+- [x] #5 Focused automated coverage verifies the filter model and shared TUI filtering behavior.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Treat PR #81 as an idea source and rebuild its branch from current main.
+2. Preserve the existing TUI milestone filter implementation and add the missing Web UI parity option for No milestone.
+3. Route No milestone through shared task filtering so task list and Kanban use the same behavior.
+4. Add focused regression coverage and run full verification before updating the PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added shared No milestone milestone-filter constants using the Web UI sentinel value. The TUI task list and Kanban milestone pickers now offer No milestone next to All and active milestones. The filter header renders the user-facing label instead of the sentinel, and shared task filtering now treats the sentinel as tasks with no milestone assignment. Existing title/alias milestone filtering still uses the existing resolver path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebuilt PR #81 on current main as BACK-447. The stale task-24.1 diff was discarded; the branch now adds Web-parity No milestone filtering to the existing TUI milestone filter UX for both task list and Kanban views, backed by shared filtering tests and full local verification.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/test/unified-view-filters.test.ts
+++ b/src/test/unified-view-filters.test.ts
@@ -7,6 +7,7 @@ import {
 	mergeUnifiedViewFilters,
 	type UnifiedViewFilters,
 } from "../ui/unified-view.ts";
+import { NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
 import { applyTaskFilters } from "../utils/task-search.ts";
 
 describe("unified view filter state", () => {
@@ -135,5 +136,64 @@ describe("unified view filter state", () => {
 		expect(kanbanResults).toEqual(["task-1", "task-2"]);
 		expect(listSharedResults).toEqual(["task-1", "task-2"]);
 		expect(listStatusResults).toEqual(["task-1"]);
+	});
+
+	it("filters unassigned milestone tasks with the shared No milestone value", () => {
+		const tasks: Task[] = [
+			{
+				id: "task-1",
+				title: "Unassigned release task",
+				status: "To Do",
+				labels: [],
+				assignee: [],
+				createdDate: "2026-01-01",
+				dependencies: [],
+			},
+			{
+				id: "task-2",
+				title: "Empty milestone task",
+				status: "To Do",
+				labels: [],
+				milestone: "  ",
+				assignee: [],
+				createdDate: "2026-01-02",
+				dependencies: [],
+			},
+			{
+				id: "task-3",
+				title: "Assigned release task",
+				status: "To Do",
+				labels: [],
+				milestone: "m-1",
+				assignee: [],
+				createdDate: "2026-01-03",
+				dependencies: [],
+			},
+			{
+				id: "task-4",
+				title: "Literal sentinel title task",
+				status: "To Do",
+				labels: [],
+				milestone: "__none",
+				assignee: [],
+				createdDate: "2026-01-04",
+				dependencies: [],
+			},
+		];
+
+		const sharedFilters = {
+			searchQuery: "",
+			priorityFilter: "",
+			labelFilter: [],
+			milestoneFilter: NO_MILESTONE_FILTER_VALUE,
+		};
+
+		const kanbanResults = filterTasksForKanban(tasks, sharedFilters).map((task) => task.id);
+		const listResults = applyTaskFilters(tasks, { milestone: NO_MILESTONE_FILTER_VALUE }).map((task) => task.id);
+		const literalMilestoneResults = applyTaskFilters(tasks, { milestone: "__none" }).map((task) => task.id);
+
+		expect(kanbanResults).toEqual(["task-1", "task-2"]);
+		expect(listResults).toEqual(["task-1", "task-2"]);
+		expect(literalMilestoneResults).toEqual(["task-4"]);
 	});
 });

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -9,6 +9,7 @@ import {
 import { Core } from "../core/backlog.ts";
 import type { Milestone, Task } from "../types/index.ts";
 import { collectAvailableLabels } from "../utils/label-filter.ts";
+import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
 import { applySharedTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { compareTaskIds } from "../utils/task-sorting.ts";
 import { createFilterHeader, type FilterHeader, type FilterState } from "./components/filter-header.ts";
@@ -566,7 +567,11 @@ export async function renderBoardTui(
 					screen,
 					title: "Milestone Filter",
 					selectedValue: sharedFilters.milestoneFilter,
-					choices: [{ label: "All", value: "" }, ...availableMilestones.map((value) => ({ label: value, value }))],
+					choices: [
+						{ label: "All", value: "" },
+						{ label: NO_MILESTONE_FILTER_LABEL, value: NO_MILESTONE_FILTER_VALUE },
+						...availableMilestones.map((value) => ({ label: value, value })),
+					],
 				});
 				if (selected !== null) {
 					sharedFilters.milestoneFilter = selected;

--- a/src/ui/components/filter-header.ts
+++ b/src/ui/components/filter-header.ts
@@ -6,6 +6,7 @@
 import type { BoxInterface, ScreenInterface, TextboxInterface } from "neo-neo-bblessed";
 import { box, textbox } from "neo-neo-bblessed";
 import { formatLabelSummary } from "../../utils/label-filter.ts";
+import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../../utils/milestone-filter.ts";
 
 export type FilterControlId = "search" | "status" | "priority" | "labels" | "milestone";
 
@@ -605,7 +606,10 @@ export class FilterHeader {
 			case "priority":
 				return this.state.priority ? `${this.state.priority} ▼` : "All ▼";
 			case "milestone":
-				return this.state.milestone ? `${this.state.milestone} ▼` : "All ▼";
+				if (!this.state.milestone) {
+					return "All ▼";
+				}
+				return `${this.state.milestone === NO_MILESTONE_FILTER_VALUE ? NO_MILESTONE_FILTER_LABEL : this.state.milestone} ▼`;
 			case "labels": {
 				const summary = formatLabelSummary(this.state.labels).replace(/^Labels:\s*/, "");
 				return `${summary} ▼`;

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -12,6 +12,7 @@ import {
 } from "../formatters/task-plain-text.ts";
 import type { Milestone, Task, TaskSearchResult } from "../types/index.ts";
 import { collectAvailableLabels } from "../utils/label-filter.ts";
+import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
 import { applyTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
@@ -361,6 +362,7 @@ export async function viewTaskEnhanced(
 				selectedValue: milestoneFilter,
 				choices: [
 					{ label: "All", value: "" },
+					{ label: NO_MILESTONE_FILTER_LABEL, value: NO_MILESTONE_FILTER_VALUE },
 					...availableMilestoneTitles.map((milestone) => ({ label: milestone, value: milestone })),
 				],
 			});
@@ -591,6 +593,9 @@ export async function viewTaskEnhanced(
 			filteredTasks = searchResults.filter((r): r is TaskSearchResult => r.type === "task").map((r) => r.task);
 			if (milestoneFilter) {
 				filteredTasks = filteredTasks.filter((task) => {
+					if (milestoneFilter === NO_MILESTONE_FILTER_VALUE) {
+						return !task.milestone?.trim();
+					}
 					if (!task.milestone) return false;
 					const taskMilestoneTitle = resolveMilestoneLabel(task.milestone);
 					return taskMilestoneTitle.toLowerCase() === milestoneFilter.toLowerCase();
@@ -625,7 +630,9 @@ export async function viewTaskEnhanced(
 				activeFilters.push(`Labels: {yellow-fg}${labelFilter.join(", ")}{/}`);
 			}
 			if (milestoneFilter) {
-				activeFilters.push(`Milestone: {magenta-fg}${milestoneFilter}{/}`);
+				const milestoneFilterLabel =
+					milestoneFilter === NO_MILESTONE_FILTER_VALUE ? NO_MILESTONE_FILTER_LABEL : milestoneFilter;
+				activeFilters.push(`Milestone: {magenta-fg}${milestoneFilterLabel}{/}`);
 			}
 			let listPaneMessage: string;
 			if (activeFilters.length > 0) {

--- a/src/utils/milestone-filter.ts
+++ b/src/utils/milestone-filter.ts
@@ -1,6 +1,9 @@
 import Fuse from "fuse.js";
 import type { Milestone } from "../types/index.ts";
 
+export const NO_MILESTONE_FILTER_VALUE = "\u0000no-milestone";
+export const NO_MILESTONE_FILTER_LABEL = "No milestone";
+
 interface MilestoneCandidate {
 	value: string;
 	compact: string;

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -5,6 +5,7 @@
 
 import Fuse from "fuse.js";
 import type { Task } from "../types/index.ts";
+import { NO_MILESTONE_FILTER_VALUE } from "./milestone-filter.ts";
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "./modified-files.ts";
 
 export interface TaskSearchOptions {
@@ -203,6 +204,9 @@ function applyMilestoneFilter(
 	const normalizedMilestone = milestone.trim().toLowerCase();
 	if (!normalizedMilestone) {
 		return tasks;
+	}
+	if (normalizedMilestone === NO_MILESTONE_FILTER_VALUE) {
+		return tasks.filter((task) => !task.milestone?.trim());
 	}
 
 	return tasks.filter((task) => {


### PR DESCRIPTION
## Summary
- Treats the old TASK-24.1 PR as the idea source and rebuilds the branch on current main.
- Adds the Web UI No milestone option to the existing TUI milestone filters for task list and Kanban views.
- Uses a shared milestone filter sentinel so task list and board filtering stay consistent.

## Related Task
BACK-447 - Add No milestone option to TUI milestone filters

## Testing
- bun test src/test/unified-view-filters.test.ts src/test/task-viewer-milestone-filter-model.test.ts src/test/filter-header-navigation.test.ts src/test/cli-milestone-filter.test.ts
- bunx tsc --noEmit
- bun run check .
- bun test