### PR TITLE
TASK-217.01 - Sequences server: endpoints for list and move

### DIFF
--- a/backlog/tasks/task-217.01 - Sequences-server-endpoints-for-list-and-move.md
+++ b/backlog/tasks/task-217.01 - Sequences-server-endpoints-for-list-and-move.md
@@ -1,11 +1,11 @@
 ---
 id: task-217.01
 title: 'Sequences server: endpoints for list and move'
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-08-23 19:13'
-updated_date: '2025-08-26 19:53'
+updated_date: '2025-08-26 20:14'
 labels:
   - sequences
 dependencies: []
@@ -18,11 +18,16 @@ Provide GET /sequences (using computeSequences from task-213) and POST /sequence
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 GET /sequences returns { unsequenced: Task[], sequences: Sequence[] } (Done excluded)
-- [ ] #2 POST /sequences/move applies join semantics: set moved deps to previous sequence; do not modify others; prevent move to Unsequenced unless isolated
-- [ ] #3 Input validates task ids/target; returns meaningful errors; updates persisted
+- [x] #1 GET /sequences returns { unsequenced: Task[], sequences: Sequence[] } (Done excluded)
+- [x] #2 POST /sequences/move applies join semantics: set moved deps to previous sequence; do not modify others; prevent move to Unsequenced unless isolated
+- [x] #3 Input validates task ids/target; returns meaningful errors; updates persisted
 <!-- AC:END -->
+
 
 ## Implementation Plan
 
 1. Add GET /api/sequences returning {unsequenced, sequences} (Done excluded)\n2. Add POST /api/sequences/move with join semantics and Unsequenced checks\n3. Validate inputs; persist changed tasks; return updated sequences\n4. Keep code aligned with core helpers (computeSequences, adjustDependenciesForMove, canMoveToUnsequenced)\n5. Run lint/types/tests
+
+## Implementation Notes
+
+Implemented sequences endpoints as a thin server bridge to core logic.\n\nEndpoints:\n- GET /sequences and GET /api/sequences → core.listActiveSequences() → { unsequenced, sequences } (Done excluded)\n- POST /sequences/move and POST /api/sequences/move → core.moveTaskInSequences({ taskId, unsequenced?, targetSequenceIndex? })\n\nArchitecture:\n- Server delegates; core owns business rules.\n- Core helpers: planMoveToSequence (join semantics + ordinal anchor on Seq 1), planMoveToUnsequenced (isolation check + clear deps/ordinal).\n- TUI updated to call the same plan helpers, ensuring consistent behavior across UI and API.\n\nValidation & Persistence:\n- Core validates inputs and task existence; server only forwards and returns messages.\n- Bulk updates persisted via core.updateTasksBulk; response includes recomputed sequences.\n\nQuality:\n- Tests pass (bun test); no env overrides.\n- Biome check/lint/format pass; types pass.

--- a/backlog/tasks/task-217.01 - Sequences-server-endpoints-for-list-and-move.md
+++ b/backlog/tasks/task-217.01 - Sequences-server-endpoints-for-list-and-move.md
@@ -1,10 +1,11 @@
 ---
 id: task-217.01
 title: 'Sequences server: endpoints for list and move'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2025-08-23 19:13'
-updated_date: '2025-08-26 16:46'
+updated_date: '2025-08-26 19:53'
 labels:
   - sequences
 dependencies: []
@@ -21,3 +22,7 @@ Provide GET /sequences (using computeSequences from task-213) and POST /sequence
 - [ ] #2 POST /sequences/move applies join semantics: set moved deps to previous sequence; do not modify others; prevent move to Unsequenced unless isolated
 - [ ] #3 Input validates task ids/target; returns meaningful errors; updates persisted
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add GET /api/sequences returning {unsequenced, sequences} (Done excluded)\n2. Add POST /api/sequences/move with join semantics and Unsequenced checks\n3. Validate inputs; persist changed tasks; return updated sequences\n4. Keep code aligned with core helpers (computeSequences, adjustDependenciesForMove, canMoveToUnsequenced)\n5. Run lint/types/tests

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2,12 +2,13 @@ import { join } from "node:path";
 import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
 import { FileSystem } from "../file-system/operations.ts";
 import { GitOperations } from "../git/operations.ts";
-import type { BacklogConfig, Decision, Document, Task } from "../types/index.ts";
+import type { BacklogConfig, Decision, Document, Sequence, Task } from "../types/index.ts";
 import { openInEditor } from "../utils/editor.ts";
 import { getTaskFilename, getTaskPath } from "../utils/task-path.ts";
 import { migrateConfig, needsMigration } from "./config-migration.ts";
 import { filterTasksByLatestState, getLatestTaskStatesForIds } from "./cross-branch-tasks.ts";
 import { loadRemoteTasks, resolveTaskConflict } from "./remote-tasks.ts";
+import { computeSequences, planMoveToSequence, planMoveToUnsequenced } from "./sequences.ts";
 
 interface BlessedScreen {
 	program: {
@@ -337,6 +338,48 @@ export class Core {
 			await this.git.stageBacklogDirectory(backlogDir);
 			await this.git.commitChanges(commitMessage || `Update ${tasks.length} tasks`);
 		}
+	}
+
+	// Sequences operations (business logic lives in core, not server)
+	async listActiveSequences(): Promise<{ unsequenced: Task[]; sequences: Sequence[] }> {
+		const all = await this.fs.listTasks();
+		const active = all.filter((t) => (t.status || "").toLowerCase() !== "done");
+		return computeSequences(active);
+	}
+
+	async moveTaskInSequences(params: {
+		taskId: string;
+		unsequenced?: boolean;
+		targetSequenceIndex?: number;
+	}): Promise<{ unsequenced: Task[]; sequences: Sequence[] }> {
+		const taskId = String(params.taskId || "").trim();
+		if (!taskId) throw new Error("taskId is required");
+
+		const allTasks = await this.fs.listTasks();
+		const exists = allTasks.some((t) => t.id === taskId);
+		if (!exists) throw new Error(`Task ${taskId} not found`);
+
+		const active = allTasks.filter((t) => (t.status || "").toLowerCase() !== "done");
+		const { sequences } = computeSequences(active);
+
+		if (params.unsequenced) {
+			const res = planMoveToUnsequenced(allTasks, taskId);
+			if (!res.ok) throw new Error(res.error);
+			await this.updateTasksBulk(res.changed, `Move ${taskId} to Unsequenced`);
+		} else {
+			const targetSequenceIndex = params.targetSequenceIndex;
+			if (targetSequenceIndex === undefined || Number.isNaN(targetSequenceIndex)) {
+				throw new Error("targetSequenceIndex must be a number");
+			}
+			if (targetSequenceIndex < 1) throw new Error("targetSequenceIndex must be >= 1");
+			const changed = planMoveToSequence(allTasks, sequences, taskId, targetSequenceIndex);
+			if (changed.length > 0) await this.updateTasksBulk(changed, `Update deps/order for ${taskId}`);
+		}
+
+		// Return updated sequences
+		const afterAll = await this.fs.listTasks();
+		const afterActive = afterAll.filter((t) => (t.status || "").toLowerCase() !== "done");
+		return computeSequences(afterActive);
 	}
 
 	async archiveTask(taskId: string, autoCommit?: boolean): Promise<boolean> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -101,6 +101,12 @@ export class BacklogServer {
 					"/api/statistics": {
 						GET: async () => await this.handleGetStatistics(),
 					},
+					"/api/sequences": {
+						GET: async () => await this.handleGetSequences(),
+					},
+					"/api/sequences/move": {
+						POST: async (req) => await this.handleMoveSequence(req),
+					},
 				},
 				fetch: async (req, server) => {
 					return await this.handleRequest(req, server);
@@ -551,6 +557,33 @@ export class BacklogServer {
 		} catch (error) {
 			console.error("Error reordering task:", error);
 			return Response.json({ error: "Failed to reorder task" }, { status: 500 });
+		}
+	}
+
+	// Sequences handlers
+	private async handleGetSequences(): Promise<Response> {
+		const data = await this.core.listActiveSequences();
+		return Response.json(data);
+	}
+
+	private async handleMoveSequence(req: Request): Promise<Response> {
+		try {
+			const body = await req.json();
+			const taskId = String(body.taskId || "").trim();
+			const moveToUnsequenced = Boolean(body.unsequenced === true);
+			const targetSequenceIndex = body.targetSequenceIndex !== undefined ? Number(body.targetSequenceIndex) : undefined;
+
+			if (!taskId) return Response.json({ error: "taskId is required" }, { status: 400 });
+
+			const next = await this.core.moveTaskInSequences({
+				taskId,
+				unsequenced: moveToUnsequenced,
+				targetSequenceIndex,
+			});
+			return Response.json(next);
+		} catch (error) {
+			const message = (error as Error)?.message || "Invalid request";
+			return Response.json({ error: message }, { status: 400 });
 		}
 	}
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -101,6 +101,12 @@ export class BacklogServer {
 					"/api/statistics": {
 						GET: async () => await this.handleGetStatistics(),
 					},
+					"/sequences": {
+						GET: async () => await this.handleGetSequences(),
+					},
+					"/sequences/move": {
+						POST: async (req) => await this.handleMoveSequence(req),
+					},
 					"/api/sequences": {
 						GET: async () => await this.handleGetSequences(),
 					},


### PR DESCRIPTION
## Implementation Notes

Implemented sequences endpoints as a thin server bridge to core logic.

Endpoints:
- GET /sequences and GET /api/sequences → core.listActiveSequences() → { unsequenced, sequences } (Done excluded)
- POST /sequences/move and POST /api/sequences/move → core.moveTaskInSequences({ taskId, unsequenced?, targetSequenceIndex? })

-Architecture:
- Server delegates; core owns business rules.
- Core helpers: planMoveToSequence (join semantics + ordinal anchor on Seq 1), planMoveToUnsequenced (isolation check + clear deps/ordinal).
- TUI updated to call the same plan helpers, ensuring consistent behavior across UI and API.

Validation & Persistence:
- Core validates inputs and task existence; server only forwards and returns messages.
- Bulk updates persisted via core.updateTasksBulk; response includes recomputed sequences.

Quality:
- Tests pass (bun test); no env overrides.
- Biome check/lint/format pass; types pass.
