### PR TITLE
Add cross-branch ID check backlog task

### DIFF
--- a/.backlog/tasks/task-87 - Cross-branch-task-ID-checking-and-branch-info.md
+++ b/.backlog/tasks/task-87 - Cross-branch-task-ID-checking-and-branch-info.md
@@ -1,0 +1,25 @@
+---
+id: task-87
+title: Cross-branch task ID checking and branch info
+status: To Do
+assignee: []
+created_date: '2025-06-19'
+labels: []
+dependencies: []
+---
+
+## Description
+
+Check last task ID across all branches when creating tasks. Display branch containing latest task version in board.
+
+## Acceptance Criteria
+
+- [ ] `backlog task create` checks all local and remote branches for the highest task ID
+- [ ] New tasks use an ID greater than any found across branches
+- [ ] `backlog board` displays which branch has the latest version of each task
+
+## Implementation Plan
+
+1. Fetch and scan `.backlog/tasks` across all branches to determine the max ID
+2. Integrate branch detection into task creation logic
+3. Update board rendering to show the branch that last modified each task


### PR DESCRIPTION
## Summary
- add task-87 describing how backlog should check latest task ID across all branches
- include board enhancement to show which branch has the latest task version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853a3d0cad8833388bf93841a44d99a