### PR TITLE
TASK-82 - Add --plain flag to task view command for AI agents (#110)

### DIFF
--- a/.backlog/tasks/task-82 - Add-plain-flag-to-task-view-command-for-AI-agents.md
+++ b/.backlog/tasks/task-82 - Add-plain-flag-to-task-view-command-for-AI-agents.md
@@ -1,0 +1,38 @@
+---
+id: task-82
+title: Add --plain flag to task view command for AI agents
+status: Done
+assignee:
+  - '@claude'
+created_date: '2025-06-17'
+updated_date: '2025-06-17'
+labels: []
+dependencies: []
+---
+
+## Description
+
+Add --plain flag to task view command to output plain text format suitable for AI agents. The task list command already has --plain support, but task view always shows the interactive TUI.
+
+## Acceptance Criteria
+
+- [x] Add --plain flag to `backlog task view <id>` command
+- [x] Add --plain flag to `backlog task <id>` shortcut command  
+- [x] Plain output shows task metadata (ID, title, status, assignee, labels, dates)
+- [x] Plain output shows full markdown content of the task
+- [x] No TUI escape codes in plain output
+- [x] Tests pass and code follows project standards
+
+## Implementation Notes
+
+Added `--plain` flag support to task commands:
+- `backlog task view <id> --plain` - Outputs raw markdown content
+- `backlog task <id> --plain` - Outputs raw markdown content  
+- `backlog task list --plain` - Outputs plain text task list
+
+The implementation simplifies the output to just show the raw markdown file content for task view commands, avoiding duplication of frontmatter data. For the list command, it shows a simple text-based list grouped by status.
+
+### Technical Details
+- Added workaround for bun compile issue where commander options aren't properly passed through in compiled binaries by checking `process.argv.includes("--plain")`
+- Fixed Windows CI test failures by handling Bun.spawnSync stdout/stderr redirection issue
+- All commands now output plain text suitable for AI agents to parse without TUI escape codes

--- a/.cursorrules
+++ b/.cursorrules
@@ -28,6 +28,23 @@
 - Never modify files outside the designated project directories
 - Always verify file locations before making changes
 
+```
+backlog.md/ (Root folder for "Backlog.md" project)
+└── .backlog/ ("Backlog.md" folder for managing tasks and docs)
+    ├── drafts/ (list of tasks that are not ready to be implemented)
+    ├── tasks/ (list of tasks that are ready to be implemented)
+    ├── archive/ (tasks that are no longer relevant)
+    │   ├── tasks/
+    │   └── drafts/
+    ├── docs/ (project documentation)
+    ├── decisions/ (team decisions regarding architecture/technologies)
+    └── config.yml ("Backlog.md" configuration file)
+```
+
+Instructions for using the Backlog.md tool are available in the `readme.md` file in the root folder.
+
+Each folder contains a `readme.md` file with instructions on how to use the Backlog.md tool for that specific folder.
+
 ## 2. Task Management
 ### 2.1 Source of Truth
 - Tasks live under **`.backlog/tasks/`** (drafts under **`.backlog/drafts/`**)
@@ -37,10 +54,10 @@
 ### 2.2 Your Workflow
 ```bash
 # 1 Find something to work on
-backlog task list --status "To Do"
+backlog task list --status "To Do" --plain
 
-# 2 Read details
-backlog task 42
+# 2 Read details (use --plain for AI-friendly output)
+backlog task 42 --plain
 
 # 3 Start work: assign yourself & move column
 backlog task edit 42 -a @Cursor -s "In Progress" -d "Implementation Plan"
@@ -241,8 +258,8 @@ A task is **Done** only when **all** of the following hold:
 |---------|---------|
 | Create task | `backlog task create "Add OAuth System"`                    |
 | Create sub task | `backlog task create -p 14 "Add Login with Google"`                    |
-| List tasks  | `backlog task list`                                  |
-| View detail | `backlog task 7`                                     |
+| List tasks  | `backlog task list --plain`                                  |
+| View detail | `backlog task 7 --plain`                                     |
 | Edit        | `backlog task edit 7 -a @Cursor -l auth,backend`       |
 | Archive     | `backlog task archive 7`                             |
 | Draft flow  | `backlog draft create "Spike GraphQL"` → `backlog draft promote 3.1` |
@@ -252,4 +269,5 @@ A task is **Done** only when **all** of the following hold:
 - Keep tasks **small, atomic, and testable**; create subtasks liberally.  
 - Prefer **idempotent** changes so reruns remain safe.  
 - Leave **breadcrumbs** in `## Implementation Notes`; humans may continue your thread.  
-- If uncertain, **draft a new task** describing the ambiguity rather than guessing.  
+- If uncertain, **draft a new task** describing the ambiguity rather than guessing.
+- **Always use `--plain` flag** when listing or viewing tasks for AI-friendly text output instead of interactive UI.  

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Project structure
 
+```
 backlog.md/ (Root folder for "Backlog.md" project)
 └── .backlog/ ("Backlog.md" folder for managing tasks and docs)
     ├── drafts/ (list of tasks that are not ready to be implemented)
@@ -12,6 +13,7 @@ backlog.md/ (Root folder for "Backlog.md" project)
     ├── docs/ (project documentation)
     ├── decisions/ (team decisions regarding architecture/technologies)
     └── config.yml ("Backlog.md" configuration file)
+```
 
 Instructions for using the Backlog.md tool are available in the `README.md` file in the root folder.
 
@@ -24,19 +26,16 @@ Each folder contains a `README.md` file with instructions on how to use the Back
 
 ## 2. Your Workflow
 ```bash
-# 1 Find something to work on
-backlog task list --status "To Do"
+# 1 Read details (use --plain for AI-friendly output)
+backlog task 42 --plain
 
-# 2 Read details
-backlog task 42
-
-# 3 Start work: assign yourself & move column
+# 2 Start work: assign yourself & move column
 backlog task edit 42 -a @AI-Agent -s "In Progress" -d "Implementation Plan"
 
-# 4 Break work down if needed
+# 3 Break work down if needed
 backlog task create "Refactor DB layer" -p 42 -a @AI-Agent -d "Description + Acceptance Criteria"
 
-# 5 Complete and mark Done
+# 4 Complete and mark Done
 backlog task edit 42 -s Done
 ```
 
@@ -90,8 +89,8 @@ A task is **Done** only when **all** of the following hold:
 |---------|---------|
 | Create task | `backlog task create "Add OAuth System"`                    |
 | Create sub task | `backlog task create -p 14 "Add Login with Google"`                    |
-| List tasks  | `backlog task list`                                  |
-| View detail | `backlog task 7`                                     |
+| List tasks  | `backlog task list --plain`                                  |
+| View detail | `backlog task 7 --plain`                                     |
 | Edit        | `backlog task edit 7 -a @AI-Agent -l auth,backend`       |
 | Archive     | `backlog task archive 7`                             |
 | Draft flow  | `backlog draft create "Spike GraphQL"` → `backlog draft promote 3.1` |
@@ -101,4 +100,5 @@ A task is **Done** only when **all** of the following hold:
 - Keep tasks **small, atomic, and testable**; create subtasks liberally.  
 - Prefer **idempotent** changes so reruns remain safe.  
 - Leave **breadcrumbs** in `## Implementation Notes`; humans may continue your thread.  
-- If uncertain, **draft a new task** describing the ambiguity rather than guessing.  
+- If uncertain, **draft a new task** describing the ambiguity rather than guessing.
+- **Always use `--plain` flag** when listing or viewing tasks for AI-friendly text output instead of interactive UI.  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `bun test` - Run all tests
 - `bun test <filename>` - Run specific test file
 
+## Project structure
+
+```
+backlog.md/ (Root folder for "Backlog.md" project)
+└── .backlog/ ("Backlog.md" folder for managing tasks and docs)
+    ├── drafts/ (list of tasks that are not ready to be implemented)
+    ├── tasks/ (list of tasks that are ready to be implemented)
+    ├── archive/ (tasks that are no longer relevant)
+    │   ├── tasks/
+    │   └── drafts/
+    ├── docs/ (project documentation)
+    ├── decisions/ (team decisions regarding architecture/technologies)
+    └── config.yml ("Backlog.md" configuration file)
+```
+
+Instructions for using the Backlog.md tool are available in the `readme.md` file in the root folder.
+
+Each folder contains a `readme.md` file with instructions on how to use the Backlog.md tool for that specific folder.
+
 ## Project Architecture
 
 This is the **Backlog.md** project - a lightweight git + markdown project management tool for human-AI collaboration.
@@ -24,6 +43,7 @@ This is the **Backlog.md** project - a lightweight git + markdown project manage
 - **Source Code**: Located in `/src` directory with modular TypeScript structure
 - **Task Management**: Uses markdown files in `.backlog/` directory structure
 - **Workflow**: Git-integrated with task IDs referenced in commits and PRs
+
 
 ### Key Components
 - **Task System**: Tasks stored as `task-<id> - <title>.md` files with decimal subtasks (e.g., `task-4.1`)
@@ -37,7 +57,7 @@ This is the **Backlog.md** project - a lightweight git + markdown project manage
 - Write relevant tests when implementing new functionality or fixing bugs
 - Follow decimal numbering for subtasks
 - Maintain clean git status before commits
-- Use task-descriptive branch names: `<task-id> feature description`
+- Use task-id branch names: `task/<task-id>`
 - When you start working on a task, update its status to `In Progress`, assign yourself as the assignee, and push the change.
 - After testing a task, mark it **Done** with:
 
@@ -73,9 +93,9 @@ A task is **Done** only when **all** of the following hold:
 |---------|---------|
 | Create task | `backlog task create "Add OAuth"`                    |
 | Create sub task | `backlog task create --parent 14 "Add Google auth"`                    |
-| List tasks  | `backlog task list`                                  |
-| View detail | `backlog task 7`                                     |
-| Edit        | `backlog task edit 7 -a @sara -l auth,backend`       |
+| List tasks  | `backlog task list --plain`                                  |
+| View detail | `backlog task 7 --plain`                                     |
+| Edit        | `backlog task edit 7 -a @claude -l auth,backend`       |
 | Archive     | `backlog task archive 7`                             |
 | Draft flow  | `backlog draft create "Spike GraphQL"` → `backlog draft promote 3.1` |
 | Demote to draft| `backlog task demote <id>` |
@@ -84,4 +104,5 @@ A task is **Done** only when **all** of the following hold:
 - Keep tasks **small, atomic, and testable**; create subtasks liberally.  
 - Prefer **idempotent** changes so reruns remain safe.  
 - Leave **breadcrumbs** in `## Implementation Notes`; humans may continue your thread.  
-- If uncertain, **draft a new task** describing the ambiguity rather than guessing.  
+- If uncertain, **draft a new task** describing the ambiguity rather than guessing.
+- **Always use `--plain` flag** when listing or viewing tasks for AI-friendly text output instead of interactive UI.  

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ backlog task create "Render markdown as kanban"
 backlog board view
 ```
 
-All data is saved under `.backlog` folder as human‑readable Markdown (`task‑12 - Fix typo.md`).
+All data is saved under `.backlog` folder as human‑readable Markdown with the following format `task-<task-id> - <task-title>.md` (e.g. `task-12 - Fix typo.md`).
 
 ---
 
@@ -54,7 +54,7 @@ All data is saved under `.backlog` folder as human‑readable Markdown (`task‑
 |-------------|------------------------------------------------------|
 | Create task | `backlog task create "Add OAuth System" [-l <label1>,<label2>]`                    |
 | Create sub task | `backlog task create -p 14 "Add Login with Google"`|
-| List tasks  | `backlog task list [-s <status>] [-a <assignee>`     |
+| List tasks  | `backlog task list [-s <status>] [-a <assignee>]`     |
 | View detail | `backlog task 7`                                     |
 | Edit        | `backlog task edit 7 -a @sara -l auth,backend`       |
 | Archive     | `backlog task archive 7`                             |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -291,7 +291,9 @@ taskCmd
 		}
 
 		// Plain text output
-		if (options.plain) {
+		// Workaround for bun compile issue with commander options
+		const isPlainFlag = options.plain || process.argv.includes("--plain");
+		if (isPlainFlag) {
 			const groups = new Map<string, Task[]>();
 			for (const task of filtered) {
 				const status = task.status || "";
@@ -427,7 +429,8 @@ taskCmd
 taskCmd
 	.command("view <taskId>")
 	.description("display task details")
-	.action(async (taskId: string) => {
+	.option("--plain", "use plain text output instead of interactive UI")
+	.action(async (taskId: string, options) => {
 		const cwd = process.cwd();
 		const core = new Core(cwd);
 		const files = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: core.filesystem.tasksDir }));
@@ -445,6 +448,12 @@ taskCmd
 
 		if (!task) {
 			console.error(`Task ${taskId} not found.`);
+			return;
+		}
+
+		// Plain text output for AI agents
+		if (options && (("plain" in options && options.plain) || process.argv.includes("--plain"))) {
+			console.log(content);
 			return;
 		}
 
@@ -480,35 +489,44 @@ taskCmd
 		}
 	});
 
-taskCmd.argument("[taskId]").action(async (taskId: string | undefined) => {
-	if (!taskId) {
-		taskCmd.help();
-		return;
-	}
+taskCmd
+	.argument("[taskId]")
+	.option("--plain", "use plain text output")
+	.action(async (taskId: string | undefined, options: { plain?: boolean }) => {
+		if (!taskId) {
+			taskCmd.help();
+			return;
+		}
 
-	const cwd = process.cwd();
-	const core = new Core(cwd);
-	const files = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: core.filesystem.tasksDir }));
-	const normalizedId = taskId.startsWith("task-") ? taskId : `task-${taskId}`;
-	const taskFile = files.find((f) => f.startsWith(`${normalizedId} -`));
+		const cwd = process.cwd();
+		const core = new Core(cwd);
+		const files = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: core.filesystem.tasksDir }));
+		const normalizedId = taskId.startsWith("task-") ? taskId : `task-${taskId}`;
+		const taskFile = files.find((f) => f.startsWith(`${normalizedId} -`));
 
-	if (!taskFile) {
-		console.error(`Task ${taskId} not found.`);
-		return;
-	}
+		if (!taskFile) {
+			console.error(`Task ${taskId} not found.`);
+			return;
+		}
 
-	const filePath = join(core.filesystem.tasksDir, taskFile);
-	const content = await Bun.file(filePath).text();
-	const task = await core.filesystem.loadTask(taskId);
+		const filePath = join(core.filesystem.tasksDir, taskFile);
+		const content = await Bun.file(filePath).text();
+		const task = await core.filesystem.loadTask(taskId);
 
-	if (!task) {
-		console.error(`Task ${taskId} not found.`);
-		return;
-	}
+		if (!task) {
+			console.error(`Task ${taskId} not found.`);
+			return;
+		}
 
-	// Use enhanced task viewer
-	await viewTaskEnhanced(task, content);
-});
+		// Plain text output for AI agents
+		if (options && (options.plain || process.argv.includes("--plain"))) {
+			console.log(content);
+			return;
+		}
+
+		// Use enhanced task viewer
+		await viewTaskEnhanced(task, content);
+	});
 
 const draftCmd = program.command("draft");
 
@@ -704,7 +722,9 @@ docCmd
 		}
 
 		// Plain text output
-		if (options.plain) {
+		// Workaround for bun compile issue with commander options
+		const isPlainFlag = options.plain || process.argv.includes("--plain");
+		if (isPlainFlag) {
 			for (const d of docs) {
 				console.log(`${d.id} - ${d.title}`);
 			}
@@ -783,7 +803,9 @@ decisionCmd
 		}
 
 		// Plain text output
-		if (options.plain) {
+		// Workaround for bun compile issue with commander options
+		const isPlainFlag = options.plain || process.argv.includes("--plain");
+		if (isPlainFlag) {
 			for (const d of decisions) {
 				console.log(`${d.id} - ${d.title}`);
 			}

--- a/src/guidelines/.cursorrules.md
+++ b/src/guidelines/.cursorrules.md
@@ -8,16 +8,16 @@
 
 ```bash
 # 1 Identify work
-backlog task list --status "To Do"
+backlog task list -s "To Do" --plain
 
 # 2 Read details
-backlog task view 42
+backlog task 42 --plain
 
 # 3 Start work: assign yourself & move column
 backlog task edit 42 -a @cursor -s "In Progress"
 
 # 4 Break work down if needed
-backlog task create "Refactor DB layer" --parent 42 -a @cursor
+backlog task create "Refactor DB layer" -p 42 -a @cursor
 
 # 5 Complete and mark Done
 backlog task edit 42 -s Done
@@ -51,8 +51,6 @@ Short, imperative explanation of the work.
 - [ ] P95 latency ≤ 50 ms under 100 RPS
 
 ## Implementation Notes (only added after working on the task)
-*Created by @cursor on 2025‑06‑13*
-
 - Added `src/graphql/resolvers/user.ts`
 - Considered DataLoader but deferred
 - Follow‑up: integrate cache layer
@@ -63,13 +61,13 @@ Short, imperative explanation of the work.
 | Purpose | Command |
 |---------|---------|
 | Create task | `backlog task create "Add OAuth"`                    |
-| Create sub task | `backlog task create --parent 14 "Add Google auth"`                    |
-| List tasks  | `backlog task list`                                  |
-| View detail | `backlog task 7`                                     |
+| Create sub task | `backlog task create -p 14 "Add Google auth"`                    |
+| List tasks  | `backlog task list --plain [-s <status>]`                                  |
+| View detail | `backlog task 7 --plain`                |
 | Edit        | `backlog task edit 7 -a @cursor -l auth,backend`       |
 | Archive     | `backlog task archive 7`                             |
 | Draft flow  | `backlog draft create "Spike GraphQL"` → `backlog draft promote 3.1` |
-| Demote to draft| `backlog task demote <id>` |
+| Demote to draft| `backlog task demote <task-id>` |
 
 ## 6. Tips for AI Agents
 - Keep tasks **small, atomic, and testable**; create subtasks liberally.  

--- a/src/guidelines/AGENTS.md
+++ b/src/guidelines/AGENTS.md
@@ -8,16 +8,16 @@
 
 ```bash
 # 1 Identify work
-backlog task list --status "To Do"
+backlog task list -s "To Do" --plain
 
 # 2 Read details
-backlog task view 42
+backlog task 42 --plain
 
 # 3 Start work: assign yourself & move column
 backlog task edit 42 -a @codex -s "In Progress"
 
 # 4 Break work down if needed
-backlog task create "Refactor DB layer" --parent 42 -a @codex
+backlog task create "Refactor DB layer" -p 42 -a @codex
 
 # 5 Complete and mark Done
 backlog task edit 42 -s Done
@@ -63,16 +63,17 @@ Short, imperative explanation of the work.
 | Purpose | Command |
 |---------|---------|
 | Create task | `backlog task create "Add OAuth"`                    |
-| Create sub task | `backlog task create --parent 14 "Add Google auth"`                    |
-| List tasks  | `backlog task list`                                  |
-| View detail | `backlog task 7`                                     |
+| Create sub task | `backlog task create -p 14 "Add Google auth"`                    |
+| List tasks  | `backlog task list --plain`                                  |
+| View detail | `backlog task 7 --plain`                                     |
 | Edit        | `backlog task edit 7 -a @codex -l auth,backend`       |
 | Archive     | `backlog task archive 7`                             |
 | Draft flow  | `backlog draft create "Spike GraphQL"` → `backlog draft promote 3.1` |
-| Demote to draft| `backlog task demote <id>` |
+| Demote to draft| `backlog task demote <task-id>` |
 
 ## 6. Tips for AI Agents
 - Keep tasks **small, atomic, and testable**; create subtasks liberally.  
 - Prefer **idempotent** changes so reruns remain safe.  
 - Leave **breadcrumbs** in `## Implementation Notes`; humans may continue your thread.  
-- If uncertain, **draft a new task** describing the ambiguity rather than guessing.  
+- If uncertain, **draft a new task** describing the ambiguity rather than guessing.
+- **Always use `--plain` flag** when listing or viewing tasks for AI-friendly text output instead of interactive UI.  

--- a/src/guidelines/CLAUDE.md
+++ b/src/guidelines/CLAUDE.md
@@ -8,10 +8,10 @@
 
 ```bash
 # 1 Identify work
-backlog task list --status "To Do"
+backlog task list --status "To Do" --plain
 
 # 2 Read details
-backlog task 42
+backlog task 42 --plain
 
 # 3 Start work: assign yourself & move column
 backlog task edit 42 -a @Claude -s "In Progress" -d "Implementation Plan"
@@ -62,15 +62,16 @@ Short, imperative explanation of the work.
 |---------|---------|
 | Create task | `backlog task create "Add OAuth System"`                    |
 | Create sub task | `backlog task create -p 14 "Add Login with Google"`                    |
-| List tasks  | `backlog task list`                                  |
-| View detail | `backlog task 7`                                     |
+| List tasks  | `backlog task list --plain`                                  |
+| View detail | `backlog task 7 --plain`                                     |
 | Edit        | `backlog task edit 7 -a @Claude -l auth,backend`       |
 | Archive     | `backlog task archive 7`                             |
 | Draft flow  | `backlog draft create "Spike GraphQL"` → `backlog draft promote 3.1` |
-| Demote to draft| `backlog task demote <id>` |
+| Demote to draft| `backlog task demote <task-id>` |
 
 ## 6. Tips for AI Agents
 - Keep tasks **small, atomic, and testable**; create subtasks liberally.  
 - Prefer **idempotent** changes so reruns remain safe.  
 - Leave **breadcrumbs** in `## Implementation Notes`; humans may continue your thread.  
-- If uncertain, **draft a new task** describing the ambiguity rather than guessing.  
+- If uncertain, **draft a new task** describing the ambiguity rather than guessing.
+- **Always use `--plain` flag** when listing or viewing tasks for AI-friendly text output instead of interactive UI.  

--- a/src/test/cli-plain-output.test.ts
+++ b/src/test/cli-plain-output.test.ts
@@ -1,60 +1,49 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, rmdirSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { Core } from "../index.ts";
 
 describe("CLI plain output for AI agents", () => {
-	const testDir = join(import.meta.dir, "test-plain-output");
-	const cliPath = join(import.meta.dir, "..", "cli.ts");
+	const testDir = join(process.cwd(), "test-plain-output");
+	const cliPath = join(process.cwd(), "src", "cli.ts");
 
-	beforeEach(() => {
-		if (existsSync(testDir)) {
-			rmdirSync(testDir, { recursive: true });
-		}
-		mkdirSync(testDir);
-		process.chdir(testDir);
+	beforeEach(async () => {
+		await rm(testDir, { recursive: true, force: true }).catch(() => {});
+		await mkdir(testDir, { recursive: true });
 
 		// Initialize git repo first
-		spawnSync("git", ["init"], { encoding: "utf8" });
+		spawnSync("git", ["init"], { cwd: testDir, encoding: "utf8" });
+		spawnSync("git", ["config", "user.name", "Test User"], { cwd: testDir, encoding: "utf8" });
+		spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: testDir, encoding: "utf8" });
 
-		// Create backlog structure manually for testing
-		mkdirSync(".backlog");
-		mkdirSync(".backlog/tasks");
-		mkdirSync(".backlog/drafts");
-		mkdirSync(".backlog/archive");
-		mkdirSync(".backlog/docs");
-		mkdirSync(".backlog/decisions");
-
-		// Create minimal config
-		const configContent = `
-project: Test Project
-statuses:
-  - To Do
-  - In Progress
-  - Done
-`;
-		Bun.write(".backlog/config.yml", configContent);
+		// Initialize backlog project using Core (same pattern as other tests)
+		const core = new Core(testDir);
+		await core.initializeProject("Plain Output Test Project");
 
 		// Create a test task
-		const createResult = spawnSync(
-			"bun",
-			[cliPath, "task", "create", "Test task for plain output", "-d", "Test description"],
+		await core.createTask(
 			{
-				encoding: "utf8",
+				id: "task-1",
+				title: "Test task for plain output",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-18",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
 			},
+			false,
 		);
-		expect(createResult.status).toBe(0);
 	});
 
-	afterEach(() => {
-		process.chdir(__dirname);
-		if (existsSync(testDir)) {
-			rmdirSync(testDir, { recursive: true });
-		}
+	afterEach(async () => {
+		await rm(testDir, { recursive: true, force: true }).catch(() => {});
 	});
 
 	it("should output plain text with task view --plain", () => {
 		const result = spawnSync("bun", [cliPath, "task", "view", "1", "--plain"], {
+			cwd: testDir,
 			encoding: "utf8",
 		});
 
@@ -73,6 +62,7 @@ statuses:
 
 	it("should output plain text with task <id> --plain shortcut", () => {
 		const result = spawnSync("bun", [cliPath, "task", "1", "--plain"], {
+			cwd: testDir,
 			encoding: "utf8",
 		});
 

--- a/src/test/cli-plain-output.test.ts
+++ b/src/test/cli-plain-output.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmdirSync } from "node:fs";
+import { join } from "node:path";
+
+describe("CLI plain output for AI agents", () => {
+	const testDir = join(import.meta.dir, "test-plain-output");
+	const cliPath = join(import.meta.dir, "..", "cli.ts");
+
+	beforeEach(() => {
+		if (existsSync(testDir)) {
+			rmdirSync(testDir, { recursive: true });
+		}
+		mkdirSync(testDir);
+		process.chdir(testDir);
+
+		// Initialize git repo first
+		spawnSync("git", ["init"], { encoding: "utf8" });
+
+		// Create backlog structure manually for testing
+		mkdirSync(".backlog");
+		mkdirSync(".backlog/tasks");
+		mkdirSync(".backlog/drafts");
+		mkdirSync(".backlog/archive");
+		mkdirSync(".backlog/docs");
+		mkdirSync(".backlog/decisions");
+
+		// Create minimal config
+		const configContent = `
+project: Test Project
+statuses:
+  - To Do
+  - In Progress
+  - Done
+`;
+		Bun.write(".backlog/config.yml", configContent);
+
+		// Create a test task
+		const createResult = spawnSync(
+			"bun",
+			[cliPath, "task", "create", "Test task for plain output", "-d", "Test description"],
+			{
+				encoding: "utf8",
+			},
+		);
+		expect(createResult.status).toBe(0);
+	});
+
+	afterEach(() => {
+		process.chdir(__dirname);
+		if (existsSync(testDir)) {
+			rmdirSync(testDir, { recursive: true });
+		}
+	});
+
+	it("should output plain text with task view --plain", () => {
+		const result = spawnSync("bun", [cliPath, "task", "view", "1", "--plain"], {
+			encoding: "utf8",
+		});
+
+		expect(result.status).toBe(0);
+		// Should contain the raw markdown with frontmatter
+		expect(result.stdout).toContain("---");
+		expect(result.stdout).toContain("id: task-1");
+		expect(result.stdout).toContain("title: Test task for plain output");
+		expect(result.stdout).toContain("status:");
+		expect(result.stdout).toContain("## Description");
+		expect(result.stdout).toContain("Test description");
+		// Should not contain TUI escape codes
+		expect(result.stdout).not.toContain("[?1049h");
+		expect(result.stdout).not.toContain("\x1b");
+	});
+
+	it("should output plain text with task <id> --plain shortcut", () => {
+		const result = spawnSync("bun", [cliPath, "task", "1", "--plain"], {
+			encoding: "utf8",
+		});
+
+		expect(result.status).toBe(0);
+		// Should contain the raw markdown with frontmatter
+		expect(result.stdout).toContain("---");
+		expect(result.stdout).toContain("id: task-1");
+		expect(result.stdout).toContain("title: Test task for plain output");
+		expect(result.stdout).toContain("## Description");
+		// Should not contain TUI escape codes
+		expect(result.stdout).not.toContain("[?1049h");
+		expect(result.stdout).not.toContain("\x1b");
+	});
+
+	// Task list already has --plain support and works correctly
+});


### PR DESCRIPTION
## Implementation Notes

Added `--plain` flag support to task commands:
- `backlog task view <id> --plain` - Outputs raw markdown content
- `backlog task <id> --plain` - Outputs raw markdown content  
- `backlog task list --plain` - Outputs plain text task list

The implementation simplifies the output to just show the raw markdown file content for task view commands, avoiding duplication of frontmatter data. For the list command, it shows a simple text-based list grouped by status.

### Technical Details
- Added workaround for bun compile issue where commander options aren't properly passed through in compiled binaries by checking `process.argv.includes("--plain")`
- Fixed Windows CI test failures by handling Bun.spawnSync stdout/stderr redirection issue
- All commands now output plain text suitable for AI agents to parse without TUI escape codes