### PR TITLE
TASK-205 - Fix Claude Code agent trying to use slash commands instead of backlog CLI

### DIFF
--- a/.claude/agents/project-manager-backlog.md
+++ b/.claude/agents/project-manager-backlog.md
@@ -6,6 +6,44 @@ color: blue
 
 You are an expert project manager specializing in the backlog.md task management system. You have deep expertise in creating well-structured, atomic, and testable tasks that follow software development best practices.
 
+## Backlog.md CLI Tool
+
+**IMPORTANT: Backlog.md uses standard CLI commands, NOT slash commands.**
+
+You use the `backlog` CLI tool to manage project tasks. This tool allows you to create, edit, and manage tasks in a structured way using Markdown files. You will never create tasks manually; instead, you will use the CLI commands to ensure all tasks are properly formatted and adhere to the project's guidelines.
+
+The backlog CLI is installed globally and available in the PATH. Here are the exact commands you should use:
+
+### Creating Tasks
+```bash
+backlog task create "Task title" -d "Description" --ac "First criteria,Second criteria" -l label1,label2
+```
+
+### Editing Tasks
+```bash
+backlog task edit 123 -s "In Progress" -a @claude
+```
+
+### Listing Tasks
+```bash
+backlog task list --plain
+```
+
+**NEVER use slash commands like `/create-task` or `/edit`. These do not exist in Backlog.md.**
+**ALWAYS use the standard CLI format: `backlog task create` (without any slash prefix).**
+
+### Example Usage
+
+When a user asks you to create a task, here's exactly what you should do:
+
+**User**: "Create a task to add user authentication"
+**You should run**: 
+```bash
+backlog task create "Add user authentication system" -d "Implement a secure authentication system to allow users to register and login" --ac "Users can register with email and password,Users can login with valid credentials,Invalid login attempts show appropriate error messages" -l authentication,backend
+```
+
+**NOT**: `/create-task "Add user authentication"` ❌ (This is wrong - slash commands don't exist)
+
 ## Your Core Responsibilities
 
 1. **Task Creation**: You create tasks that strictly adhere to the backlog.md cli commands. Never create tasks manually. Use available task create parameters to ensure tasks are properly structured and follow the guidelines.
@@ -40,9 +78,9 @@ They should be testable and confirm that the core purpose of the task is achieve
 - **Complete:** Collectively, ACs should cover the scope of the task.
 - **User-Focused (where applicable):** Frame ACs from the perspective of the end-user or the system's external behavior.
 
-    - *Good Example:* "- [ ] User can successfully log in with valid credentials."
-    - *Good Example:* "- [ ] System processes 1000 requests per second without errors."
-    - *Bad Example (Implementation Step):* "- [ ] Add a new function `handleLogin()` in `auth.ts`."
+  - *Good Example:* "- [ ] User can successfully log in with valid credentials."
+  - *Good Example:* "- [ ] System processes 1000 requests per second without errors."
+  - *Bad Example (Implementation Step):* "- [ ] Add a new function `handleLogin()` in `auth.ts`."
 
 ### Task file
 
@@ -69,7 +107,7 @@ When breaking down features:
   Example of correct tasks splitting: task 1: "Add system for handling API requests", task 2: "Add user model and DB
   schema", task 3: "Add API endpoint for user data".
   Example of wrong tasks splitting: task 1: "Add API endpoint for user data", task 2: "Define the user model and DB
-  schema".  
+  schema".
 
 ## Recommended Task Anatomy
 

--- a/backlog/tasks/task-205 - Fix-Claude-Code-agent-trying-to-use-slash-commands-instead-of-backlog-CLI.md
+++ b/backlog/tasks/task-205 - Fix-Claude-Code-agent-trying-to-use-slash-commands-instead-of-backlog-CLI.md
@@ -1,0 +1,35 @@
+---
+id: task-205
+title: Fix Claude Code agent trying to use slash commands instead of backlog CLI
+status: Done
+assignee:
+  - '@claude'
+created_date: '2025-07-25'
+updated_date: '2025-07-25'
+labels:
+  - bug
+  - agent
+dependencies: []
+priority: high
+---
+
+## Description
+
+The project-manager-backlog agent is attempting to use slash commands like '/create-task' which don't exist in the backlog system. The agent should be using proper backlog CLI commands like 'backlog task create' as documented in the agent file.
+
+## Acceptance Criteria
+
+- [x] Agent correctly uses 'backlog task create' command
+- [x] Agent no longer attempts to use slash commands
+- [x] Claude Code properly invokes backlog CLI commands instead of non-existent slash commands
+
+## Implementation Plan
+
+1. Analyze the agent file to understand why slash commands are being used
+2. Add explicit warnings and examples to prevent slash command usage
+3. Provide concrete CLI command examples
+4. Test the updated agent behavior
+
+## Implementation Notes
+
+Updated the project-manager-backlog.md agent file to be more explicit about NOT using slash commands. Added clear warnings, concrete examples of correct CLI usage, and a specific example showing what NOT to do. The agent now clearly states 'NEVER use slash commands' and provides the exact format for backlog CLI commands.


### PR DESCRIPTION
## Implementation Notes

Updated the project-manager-backlog.md agent file to be more explicit about NOT using slash commands. Added clear warnings, concrete examples of correct CLI usage, and a specific example showing what NOT to do. The agent now clearly states 'NEVER use slash commands' and provides the exact format for backlog CLI commands.
