### PR TITLE
TASK-164 - Add auto_commit config option with default false

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The web interface provides:
 | Web interface | `backlog browser` (launches web UI on port 6420) |
 | Web custom port | `backlog browser --port 8080 --no-open` |
 | Config editor | `backlog config set defaultEditor "code --wait"` |
+| Enable auto-commit | `backlog config set autoCommit true` |
 | View config | `backlog config list` |
 
 Full help: `backlog --help`
@@ -138,8 +139,11 @@ Key options:
 | `default_port`    | Web UI port        | `6420`                        |
 | `auto_open_browser`| Open browser automatically | `true`            |
 | `remote_operations`| Enable remote git operations | `true`           |
+| `auto_commit`     | Automatically commit task changes | `false`       |
 
 > **Note**: Set `remote_operations: false` to work offline. This disables git fetch operations and loads tasks from local branches only, useful when working without network connectivity.
+
+> **Git Control**: By default, `auto_commit` is set to `false`, giving you full control over your git history. Task operations will modify files but won't automatically commit changes. Set `auto_commit: true` if you prefer automatic commits for each task operation.
 
 ---
 

--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -10,3 +10,4 @@ default_editor: "rider"
 auto_open_browser: true
 default_port: 6420
 remote_operations: true
+auto_commit: false

--- a/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
+++ b/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
@@ -1,7 +1,7 @@
 ---
 id: task-164
 title: Add auto_commit config option with default false
-status: In Progress
+status: Done
 assignee: []
 created_date: '2025-07-07'
 updated_date: '2025-07-07'
@@ -17,13 +17,13 @@ Add configuration option to disable automatic git commits based on user feedback
 
 ## Acceptance Criteria
 
-- [ ] Add autoCommit field to BacklogConfig type definition
-- [ ] Update config schema migration to include autoCommit with default false
-- [ ] Modify Core class to respect autoCommit setting for all git operations
-- [ ] Update CLI commands to check autoCommit config before committing
-- [ ] Add config command support for setting autoCommit option
-- [ ] Update tests to verify autoCommit behavior works correctly
-- [ ] Add documentation for autoCommit configuration option
+- [x] Add autoCommit field to BacklogConfig type definition
+- [x] Update config schema migration to include autoCommit with default false
+- [x] Modify Core class to respect autoCommit setting for all git operations
+- [x] Update CLI commands to check autoCommit config before committing
+- [x] Add config command support for setting autoCommit option
+- [x] Update tests to verify autoCommit behavior works correctly
+- [x] Add documentation for autoCommit configuration option
 
 ## Implementation Notes
 

--- a/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
+++ b/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
@@ -1,0 +1,15 @@
+---
+id: task-164
+title: Add auto_commit config option with default false
+status: To Do
+assignee: []
+created_date: '2025-07-07'
+labels:
+  - enhancement
+  - config
+dependencies: []
+---
+
+## Description
+
+Add configuration option to disable automatic git commits based on user feedback in issues #160 and #164. Users want control over their git history and commit conventions.

--- a/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
+++ b/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
@@ -24,3 +24,32 @@ Add configuration option to disable automatic git commits based on user feedback
 - [ ] Add config command support for setting autoCommit option
 - [ ] Update tests to verify autoCommit behavior works correctly
 - [ ] Add documentation for autoCommit configuration option
+
+## Implementation Notes
+
+Successfully implemented autoCommit configuration option with default false value.
+
+**Implementation Details:**
+- Added autoCommit field to BacklogConfig type definition
+- Updated config migration to include autoCommit with default false for existing projects
+- Modified Core class methods to check autoCommit config before performing git operations
+- Updated CLI commands to remove hardcoded autoCommit=true parameters
+- Added config command support for getting/setting autoCommit option
+- All git operations now respect the autoCommit setting from config
+
+**Files Modified:**
+- src/types/index.ts - Added autoCommit?: boolean to BacklogConfig
+- src/core/config-migration.ts - Added autoCommit: false to defaults and migration
+- src/core/backlog.ts - Added shouldAutoCommit() helper and updated all methods
+- src/cli.ts - Removed hardcoded autoCommit=true from CLI commands, added config support
+- src/file-system/operations.ts - Added autoCommit serialization and parsing
+
+**Usage:**
+- bun run cli config set autoCommit true/false
+- bun run cli config get autoCommit
+- bun run cli config list (shows autoCommit value)
+
+**Backward Compatibility:**
+- Existing projects will have autoCommit=false after migration
+- Project initialization still defaults to autoCommit=true for the init commit
+- All Core methods accept optional autoCommit parameter to override config

--- a/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
+++ b/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
@@ -1,7 +1,7 @@
 ---
 id: task-164
 title: Add auto_commit config option with default false
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2025-07-07'
 updated_date: '2025-07-07'

--- a/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
+++ b/backlog/tasks/task-164 - Add-auto_commit-config-option-with-default-false.md
@@ -4,6 +4,7 @@ title: Add auto_commit config option with default false
 status: To Do
 assignee: []
 created_date: '2025-07-07'
+updated_date: '2025-07-07'
 labels:
   - enhancement
   - config
@@ -13,3 +14,13 @@ dependencies: []
 ## Description
 
 Add configuration option to disable automatic git commits based on user feedback in issues #160 and #164. Users want control over their git history and commit conventions.
+
+## Acceptance Criteria
+
+- [ ] Add autoCommit field to BacklogConfig type definition
+- [ ] Update config schema migration to include autoCommit with default false
+- [ ] Modify Core class to respect autoCommit setting for all git operations
+- [ ] Update CLI commands to check autoCommit config before committing
+- [ ] Add config command support for setting autoCommit option
+- [ ] Update tests to verify autoCommit behavior works correctly
+- [ ] Add documentation for autoCommit configuration option

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -414,11 +414,11 @@ taskCmd
 		}
 
 		if (options.draft) {
-			const filepath = await core.createDraft(task, true);
+			const filepath = await core.createDraft(task);
 			console.log(`Created draft ${id}`);
 			console.log(`File: ${filepath}`);
 		} else {
-			const filepath = await core.createTask(task, true);
+			const filepath = await core.createTask(task);
 			console.log(`Created task ${id}`);
 			console.log(`File: ${filepath}`);
 		}
@@ -646,7 +646,7 @@ taskCmd
 			task.description = updateTaskImplementationNotes(task.description, String(options.notes));
 		}
 
-		await core.updateTask(task, true);
+		await core.updateTask(task);
 		console.log(`Updated task ${task.id}`);
 	});
 
@@ -687,7 +687,7 @@ taskCmd
 	.action(async (taskId: string) => {
 		const cwd = process.cwd();
 		const core = new Core(cwd);
-		const success = await core.archiveTask(taskId, true);
+		const success = await core.archiveTask(taskId);
 		if (success) {
 			console.log(`Archived task ${taskId}`);
 		} else {
@@ -701,7 +701,7 @@ taskCmd
 	.action(async (taskId: string) => {
 		const cwd = process.cwd();
 		const core = new Core(cwd);
-		const success = await core.demoteTask(taskId, true);
+		const success = await core.demoteTask(taskId);
 		if (success) {
 			console.log(`Demoted task ${taskId}`);
 		} else {
@@ -765,7 +765,7 @@ draftCmd
 		const core = new Core(cwd);
 		const id = await generateNextId(core);
 		const task = buildTaskFromOptions(id, title, options);
-		const filepath = await core.createDraft(task, true);
+		const filepath = await core.createDraft(task);
 		console.log(`Created draft ${id}`);
 		console.log(`File: ${filepath}`);
 	});
@@ -790,7 +790,7 @@ draftCmd
 	.action(async (taskId: string) => {
 		const cwd = process.cwd();
 		const core = new Core(cwd);
-		const success = await core.promoteDraft(taskId, true);
+		const success = await core.promoteDraft(taskId);
 		if (success) {
 			console.log(`Promoted draft ${taskId}`);
 		} else {
@@ -1182,10 +1182,13 @@ configCmd
 				case "remoteOperations":
 					console.log(config.remoteOperations?.toString() || "");
 					break;
+				case "autoCommit":
+					console.log(config.autoCommit?.toString() || "");
+					break;
 				default:
 					console.error(`Unknown config key: ${key}`);
 					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, milestones, dateFormat, maxColumnWidth, backlogDirectory, defaultPort, autoOpenBrowser, remoteOperations",
+						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, milestones, dateFormat, maxColumnWidth, backlogDirectory, defaultPort, autoOpenBrowser, remoteOperations, autoCommit",
 					);
 					process.exit(1);
 			}
@@ -1277,6 +1280,18 @@ configCmd
 					}
 					break;
 				}
+				case "autoCommit": {
+					const boolValue = value.toLowerCase();
+					if (boolValue === "true" || boolValue === "1" || boolValue === "yes") {
+						config.autoCommit = true;
+					} else if (boolValue === "false" || boolValue === "0" || boolValue === "no") {
+						config.autoCommit = false;
+					} else {
+						console.error("autoCommit must be true or false");
+						process.exit(1);
+					}
+					break;
+				}
 				case "statuses":
 				case "labels":
 				case "milestones":
@@ -1327,6 +1342,7 @@ configCmd
 			console.log(`  autoOpenBrowser: ${config.autoOpenBrowser ?? "(not set)"}`);
 			console.log(`  defaultPort: ${config.defaultPort ?? "(not set)"}`);
 			console.log(`  remoteOperations: ${config.remoteOperations ?? "(not set)"}`);
+			console.log(`  autoCommit: ${config.autoCommit ?? "(not set)"}`);
 		} catch (err) {
 			console.error("Failed to list config values", err);
 			process.exitCode = 1;

--- a/src/core/config-migration.ts
+++ b/src/core/config-migration.ts
@@ -17,6 +17,7 @@ export function migrateConfig(config: Partial<BacklogConfig>): BacklogConfig {
 		autoOpenBrowser: true,
 		defaultPort: 6420,
 		remoteOperations: true,
+		autoCommit: false,
 	};
 
 	// Merge provided config with defaults, ensuring all fields exist
@@ -49,6 +50,7 @@ export function needsMigration(config: Partial<BacklogConfig>): boolean {
 		{ field: "defaultPort", hasDefault: true },
 		{ field: "autoOpenBrowser", hasDefault: true },
 		{ field: "remoteOperations", hasDefault: true },
+		{ field: "autoCommit", hasDefault: true },
 	];
 
 	return expectedFieldsWithDefaults.some(({ field }) => {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -567,6 +567,9 @@ export class FileSystem {
 				case "remote_operations":
 					config.remoteOperations = value.toLowerCase() === "true";
 					break;
+				case "auto_commit":
+					config.autoCommit = value.toLowerCase() === "true";
+					break;
 			}
 		}
 
@@ -585,6 +588,7 @@ export class FileSystem {
 			autoOpenBrowser: config.autoOpenBrowser,
 			defaultPort: config.defaultPort,
 			remoteOperations: config.remoteOperations,
+			autoCommit: config.autoCommit,
 		};
 	}
 
@@ -604,6 +608,7 @@ export class FileSystem {
 			...(typeof config.autoOpenBrowser === "boolean" ? [`auto_open_browser: ${config.autoOpenBrowser}`] : []),
 			...(config.defaultPort ? [`default_port: ${config.defaultPort}`] : []),
 			...(typeof config.remoteOperations === "boolean" ? [`remote_operations: ${config.remoteOperations}`] : []),
+			...(typeof config.autoCommit === "boolean" ? [`auto_commit: ${config.autoCommit}`] : []),
 		];
 
 		return `${lines.join("\n")}\n`;

--- a/src/test/auto-commit.test.ts
+++ b/src/test/auto-commit.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { Core } from "../core/backlog.ts";
+import type { Task } from "../types/index.ts";
+
+describe("Auto-commit configuration", () => {
+	const testDir = join(process.cwd(), "test-auto-commit");
+	let core: Core;
+
+	beforeEach(async () => {
+		await rm(testDir, { recursive: true, force: true }).catch(() => {});
+		await mkdir(testDir, { recursive: true });
+
+		// Configure git for tests
+		await Bun.spawn(["git", "init"], { cwd: testDir }).exited;
+		await Bun.spawn(["git", "config", "user.email", "test@example.com"], { cwd: testDir }).exited;
+		await Bun.spawn(["git", "config", "user.name", "Test User"], { cwd: testDir }).exited;
+
+		core = new Core(testDir);
+		await core.initializeProject("Test Auto-commit Project");
+	});
+
+	describe("Config migration", () => {
+		it("should include autoCommit in default config with false value", async () => {
+			const config = await core.filesystem.loadConfig();
+			expect(config).toBeDefined();
+			expect(config!.autoCommit).toBe(false);
+		});
+
+		it("should migrate existing config to include autoCommit", async () => {
+			// Create config without autoCommit
+			const oldConfig = {
+				projectName: "Test Project",
+				statuses: ["To Do", "Done"],
+				labels: [],
+				milestones: [],
+				dateFormat: "yyyy-mm-dd",
+			};
+			await core.filesystem.saveConfig(oldConfig as any);
+
+			// Trigger migration
+			await core.ensureConfigMigrated();
+
+			const migratedConfig = await core.filesystem.loadConfig();
+			expect(migratedConfig).toBeDefined();
+			expect(migratedConfig!.autoCommit).toBe(false);
+		});
+	});
+
+	describe("Core operations with autoCommit disabled", () => {
+		beforeEach(async () => {
+			// Set autoCommit to false
+			const config = await core.filesystem.loadConfig();
+			config!.autoCommit = false;
+			await core.filesystem.saveConfig(config!);
+		});
+
+		it("should not auto-commit when creating task with autoCommit disabled in config", async () => {
+			const task: Task = {
+				id: "task-1",
+				title: "Test Task",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-07-07",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+			};
+
+			await core.createTask(task);
+
+			// Check that there are uncommitted changes
+			const git = await core.getGitOps();
+			const isClean = await git.isClean();
+			expect(isClean).toBe(false);
+		});
+
+		it("should auto-commit when explicitly passing true to createTask", async () => {
+			const task: Task = {
+				id: "task-2",
+				title: "Test Task 2",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-07-07",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+			};
+
+			await core.createTask(task, true);
+
+			// Check that working directory is clean (changes were committed)
+			const git = await core.getGitOps();
+			const isClean = await git.isClean();
+			expect(isClean).toBe(true);
+		});
+
+		it("should not auto-commit when updating task with autoCommit disabled in config", async () => {
+			// First create a task with explicit commit
+			const task: Task = {
+				id: "task-3",
+				title: "Test Task",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-07-07",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+			};
+			await core.createTask(task, true);
+
+			// Update the task (should not auto-commit)
+			task.title = "Updated Task";
+			await core.updateTask(task);
+
+			// Check that there are uncommitted changes
+			const git = await core.getGitOps();
+			const isClean = await git.isClean();
+			expect(isClean).toBe(false);
+		});
+
+		it("should not auto-commit when archiving task with autoCommit disabled in config", async () => {
+			// First create a task with explicit commit
+			const task: Task = {
+				id: "task-4",
+				title: "Test Task",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-07-07",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+			};
+			await core.createTask(task, true);
+
+			// Archive the task (should not auto-commit)
+			await core.archiveTask("task-4");
+
+			// Check that there are uncommitted changes
+			const git = await core.getGitOps();
+			const isClean = await git.isClean();
+			expect(isClean).toBe(false);
+		});
+	});
+
+	describe("Core operations with autoCommit enabled", () => {
+		beforeEach(async () => {
+			// Set autoCommit to true
+			const config = await core.filesystem.loadConfig();
+			config!.autoCommit = true;
+			await core.filesystem.saveConfig(config!);
+
+			// Commit the config change to start with a clean state
+			const git = await core.getGitOps();
+			await git.addFile(join(testDir, "backlog", "config.yml"));
+			await git.commitChanges("Update autoCommit config for test");
+		});
+
+		it("should auto-commit when creating task with autoCommit enabled in config", async () => {
+			const task: Task = {
+				id: "task-5",
+				title: "Test Task",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-07-07",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+			};
+
+			await core.createTask(task);
+
+			// Check that working directory is clean (changes were committed)
+			const git = await core.getGitOps();
+			const isClean = await git.isClean();
+			expect(isClean).toBe(true);
+		});
+
+		it("should not auto-commit when explicitly passing false to createTask", async () => {
+			const task: Task = {
+				id: "task-6",
+				title: "Test Task",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-07-07",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+			};
+
+			await core.createTask(task, false);
+
+			// Check that there are uncommitted changes
+			const git = await core.getGitOps();
+			const isClean = await git.isClean();
+			expect(isClean).toBe(false);
+		});
+	});
+
+	describe("Draft operations", () => {
+		beforeEach(async () => {
+			// Set autoCommit to false
+			const config = await core.filesystem.loadConfig();
+			config!.autoCommit = false;
+			await core.filesystem.saveConfig(config!);
+		});
+
+		it("should respect autoCommit config for draft operations", async () => {
+			const task: Task = {
+				id: "draft-1",
+				title: "Test Draft",
+				status: "Draft",
+				assignee: [],
+				createdDate: "2025-07-07",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+			};
+
+			await core.createDraft(task);
+
+			// Check that there are uncommitted changes
+			const git = await core.getGitOps();
+			const isClean = await git.isClean();
+			expect(isClean).toBe(false);
+		});
+
+		it("should respect autoCommit config for promote draft operations", async () => {
+			// First create a draft with explicit commit
+			const task: Task = {
+				id: "draft-2",
+				title: "Test Draft",
+				status: "Draft",
+				assignee: [],
+				createdDate: "2025-07-07",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+			};
+			await core.createDraft(task, true);
+
+			// Promote the draft (should not auto-commit)
+			await core.promoteDraft("draft-2");
+
+			// Check that there are uncommitted changes
+			const git = await core.getGitOps();
+			const isClean = await git.isClean();
+			expect(isClean).toBe(false);
+		});
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,7 @@ export interface BacklogConfig {
 	autoOpenBrowser?: boolean;
 	defaultPort?: number;
 	remoteOperations?: boolean;
+	autoCommit?: boolean;
 }
 
 export interface ParsedMarkdown {


### PR DESCRIPTION
## Implementation Notes

Successfully implemented autoCommit configuration option with default false value.

**Implementation Details:**
- Added autoCommit field to BacklogConfig type definition
- Updated config migration to include autoCommit with default false for existing projects
- Modified Core class methods to check autoCommit config before performing git operations
- Updated CLI commands to remove hardcoded autoCommit=true parameters
- Added config command support for getting/setting autoCommit option
- All git operations now respect the autoCommit setting from config

**Files Modified:**
- src/types/index.ts - Added autoCommit?: boolean to BacklogConfig
- src/core/config-migration.ts - Added autoCommit: false to defaults and migration
- src/core/backlog.ts - Added shouldAutoCommit() helper and updated all methods
- src/cli.ts - Removed hardcoded autoCommit=true from CLI commands, added config support
- src/file-system/operations.ts - Added autoCommit serialization and parsing

**Usage:**
- bun run cli config set autoCommit true/false
- bun run cli config get autoCommit
- bun run cli config list (shows autoCommit value)

**Backward Compatibility:**
- Existing projects will have autoCommit=false after migration
- Project initialization still defaults to autoCommit=true for the init commit
- All Core methods accept optional autoCommit parameter to override config

Closes #160 and #164 