### PR TITLE
TASK-83 - Add case-insensitive status filter support

### DIFF
--- a/.backlog/tasks/task-83 - Add-case-insensitive-status-filter-support.md
+++ b/.backlog/tasks/task-83 - Add-case-insensitive-status-filter-support.md
@@ -1,9 +1,11 @@
 ---
 id: task-83
 title: Add case-insensitive status filter support
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2025-06-18'
+updated_date: '2025-06-19'
 labels:
   - enhancement
   - cli
@@ -16,8 +18,15 @@ Allow status filtering to be case-insensitive when using --status/-s flag.
 
 ## Acceptance Criteria
 
-- [ ] Status filtering works case-insensitively (e.g., "done", "Done", "DONE" all match "Done" status)
-- [ ] Case-insensitive filtering works for both --status and -s flags
-- [ ] Existing functionality maintains backward compatibility
-- [ ] Update help text to reflect case-insensitive behavior
-- [ ] Add tests for case-insensitive filtering with both flags
+- [x] Status filtering works case-insensitively (e.g., "done", "Done", "DONE" all match "Done" status)
+- [x] Case-insensitive filtering works for both --status and -s flags
+- [x] Existing functionality maintains backward compatibility
+- [x] Update help text to reflect case-insensitive behavior
+- [x] Add tests for case-insensitive filtering with both flags
+
+## Implementation Notes
+
+- Modified `src/cli.ts` to convert both the input status and task status to lowercase before comparison (line 282-283)
+- Updated help text for the `--status` flag to indicate case-insensitive behavior
+- Added comprehensive test coverage in `src/test/cli.test.ts` including tests for lowercase, uppercase, mixed case, and the -s shorthand flag
+- The change is backward compatible as it makes the filtering more permissive rather than restrictive

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -268,7 +268,7 @@ taskCmd
 taskCmd
 	.command("list")
 	.description("list tasks grouped by status")
-	.option("-s, --status <status>", "filter tasks by status")
+	.option("-s, --status <status>", "filter tasks by status (case-insensitive)")
 	.option("-a, --assignee <assignee>", "filter tasks by assignee")
 	.option("--plain", "use plain text output instead of interactive UI")
 	.action(async (options) => {
@@ -279,7 +279,8 @@ taskCmd
 
 		let filtered = tasks;
 		if (options.status) {
-			filtered = filtered.filter((t) => t.status === options.status);
+			const statusLower = options.status.toLowerCase();
+			filtered = filtered.filter((t) => t.status.toLowerCase() === statusLower);
 		}
 		if (options.assignee) {
 			filtered = filtered.filter((t) => t.assignee.includes(options.assignee));

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -300,6 +300,71 @@ describe("CLI Integration", () => {
 			expect(out).not.toContain("task-1");
 		});
 
+		it("should filter tasks by status case-insensitively", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-1",
+					title: "First Task",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					description: "First test task",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-2",
+					title: "Second Task",
+					status: "Done",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					description: "Second test task",
+				},
+				false,
+			);
+
+			// Test lowercase
+			const resultLower = Bun.spawnSync(["bun", CLI_PATH, "task", "list", "--plain", "--status", "done"], {
+				cwd: TEST_DIR,
+			});
+			const outLower = resultLower.stdout.toString();
+			expect(outLower).toContain("Done:");
+			expect(outLower).toContain("task-2 - Second Task");
+			expect(outLower).not.toContain("task-1");
+
+			// Test uppercase
+			const resultUpper = Bun.spawnSync(["bun", CLI_PATH, "task", "list", "--plain", "--status", "DONE"], {
+				cwd: TEST_DIR,
+			});
+			const outUpper = resultUpper.stdout.toString();
+			expect(outUpper).toContain("Done:");
+			expect(outUpper).toContain("task-2 - Second Task");
+			expect(outUpper).not.toContain("task-1");
+
+			// Test mixed case
+			const resultMixed = Bun.spawnSync(["bun", CLI_PATH, "task", "list", "--plain", "--status", "DoNe"], {
+				cwd: TEST_DIR,
+			});
+			const outMixed = resultMixed.stdout.toString();
+			expect(outMixed).toContain("Done:");
+			expect(outMixed).toContain("task-2 - Second Task");
+			expect(outMixed).not.toContain("task-1");
+
+			// Test with -s flag
+			const resultShort = Bun.spawnSync(["bun", CLI_PATH, "task", "list", "--plain", "-s", "done"], { cwd: TEST_DIR });
+			const outShort = resultShort.stdout.toString();
+			expect(outShort).toContain("Done:");
+			expect(outShort).toContain("task-2 - Second Task");
+			expect(outShort).not.toContain("task-1");
+		});
+
 		it("should filter tasks by assignee", async () => {
 			const core = new Core(TEST_DIR);
 


### PR DESCRIPTION
## Implementation Notes

- Modified `src/cli.ts` to convert both the input status and task status to lowercase before comparison (line 282-283)
- Updated help text for the `--status` flag to indicate case-insensitive behavior
- Added comprehensive test coverage in `src/test/cli.test.ts` including tests for lowercase, uppercase, mixed case, and the -s shorthand flag
- The change is backward compatible as it makes the filtering more permissive rather than restrictive
