### PR TITLE
TASK-214 - Add CLI command to list sequences

### DIFF
--- a/backlog/tasks/task-214 - Add-CLI-command-to-list-sequences.md
+++ b/backlog/tasks/task-214 - Add-CLI-command-to-list-sequences.md
@@ -1,10 +1,11 @@
 ---
 id: task-214
 title: Add CLI command to list sequences
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2025-07-27'
-updated_date: '2025-08-23 19:11'
+updated_date: '2025-08-23 21:53'
 labels:
   - sequences
   - cli
@@ -18,9 +19,23 @@ Provide a command to inspect computed sequences. The command is interactive by d
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Introduce a \'backlog sequence list\' command; interactive by default; --plain outputs text
-- [ ] #2 Plain output lists each sequence index and tasks as "task-<id> - <title>"
-- [ ] #3 Reuse core compute function from task-213; do not duplicate logic in CLI
-- [ ] #4 CLI help text explains usage and --plain flag
-- [ ] #5 Tests verify plain output format
+- [x] #1 Introduce a \'backlog sequence list\' command; interactive by default; --plain outputs text
+- [x] #2 Plain output lists each sequence index and tasks as "task-<id> - <title>"
+- [x] #3 Reuse core compute function from task-213; do not duplicate logic in CLI
+- [x] #4 CLI help text explains usage and --plain flag
+- [x] #5 Tests verify plain output format
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add CLI group "sequence" with subcommand "list".
+2. Reuse computeSequences to compute layered groups from tasks.
+3. --plain: print machine-readable output: for each sequence, show "Sequence <n>:" and lines "  task-<id> - <title>".
+4. Interactive default: open scrollable viewer with the same grouped content (no special TUI; 215.x will add rich TUI).
+5. Provide descriptive help/description for the command and flags.
+6. Add tests: create tasks with dependencies and assert plain output formatting.
+7. Run tests, lint check; adjust as needed.
+
+## Implementation Notes
+
+Implemented sequence CLI command with interactive default and --plain format. Reused computeSequences, printed sequences deterministically, and added tests asserting plain output. Command help describes usage/flags. All tests pass locally.

--- a/src/test/cli-sequences-plain.test.ts
+++ b/src/test/cli-sequences-plain.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+describe("CLI sequences --plain output", () => {
+	const cliPath = join(process.cwd(), "src", "cli.ts");
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-cli-sequences");
+		try {
+			await rm(TEST_DIR, { recursive: true, force: true });
+		} catch {}
+		await mkdir(TEST_DIR, { recursive: true });
+
+		// Initialize git repo
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		// Initialize backlog project
+		const core = new Core(TEST_DIR);
+		await core.initializeProject("Sequences CLI Test");
+
+		// Create tasks: 1,2 -> 4 ; 3 -> 5 -> 6
+		await core.createTask(
+			{
+				id: "task-1",
+				title: "A",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-18",
+				labels: [],
+				dependencies: [],
+				body: "Test A",
+			},
+			false,
+		);
+		await core.createTask(
+			{
+				id: "task-2",
+				title: "B",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-18",
+				labels: [],
+				dependencies: [],
+				body: "Test B",
+			},
+			false,
+		);
+		await core.createTask(
+			{
+				id: "task-3",
+				title: "C",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-18",
+				labels: [],
+				dependencies: [],
+				body: "Test C",
+			},
+			false,
+		);
+		await core.createTask(
+			{
+				id: "task-4",
+				title: "D",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-18",
+				labels: [],
+				dependencies: ["task-1", "task-2"],
+				body: "Test D",
+			},
+			false,
+		);
+		await core.createTask(
+			{
+				id: "task-5",
+				title: "E",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-18",
+				labels: [],
+				dependencies: ["task-3"],
+				body: "Test E",
+			},
+			false,
+		);
+		await core.createTask(
+			{
+				id: "task-6",
+				title: "F",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-18",
+				labels: [],
+				dependencies: ["task-5"],
+				body: "Test F",
+			},
+			false,
+		);
+	});
+
+	afterEach(async () => {
+		try {
+			await safeCleanup(TEST_DIR);
+		} catch {}
+	});
+
+	it("prints sequences in plain format", async () => {
+		const result = await $`bun ${cliPath} sequence list --plain`.cwd(TEST_DIR).quiet();
+		if (result.exitCode !== 0) {
+			console.error("STDOUT:", result.stdout.toString());
+			console.error("STDERR:", result.stderr.toString());
+		}
+		expect(result.exitCode).toBe(0);
+		const out = result.stdout.toString().trim();
+		const expected = [
+			"Sequence 1:",
+			"  task-1 - A",
+			"  task-2 - B",
+			"  task-3 - C",
+			"Sequence 2:",
+			"  task-4 - D",
+			"  task-5 - E",
+			"Sequence 3:",
+			"  task-6 - F",
+		];
+		for (const line of expected) {
+			expect(out).toContain(line);
+		}
+		// No TUI escape codes in plain output
+		expect(out).not.toContain("[?1049h");
+		expect(out).not.toContain("\x1b");
+	});
+});


### PR DESCRIPTION
## Implementation Notes

- Implemented sequence CLI command with interactive default and --plain format. 
- Reused computeSequences, printed sequences deterministically, and added tests asserting plain output. 
- Command help describes usage/flags. 
- All tests pass locally.
