### PR TITLE
TASK-203 - Show meaningful description in web kanban

### DIFF
--- a/backlog/tasks/task-203 - Show-meaningful-description-in-web-kanban.md
+++ b/backlog/tasks/task-203 - Show-meaningful-description-in-web-kanban.md
@@ -1,8 +1,8 @@
 ---
 id: task-203
 title: Show meaningful description in web kanban
-status: To Do
-assignee: []
+status: Done
+assignee: [agavr]
 created_date: '2025-07-25'
 labels:
   - frontend
@@ -19,8 +19,26 @@ Related to: https://github.com/MrLesk/Backlog.md/issues/233
 
 ## Acceptance Criteria
 
-- [ ] Raw '## Description' header is stripped from task preview in web kanban view
-- [ ] Actual task description content is displayed in web kanban cards
-- [ ] Task preview shows meaningful context (first ~100-150 characters of description)
-- [ ] Preview text is properly truncated with ellipsis if needed
-- [ ] Web kanban view maintains clean visual appearance
+- [x] Raw '## Description' header is stripped from task preview in web kanban view
+- [x] Actual task description content is displayed in web kanban cards
+- [x] Task preview shows meaningful context (first ~100-150 characters of description)
+- [x] Preview text is properly truncated with ellipsis if needed
+- [x] Web kanban view maintains clean visual appearance
+
+## Implementation Plan
+
+1. **Locate web kanban card component**: Find the component that renders task cards in the web kanban view
+2. **Parse task content**: Identify how task content is currently being parsed and displayed
+3. **Strip headers**: Implement logic to remove '## Description' header from the content
+4. **Extract description**: Parse and extract the actual description text
+5. **Add truncation**: Implement text truncation logic with ellipsis for descriptions over 100-150 characters
+6. **Test changes**: Verify the web kanban view displays meaningful descriptions correctly
+7. **Clean up**: Ensure code follows project standards and passes linting
+
+## Implementation Notes
+
+- Modified `TaskCard.tsx` component to extract and display meaningful description content
+- Added `extractDescription` function that uses regex to extract content after the "## Description" header
+- Added `truncateText` function to limit description to 120 characters with ellipsis
+- The implementation handles edge cases: tasks without Description headers and empty bodies
+- All build checks pass successfully (TypeScript, Biome linting, and production build)

--- a/backlog/tasks/task-203 - Show-meaningful-description-in-web-kanban.md
+++ b/backlog/tasks/task-203 - Show-meaningful-description-in-web-kanban.md
@@ -2,8 +2,10 @@
 id: task-203
 title: Show meaningful description in web kanban
 status: Done
-assignee: [agavr]
+assignee:
+  - '@claude'
 created_date: '2025-07-25'
+updated_date: '2025-07-26'
 labels:
   - frontend
   - enhancement

--- a/src/web/components/TaskCard.tsx
+++ b/src/web/components/TaskCard.tsx
@@ -32,6 +32,27 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit }) => {
     return new Date(dateStr).toLocaleDateString();
   };
 
+  const extractDescription = (body: string): string => {
+    if (!body) return '';
+    
+    // Extract the Description section content
+    const regex = /## Description\s*\n([\s\S]*?)(?=\n## |$)/i;
+    const match = body.match(regex);
+    
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+    
+    // If no Description header found, return the body as-is
+    // but remove any headers that might be at the start
+    return body.replace(/^##\s+\w+.*\n/i, '').trim();
+  };
+
+  const truncateText = (text: string, maxLength: number = 120): string => {
+    if (!text || text.length <= maxLength) return text;
+    return text.substring(0, maxLength).trim() + '...';
+  };
+
   return (
     <div
       className={`bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md p-3 mb-2 cursor-pointer transition-all duration-200 hover:shadow-md dark:hover:shadow-lg hover:border-stone-500 dark:hover:border-stone-400 ${getPriorityClass(task.priority)} ${
@@ -51,7 +72,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit }) => {
       
       {task.body && (
         <p className="text-sm text-gray-600 dark:text-gray-300 mb-3 line-clamp-3 transition-colors duration-200">
-          {task.body}
+          {truncateText(extractDescription(task.body))}
         </p>
       )}
       


### PR DESCRIPTION
## Summary
- Strip raw '## Description' header from task preview in web kanban view
- Display actual task description content for better context
- Implement smart truncation (120 chars) with ellipsis for clean appearance

## Test plan
- [x] Open web UI with `backlog browser`
- [x] View kanban board with various tasks
- [x] Verify descriptions show content instead of "## Description"
- [x] Check that long descriptions are truncated with "..."
- [x] Ensure visual appearance remains clean and readable
- [x] Test with tasks that have no description section

Fixes #233