### PR TITLE
TASK-258 - Filesystem: ignore leading zeros in task IDs

### DIFF
--- a/backlog/tasks/task-258 - Filesystem-ignore-leading-zeros-in-task-IDs.md
+++ b/backlog/tasks/task-258 - Filesystem-ignore-leading-zeros-in-task-IDs.md
@@ -1,0 +1,52 @@
+---
+id: task-258
+title: 'Filesystem: ignore leading zeros in task IDs'
+status: Done
+assignee:
+  - '@codex'
+created_date: '2025-09-06 23:24'
+updated_date: '2025-09-06 23:24'
+labels:
+  - filesystem
+  - cli
+dependencies: []
+priority: high
+---
+
+## Description
+
+Implement a reusable task ID parser in filesystem resolvers so that numeric equivalence is used when matching task IDs, ignoring leading zeros.
+
+- Match task-0001 when user inputs 1 and vice versa
+- Apply to tasks and drafts; supports dotted IDs (e.g. 3.01 == 3.1)
+- Do not change ID generation or filenames; only resolution
+- Behavior independent of zeroPaddedIds width
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Task operations ignore leading zeros: view/edit/archive/demote accept padded/non-padded IDs equally for tasks and drafts.
+- [x] #2 Dotted IDs compare by numeric segments: 3.01 == 3.1, preserving suffixes and titles.
+- [x] #3 Feature works regardless of config zeroPaddedIds (tested with 3 and 0).
+- [x] #4 No change to ID generation or saved filenames; only resolver behavior updated.
+- [x] #5 Tests added and passing; type-check and lint pass.
+<!-- AC:END -->
+
+
+## Implementation Notes
+
+Implementation Summary:
+
+- Added numeric, zero-padding-agnostic ID parsing for filesystem resolvers in src/utils/task-path.ts.
+  - New helpers: parseIdSegments(), extractSegmentsFromFilename(), idsMatchLoosely()
+  - Updated getTaskPath/getTaskFilename/getDraftPath to fall back to loose numeric matching.
+- Added tests validating padded/unpadded and dotted IDs in src/test/task-path.test.ts.
+- Verified full test suite passes with zeroPaddedIds=3 and with zeroPaddedIds=0 (via CLI config set).
+- No changes to ID generation or file naming; only resolution behavior.
+- Lint and type-check pass.
+
+Validation steps performed:
+1) bun test (all passing)
+2) bun run cli config set zeroPaddedIds 0
+3) bun test (all passing)
+4) bun run cli config set zeroPaddedIds 3
+5) bunx tsc --noEmit && bun run check .

--- a/src/test/task-path.test.ts
+++ b/src/test/task-path.test.ts
@@ -28,6 +28,9 @@ describe("Task path utilities", () => {
 		await writeFile(join(tasksDir, "task-123 - Test Task.md"), "# Test Task 123");
 		await writeFile(join(tasksDir, "task-456 - Another Task.md"), "# Another Task 456");
 		await writeFile(join(tasksDir, "task-789 - Final Task.md"), "# Final Task 789");
+		// Additional: padded and dotted ids
+		await writeFile(join(tasksDir, "task-0001 - Padded One.md"), "# Padded One");
+		await writeFile(join(tasksDir, "task-3.01 - Subtask Padded.md"), "# Subtask Padded 3.01");
 	});
 
 	afterEach(async () => {
@@ -68,6 +71,18 @@ describe("Task path utilities", () => {
 			expect(path).toContain("task-456 - Another Task.md");
 		});
 
+		it("should resolve zero-padded numeric IDs to the same task", async () => {
+			// File exists as task-0001; query with 1
+			const path1 = await getTaskPath("1", core);
+			expect(path1).toBeTruthy();
+			expect(path1).toContain("task-0001 - Padded One.md");
+
+			// Query with zero-padded input for non-padded file (123)
+			const path2 = await getTaskPath("0123", core);
+			expect(path2).toBeTruthy();
+			expect(path2).toContain("task-123 - Test Task.md");
+		});
+
 		it("should return null for non-existent task", async () => {
 			const path = await getTaskPath("999", core);
 			expect(path).toBeNull();
@@ -84,6 +99,11 @@ describe("Task path utilities", () => {
 		it("should return filename for existing task", async () => {
 			const filename = await getTaskFilename("789", core);
 			expect(filename).toBe("task-789 - Final Task.md");
+		});
+
+		it("should resolve dotted IDs ignoring leading zeros in segments", async () => {
+			const filename = await getTaskFilename("3.1", core);
+			expect(filename).toBe("task-3.01 - Subtask Padded.md");
 		});
 
 		it("should return null for non-existent task", async () => {


### PR DESCRIPTION
Implementation Summary:

- Added numeric, zero-padding-agnostic ID parsing for filesystem resolvers in src/utils/task-path.ts.
  - New helpers: parseIdSegments(), extractSegmentsFromFilename(), idsMatchLoosely()
  - Updated getTaskPath/getTaskFilename/getDraftPath to fall back to loose numeric matching.
- Added tests validating padded/unpadded and dotted IDs in src/test/task-path.test.ts.
- Verified full test suite passes with zeroPaddedIds=3 and with zeroPaddedIds=0 (via CLI config set).
- No changes to ID generation or file naming; only resolution behavior.
- Lint and type-check pass.

Validation steps performed:
1) bun test (all passing)
2) bun run cli config set zeroPaddedIds 0
3) bun test (all passing)
4) bun run cli config set zeroPaddedIds 3
5) bunx tsc --noEmit && bun run check .

Fixes #331 