### PR TITLE
TASK-234 - Clarify CLI newline handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ When re-initializing an existing project, all current configuration values are p
 | Add deps    | `backlog task edit 7 --dep task-1 --dep task-2`     |
 | Archive     | `backlog task archive 7`                             |
 
+#### Multi-line descriptions
+
+The CLI preserves literal newline characters; `\n` sequences are not converted. To enter multi-paragraph text:
+
+- **Bash/Zsh**: `backlog task create "Feature" --desc $'Line1\nLine2\n\nFinal paragraph'`
+- **POSIX sh**: `backlog task create "Feature" --desc "$(printf 'Line1\nLine2\n\nFinal paragraph')"`
+- **PowerShell**: `backlog task create "Feature" --desc "Line1`nLine2`n`nFinal paragraph"`
+
+The CLI help displays the Bash example with escaped `\\n` sequences; when typing the command, use a single `\n` to insert a newline.
+
 ### Draft Workflow
 
 | Action      | Example                                              |

--- a/backlog/tasks/task-234 - Investigate-newline-handling-in-CLI-descriptions.md
+++ b/backlog/tasks/task-234 - Investigate-newline-handling-in-CLI-descriptions.md
@@ -1,11 +1,11 @@
 ---
 id: task-234
 title: Investigate newline handling in CLI descriptions
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-08-17 15:51'
-updated_date: '2025-08-17 16:02'
+updated_date: '2025-08-24 16:05'
 labels:
   - cli
   - bug
@@ -22,9 +22,13 @@ Expected: the CLI preserves literal newline characters when provided by the shel
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Reproduce issue with --desc showing \n in output
-- [ ] #2 Define expected behavior: CLI preserves literal newlines; it does not interpret \n escape sequences
-- [ ] #3 Document supported multi-line input patterns with working examples: Bash/Zsh using $'...'; POSIX using printf; PowerShell using backtick n
-- [ ] #4 Update CLI help for --description/--desc (create/edit) to include concise multi-line examples
-- [ ] #5 Add tests: creating and editing a task with multi-paragraph descriptions preserves newlines in saved file
+- [x] #1 Reproduce issue with --desc showing \n in output
+- [x] #2 Define expected behavior: CLI preserves literal newlines; it does not interpret \n escape sequences
+- [x] #3 Document supported multi-line input patterns with working examples: Bash/Zsh using $'...'; POSIX using printf; PowerShell using backtick n
+- [x] #4 Update CLI help for --description/--desc (create/edit) to include concise multi-line examples
+- [x] #5 Add tests: creating and editing a task with multi-paragraph descriptions preserves newlines in saved file
 <!-- AC:END -->
+
+## Implementation Notes
+
+Documented newline handling for descriptions

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -953,7 +953,10 @@ const taskCmd = program.command("task").aliases(["tasks"]);
 
 taskCmd
 	.command("create <title>")
-	.option("-d, --description <text>")
+	.option(
+		"-d, --description <text>",
+		"task description (multi-line: bash $'Line1\\nLine2', POSIX printf, PowerShell \"Line1`nLine2\")",
+	)
 	.option("--desc <text>", "alias for --description")
 	.option("-a, --assignee <assignee>")
 	.option("-s, --status <status>")
@@ -1240,7 +1243,10 @@ taskCmd
 	.command("edit <taskId>")
 	.description("edit an existing task")
 	.option("-t, --title <title>")
-	.option("-d, --description <text>")
+	.option(
+		"-d, --description <text>",
+		"task description (multi-line: bash $'Line1\\nLine2', POSIX printf, PowerShell \"Line1`nLine2\")",
+	)
 	.option("--desc <text>", "alias for --description")
 	.option("-a, --assignee <assignee>")
 	.option("-s, --status <status>")
@@ -1598,7 +1604,10 @@ draftCmd
 
 draftCmd
 	.command("create <title>")
-	.option("-d, --description <text>")
+	.option(
+		"-d, --description <text>",
+		"task description (multi-line: bash $'Line1\\nLine2', POSIX printf, PowerShell \"Line1`nLine2\")",
+	)
 	.option("--desc <text>", "alias for --description")
 	.option("-a, --assignee <assignee>")
 	.option("-s, --status <status>")

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -427,6 +427,8 @@ A task is **Done** only when **ALL** of the following are complete:
 | Add notes        | `backlog task edit 42 --notes "Implementation details"`  |
 | Add dependencies | `backlog task edit 42 --dep task-1 --dep task-2`         |
 
+Descriptions support literal newlines; shell examples may show escaped `\\n`, but enter a single `\n` to create a newline.
+
 ### Task Operations
 
 | Action             | Command                                      |

--- a/src/test/description-newlines.test.ts
+++ b/src/test/description-newlines.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+describe("CLI description newline handling", () => {
+	const cliPath = join(process.cwd(), "src", "cli.ts");
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-desc-newlines");
+		try {
+			await rm(TEST_DIR, { recursive: true, force: true });
+		} catch {}
+		await mkdir(TEST_DIR, { recursive: true });
+
+		await $`git init`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email "test@example.com"`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await core.initializeProject("Desc Newlines Test Project");
+	});
+
+	afterEach(async () => {
+		try {
+			await safeCleanup(TEST_DIR);
+		} catch {}
+	});
+
+	it("should preserve literal newlines when creating task", async () => {
+		const desc = "First line\nSecond line\n\nThird paragraph";
+		await $`bun ${[cliPath, "task", "create", "Multi-line", "--desc", desc]}`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		const task = await core.filesystem.loadTask("task-1");
+		expect(task?.body).toContain(desc);
+	});
+
+	it("should preserve literal newlines when editing task", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-1",
+				title: "Edit me",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-07-04",
+				labels: [],
+				dependencies: [],
+				body: "## Description\n\nOriginal",
+			},
+			false,
+		);
+
+		const desc = "First line\nSecond line\n\nThird paragraph";
+		await $`bun ${[cliPath, "task", "edit", "1", "--desc", desc]}`.cwd(TEST_DIR).quiet();
+
+		const updated = await core.filesystem.loadTask("task-1");
+		expect(updated?.body).toContain(desc);
+	});
+
+	it("should not interpret \\n sequences as newlines", async () => {
+		const literal = "First line\\nSecond line";
+		await $`bun ${[cliPath, "task", "create", "Literal", "--desc", literal]}`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		const task = await core.filesystem.loadTask("task-1");
+		expect(task?.body).toContain("First line\\nSecond line");
+	});
+});


### PR DESCRIPTION
## Summary
- explain shell-specific multi-line description entry in CLI help
- document newline behavior in README with Bash, POSIX, and PowerShell examples
- test that task creation and editing preserve literal newlines without interpreting `\n`
- clarify newline entry in agent guidelines

## Testing
- `bun run format`
- `bun run lint`
- `bun test src/test/description-newlines.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab360a23388333b2c4c15fc268a9f7