### PR TITLE
TASK-245: Fix case insensitive priority filtering test

### DIFF
--- a/src/test/cli-priority-filtering.test.ts
+++ b/src/test/cli-priority-filtering.test.ts
@@ -125,8 +125,20 @@ describe("CLI Priority Filtering", () => {
 		expect(lowerResult.exitCode).toBe(0);
 		expect(mixedResult.exitCode).toBe(0);
 
-		const outputs = [upperResult.stdout.toString(), lowerResult.stdout.toString(), mixedResult.stdout.toString()];
-		for (const output of outputs) {
+		const [upperOutput, lowerOutput, mixedOutput] = [
+			upperResult.stdout.toString(),
+			lowerResult.stdout.toString(),
+			mixedResult.stdout.toString(),
+		];
+		const taskLists = [upperOutput, lowerOutput, mixedOutput].map((out) =>
+			out.split("\n").filter((line) => line.includes("task-")),
+		);
+		if (taskLists[1].length > 0) {
+			expect(taskLists[0]).toEqual(taskLists[1]);
+			expect(taskLists[2]).toEqual(taskLists[1]);
+		}
+
+		for (const output of [upperOutput, lowerOutput, mixedOutput]) {
 			if (output.includes("task-")) {
 				expect(output).toMatch(/\[HIGH\]/);
 				expect(output).not.toMatch(/\[MEDIUM\]/);


### PR DESCRIPTION
## Summary
- assert all casing variants produce identical task output for priority filter

## Testing
- `bun run lint src/test/cli-priority-filtering.test.ts`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b331efd3a483338d765f5a8032516d