### PR TITLE
TASK-213 - Compute sequences from task dependencies

### DIFF
--- a/backlog/tasks/task-213 - Compute-sequences-from-task-dependencies.md
+++ b/backlog/tasks/task-213 - Compute-sequences-from-task-dependencies.md
@@ -1,10 +1,11 @@
 ---
 id: task-213
 title: Compute sequences from task dependencies
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2025-07-27'
-updated_date: '2025-08-23 19:24'
+updated_date: '2025-08-23 21:13'
 labels:
   - sequences
   - core
@@ -17,10 +18,25 @@ Introduce core logic to compute sequences (parallelizable groups of tasks) solel
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Add a pure function (e.g., computeSequences(tasks: Task[]) → Sequence[]) that takes all tasks and returns an ordered list of sequences. Each sequence contains tasks whose dependencies are satisfied by earlier sequences.
-- [ ] #2 Sequence 1 contains all tasks with no dependencies; subsequent sequences contain tasks whose dependencies appear in earlier sequences.
-- [ ] #3 Tasks with no dependencies between them are grouped into the same sequence.
-- [ ] #4 Sequence numbering starts at 1 and increases monotonically; every task appears exactly once.
-- [ ] #5 Provide an appropriate Sequence type/interface and export it so it can be reused by CLI, TUI and web layers.
-- [ ] #6 Add unit tests covering scenarios such as: no dependencies, simple chains, parallel branches and complex graphs.
+- [x] #1 Add a pure function (e.g., computeSequences(tasks: Task[]) → Sequence[]) that takes all tasks and returns an ordered list of sequences. Each sequence contains tasks whose dependencies are satisfied by earlier sequences.
+- [x] #2 Sequence 1 contains all tasks with no dependencies; subsequent sequences contain tasks whose dependencies appear in earlier sequences.
+- [x] #3 Tasks with no dependencies between them are grouped into the same sequence.
+- [x] #4 Sequence numbering starts at 1 and increases monotonically; every task appears exactly once.
+- [x] #5 Provide an appropriate Sequence type/interface and export it so it can be reused by CLI, TUI and web layers.
+- [x] #6 Add unit tests covering scenarios such as: no dependencies, simple chains, parallel branches and complex graphs.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add Sequence type to src/types/index.ts (index, tasks).
+2. Implement computeSequences(tasks) in src/core/sequences.ts using layered topological sort (Kahn):
+   - Consider only dependencies within the provided task set (ignore external IDs).
+   - Stable ordering within a sequence by task ID.
+   - If a cycle remains, emit remaining tasks as a final sequence (deterministic order), to surface in downstream UIs.
+3. Add tests in src/test/sequences.test.ts for: no deps, chain, parallel branches, complex graphs, external deps ignored.
+4. Keep surface area minimal for reuse by CLI/TUI/web; no UI changes yet.
+5. Run test suite and checks; iterate on feedback.
+
+## Implementation Notes
+
+Implemented computeSequences with layered topological sort (Kahn). Added Sequence type and tests covering no-deps, chains, parallel branches, complex graphs, and external-dep ignore. Stable ordering by task ID; cycles emitted as final deterministic layer (surfaced for UIs). All tests pass locally.

--- a/src/core/sequences.ts
+++ b/src/core/sequences.ts
@@ -1,0 +1,73 @@
+import type { Sequence, Task } from "../types/index.ts";
+import { sortByTaskId } from "../utils/task-sorting.ts";
+
+/**
+ * Compute execution sequences (layers) from task dependencies.
+ * - Sequence 1 contains tasks with no dependencies among the provided set.
+ * - Subsequent sequences contain tasks whose dependencies appear in earlier sequences.
+ * - Dependencies that reference tasks outside the provided set are ignored for layering.
+ * - If cycles exist, any remaining tasks are emitted in a final sequence to ensure each task
+ *   appears exactly once (consumers may choose to surface a warning in that case).
+ */
+export function computeSequences(tasks: Task[]): Sequence[] {
+	// Map task id -> task for fast lookups
+	const byId = new Map<string, Task>();
+	for (const t of tasks) byId.set(t.id, t);
+
+	const ids = new Set(Array.from(byId.keys()));
+
+	// Build adjacency list and indegree counts considering only dependencies within provided set
+	const successors = new Map<string, string[]>();
+	const indegree = new Map<string, number>();
+
+	for (const id of ids) {
+		successors.set(id, []);
+		indegree.set(id, 0);
+	}
+
+	for (const t of tasks) {
+		const deps = Array.isArray(t.dependencies) ? t.dependencies : [];
+		for (const dep of deps) {
+			if (!ids.has(dep)) continue; // ignore external deps
+			successors.get(dep)?.push(t.id);
+			indegree.set(t.id, (indegree.get(t.id) || 0) + 1);
+		}
+	}
+
+	// Kahn-style layered topological grouping
+	const remaining = new Set(ids);
+	const sequences: Sequence[] = [];
+
+	while (remaining.size > 0) {
+		// Pick all nodes with indegree 0
+		const layerIds: string[] = [];
+		for (const id of remaining) {
+			if ((indegree.get(id) || 0) === 0) layerIds.push(id);
+		}
+
+		if (layerIds.length === 0) {
+			// Cycle detected among remaining tasks; emit them as a final sequence (sorted for determinism)
+			const finalTasks = sortByTaskId(
+				Array.from(remaining)
+					.map((id) => byId.get(id))
+					.filter((t): t is Task => Boolean(t)),
+			);
+			sequences.push({ index: sequences.length + 1, tasks: finalTasks });
+			break;
+		}
+
+		// Sort layer by task id for stable ordering
+		const layerTasks = sortByTaskId(layerIds.map((id) => byId.get(id)).filter((t): t is Task => Boolean(t)));
+		sequences.push({ index: sequences.length + 1, tasks: layerTasks });
+
+		// Remove layer from graph, decrement successors' indegree
+		for (const id of layerIds) {
+			remaining.delete(id);
+			for (const succ of successors.get(id) || []) {
+				indegree.set(succ, (indegree.get(succ) || 0) - 1);
+			}
+		}
+	}
+
+	return sequences;
+}

--- a/src/test/sequences.test.ts
+++ b/src/test/sequences.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { computeSequences } from "../core/sequences.ts";
+import type { Task } from "../types/index.ts";
+
+function task(id: string, deps: string[] = []): Task {
+	return {
+		id,
+		title: id,
+		status: "To Do",
+		assignee: [],
+		createdDate: "2025-01-01",
+		labels: [],
+		dependencies: deps,
+		body: "## Description\n\nTest",
+	};
+}
+
+describe("computeSequences", () => {
+	it("groups all independent tasks into sequence 1", () => {
+		const tasks = [task("task-1"), task("task-2"), task("task-3")];
+		const seqs = computeSequences(tasks);
+		expect(seqs.length).toBe(1);
+		expect(seqs[0].index).toBe(1);
+		expect(seqs[0].tasks.map((t) => t.id)).toEqual(["task-1", "task-2", "task-3"]);
+	});
+
+	it("handles a simple chain A -> B -> C", () => {
+		const tasks = [task("task-1"), task("task-2", ["task-1"]), task("task-3", ["task-2"])];
+		const seqs = computeSequences(tasks);
+		expect(seqs.length).toBe(3);
+		expect(seqs[0].tasks.map((t) => t.id)).toEqual(["task-1"]);
+		expect(seqs[1].tasks.map((t) => t.id)).toEqual(["task-2"]);
+		expect(seqs[2].tasks.map((t) => t.id)).toEqual(["task-3"]);
+	});
+
+	it("groups parallel branches (A -> C, B -> C) into same sequence", () => {
+		const tasks = [task("task-1"), task("task-2"), task("task-3", ["task-1", "task-2"])];
+		const seqs = computeSequences(tasks);
+		expect(seqs.length).toBe(2);
+		// First layer contains 1 and 2 in id order
+		expect(seqs[0].tasks.map((t) => t.id)).toEqual(["task-1", "task-2"]);
+		// Second layer contains 3
+		expect(seqs[1].tasks.map((t) => t.id)).toEqual(["task-3"]);
+	});
+
+	it("handles a more complex graph", () => {
+		// 1,2 -> 4 ; 3 -> 5 -> 6
+		const tasks = [
+			task("task-1"),
+			task("task-2"),
+			task("task-3"),
+			task("task-4", ["task-1", "task-2"]),
+			task("task-5", ["task-3"]),
+			task("task-6", ["task-5"]),
+		];
+		const seqs = computeSequences(tasks);
+		expect(seqs.length).toBe(3);
+		expect(seqs[0].tasks.map((t) => t.id)).toEqual(["task-1", "task-2", "task-3"]);
+		// Second layer should include 4 and 5 (order by id)
+		expect(seqs[1].tasks.map((t) => t.id)).toEqual(["task-4", "task-5"]);
+		// Final layer 6
+		expect(seqs[2].tasks.map((t) => t.id)).toEqual(["task-6"]);
+	});
+
+	it("ignores external dependencies not present in the task set", () => {
+		const tasks = [task("task-1", ["task-999"])];
+		const seqs = computeSequences(tasks);
+		expect(seqs.length).toBe(1);
+		expect(seqs[0].tasks.map((t) => t.id)).toEqual(["task-1"]);
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,6 +49,13 @@ export interface Document {
 	lastModified?: string;
 }
 
+export interface Sequence {
+	/** 1-based sequence index */
+	index: number;
+	/** Tasks that can be executed in parallel within this sequence */
+	tasks: Task[];
+}
+
 export interface BacklogConfig {
 	projectName: string;
 	defaultAssignee?: string;


### PR DESCRIPTION
## Implementation Notes

- Implemented compute Sequences with layered topological sort (Kahn). 
- Added Sequence type and tests covering no-deps, chains, parallel branches, complex graphs, and external-dep ignore.
- Stable ordering by task ID; cycles emitted as final deterministic layer (surfaced for UIs). 
- All tests pass locally.
