### PR TITLE
TASK-67 - Add -p shorthand for --parent option in task create command

### DIFF
--- a/.backlog/tasks/task-67 - add-p-shorthand-for-parent-option-in-task-create-command.md
+++ b/.backlog/tasks/task-67 - add-p-shorthand-for-parent-option-in-task-create-command.md
@@ -1,9 +1,10 @@
 ---
 id: task-67
 title: Add -p shorthand for --parent option in task create command
-status: To Do
+status: Done
 assignee: []
 created_date: '2025-06-15'
+updated_date: '2025-06-15'
 labels:
   - cli
   - enhancement
@@ -16,8 +17,18 @@ Add support for using -p as a shorthand alias for --parent when creating tasks. 
 
 ## Acceptance Criteria
 
-- [ ] `-p` option works as an alias for `--parent` in the `task create` command
-- [ ] Both `backlog task create "Task title" -p task-5` and `backlog task create "Task title" --parent task-5` produce the same result
-- [ ] Help text shows `-p` as the shorthand for `--parent`
-- [ ] Existing `--parent` functionality remains unchanged
-- [ ] Tests are added to verify both options work correctly
+- [x] `-p` option works as an alias for `--parent` in the `task create` command
+- [x] Both `backlog task create "Task title" -p task-5` and `backlog task create "Task title" --parent task-5` produce the same result
+- [x] Help text shows `-p` as the shorthand for `--parent`
+- [x] Existing `--parent` functionality remains unchanged
+- [x] Tests are added to verify both options work correctly
+
+## Implementation Notes
+
+- Added `-p` as a shorthand for `--parent` in the task create command (src/cli.ts:243)
+- The implementation was straightforward - simply updated the option definition to include both the shorthand and long form
+- Created comprehensive test suite in `src/test/cli-parent-shorthand.test.ts` that verifies:
+  - The `-p` shorthand creates subtasks with the correct parent
+  - Both `-p` and `--parent` produce identical results
+  - The help text correctly displays the shorthand option
+- The test subtask (task-67.1) was successfully created using the new `-p` option to verify functionality

--- a/.backlog/tasks/task-67.1 - test-subtask-with-p-option.md
+++ b/.backlog/tasks/task-67.1 - test-subtask-with-p-option.md
@@ -1,0 +1,12 @@
+---
+id: task-67.1
+title: Test subtask with -p option
+status: To Do
+assignee: []
+created_date: '2025-06-15'
+labels: []
+dependencies: []
+parent_task_id: task-67
+---
+
+## Description

--- a/scripts/cli-download.cjs
+++ b/scripts/cli-download.cjs
@@ -77,7 +77,7 @@ async function downloadBinary(binaryName, binaryPath) {
 							file.on("finish", () => {
 								file.close();
 								// Make executable on Unix
-								if (process.platform !== 'win32') {
+								if (process.platform !== "win32") {
 									chmodSync(binaryPath, 0o755);
 								}
 								console.log("Download complete!");
@@ -94,7 +94,7 @@ async function downloadBinary(binaryName, binaryPath) {
 					file.on("finish", () => {
 						file.close();
 						// Make executable on Unix
-						if (process.platform !== 'win32') {
+						if (process.platform !== "win32") {
 							chmodSync(binaryPath, 0o755);
 						}
 						console.log("Download complete!");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -240,7 +240,7 @@ taskCmd
 	.option("-s, --status <status>")
 	.option("-l, --labels <labels>")
 	.option("--draft")
-	.option("--parent <taskId>")
+	.option("-p, --parent <taskId>", "specify parent task ID")
 	.action(async (title: string, options) => {
 		const cwd = process.cwd();
 		const core = new Core(cwd);

--- a/src/test/cli-parent-shorthand.test.ts
+++ b/src/test/cli-parent-shorthand.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("CLI parent shorthand option", () => {
+	let testDir: string;
+	const cliPath = join(process.cwd(), "src", "cli.ts");
+
+	beforeAll(async () => {
+		testDir = await mkdtemp(join(tmpdir(), "backlog-test-"));
+		// Initialize a test project using the CLI directly
+		const initResult = await Bun.spawn(["bun", "run", cliPath, "init", "Test Project"], {
+			cwd: testDir,
+		}).exited;
+		expect(initResult).toBe(0);
+	});
+
+	afterAll(async () => {
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	it("should accept -p as shorthand for --parent", async () => {
+		// Create parent task
+		const createParent = await Bun.spawn(["bun", "run", cliPath, "task", "create", "Parent Task"], { cwd: testDir })
+			.exited;
+		expect(createParent).toBe(0);
+
+		// Create subtask using -p shorthand
+		const createSubtaskShort = await Bun.spawn(
+			["bun", "run", cliPath, "task", "create", "Subtask with -p", "-p", "task-1"],
+			{ cwd: testDir },
+		).exited;
+		expect(createSubtaskShort).toBe(0);
+
+		// Verify the subtask was created with correct parent
+		const subtaskFile = await Bun.file(join(testDir, ".backlog/tasks/task-1.1 - subtask-with-p.md")).text();
+		expect(subtaskFile).toContain("parent_task_id: task-1");
+	});
+
+	it("should work the same as --parent option", async () => {
+		// Create subtask using --parent
+		const createSubtaskLong = await Bun.spawn(
+			["bun", "run", cliPath, "task", "create", "Subtask with --parent", "--parent", "task-1"],
+			{ cwd: testDir },
+		).exited;
+		expect(createSubtaskLong).toBe(0);
+
+		// Verify both subtasks have the same parent
+		const subtask1 = await Bun.file(join(testDir, ".backlog/tasks/task-1.1 - subtask-with-p.md")).text();
+		const subtask2 = await Bun.file(join(testDir, ".backlog/tasks/task-1.2 - subtask-with-parent.md")).text();
+
+		expect(subtask1).toContain("parent_task_id: task-1");
+		expect(subtask2).toContain("parent_task_id: task-1");
+	});
+
+	it("should show -p in help text", async () => {
+		const helpProc = Bun.spawn(["bun", "run", cliPath, "task", "create", "--help"], { stdout: "pipe" });
+
+		const output = await new Response(helpProc.stdout).text();
+		expect(output).toContain("-p, --parent <taskId>");
+		expect(output).toContain("specify parent task ID");
+	});
+});


### PR DESCRIPTION
## Implementation Notes

- Added `-p` as a shorthand for `--parent` in the task create command (src/cli.ts:243)
- The implementation was straightforward - simply updated the option definition to include both the shorthand and long form
- Created comprehensive test suite in `src/test/cli-parent-shorthand.test.ts` that verifies:
  - The `-p` shorthand creates subtasks with the correct parent
  - Both `-p` and `--parent` produce identical results
  - The help text correctly displays the shorthand option
- The test subtask (task-67.1) was successfully created using the new `-p` option to verify functionality
