### PR TITLE
TASK-185 - Fix task listing incorrectly including README.md files

### DIFF
--- a/backlog/tasks/task-185 - Fix-task-listing-incorrectly-including-README.md-files.md
+++ b/backlog/tasks/task-185 - Fix-task-listing-incorrectly-including-README.md-files.md
@@ -1,0 +1,25 @@
+---
+id: task-185
+title: Fix task listing incorrectly including README.md files
+status: Done
+assignee:
+  - '@claude'
+created_date: '2025-07-13'
+labels: []
+dependencies: []
+---
+
+## Description
+
+Task listing was incorrectly fetching README.md and showing it as a broken task due to overly broad file patterns in utility functions. The issue was causing non-task markdown files to appear in task lists and fail parsing, creating a confusing user experience.
+
+## Acceptance Criteria
+
+- [x] README.md files are no longer picked up by task listing functions
+- [x] Task utility functions use specific 'task-*.md' pattern instead of broad '*.md' pattern
+- [x] Existing task functionality remains unaffected
+- [x] All task listing operations (active, drafts, archived, completed) use consistent patterns
+
+## Implementation Notes
+
+Fixed by updating task-path.ts utility functions to use specific 'task-*.md' pattern instead of broad '*.md' pattern. This ensures only actual task files are discovered by the task management system while excluding README.md and other documentation files.

--- a/src/utils/task-path.ts
+++ b/src/utils/task-path.ts
@@ -22,7 +22,7 @@ export async function getTaskPath(taskId: string, core?: Core | TaskPathContext)
 	const coreInstance = core || new Core(process.cwd());
 
 	try {
-		const files = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: coreInstance.filesystem.tasksDir }));
+		const files = await Array.fromAsync(new Bun.Glob("task-*.md").scan({ cwd: coreInstance.filesystem.tasksDir }));
 		const normalizedId = normalizeTaskId(taskId);
 		const taskFile = files.find((f) => f.startsWith(`${normalizedId} -`));
 
@@ -42,7 +42,7 @@ export async function getTaskPath(taskId: string, core?: Core | TaskPathContext)
 export async function getDraftPath(taskId: string, core: Core): Promise<string | null> {
 	try {
 		const draftsDir = await core.filesystem.getDraftsDir();
-		const files = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: draftsDir }));
+		const files = await Array.fromAsync(new Bun.Glob("task-*.md").scan({ cwd: draftsDir }));
 		const normalizedId = normalizeTaskId(taskId);
 		const draftFile = files.find((f) => f.startsWith(`${normalizedId} -`));
 
@@ -63,7 +63,7 @@ export async function getTaskFilename(taskId: string, core?: Core | TaskPathCont
 	const coreInstance = core || new Core(process.cwd());
 
 	try {
-		const files = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: coreInstance.filesystem.tasksDir }));
+		const files = await Array.fromAsync(new Bun.Glob("task-*.md").scan({ cwd: coreInstance.filesystem.tasksDir }));
 		const normalizedId = normalizeTaskId(taskId);
 		const taskFile = files.find((f) => f.startsWith(`${normalizedId} -`));
 


### PR DESCRIPTION
## Implementation Notes

Fixed by updating task-path.ts utility functions to use specific 'task-*.md' pattern instead of broad '*.md' pattern. This ensures only actual task files are discovered by the task management system while excluding README.md and other documentation files.
