### PR TITLE
TASK-73 - Fix Windows binary package name

### DIFF
--- a/.backlog/tasks/task-73 - fix-cli-windows-package-name.md
+++ b/.backlog/tasks/task-73 - fix-cli-windows-package-name.md
@@ -1,0 +1,26 @@
+---
+id: task-73
+title: Fix Windows binary package name resolution
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2025-06-15'
+labels:
+  - bug
+  - windows
+  - packaging
+dependencies: []
+---
+
+## Description
+`backlog board view` fails on Windows with:
+```
+Binary package not installed for win32-x64.
+```
+The CLI wrapper computes the package name using `process.platform` directly, producing `backlog.md-win32-x64`. However the published package for Windows is `backlog.md-windows-x64`. Add a mapping so Windows uses the correct package name.
+
+## Acceptance Criteria
+- [ ] CLI resolves `backlog.md-windows-x64` on Windows and spawns the binary successfully.
+- [ ] Tests cover the platform mapping logic.
+- [ ] Release workflow includes any new script files.
+

--- a/.backlog/tasks/task-73 - fix-windows-binary-package-name-resolution.md
+++ b/.backlog/tasks/task-73 - fix-windows-binary-package-name-resolution.md
@@ -1,10 +1,11 @@
 ---
 id: task-73
 title: Fix Windows binary package name resolution
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-06-15'
+updated_date: '2025-06-15'
 labels:
   - bug
   - windows
@@ -20,7 +21,13 @@ Binary package not installed for win32-x64.
 The CLI wrapper computes the package name using `process.platform` directly, producing `backlog.md-win32-x64`. However the published package for Windows is `backlog.md-windows-x64`. Add a mapping so Windows uses the correct package name.
 
 ## Acceptance Criteria
-- [ ] CLI resolves `backlog.md-windows-x64` on Windows and spawns the binary successfully.
-- [ ] Tests cover the platform mapping logic.
-- [ ] Release workflow includes any new script files.
+- [x] CLI resolves `backlog.md-windows-x64` on Windows and spawns the binary successfully.
+- [x] Tests cover the platform mapping logic.
+- [x] Release workflow includes any new script files.
+
+## Implementation Notes
+- Added resolveBinary.cjs to map win32 to windows and exported helpers
+- Updated cli.cjs to use resolveBinaryPath for selecting binary
+- Modified release workflow to package resolveBinary.cjs
+- Created unit tests for getPackageName mapping
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           mkdir -p dist
           cp scripts/cli.cjs dist/cli.js
+          cp scripts/resolveBinary.cjs dist/resolveBinary.cjs
           chmod +x dist/cli.js
       - name: Create npm-ready package.json
         shell: bash
@@ -77,7 +78,7 @@ jobs:
           jq 'del(.devDependencies,.scripts.prepare,.scripts.preinstall,.scripts.postinstall,.type) |
               .version = "'$TAG'" |
               .bin = {backlog:"cli.js"} |
-              .files = ["cli.js","package.json","README.md","LICENSE"]' package.json > dist/package.json
+              .files = ["cli.js","resolveBinary.cjs","package.json","README.md","LICENSE"]' package.json > dist/package.json
           cp LICENSE README.md dist/ 2>/dev/null || true
       - uses: actions/setup-node@v4
         with:

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,13 @@
         "lint-staged": "16.1.0",
         "prompts": "2.4.2",
       },
+      "optionalDependencies": {
+        "backlog.md-darwin-arm64": "*",
+        "backlog.md-darwin-x64": "*",
+        "backlog.md-linux-arm64": "*",
+        "backlog.md-linux-x64": "*",
+        "backlog.md-windows-x64": "*",
+      },
     },
   },
   "trustedDependencies": [
@@ -50,6 +57,16 @@
     "ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "backlog.md-darwin-arm64": ["backlog.md-darwin-arm64@0.1.25", "", { "os": "darwin", "cpu": "arm64", "bin": { "backlog": "backlog" } }, "sha512-TPVrsN923w6SAMBqMWTaIdNc9NklwtSRGh42S1f9OdchlsISHGKfNgjbpAd9TLwJx/zlF4SHBSFph+1RDAPQdA=="],
+
+    "backlog.md-darwin-x64": ["backlog.md-darwin-x64@0.1.25", "", { "os": "darwin", "cpu": "x64", "bin": { "backlog": "backlog" } }, "sha512-UsxQu1rqVi73Nykq3SymbH+m9nJVsOOnACmej6I8efDxmYvvsKNPWcDvcTMhCkG2SdnjgKhNt1xBRFB0WBjj0g=="],
+
+    "backlog.md-linux-arm64": ["backlog.md-linux-arm64@0.1.25", "", { "os": "linux", "cpu": "arm64", "bin": { "backlog": "backlog" } }, "sha512-NL1ndishoXw76jFDug8aHZYhIORkeM/AHsd2PEjC+z7Q+ycsztxJlbgSD22hQkBqCGqjSrtzFV2VpNLV8nPY1Q=="],
+
+    "backlog.md-linux-x64": ["backlog.md-linux-x64@0.1.25", "", { "os": "linux", "cpu": "x64", "bin": { "backlog": "backlog" } }, "sha512-Ut6Ym6NxBVxVT13IGle8okTdq9X5Hd9hWCjVhbhdZX4hLfkN+D7zp0+HT4YXAVWTpGc6dV9FhHMgUonl9ntpuA=="],
+
+    "backlog.md-windows-x64": ["backlog.md-windows-x64@0.1.25", "", { "os": "win32", "cpu": "x64", "bin": { "backlog": "backlog.exe" } }, "sha512-xlfc9kiK45CqrVnR5W0ERUvSBmYk5fG7DOvp4Wuz6FV38mtQHJ7Hb/5Kv1y1xolu40ZjaJq97oETNvcoi9rWJQ=="],
 
     "blessed": ["blessed@0.1.81", "", { "bin": { "blessed": "./bin/tput.js" } }, "sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ=="],
 

--- a/scripts/cli.cjs
+++ b/scripts/cli.cjs
@@ -1,16 +1,13 @@
 #!/usr/bin/env node
 
 const { spawn } = require("node:child_process");
+const { resolveBinaryPath } = require("./resolveBinary.cjs");
 
-// Resolve binary from platform-specific package
-const platform = process.platform;
-const arch = process.arch;
-const packageName = `backlog.md-${platform}-${arch}`;
 let binaryPath;
 try {
-	binaryPath = require.resolve(`${packageName}/backlog${platform === "win32" ? ".exe" : ""}`);
+	binaryPath = resolveBinaryPath();
 } catch {
-	console.error(`Binary package not installed for ${platform}-${arch}.`);
+	console.error(`Binary package not installed for ${process.platform}-${process.arch}.`);
 	process.exit(1);
 }
 

--- a/scripts/resolveBinary.cjs
+++ b/scripts/resolveBinary.cjs
@@ -1,0 +1,33 @@
+function mapPlatform(platform = process.platform) {
+	switch (platform) {
+		case "win32":
+			return "windows";
+		case "darwin":
+		case "linux":
+			return platform;
+		default:
+			return platform;
+	}
+}
+
+function mapArch(arch = process.arch) {
+	switch (arch) {
+		case "x64":
+		case "arm64":
+			return arch;
+		default:
+			return arch;
+	}
+}
+
+function getPackageName(platform = process.platform, arch = process.arch) {
+	return `backlog.md-${mapPlatform(platform)}-${mapArch(arch)}`;
+}
+
+function resolveBinaryPath(platform = process.platform, arch = process.arch) {
+	const packageName = getPackageName(platform, arch);
+	const binary = `backlog${platform === "win32" ? ".exe" : ""}`;
+	return require.resolve(`${packageName}/${binary}`);
+}
+
+module.exports = { getPackageName, resolveBinaryPath };

--- a/src/test/resolveBinary.test.ts
+++ b/src/test/resolveBinary.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getPackageName } = require("../../scripts/resolveBinary.cjs");
+
+describe("getPackageName", () => {
+	it("maps win32 platform to windows package", () => {
+		expect(getPackageName("win32", "x64")).toBe("backlog.md-windows-x64");
+	});
+
+	it("returns linux name unchanged", () => {
+		expect(getPackageName("linux", "arm64")).toBe("backlog.md-linux-arm64");
+	});
+});


### PR DESCRIPTION
## Implementation Notes
- Added resolveBinary.cjs to map win32 to windows and exported helpers
- Updated cli.cjs to use resolveBinaryPath for selecting binary
- Modified release workflow to package resolveBinary.cjs
- Created unit tests for getPackageName mapping
