### PR TITLE
TASK-215.02 - TUI sequences: navigation and detail view

### DIFF
--- a/backlog/tasks/task-214 - Add-CLI-command-to-list-sequences.md
+++ b/backlog/tasks/task-214 - Add-CLI-command-to-list-sequences.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2025-07-27'
-updated_date: '2025-08-23 21:53'
+updated_date: '2025-08-24 15:08'
 labels:
   - sequences
   - cli
@@ -24,6 +24,7 @@ Provide a command to inspect computed sequences. The command is interactive by d
 - [x] #3 Reuse core compute function from task-213; do not duplicate logic in CLI
 - [x] #4 CLI help text explains usage and --plain flag
 - [x] #5 Tests verify plain output format
+- [x] #6 Exclude tasks with status Done from sequences
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,3 +40,7 @@ Provide a command to inspect computed sequences. The command is interactive by d
 ## Implementation Notes
 
 Implemented sequence CLI command with interactive default and --plain format. Reused computeSequences, printed sequences deterministically, and added tests asserting plain output. Command help describes usage/flags. All tests pass locally.
+
+Exclude Done tasks from sequences:
+- CLI filters Done before computeSequences.
+- Added test to assert Done tasks are excluded from --plain output.

--- a/backlog/tasks/task-215.02 - TUI-sequences-navigation-and-detail-view.md
+++ b/backlog/tasks/task-215.02 - TUI-sequences-navigation-and-detail-view.md
@@ -1,9 +1,11 @@
 ---
 id: task-215.02
 title: 'TUI sequences: navigation and detail view'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2025-08-23 19:12'
+updated_date: '2025-08-24 15:08'
 labels:
   - sequences
 dependencies: []
@@ -16,7 +18,33 @@ Support keyboard navigation across sequences and tasks, and opening task detail 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Arrow keys navigate across tasks and sequences
-- [ ] #2 Enter opens task detail; q/Esc returns
-- [ ] #3 Selection highlight clearly indicates current task
+- [x] #1 Arrow keys navigate across tasks and sequences
+- [x] #2 Selection highlight clearly indicates current task
+- [x] #3 Enter opens a detail popup; Esc closes the popup; Esc (when no popup) quits sequences
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Enhance TUI to support arrow-key navigation across all sequence tasks.
+2. Highlight current task line; keep it in view while scrolling.
+3. On Enter, open task detail using existing viewer, then return to sequences.
+4. Wire CLI interactive path to pass core for loading detail content.
+5. Type-check and run tests; keep notes concise (no duplicate headers).
+
+## Implementation Notes
+
+Added navigation and detail:
+- Up/Down (and j/k) to move selection; highlighted with inverse style.
+- Keeps selection in view by adjusting container scroll.
+- Enter destroys TUI screen, opens task detail via viewTaskEnhanced, then rebuilds sequences view.
+- CLI passes core to the TUI for resolving file path and content.
+- Exit with q/Esc; plain output unaffected.
+
+Adjusted Enter action to open a Kanban-style detail popup instead of switching to the full task list view. Popup closes with q/Esc and returns focus to the sequences view.
+
+Changed Esc to close only the popup. Updated footer hint and removed global Esc to quit. Quit remains on q/C-c.
+
+Finalized behavior:
+- Popup opens with Enter; Esc closes only the popup; Esc again (no popup) quits sequences.
+- Footer updated accordingly.
+- Navigation disabled while popup is open.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2014,7 +2014,9 @@ sequenceCmd
 		const cwd = process.cwd();
 		const core = new Core(cwd);
 		const tasks = await core.filesystem.listTasks();
-		const sequences = computeSequences(tasks);
+		// Exclude tasks marked as Done from sequences (case-insensitive)
+		const activeTasks = tasks.filter((t) => (t.status || "").toLowerCase() !== "done");
+		const sequences = computeSequences(activeTasks);
 
 		// Workaround for bun compile issue with commander options
 		const isPlainFlag = options.plain || process.argv.includes("--plain");
@@ -2028,9 +2030,9 @@ sequenceCmd
 			return;
 		}
 
-		// Interactive default: read-only TUI view (215.01)
+		// Interactive default: TUI view (215.01 + 215.02 navigation/detail)
 		const { runSequencesView } = await import("./ui/sequences.ts");
-		await runSequencesView(sequences);
+		await runSequencesView(sequences, core);
 	});
 
 configCmd


### PR DESCRIPTION
## Implementation Notes

Added navigation and detail:
- Up/Down (and j/k) to move selection; highlighted with inverse style.
- Keeps selection in view by adjusting container scroll.
- Enter destroys TUI screen, opens task detail via viewTaskEnhanced, then rebuilds sequences view.
- CLI passes core to the TUI for resolving file path and content.
- Exit with q/Esc; plain output unaffected.

Adjusted Enter action to open a Kanban-style detail popup instead of switching to the full task list view. Popup closes with q/Esc and returns focus to the sequences view.

Changed Esc to close only the popup. Updated footer hint and removed global Esc to quit. Quit remains on q/C-c.

Finalized behavior:
- Popup opens with Enter; Esc closes only the popup; Esc again (no popup) quits sequences.
- Footer updated accordingly.
- Navigation disabled while popup is open.
