### PR TITLE
Add task-75 about Implementation Plan feature

### DIFF
--- a/.backlog/tasks/task-75 - add-implementation-plan-section.md
+++ b/.backlog/tasks/task-75 - add-implementation-plan-section.md
@@ -1,0 +1,24 @@
+---
+id: task-75
+title: Add Implementation Plan section
+status: To Do
+assignee: []
+created_date: '2025-06-16'
+labels:
+  - docs
+  - cli
+dependencies: []
+---
+
+## Description
+
+Introduce an **Implementation Plan** section in task files so humans and AI agents can outline their approach before starting work. Update README files and guidelines to mention this new section. Add a `--plan` (`-p`) option to `task create` and `task edit` commands so the plan can be provided via CLI.
+
+## Acceptance Criteria
+
+- [ ] Task template includes a `## Implementation Plan` section before `Implementation Notes`.
+- [ ] `.backlog/tasks/readme.md` updated with the new section in the example template.
+- [ ] Guidelines (`AGENTS.md` etc.) mention drafting an Implementation Plan.
+- [ ] CLI `task create` and `task edit` accept `--plan` / `-p` to populate the section.
+- [ ] README / CLI help documents the new option.
+


### PR DESCRIPTION
## Summary
- add new task to design Implementation Plan section in tasks

## Testing
- `backlog task create` to generate new task

------
https://chatgpt.com/codex/tasks/task_e_685006cc69e883338c4362c649071c39