### PR TITLE
TASK-230 - Add --plain to task create/edit and print plain details after operation

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,8 +1,6 @@
 # ⚠️ **IMPORTANT**
 
-1. Read the [README.md](README.md)
-2. Please follow the instructions below for instructions on how to work with Backlog.md on tasks in this
-   repository [agent-guidelines.md](src/guidelines/agent-guidelines.md)
+Follow the instructions below for instructions on how to work with Backlog.md on tasks in this repository [agent-guidelines.md](src/guidelines/agent-guidelines.md)
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # ⚠️ **IMPORTANT**
 
 Read the [agent-guidelines.md](src/guidelines/agent-guidelines.md)
+When you're working on a task, you should assign it yourself: -a @codex
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 # ⚠️ **IMPORTANT**
 
-1. Read the [README.md](README.md)
-2. Read the [agent-guidelines.md](src/guidelines/agent-guidelines.md)
+Read the [agent-guidelines.md](src/guidelines/agent-guidelines.md)
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,6 @@
 # ⚠️ **IMPORTANT**
 
-1. Read the [README.md](README.md)
-2. Read the [agent-guidelines.md](src/guidelines/agent-guidelines.md)
-3. Never use Tailwind's rounded-full class. Instead use rounded-circle custom class
+Read the [agent-guidelines.md](src/guidelines/agent-guidelines.md)
 
 ## Commands
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,7 +1,6 @@
 # ⚠️ **IMPORTANT**
 
-1. Read the [README.md](README.md)
-2. Read the [agent-guidelines.md](src/guidelines/agent-guidelines.md)
+Read the [agent-guidelines.md](src/guidelines/agent-guidelines.md)
 
 ## Commands
 

--- a/backlog/tasks/task-230 - Add-plain-to-task-create-edit-and-print-plain-details-after-operation.md
+++ b/backlog/tasks/task-230 - Add-plain-to-task-create-edit-and-print-plain-details-after-operation.md
@@ -1,0 +1,28 @@
+---
+id: task-230
+title: Add --plain to task create/edit and print plain details after operation
+status: To Do
+assignee: []
+created_date: '2025-08-12 17:10'
+updated_date: '2025-08-12 17:11'
+labels:
+  - cli
+  - plain-output
+dependencies: []
+priority: high
+---
+
+## Description
+
+Implement `--plain` flag for `backlog task create`  and `backlog task edit`. When provided, after the operation completes successfully, print the task content in the same plain-text format as `backlog task <task-id> --plain` — including the leading `File:` line pointing to the task file and the structured sections (Status, Created, Description, Acceptance Criteria, etc.).
+
+Context: We already support `--plain` for viewing tasks and drafts. Bringing this to create/edit improves shell scripting and AI agent integrations by returning the final task content immediately.
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Running: backlog task create "Example" --desc "Hello" --plain prints plain-text details of the created task using the existing formatter
+- [ ] #2 Output begins with 'File: <path>' and includes 'Task task-<id> - <title>', Status, Created, Description, Acceptance Criteria sections
+- [ ] #3 Running: backlog task edit <id> -s "In Progress" --plain prints the updated task in plain-text format after saving
+- [ ] #5 Tests cover both create/edit flows with --plain and assert 'File:' line, key sections, and absence of TUI escape codes
+- [ ] #6 Successful runs exit with code 0; behavior works with --desc alias and other supported flags
+<!-- AC:END -->

--- a/backlog/tasks/task-230 - Add-plain-to-task-create-edit-and-print-plain-details-after-operation.md
+++ b/backlog/tasks/task-230 - Add-plain-to-task-create-edit-and-print-plain-details-after-operation.md
@@ -1,10 +1,11 @@
 ---
 id: task-230
 title: Add --plain to task create/edit and print plain details after operation
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2025-08-12 17:10'
-updated_date: '2025-08-12 17:11'
+updated_date: '2025-08-12 19:13'
 labels:
   - cli
   - plain-output
@@ -20,9 +21,13 @@ Context: We already support `--plain` for viewing tasks and drafts. Bringing thi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Running: backlog task create "Example" --desc "Hello" --plain prints plain-text details of the created task using the existing formatter
-- [ ] #2 Output begins with 'File: <path>' and includes 'Task task-<id> - <title>', Status, Created, Description, Acceptance Criteria sections
-- [ ] #3 Running: backlog task edit <id> -s "In Progress" --plain prints the updated task in plain-text format after saving
-- [ ] #5 Tests cover both create/edit flows with --plain and assert 'File:' line, key sections, and absence of TUI escape codes
-- [ ] #6 Successful runs exit with code 0; behavior works with --desc alias and other supported flags
+- [x] #1 Running: backlog task create "Example" --desc "Hello" --plain prints plain-text details of the created task using the existing formatter
+- [x] #2 Output begins with 'File: <path>' and includes 'Task task-<id> - <title>', Status, Created, Description, Acceptance Criteria sections
+- [x] #3 Running: backlog task edit <id> -s "In Progress" --plain prints the updated task in plain-text format after saving
+- [x] #4 Tests cover both create/edit flows with --plain and assert 'File:' line, key sections, and absence of TUI escape codes
+- [x] #5 Successful runs exit with code 0; behavior works with --desc alias and other supported flags
 <!-- AC:END -->
+
+## Implementation Notes
+
+Implemented --plain flag for task create/edit. When provided, prints plain formatted task details after operation (starts with File: line). Added tests for both flows asserting File: line, Status/Created/Description/AC sections, and absence of TUI codes. Verified --desc alias works. All tests passing.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -958,6 +958,7 @@ taskCmd
 	.option("-s, --status <status>")
 	.option("-l, --labels <labels>")
 	.option("--priority <priority>", "set task priority (high, medium, low)")
+	.option("--plain", "use plain text output after creating")
 	.option("--ac <criteria>", "add acceptance criteria (can be used multiple times)", createMultiValueAccumulator())
 	.option(
 		"--acceptance-criteria <criteria>",
@@ -1018,12 +1019,25 @@ taskCmd
 			task.body = updateTaskImplementationNotes(task.body, String(options.notes));
 		}
 
+		// Workaround for bun compile issue with commander options
+		const isPlainFlag = options.plain || process.argv.includes("--plain");
+
 		if (options.draft) {
 			const filepath = await core.createDraft(task);
+			if (isPlainFlag) {
+				const content = await Bun.file(filepath).text();
+				console.log(formatTaskPlainText(task, content, filepath));
+				return;
+			}
 			console.log(`Created draft ${id}`);
 			console.log(`File: ${filepath}`);
 		} else {
 			const filepath = await core.createTask(task);
+			if (isPlainFlag) {
+				const content = await Bun.file(filepath).text();
+				console.log(formatTaskPlainText(task, content, filepath));
+				return;
+			}
 			console.log(`Created task ${id}`);
 			console.log(`File: ${filepath}`);
 		}
@@ -1213,6 +1227,7 @@ taskCmd
 	.option("-l, --label <labels>")
 	.option("--priority <priority>", "set task priority (high, medium, low)")
 	.option("--ordinal <number>", "set task ordinal for custom ordering")
+	.option("--plain", "use plain text output after editing")
 	.option("--add-label <label>")
 	.option("--remove-label <label>")
 	.option("--ac <criteria>", "add acceptance criteria (can be used multiple times)", createMultiValueAccumulator())
@@ -1365,6 +1380,18 @@ taskCmd
 		}
 
 		await core.updateTask(task);
+
+		// Workaround for bun compile issue with commander options
+		const isPlainFlag = options.plain || process.argv.includes("--plain");
+		if (isPlainFlag) {
+			const filePath = await getTaskPath(task.id, core);
+			if (filePath) {
+				const content = await Bun.file(filePath).text();
+				console.log(formatTaskPlainText(task, content, filePath));
+				return;
+			}
+		}
+
 		console.log(`Updated task ${task.id}`);
 	});
 

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -216,18 +216,26 @@ Bad Example (Implementation Step):
 
 ## 5. Implementing Tasks
 
-### Implementation Plan (The "how")
-Add AFTER starting work, BEFORE coding:
+### Implementation Plan (The "how") (only after starting work)
 ```bash
 backlog task edit 42 -s "In Progress" -a @{myself}
 backlog task edit 42 --plan "1. Research patterns\n2. Implement\n3. Test"
 ```
 
 ### Implementation Notes (Imagine you need to copy paste this into a PR description)
-Add AFTER completing the implementation:
 ```bash
 backlog task edit 42 --notes "Implemented using pattern X, modified files Y and Z"
 ```
+
+**IMPORTANT**: Do NOT include an Implementation Plan when creating a task. The plan is added only after you start implementation.
+- Creation phase: provide Title, Description, Acceptance Criteria, and optionally labels/priority/assignee.
+- When you begin work, switch to edit and add the plan: `backlog task edit <id> --plan "..."`.
+- Add Implementation Notes only after completing the work: `backlog task edit <id> --notes "..."`.
+
+Phase discipline: What goes where
+- Creation: Title, Description, Acceptance Criteria, labels/priority/assignee.
+- Implementation: Implementation Plan (after moving to In Progress).
+- Wrap-up: Implementation Notes, AC and Definition of Done checks.
 
 **IMPORTANT**: Only implement what's in the Acceptance Criteria. If you need to do more, either:
 1. Update the AC first: `backlog task edit 42 --ac "New requirement"`

--- a/src/test/cli-plain-create-edit.test.ts
+++ b/src/test/cli-plain-create-edit.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+describe("CLI --plain for task create/edit", () => {
+	const cliPath = join(process.cwd(), "src", "cli.ts");
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-plain-create-edit");
+		try {
+			await rm(TEST_DIR, { recursive: true, force: true });
+		} catch {}
+		await mkdir(TEST_DIR, { recursive: true });
+
+		// Initialize git repo first using shell API (same as other tests)
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		// Initialize backlog project using Core
+		const core = new Core(TEST_DIR);
+		await core.initializeProject("Plain Create/Edit Project");
+	});
+
+	afterEach(async () => {
+		try {
+			await safeCleanup(TEST_DIR);
+		} catch {}
+	});
+
+	it("prints plain details after task create --plain", async () => {
+		const result = await $`bun ${cliPath} task create "Example" --desc "Hello" --plain`.cwd(TEST_DIR).quiet();
+
+		if (result.exitCode !== 0) {
+			console.error("STDOUT:", result.stdout.toString());
+			console.error("STDERR:", result.stderr.toString());
+		}
+
+		const out = result.stdout.toString();
+		expect(result.exitCode).toBe(0);
+		// Begins with File: line and contains key sections
+		expect(out).toContain("File: ");
+		expect(out).toContain("Task task-1 - Example");
+		expect(out).toContain("Status:");
+		expect(out).toContain("Created:");
+		expect(out).toContain("Description:");
+		expect(out).toContain("Hello");
+		expect(out).toContain("Acceptance Criteria:");
+		// Should not contain TUI escape codes
+		expect(out).not.toContain("[?1049h");
+		expect(out).not.toContain("\x1b");
+	});
+
+	it("prints plain details after task edit --plain", async () => {
+		// Create base task first (without plain)
+		await $`bun ${cliPath} task create "Edit Me" --desc "First"`.cwd(TEST_DIR).quiet();
+
+		const result = await $`bun ${cliPath} task edit 1 -s "In Progress" --plain`.cwd(TEST_DIR).quiet();
+
+		if (result.exitCode !== 0) {
+			console.error("STDOUT:", result.stdout.toString());
+			console.error("STDERR:", result.stderr.toString());
+		}
+
+		const out = result.stdout.toString();
+		expect(result.exitCode).toBe(0);
+		// Begins with File: line and contains updated details
+		expect(out).toContain("File: ");
+		expect(out).toContain("Task task-1 - Edit Me");
+		expect(out).toContain("Status: ◒ In Progress");
+		expect(out).toContain("Created:");
+		expect(out).toContain("Updated:");
+		expect(out).toContain("Description:");
+		expect(out).toContain("Acceptance Criteria:");
+		// Should not contain TUI escape codes
+		expect(out).not.toContain("[?1049h");
+		expect(out).not.toContain("\x1b");
+	});
+});


### PR DESCRIPTION
## Implementation Notes

- Implemented --plain flag for task create/edit. When provided, prints plain formatted task details after operation (starts with File: line). 
- Added tests for both flows asserting File: line, Status/Created/Description/AC sections, and absence of TUI codes. 
- Verified --desc alias works. All tests passing.
