### PR TITLE
Add task to enhance basic CLI documentation

### DIFF
--- a/.backlog/tasks/task-101 - Document-basic-task-commands-and-template.md
+++ b/.backlog/tasks/task-101 - Document-basic-task-commands-and-template.md
@@ -1,0 +1,41 @@
+---
+id: task-101
+title: Document basic Backlog.md CLI commands and required task sections
+status: To Do
+assignee: []
+labels:
+  - documentation
+  - agents
+dependencies: []
+---
+
+## Description
+
+Update the agent instructions so that new contributors only learn the three
+essential commands for working with tasks: **create**, **edit** and **view**.
+The documentation should clearly list the options for these commands and
+stress that every task file must contain a description, acceptance criteria and
+an implementation plan. Guidance should focus on defining goals and expectations
+without describing implementation details.
+
+## Acceptance Criteria
+
+- [ ] AGENTS file lists `backlog task create`, `backlog task edit` and
+      `backlog task view` with their available options
+- [ ] Instructions state that each task must include a description,
+      acceptance criteria and an implementation plan
+- [ ] Guidelines emphasize writing the **what** rather than the **how**
+- [ ] Agents are reminded that tasks are implemented by others and should be
+      small enough for a single PR, using subtasks for bigger features
+
+## Implementation Plan
+
+1. Review the current AGENTS documentation and related guidelines
+2. Add a concise section describing the create, edit and view commands with all
+   supported options
+3. Document the mandatory task sections: description, acceptance criteria and
+   implementation plan
+4. Include a note that tasks should focus on goals and expectations, leaving the
+   implementation details to other agents
+5. Suggest using subtasks to break down large objectives so that each pull
+   request remains small and focused


### PR DESCRIPTION
## Summary
- add TASK-101 to document basic CLI commands for agents

## Testing
- `CI=1 bun test --reporter=junit --reporter-outfile test-junit.xml`
- `bun run check`


------
https://chatgpt.com/codex/tasks/task_e_6859b4abf8788333b4dd61c9b8403b1d