### PR TITLE
TASK-68 - Verify Windows binary uses .exe

### DIFF
--- a/.backlog/tasks/task-68 - verify-windows-binary-uses-.exe.md
+++ b/.backlog/tasks/task-68 - verify-windows-binary-uses-.exe.md
@@ -1,0 +1,20 @@
+---
+id: task-68
+title: Verify Windows binary uses .exe
+status: In Progress
+assignee: @codex
+created_date: '2025-06-15'
+labels:
+  - packaging
+dependencies: []
+---
+
+## Description
+Ensure the platform wrapper scripts select the correct compiled binary on Windows.
+The executable should include the `.exe` suffix so that global installation works
+with `npx` and `bunx`.
+
+## Acceptance Criteria
+- [ ] `cli.cjs` resolves `backlog.exe` when `process.platform` is `win32`.
+- [ ] `cli-download.cjs` downloads `backlog.exe` on Windows.
+- [ ] Unit tests cover these behaviors.

--- a/.backlog/tasks/task-68 - verify-windows-binary-uses-.exe.md
+++ b/.backlog/tasks/task-68 - verify-windows-binary-uses-.exe.md
@@ -1,9 +1,11 @@
 ---
 id: task-68
 title: Verify Windows binary uses .exe
-status: In Progress
-assignee: @codex
+status: Done
+assignee:
+  - '@codex'
 created_date: '2025-06-15'
+updated_date: '2025-06-15'
 labels:
   - packaging
 dependencies: []
@@ -15,6 +17,29 @@ The executable should include the `.exe` suffix so that global installation work
 with `npx` and `bunx`.
 
 ## Acceptance Criteria
-- [ ] `cli.cjs` resolves `backlog.exe` when `process.platform` is `win32`.
-- [ ] `cli-download.cjs` downloads `backlog.exe` on Windows.
-- [ ] Unit tests cover these behaviors.
+- [x] `cli.cjs` resolves `backlog.exe` when `process.platform` is `win32`.
+- [x] `cli-download.cjs` downloads `backlog.exe` on Windows.
+- [x] Unit tests cover these behaviors.
+
+## Implementation Notes
+
+The Windows .exe extension handling has been fully implemented:
+
+1. **getBinaryName.cjs** (shared utility):
+   - Correctly detects Windows platform using `process.platform === "win32"`
+   - Appends `.exe` extension to binary names on Windows
+   - Maps Node.js platform names to Bun target names appropriately
+
+2. **cli.cjs** (wrapper script):
+   - Uses `getBinaryName()` to resolve the correct binary name including `.exe` on Windows
+   - Spawns the binary with `windowsHide: true` option for better Windows compatibility
+
+3. **cli-download.cjs** (download script):
+   - Uses `getBinaryName()` to download the correct binary with `.exe` extension on Windows
+   - Skips chmod operation on Windows (only sets executable permissions on Unix)
+   - Also uses `windowsHide: true` when spawning the downloaded binary
+
+4. **Test Coverage**:
+   - `getBinaryName.test.ts` specifically tests that `.exe` is appended on Windows platform
+   - `build.test.ts` handles Windows executable naming in build tests
+   - All tests pass successfully

--- a/scripts/cli-download.cjs
+++ b/scripts/cli-download.cjs
@@ -6,49 +6,7 @@ const fs = require("node:fs");
 const https = require("node:https");
 const { createWriteStream, chmodSync } = require("node:fs");
 
-// Determine the correct binary based on platform and architecture
-function getBinaryName() {
-	const platform = process.platform;
-	const arch = process.arch;
-
-	let binaryName = "backlog-";
-
-	// Map Node.js platform names to Bun target names
-	switch (platform) {
-		case "linux":
-			binaryName += "bun-linux-";
-			break;
-		case "darwin":
-			binaryName += "bun-darwin-";
-			break;
-		case "win32":
-			binaryName += "bun-windows-";
-			break;
-		default:
-			console.error(`Unsupported platform: ${platform}`);
-			process.exit(1);
-	}
-
-	// Map Node.js arch names to Bun target names
-	switch (arch) {
-		case "x64":
-			binaryName += "x64";
-			break;
-		case "arm64":
-			binaryName += "arm64";
-			break;
-		default:
-			console.error(`Unsupported architecture: ${arch}`);
-			process.exit(1);
-	}
-
-	// Windows executables have .exe extension
-	if (platform === "win32") {
-		binaryName += ".exe";
-	}
-
-	return binaryName;
-}
+const { getBinaryName } = require("./getBinaryName.cjs");
 
 // Download binary from GitHub releases
 async function downloadBinary(binaryName, binaryPath) {

--- a/scripts/cli.cjs
+++ b/scripts/cli.cjs
@@ -3,49 +3,7 @@
 const { spawn } = require("node:child_process");
 const { join } = require("node:path");
 
-// Determine the correct binary based on platform and architecture
-function getBinaryName() {
-	const platform = process.platform;
-	const arch = process.arch;
-
-	let binaryName = "backlog-";
-
-	// Map Node.js platform names to Bun target names
-	switch (platform) {
-		case "linux":
-			binaryName += "bun-linux-";
-			break;
-		case "darwin":
-			binaryName += "bun-darwin-";
-			break;
-		case "win32":
-			binaryName += "bun-windows-";
-			break;
-		default:
-			console.error(`Unsupported platform: ${platform}`);
-			process.exit(1);
-	}
-
-	// Map Node.js arch names to Bun target names
-	switch (arch) {
-		case "x64":
-			binaryName += "x64";
-			break;
-		case "arm64":
-			binaryName += "arm64";
-			break;
-		default:
-			console.error(`Unsupported architecture: ${arch}`);
-			process.exit(1);
-	}
-
-	// Windows executables have .exe extension
-	if (platform === "win32") {
-		binaryName += ".exe";
-	}
-
-	return binaryName;
-}
+const { getBinaryName } = require("./getBinaryName.cjs");
 
 // Get the binary path
 const binaryName = getBinaryName();

--- a/scripts/getBinaryName.cjs
+++ b/scripts/getBinaryName.cjs
@@ -1,0 +1,39 @@
+function getBinaryName(platform = process.platform, arch = process.arch) {
+	let binaryName = "backlog-";
+
+	// Map Node.js platform names to Bun target names
+	switch (platform) {
+		case "linux":
+			binaryName += "bun-linux-";
+			break;
+		case "darwin":
+			binaryName += "bun-darwin-";
+			break;
+		case "win32":
+			binaryName += "bun-windows-";
+			break;
+		default:
+			throw new Error(`Unsupported platform: ${platform}`);
+	}
+
+	// Map Node.js arch names to Bun target names
+	switch (arch) {
+		case "x64":
+			binaryName += "x64";
+			break;
+		case "arm64":
+			binaryName += "arm64";
+			break;
+		default:
+			throw new Error(`Unsupported architecture: ${arch}`);
+	}
+
+	// Windows executables have .exe extension
+	if (platform === "win32") {
+		binaryName += ".exe";
+	}
+
+	return binaryName;
+}
+
+module.exports = { getBinaryName };

--- a/src/test/getBinaryName.test.ts
+++ b/src/test/getBinaryName.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "bun:test";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getBinaryName } = require("../../scripts/getBinaryName.cjs");
+
+describe("getBinaryName", () => {
+	it("appends .exe on Windows", () => {
+		expect(getBinaryName("win32", "x64")).toBe("backlog-bun-windows-x64.exe");
+	});
+});


### PR DESCRIPTION
## Implementation Notes

The Windows .exe extension handling has been fully implemented:

1. **getBinaryName.cjs** (shared utility):
   - Correctly detects Windows platform using `process.platform === "win32"`
   - Appends `.exe` extension to binary names on Windows
   - Maps Node.js platform names to Bun target names appropriately

2. **cli.cjs** (wrapper script):
   - Uses `getBinaryName()` to resolve the correct binary name including `.exe` on Windows
   - Spawns the binary with `windowsHide: true` option for better Windows compatibility

3. **cli-download.cjs** (download script):
   - Uses `getBinaryName()` to download the correct binary with `.exe` extension on Windows
   - Skips chmod operation on Windows (only sets executable permissions on Unix)
   - Also uses `windowsHide: true` when spawning the downloaded binary

4. **Test Coverage**:
   - `getBinaryName.test.ts` specifically tests that `.exe` is appended on Windows platform
   - `build.test.ts` handles Windows executable naming in build tests
   - All tests pass successfully