### PR TITLE
TASK-98 - Invert task order in Done column only

### DIFF
--- a/.backlog/tasks/task-98 - Invert-task-order-in-Done-column-only.md
+++ b/.backlog/tasks/task-98 - Invert-task-order-in-Done-column-only.md
@@ -1,9 +1,11 @@
 ---
 id: task-98
 title: Invert task order in Done column only
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Cursor'
 created_date: '2025-06-20'
+updated_date: '2025-06-20'
 labels:
   - ui
   - enhancement
@@ -16,7 +18,13 @@ Currently all tasks are sorted in ascending order by ID. This task is to change 
 
 ## Acceptance Criteria
 
-- [ ] Done column shows tasks in descending order by ID
-- [ ] Other status columns remain in ascending order
-- [ ] Board view reflects the new ordering
-- [ ] Exported boards show the correct ordering
+- [x] Done column shows tasks in descending order by ID
+- [x] Other status columns remain in ascending order
+- [x] Board view reflects the new ordering
+- [x] Exported boards show the correct ordering
+
+## Implementation Notes
+
+- Modified `src/ui/board.ts` to change the sort order for the "Done" column to be descending.
+- Applied the same logic to `src/board.ts` to ensure that exported boards also reflect the new sort order.
+- Kept the ascending sort order for all other columns.

--- a/src/board.ts
+++ b/src/board.ts
@@ -82,7 +82,14 @@ export function generateKanbanBoard(
 		const children = new Map<string, Task[]>();
 
 		// Use compareTaskIds for sorting instead of localeCompare
-		for (const t of items.sort((a, b) => compareTaskIds(a.id, b.id))) {
+		const sortedItems = items.sort((a, b) => {
+			if (status === "Done") {
+				return compareTaskIds(b.id, a.id); // Descending for Done
+			}
+			return compareTaskIds(a.id, b.id); // Ascending for others
+		});
+
+		for (const t of sortedItems) {
 			const parent = t.parentTaskId ? byId.get(t.parentTaskId) : undefined;
 			if (parent && parent.status === t.status) {
 				const list = children.get(parent.id) || [];

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -83,7 +83,12 @@ export async function renderBoardTui(
 				style: { selected: { fg: "white" } },
 			});
 
-			const sortedTasks = [...(tasksByStatus.get(status) ?? [])].sort((a, b) => compareTaskIds(a.id, b.id));
+			const sortedTasks = [...(tasksByStatus.get(status) ?? [])].sort((a, b) => {
+				if (status === "Done") {
+					return compareTaskIds(b.id, a.id); // Descending for Done
+				}
+				return compareTaskIds(a.id, b.id); // Ascending for others
+			});
 			const items = sortedTasks.map((task) => {
 				const assignee = task.assignee?.[0]
 					? ` {cyan-fg}${task.assignee[0].startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`


### PR DESCRIPTION
## Implementation Notes

- Modified `src/ui/board.ts` to change the sort order for the "Done" column to be descending.
- Applied the same logic to `src/board.ts` to ensure that exported boards also reflect the new sort order.
- Kept the ascending sort order for all other columns.
