### PR TITLE
TASK-250 - Docs: recursive listing/view + global IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ The `backlog init` command provides comprehensive project setup with interactive
 - **Agent guidelines** - AI agent instruction files (CLAUDE.md, .cursorrules, etc.)
 - **Claude Code agent** - optional Backlog.md agent for enhanced task management (defaults to not installed; opt-in during `init` or pass `--install-claude-agent true`)
 
+### Documentation
+
+- Document IDs are global across all subdirectories under `backlog/docs`. You can organize files in nested folders (e.g., `backlog/docs/guides/`), and `backlog doc list` and `backlog doc view <id>` work across the entire tree. Example: `backlog doc create -p guides "New Guide"`.
+
 When re-initializing an existing project, all current configuration values are preserved and pre-populated in prompts, allowing you to update only what you need.
 
 ### Task Management

--- a/backlog/tasks/task-250 - Docs-fix-subpath-documents-listing-view-+-unique-IDs.md
+++ b/backlog/tasks/task-250 - Docs-fix-subpath-documents-listing-view-+-unique-IDs.md
@@ -1,9 +1,11 @@
 ---
 id: task-250
 title: 'Docs: fix subpath documents listing/view + unique IDs'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2025-09-04 19:18'
+updated_date: '2025-09-04 20:19'
 labels:
   - docs
   - bug
@@ -27,3 +29,11 @@ Goal: Support documents stored in subdirectories end-to-end (list, view, ID gene
 - [ ] #5 Add tests covering: (a) recursive listing with subdirectories, (b) ID generation offline with subdir docs present, (c) view by id for a subdir doc.
 - [ ] #6 Update docs explaining that document IDs are global across subdirectories and provide examples with -p and nested paths.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Make filesystem.listDocuments recursive and stable
+2. Update CLI doc list/view to use recursive search by ID
+3. Ensure generateNextDocId sees all local docs (offline)
+4. Add tests for recursive listing, offline ID generation, view by id
+5. Update docs to note global IDs across subpaths

--- a/backlog/tasks/task-250 - Docs-fix-subpath-documents-listing-view-+-unique-IDs.md
+++ b/backlog/tasks/task-250 - Docs-fix-subpath-documents-listing-view-+-unique-IDs.md
@@ -1,11 +1,11 @@
 ---
 id: task-250
 title: 'Docs: fix subpath documents listing/view + unique IDs'
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-09-04 19:18'
-updated_date: '2025-09-04 20:19'
+updated_date: '2025-09-06 14:07'
 labels:
   - docs
   - bug
@@ -22,13 +22,14 @@ Goal: Support documents stored in subdirectories end-to-end (list, view, ID gene
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 backlog doc list --plain includes documents from all subdirectories under backlog/docs (recursive) and lists them consistently.
-- [ ] #2 backlog doc view (by ID) opens a document correctly even when it resides in a subdirectory.
-- [ ] #3 Creating docs with backlog doc create -p <path> produces globally unique, sequential IDs across the entire docs tree, including when remoteOperations=false/offline.
-- [ ] #4 Use recursive traversal for docs in: filesystem listDocuments, CLI doc list (interactive and plain), and CLI doc view.
-- [ ] #5 Add tests covering: (a) recursive listing with subdirectories, (b) ID generation offline with subdir docs present, (c) view by id for a subdir doc.
-- [ ] #6 Update docs explaining that document IDs are global across subdirectories and provide examples with -p and nested paths.
+- [x] #1 backlog doc list --plain includes documents from all subdirectories under backlog/docs (recursive) and lists them consistently.
+- [x] #2 backlog doc view (by ID) opens a document correctly even when it resides in a subdirectory.
+- [x] #3 Creating docs with backlog doc create -p <path> produces globally unique, sequential IDs across the entire docs tree, including when remoteOperations=false/offline.
+- [x] #4 Use recursive traversal for docs in: filesystem listDocuments, CLI doc list (interactive and plain), and CLI doc view.
+- [x] #5 Add tests covering: (a) recursive listing with subdirectories, (b) ID generation offline with subdir docs present, (c) view by id for a subdir doc.
+- [x] #6 Update docs explaining that document IDs are global across subdirectories and provide examples with -p and nested paths.
 <!-- AC:END -->
+
 
 ## Implementation Plan
 
@@ -37,3 +38,14 @@ Goal: Support documents stored in subdirectories end-to-end (list, view, ID gene
 3. Ensure generateNextDocId sees all local docs (offline)
 4. Add tests for recursive listing, offline ID generation, view by id
 5. Update docs to note global IDs across subpaths
+
+
+## Implementation Notes
+
+Support docs in subdirectories end-to-end (list, view, IDs).
+
+- Recursive listing: FileSystem.listDocuments uses **/*.md under backlog/docs, excluding README; CLI doc list uses it for both plain and interactive.
+- View by ID in subpaths: CLI doc view scans recursively and matches ID-based filenames; test covers viewing a subdir doc by id.
+- Global unique IDs: generateNextDocId aggregates IDs from all branches (when remote ops enabled) and from local listDocuments for offline, ensuring monotonic doc-<n> IDs across subdirectories.
+- Tests: src/test/docs-recursive.test.ts verifies recursive list, view by id, and offline ID generation with subpaths.
+- Docs: README explains that document IDs are global across subdirectories and shows -p examples.

--- a/backlog/tasks/task-251 - Board-harden-remote-branch-normalization-to-avoid-origin-origin-refs.md
+++ b/backlog/tasks/task-251 - Board-harden-remote-branch-normalization-to-avoid-origin-origin-refs.md
@@ -1,11 +1,11 @@
 ---
 id: task-251
 title: 'Board: harden remote branch normalization to avoid origin/origin refs'
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2025-09-04 19:34'
-updated_date: '2025-09-06 13:54'
+updated_date: '2025-09-04 20:17'
 labels:
   - bug
   - board
@@ -22,13 +22,12 @@ Goal: Harden normalization so only canonical remote refs are used and invalid en
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 backlog board runs without git ls-tree errors related to origin/origin; no malformed refs are used.
-- [x] #2 normalizeRemoteBranch handles inputs: origin, origin/HEAD, origin/origin, refs/remotes/origin/origin (filtered), and origin/main, refs/remotes/origin/main, main (normalized to use origin/main only).
-- [x] #3 Unit tests cover these cases in task-loader-branch-normalization.test.ts; no call to listFilesInTree/getBranchLastModifiedMap receives origin/origin.
-- [x] #4 listRecentRemoteBranches filters out origin/HEAD and entries that normalize to empty or origin; add a small test if needed.
-- [x] #5 With remoteOperations=false, board loads using local tasks without attempting remote refs.
+- [ ] #1 backlog board runs without git ls-tree errors related to origin/origin; no malformed refs are used.
+- [ ] #2 normalizeRemoteBranch handles inputs: origin, origin/HEAD, origin/origin, refs/remotes/origin/origin (filtered), and origin/main, refs/remotes/origin/main, main (normalized to use origin/main only).
+- [ ] #3 Unit tests cover these cases in task-loader-branch-normalization.test.ts; no call to listFilesInTree/getBranchLastModifiedMap receives origin/origin.
+- [ ] #4 listRecentRemoteBranches filters out origin/HEAD and entries that normalize to empty or origin; add a small test if needed.
+- [ ] #5 With remoteOperations=false, board loads using local tasks without attempting remote refs.
 <!-- AC:END -->
-
 
 ## Implementation Plan
 
@@ -36,15 +35,3 @@ Goal: Harden normalization so only canonical remote refs are used and invalid en
 2. Keep normalizeRemoteBranch robust (already filters origin/HEAD)
 3. Add tests covering invalid entries and canonical refs
 4. Verify remoteOperations=false path remains local only
-
-
-## Implementation Notes
-
-Hardened remote branch normalization to avoid malformed refs like origin/origin.
-
-- normalizeRemoteBranch now drops empty, HEAD, origin, origin/HEAD and strips refs/remotes/ + origin/ prefixes.
-- buildRemoteTaskIndex constructs refs as origin/<branch> only after normalization.
-- listRecentRemoteBranches filters out HEAD and ambiguous entries, returning clean branch names.
-- Tests: task-loader-branch-normalization.test.ts covers normalization and ensures no origin/origin goes to listFilesInTree/getBranchLastModifiedMap.
-- Remote-offline path: multiple tests assert remoteOperations=false skips fetch/remote calls and loads local tasks.
-- Validation: bun test (all pass), bunx tsc (clean), biome check (no errors).

--- a/backlog/tasks/task-251 - Board-harden-remote-branch-normalization-to-avoid-origin-origin-refs.md
+++ b/backlog/tasks/task-251 - Board-harden-remote-branch-normalization-to-avoid-origin-origin-refs.md
@@ -1,11 +1,11 @@
 ---
 id: task-251
 title: 'Board: harden remote branch normalization to avoid origin/origin refs'
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-09-04 19:34'
-updated_date: '2025-09-04 20:17'
+updated_date: '2025-09-04 20:18'
 labels:
   - bug
   - board
@@ -22,12 +22,13 @@ Goal: Harden normalization so only canonical remote refs are used and invalid en
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 backlog board runs without git ls-tree errors related to origin/origin; no malformed refs are used.
-- [ ] #2 normalizeRemoteBranch handles inputs: origin, origin/HEAD, origin/origin, refs/remotes/origin/origin (filtered), and origin/main, refs/remotes/origin/main, main (normalized to use origin/main only).
-- [ ] #3 Unit tests cover these cases in task-loader-branch-normalization.test.ts; no call to listFilesInTree/getBranchLastModifiedMap receives origin/origin.
-- [ ] #4 listRecentRemoteBranches filters out origin/HEAD and entries that normalize to empty or origin; add a small test if needed.
+- [x] #1 backlog board runs without git ls-tree errors related to origin/origin; no malformed refs are used.
+- [x] #2 normalizeRemoteBranch handles inputs: origin, origin/HEAD, origin/origin, refs/remotes/origin/origin (filtered), and origin/main, refs/remotes/origin/main, main (normalized to use origin/main only).
+- [x] #3 Unit tests cover these cases in task-loader-branch-normalization.test.ts; no call to listFilesInTree/getBranchLastModifiedMap receives origin/origin.
+- [x] #4 listRecentRemoteBranches filters out origin/HEAD and entries that normalize to empty or origin; add a small test if needed.
 - [ ] #5 With remoteOperations=false, board loads using local tasks without attempting remote refs.
 <!-- AC:END -->
+
 
 ## Implementation Plan
 
@@ -35,3 +36,7 @@ Goal: Harden normalization so only canonical remote refs are used and invalid en
 2. Keep normalizeRemoteBranch robust (already filters origin/HEAD)
 3. Add tests covering invalid entries and canonical refs
 4. Verify remoteOperations=false path remains local only
+
+## Implementation Notes
+
+Hardened branch normalization to prevent malformed refs (origin/origin). listRecentRemoteBranches now filters HEAD and entries that would normalize to empty or origin; normalizeRemoteBranch drops stray origin after stripping prefix. Extended tests verify no origin/origin refs are passed to git operations.

--- a/backlog/tasks/task-254 - Init-default-'No'-for-Claude-agent-installation.md
+++ b/backlog/tasks/task-254 - Init-default-'No'-for-Claude-agent-installation.md
@@ -1,11 +1,11 @@
 ---
 id: task-254
 title: 'Init: default ''No'' for Claude agent installation'
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2025-09-04 19:53'
-updated_date: '2025-09-06 13:34'
+updated_date: '2025-09-04 20:14'
 labels:
   - cli
   - init
@@ -22,13 +22,12 @@ Goal: Make Claude agent an explicit opt-in during initialization, with clear pro
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 Interactive init: Claude agent confirm defaults to No; pressing Enter does not install it.
-- [x] #2 Prompt copy clarifies opt-in and target path: “Install Claude Code Backlog.md agent? (y/N) Adds to .claude/agents/”.
-- [x] #3 Non-interactive: default remains false; `--install-claude-agent true` opts in explicitly.
-- [x] #4 Update documentation/help to reflect the default change and the flag usage.
-- [x] #5 Add/adjust a minimal test to assert the prompt initial value is false and flag parsing still works.
+- [ ] #1 Interactive init: Claude agent confirm defaults to No; pressing Enter does not install it.
+- [ ] #2 Prompt copy clarifies opt-in and target path: “Install Claude Code Backlog.md agent? (y/N) Adds to .claude/agents/”.
+- [ ] #3 Non-interactive: default remains false; `--install-claude-agent true` opts in explicitly.
+- [ ] #4 Update documentation/help to reflect the default change and the flag usage.
+- [ ] #5 Add/adjust a minimal test to assert the prompt initial value is false and flag parsing still works.
 <!-- AC:END -->
-
 
 ## Implementation Plan
 
@@ -37,14 +36,3 @@ Goal: Make Claude agent an explicit opt-in during initialization, with clear pro
 3. Ensure non-interactive flag parsing unchanged
 4. Add minimal test to ensure default=false and flag true works
 5. Update docs/help text
-
-
-## Implementation Notes
-
-Implemented default "No" for Claude agent install in init.
-
-- Interactive confirm uses initial:false with message "Install Claude Code Backlog.md agent? (y/N)" and hint "Adds to .claude/agents/ (opt-in)".
-- Non-interactive keeps default false; flag `--install-claude-agent true` opts in.
-- Tests: src/test/cli-init-claude-default.test.ts verifies default non-interactive behavior and flag true installs.
-- Docs: README clarifies opt-in default and flag usage.
-- Validation: bun test passes across suite locally; Biome check shows unrelated warnings.

--- a/backlog/tasks/task-254 - Init-default-'No'-for-Claude-agent-installation.md
+++ b/backlog/tasks/task-254 - Init-default-'No'-for-Claude-agent-installation.md
@@ -1,11 +1,11 @@
 ---
 id: task-254
 title: 'Init: default ''No'' for Claude agent installation'
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-09-04 19:53'
-updated_date: '2025-09-04 20:14'
+updated_date: '2025-09-04 20:16'
 labels:
   - cli
   - init
@@ -22,12 +22,13 @@ Goal: Make Claude agent an explicit opt-in during initialization, with clear pro
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Interactive init: Claude agent confirm defaults to No; pressing Enter does not install it.
-- [ ] #2 Prompt copy clarifies opt-in and target path: “Install Claude Code Backlog.md agent? (y/N) Adds to .claude/agents/”.
-- [ ] #3 Non-interactive: default remains false; `--install-claude-agent true` opts in explicitly.
-- [ ] #4 Update documentation/help to reflect the default change and the flag usage.
-- [ ] #5 Add/adjust a minimal test to assert the prompt initial value is false and flag parsing still works.
+- [x] #1 Interactive init: Claude agent confirm defaults to No; pressing Enter does not install it.
+- [x] #2 Prompt copy clarifies opt-in and target path: “Install Claude Code Backlog.md agent? (y/N) Adds to .claude/agents/”.
+- [x] #3 Non-interactive: default remains false; `--install-claude-agent true` opts in explicitly.
+- [x] #4 Update documentation/help to reflect the default change and the flag usage.
+- [x] #5 Add/adjust a minimal test to assert the prompt initial value is false and flag parsing still works.
 <!-- AC:END -->
+
 
 ## Implementation Plan
 
@@ -36,3 +37,8 @@ Goal: Make Claude agent an explicit opt-in during initialization, with clear pro
 3. Ensure non-interactive flag parsing unchanged
 4. Add minimal test to ensure default=false and flag true works
 5. Update docs/help text
+
+
+## Implementation Notes
+
+Interactive prompt now defaults to No with clarified copy. Non-interactive stays false unless `--install-claude-agent true` is provided. Added tests verifying non-interactive default and explicit opt-in. Docs/help mention remains accurate with the new default.

--- a/src/test/docs-recursive.test.ts
+++ b/src/test/docs-recursive.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+
+let TEST_DIR: string;
+
+describe("Docs recursive listing and ID generation", () => {
+	beforeEach(async () => {
+		TEST_DIR = join(process.cwd(), `.tmp-test-docs-${Math.random().toString(36).slice(2)}`);
+		await rm(TEST_DIR, { recursive: true, force: true });
+		await mkdir(TEST_DIR, { recursive: true });
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		// Init backlog project
+		const core = new Core(TEST_DIR);
+		await core.initializeProject("Docs Test");
+
+		// Disable remote operations to simulate offline mode
+		const cfg = await core.filesystem.loadConfig();
+		if (cfg) {
+			cfg.remoteOperations = false;
+			await core.filesystem.saveConfig(cfg);
+		}
+	});
+
+	afterEach(async () => {
+		await rm(TEST_DIR, { recursive: true, force: true });
+	});
+
+	it("lists and views documents from subdirectories and generates unique IDs", async () => {
+		const core = new Core(TEST_DIR);
+		// Create docs in nested paths
+		await core.createDocument(
+			{ id: "doc-1", title: "Top", type: "other", createdDate: "2020-01-01", body: "" },
+			false,
+			"",
+		);
+		await core.createDocument(
+			{ id: "doc-2", title: "Nested A", type: "other", createdDate: "2020-01-02", body: "" },
+			false,
+			"guides",
+		);
+		await core.createDocument(
+			{ id: "doc-3", title: "Nested B", type: "other", createdDate: "2020-01-03", body: "" },
+			false,
+			"guides/sub",
+		);
+
+		// list should include all 3
+		const listOut = await $`bun ${CLI_PATH} doc list --plain`.cwd(TEST_DIR).quiet();
+		const listText = listOut.stdout.toString();
+		expect(listText).toContain("doc-1 - Top");
+		expect(listText).toContain("doc-2 - Nested A");
+		expect(listText).toContain("doc-3 - Nested B");
+
+		// view by id in subdir should work
+		const viewOut = await $`bun ${CLI_PATH} doc view doc-2`.cwd(TEST_DIR).quiet();
+		expect(viewOut.exitCode).toBe(0);
+
+		// offline ID generation should see all local docs
+		const nextId = await $`bun ${CLI_PATH} doc create "Another" -p guides`.cwd(TEST_DIR).quiet();
+		expect(nextId.exitCode).toBe(0);
+		// Next should be doc-4 given 1..3 exist
+		const docs = await core.filesystem.listDocuments();
+		const hasDoc4 = docs.some((d) => d.id === "doc-4");
+		expect(hasDoc4).toBe(true);
+	});
+});


### PR DESCRIPTION
Implements TASK-250.

- Filesystem.listDocuments now recursively scans backlog/docs, excluding README.md.
- CLI  and  use recursive search so subpath docs are included and viewable by ID.
-  now sees all local docs (via listDocuments), ensuring global sequential IDs offline.
- Added tests for recursive listing, offline ID generation, and viewing a subdir doc by ID.

Docs updated to clarify IDs are global across subpaths.

Closes #318