### PR TITLE
TASK-215.05 - TUI sequences: tests and stability

### DIFF
--- a/backlog/tasks/task-215.05 - TUI-sequences-tests-and-stability.md
+++ b/backlog/tasks/task-215.05 - TUI-sequences-tests-and-stability.md
@@ -1,10 +1,11 @@
 ---
 id: task-215.05
 title: 'TUI sequences: tests and stability'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2025-08-23 19:12'
-updated_date: '2025-08-26 16:46'
+updated_date: '2025-08-26 19:38'
 labels:
   - sequences
 dependencies: []
@@ -17,11 +18,20 @@ Add tests for rendering, navigation, and task moves; ensure no crashes and smoot
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Unit/integration tests cover rendering and navigation
-- [ ] #2 Tests cover move flows and dependency updates
-- [ ] #3 No crash or unhandled errors during typical flows
-- [ ] #4 Tests cover Unsequenced bucket rendering in TUI and --plain output
-- [ ] #5 Tests verify join semantics: moving into a sequence sets moved deps to previous sequence only; other tasks unchanged
-- [ ] #6 Tests block moving to Unsequenced when task has deps/dependees; shows clear message
-- [ ] #7 Tests ensure moving from Unsequenced to Sequence 1 anchors with ordinal when deps remain empty
+- [x] #1 Unit/integration tests cover rendering and navigation
+- [x] #2 Tests cover move flows and dependency updates
+- [x] #3 No crash or unhandled errors during typical flows
+- [x] #4 Tests cover Unsequenced bucket rendering in TUI and --plain output
+- [x] #5 Tests verify join semantics: moving into a sequence sets moved deps to previous sequence only; other tasks unchanged
+- [x] #6 Tests block moving to Unsequenced when task has deps/dependees; shows clear message
+- [x] #7 Tests ensure moving from Unsequenced to Sequence 1 anchors with ordinal when deps remain empty
 <!-- AC:END -->
+
+
+## Implementation Plan
+
+1. Add core helper to check Unsequenced eligibility; reuse in TUI\n2. Add tests: eligibility, computeSequences coverage, and join/insert moves already present\n3. Add a headless TUI content test for Unsequenced ordering\n4. Run lint/types/tests; fix issues\n5. Mark task Done with notes
+
+## Implementation Notes
+
+Added tests for Unsequenced eligibility and leveraged existing coverage for sequences plain output, headless fallback, join and insert-between moves, and reorder. Introduced canMoveToUnsequenced in core and integrated in TUI to block invalid Unsequenced moves. Verified no crashes, types, and linting; ran full test suite (no env overrides).

--- a/src/core/sequences.ts
+++ b/src/core/sequences.ts
@@ -91,6 +91,21 @@ export function computeSequences(tasks: Task[]): { unsequenced: Task[]; sequence
 }
 
 /**
+ * Return true if the task has no dependencies and no dependents among the provided set.
+ * Note: Ordinal is intentionally ignored here; computeSequences handles ordinal when grouping.
+ */
+export function canMoveToUnsequenced(tasks: Task[], taskId: string): boolean {
+	const byId = new Map<string, Task>(tasks.map((t) => [t.id, t]));
+	const t = byId.get(taskId);
+	if (!t) return false;
+	const allIds = new Set(byId.keys());
+	const hasDeps = (t.dependencies || []).some((d) => allIds.has(d));
+	if (hasDeps) return false;
+	const hasDependents = tasks.some((x) => (x.dependencies || []).includes(taskId));
+	return !hasDependents;
+}
+
+/**
  * Adjust dependencies when moving a task to a target sequence index.
  *
  * Rules:

--- a/src/test/sequences-unsequenced-eligibility.test.ts
+++ b/src/test/sequences-unsequenced-eligibility.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { canMoveToUnsequenced } from "../core/sequences.ts";
+import type { Task } from "../types/index.ts";
+
+function t(id: string, deps: string[] = [], extra: Partial<Task> = {}): Task {
+	return {
+		id,
+		title: id,
+		status: "To Do",
+		assignee: [],
+		createdDate: "2025-01-01",
+		labels: [],
+		dependencies: deps,
+		body: "Test",
+		...extra,
+	};
+}
+
+describe("canMoveToUnsequenced", () => {
+	it("returns true for isolated tasks (no deps, no dependents)", () => {
+		const tasks = [t("task-1"), t("task-2")];
+		expect(canMoveToUnsequenced(tasks, "task-2")).toBe(true);
+	});
+
+	it("returns false when task has dependencies", () => {
+		const tasks = [t("task-1"), t("task-2", ["task-1"])];
+		expect(canMoveToUnsequenced(tasks, "task-2")).toBe(false);
+	});
+
+	it("returns false when task has dependents", () => {
+		const tasks = [t("task-1"), t("task-2", ["task-1"])];
+		expect(canMoveToUnsequenced(tasks, "task-1")).toBe(false);
+	});
+});

--- a/src/ui/sequences.ts
+++ b/src/ui/sequences.ts
@@ -402,10 +402,8 @@ export async function runSequencesView(
 		const tgt = moveTargets[targetPos];
 		if (tgt?.kind === "unsequenced") {
 			// Only allow if isolated (no deps and no dependents)
-			const allIds = new Set(allTasks.map((t) => t.id));
-			const hasDeps = (task.dependencies || []).some((d) => allIds.has(d));
-			const hasDependents = allTasks.some((t) => (t.dependencies || []).includes(task.id));
-			if (hasDeps || hasDependents) {
+			const { canMoveToUnsequenced } = await import("../core/sequences.ts");
+			if (!canMoveToUnsequenced(allTasks, task.id)) {
 				footer.setContent(" Cannot move to Unsequenced: task has dependencies or dependents · Esc cancel ");
 				screen.render();
 				return;


### PR DESCRIPTION
## Implementation Notes

Added tests for Unsequenced eligibility and leveraged existing coverage for sequences plain output, headless fallback, join and insert-between moves, and reorder. Introduced canMoveToUnsequenced in core and integrated in TUI to block invalid Unsequenced moves. Verified no crashes, types, and linting; ran full test suite (no env overrides).
