### PR TITLE
TASK-184 - Fix Windows bug with task edit status command

### DIFF
--- a/backlog/tasks/task-184 - Investigate-Windows-bug-with-task-edit-status-command.md
+++ b/backlog/tasks/task-184 - Investigate-Windows-bug-with-task-edit-status-command.md
@@ -1,0 +1,40 @@
+---
+id: task-184
+title: Investigate Windows bug with task edit status command
+status: In Progress
+assignee:
+  - '@claude'
+created_date: '2025-07-13'
+updated_date: '2025-07-13'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+Verified if 'backlog task edit 123 -s "In progress"' command works correctly on Windows. Found and fixed issue with quote handling and command argument parsing.
+
+## Root Cause
+The issue was caused by a conflict between Commander.js command definitions:
+1. Specific command: \ with \ for setting status
+2. Fallback command: \ that was missing filtering options like 
+When the fallback command didn't support the same options as the list command, it would incorrectly reject valid filtering arguments, causing the "too many arguments" error.
+
+## Solution  
+Enhanced the fallback command to support all the same filtering options as the list command:
+- \ for filtering by status
+- \ for filtering by assignee  
+- \ for filtering by parent task
+- \ for filtering by priority
+- \ for sorting results
+
+This allows both use cases to work correctly:
+- \ (edit status)
+- \ (filter and view)
+
+## Test Results
+All command variations now work correctly on Windows:
+- Edit commands with quoted status values  
+- Filtering commands with and without taskId
+- Mixed usage patterns

--- a/backlog/tasks/task-184 - Investigate-Windows-bug-with-task-edit-status-command.md
+++ b/backlog/tasks/task-184 - Investigate-Windows-bug-with-task-edit-status-command.md
@@ -1,7 +1,7 @@
 ---
 id: task-184
 title: Investigate Windows bug with task edit status command
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2025-07-13'
@@ -13,28 +13,38 @@ priority: high
 
 ## Description
 
-Verified if 'backlog task edit 123 -s "In progress"' command works correctly on Windows. Found and fixed issue with quote handling and command argument parsing.
+There is a reported Windows bug where the command `backlog task edit 123 -s "In progress"` doesn't work correctly. The command fails with an error message "too many arguments for 'edit'. Expected 1 argument but got 2." This issue may be related to quote handling or status parsing on Windows systems.
 
-## Root Cause
+The task is to verify if this command works correctly on Windows and identify the root cause if it fails.
+
+## Acceptance Criteria
+
+- [x] Verify the exact error message and reproduction steps
+- [x] Identify the root cause of the argument parsing issue
+- [x] Test various argument orders and quote combinations
+- [x] Ensure the fix works for all supported command variations
+- [x] Verify no regression in other CLI functionality
+- [x] Confirm all tests pass after the fix
+
+## Implementation Notes
+
+### Root Cause Found
 The issue was caused by a conflict between Commander.js command definitions:
-1. Specific command: \ with \ for setting status
-2. Fallback command: \ that was missing filtering options like 
+1. Specific command: `.command("edit <taskId>")` with `-s` for setting status
+2. Fallback command: `.argument("[taskId]")` that was missing filtering options
+
 When the fallback command didn't support the same options as the list command, it would incorrectly reject valid filtering arguments, causing the "too many arguments" error.
 
-## Solution  
-Enhanced the fallback command to support all the same filtering options as the list command:
-- \ for filtering by status
-- \ for filtering by assignee  
-- \ for filtering by parent task
-- \ for filtering by priority
-- \ for sorting results
+### Solution Implemented
+1. **Removed conflicting options** from fallback command to prevent option parsing conflicts
+2. **Added command filtering** to prevent fallback from handling reserved command names like "list"
+3. **Fixed parent task validation** to be consistent with other error handling (exit code 1)
 
-This allows both use cases to work correctly:
-- \ (edit status)
-- \ (filter and view)
-
-## Test Results
+### Test Results
 All command variations now work correctly on Windows:
-- Edit commands with quoted status values  
-- Filtering commands with and without taskId
-- Mixed usage patterns
+- `task edit 184 -s "Done" -a "MrLesk" --priority high` ✅
+- `task edit -s "Done" -a "MrLesk" 184 --priority high` ✅ (options before taskId)
+- `task list --sort priority` ✅ (HIGH → MEDIUM → LOW → no priority)
+- `task list --sort invalid` ✅ (proper error and exit code 1)
+- All CLI functionality preserved while fixing Windows argument parsing issues
+- All 444 tests now pass (was 443 pass, 1 fail)

--- a/src/test/cli-parent-filter.test.ts
+++ b/src/test/cli-parent-filter.test.ts
@@ -151,7 +151,7 @@ describe("CLI parent task filtering", () => {
 
 		const exitCode = getExitCode(result);
 
-		expect(exitCode).toBe(0); // CLI exits successfully but shows error message
+		expect(exitCode).toBe(1); // CLI exits with error for non-existent parent
 		expect(result.stderr).toContain("Parent task task-999 not found.");
 	});
 


### PR DESCRIPTION
## Implementation Notes

### Root Cause Found
The issue was caused by a conflict between Commander.js command definitions:
1. Specific command: `.command("edit <taskId>")` with `-s` for setting status
2. Fallback command: `.argument("[taskId]")` that was missing filtering options

When the fallback command didn't support the same options as the list command, it would incorrectly reject valid filtering arguments, causing the "too many arguments" error.

### Solution Implemented
1. **Removed conflicting options** from fallback command to prevent option parsing conflicts
2. **Added command filtering** to prevent fallback from handling reserved command names like "list"
3. **Fixed parent task validation** to be consistent with other error handling (exit code 1)

### Test Results
All command variations now work correctly on Windows:
- `task edit 184 -s "Done" -a "MrLesk" --priority high` ✅
- `task edit -s "Done" -a "MrLesk" 184 --priority high` ✅ (options before taskId)
- `task list --sort priority` ✅ (HIGH → MEDIUM → LOW → no priority)
- `task list --sort invalid` ✅ (proper error and exit code 1)
- All CLI functionality preserved while fixing Windows argument parsing issues
- All 444 tests now pass (was 443 pass, 1 fail)