### PR TITLE
BACK-445 - Add command filters to web search

### DIFF
--- a/backlog/tasks/back-445 - Add-command-filters-to-web-search.md
+++ b/backlog/tasks/back-445 - Add-command-filters-to-web-search.md
@@ -1,16 +1,26 @@
 ---
 id: BACK-445
 title: Add command filters to web search
-status: To Do
+status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-04-26 08:19'
+updated_date: '2026-04-26 08:26'
 labels:
   - web-ui
   - search
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/pull/338'
+modified_files:
+  - src/web/components/SideNavigation.tsx
+  - src/web/utils/search-command-query.ts
+  - src/web/lib/api.ts
+  - src/server/index.ts
+  - src/core/search-service.ts
+  - src/test/search-command-query.test.ts
+  - src/test/search-service.test.ts
+  - src/test/server-search-endpoint.test.ts
 priority: medium
 ---
 
@@ -22,16 +32,38 @@ Add field:value command filters to the browser search experience so users can na
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Browser search supports field:value command filters for task fields such as status, priority, assignee, and labels.
-- [ ] #2 Command filters can be combined with free-text search without breaking existing text search results.
-- [ ] #3 Search behavior handles unknown or malformed command filters predictably without crashing the UI.
-- [ ] #4 The PR title and task references use the current BACK task ID format.
-- [ ] #5 Focused automated coverage verifies command parsing/filtering and the relevant web search behavior.
+- [x] #1 Browser search supports field:value command filters for task fields such as status, priority, assignee, and labels.
+- [x] #2 Command filters can be combined with free-text search without breaking existing text search results.
+- [x] #3 Search behavior handles unknown or malformed command filters predictably without crashing the UI.
+- [x] #4 The PR title and task references use the current BACK task ID format.
+- [x] #5 Focused automated coverage verifies command parsing/filtering and the relevant web search behavior.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebuild PR #338 on current main with the new BACK-445 task ID.
+2. Parse sidebar field:value commands into API search parameters while preserving free-text search.
+3. Add assignee support to the centralized search filters exposed through /api/search.
+4. Cover parser, search service, and search endpoint behavior with focused tests.
+5. Push the refreshed PR branch and trigger checks/review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented command parsing for the sidebar search input and routed parsed filters through the existing /api/search endpoint. Added assignee support to the centralized SearchService filter path so status, priority, assignee, labels, type, and modified file command filters can combine with free-text queries. Task-only command filters default sidebar search to task results unless the user supplies an explicit type filter. Unknown or malformed commands are preserved as normal text search terms.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rebuilt PR #338 on current main under BACK-445. The browser sidebar now parses field:value search commands, sends structured filters to the centralized search API, and keeps unknown or malformed command tokens as plain text. The shared search service and API now support assignee filters, with focused parser/service/API coverage plus full suite verification.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/core/search-service.ts
+++ b/src/core/search-service.ts
@@ -25,6 +25,7 @@ interface TaskSearchEntity extends BaseSearchEntity {
 	readonly task: Task;
 	readonly statusLower: string;
 	readonly priorityLower?: SearchPriorityFilter;
+	readonly assigneesLower: string[];
 	readonly labelsLower: string[];
 	readonly idVariants: string[];
 	readonly dependencyIds: string[];
@@ -46,6 +47,7 @@ type SearchEntity = TaskSearchEntity | DocumentSearchEntity | DecisionSearchEnti
 type NormalizedFilters = {
 	statuses?: string[];
 	priorities?: SearchPriorityFilter[];
+	assignees?: string[];
 	labels?: string[];
 	modifiedFiles?: string[];
 };
@@ -225,6 +227,7 @@ export class SearchService {
 			task,
 			statusLower: task.status.toLowerCase(),
 			priorityLower: task.priority ? (task.priority.toLowerCase() as SearchPriorityFilter) : undefined,
+			assigneesLower: (task.assignee ?? []).map((assignee) => assignee.toLowerCase()),
 			labelsLower: (task.labels || []).map((label) => label.toLowerCase()),
 			idVariants: createTaskIdVariants(task.id),
 			dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdVariants(dependency)),
@@ -327,6 +330,15 @@ export class SearchService {
 				return allowedPriorities.has(task.priorityLower);
 			});
 		}
+		if (filters.assignees && filters.assignees.length > 0) {
+			const requiredAssignees = new Set(filters.assignees);
+			filtered = filtered.filter((task) => {
+				if (!task.assigneesLower || task.assigneesLower.length === 0) {
+					return false;
+				}
+				return task.assigneesLower.some((assignee) => requiredAssignees.has(assignee));
+			});
+		}
 		if (filters.labels && filters.labels.length > 0) {
 			const requiredLabels = new Set(filters.labels);
 			filtered = filtered.filter((task) => {
@@ -351,6 +363,17 @@ export class SearchService {
 
 		if (filters.priorities && filters.priorities.length > 0) {
 			if (!task.priorityLower || !filters.priorities.includes(task.priorityLower)) {
+				return false;
+			}
+		}
+
+		if (filters.assignees && filters.assignees.length > 0) {
+			if (!task.assigneesLower || task.assigneesLower.length === 0) {
+				return false;
+			}
+			const assigneeSet = new Set(task.assigneesLower);
+			const anyMatch = filters.assignees.some((assignee) => assigneeSet.has(assignee));
+			if (!anyMatch) {
 				return false;
 			}
 		}
@@ -380,12 +403,14 @@ export class SearchService {
 
 		const statuses = this.normalizeStringArray(filters.status);
 		const priorities = this.normalizePriorityArray(filters.priority);
+		const assignees = this.normalizeStringArray(filters.assignee);
 		const labels = this.normalizeLabelsArray(filters.labels);
 		const modifiedFiles = normalizeModifiedFileFilters(filters.modifiedFiles);
 
 		return {
 			statuses,
 			priorities,
+			assignees,
 			labels,
 			modifiedFiles,
 		};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -709,11 +709,16 @@ export class BacklogServer {
 			const typeParams = [...url.searchParams.getAll("type"), ...url.searchParams.getAll("types")];
 			const statusParams = url.searchParams.getAll("status");
 			const priorityParamsRaw = url.searchParams.getAll("priority");
+			const assigneeParamsRaw = [...url.searchParams.getAll("assignee"), ...url.searchParams.getAll("assignees")];
 			const labelParamsRaw = [...url.searchParams.getAll("label"), ...url.searchParams.getAll("labels")];
 			const modifiedFileParamsRaw = [
 				...url.searchParams.getAll("modifiedFile"),
 				...url.searchParams.getAll("modifiedFiles"),
 			];
+			const assigneesCsv = url.searchParams.get("assignees");
+			if (assigneesCsv) {
+				assigneeParamsRaw.push(...assigneesCsv.split(","));
+			}
 			const labelsCsv = url.searchParams.get("labels");
 			if (labelsCsv) {
 				labelParamsRaw.push(...labelsCsv.split(","));
@@ -749,6 +754,7 @@ export class BacklogServer {
 			const filters: {
 				status?: string | string[];
 				priority?: SearchPriorityFilter | SearchPriorityFilter[];
+				assignee?: string | string[];
 				labels?: string | string[];
 				modifiedFiles?: string | string[];
 			} = {};
@@ -773,6 +779,13 @@ export class BacklogServer {
 				}
 				const casted = normalizedPriorities as SearchPriorityFilter[];
 				filters.priority = casted.length === 1 ? casted[0] : casted;
+			}
+
+			if (assigneeParamsRaw.length > 0) {
+				const normalizedAssignees = assigneeParamsRaw.map((value) => value.trim()).filter((value) => value.length > 0);
+				if (normalizedAssignees.length > 0) {
+					filters.assignee = normalizedAssignees.length === 1 ? normalizedAssignees[0] : normalizedAssignees;
+				}
 			}
 
 			if (labelParamsRaw.length > 0) {

--- a/src/test/search-command-query.test.ts
+++ b/src/test/search-command-query.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { parseSearchCommandQuery } from "../web/utils/search-command-query.ts";
+
+describe("parseSearchCommandQuery", () => {
+	it("parses task filters and keeps remaining words as the text query", () => {
+		expect(parseSearchCommandQuery("status:Done priority:high label:bug assignee:@alex fix login")).toEqual({
+			query: "fix login",
+			status: "Done",
+			priority: "high",
+			labels: ["bug"],
+			assignee: "@alex",
+		});
+	});
+
+	it("supports quoted values with spaces", () => {
+		expect(parseSearchCommandQuery('status:"In Progress" label:"customer bug" fix login')).toEqual({
+			query: "fix login",
+			status: "In Progress",
+			labels: ["customer bug"],
+		});
+	});
+
+	it("collects repeated labels and label aliases", () => {
+		expect(parseSearchCommandQuery("label:bug labels:frontend labels:regression layout")).toEqual({
+			query: "layout",
+			labels: ["bug", "frontend", "regression"],
+		});
+	});
+
+	it("supports type and modified file aliases", () => {
+		expect(
+			parseSearchCommandQuery(
+				"type:task types:document modifiedFile:src/web/App.tsx modifiedFiles:src/core/search.ts nav",
+			),
+		).toEqual({
+			query: "nav",
+			types: ["task", "document"],
+			modifiedFiles: ["src/web/App.tsx", "src/core/search.ts"],
+		});
+	});
+
+	it("keeps unknown fields in the text query", () => {
+		expect(parseSearchCommandQuery("project:web status:Done fix login")).toEqual({
+			query: "project:web fix login",
+			status: "Done",
+		});
+	});
+
+	it("keeps malformed and unsupported tokens in the text query", () => {
+		expect(parseSearchCommandQuery('status: priority:urgent type:note status:"In Progress fix')).toEqual({
+			query: 'status: priority:urgent type:note status:"In Progress fix',
+		});
+	});
+
+	it("returns an empty query when all tokens are filters", () => {
+		expect(parseSearchCommandQuery("status:Done labels:bug")).toEqual({
+			query: "",
+			status: "Done",
+			labels: ["bug"],
+		});
+	});
+});

--- a/src/test/search-service.test.ts
+++ b/src/test/search-service.test.ts
@@ -185,6 +185,38 @@ describe("SearchService", () => {
 		expect(anyFiltered.map((result) => result.task.id)).toStrictEqual(["TASK-2"]);
 	});
 
+	it("filters tasks by assignee with and without a text query", async () => {
+		const assignedTask: Task = {
+			...baseTask,
+			id: "task-2",
+			title: "Assigned search task",
+			assignee: ["@alex"],
+			rawContent: "## Description\nAssigned search work",
+		};
+
+		await filesystem.saveTask(baseTask);
+		await filesystem.saveTask(assignedTask);
+
+		await search.ensureInitialized();
+
+		const assigneeFiltered = search
+			.search({
+				types: ["task"],
+				filters: { assignee: "@alex" },
+			})
+			.filter(isTaskResult);
+		expect(assigneeFiltered.map((result) => result.task.id)).toStrictEqual(["TASK-2"]);
+
+		const queryAndAssigneeFiltered = search
+			.search({
+				query: "search",
+				types: ["task"],
+				filters: { assignee: "@codex" },
+			})
+			.filter(isTaskResult);
+		expect(queryAndAssigneeFiltered.map((result) => result.task.id)).toStrictEqual(["TASK-1"]);
+	});
+
 	it("searches and filters tasks by modified file paths", async () => {
 		const uiTask: Task = {
 			...baseTask,

--- a/src/test/server-search-endpoint.test.ts
+++ b/src/test/server-search-endpoint.test.ts
@@ -132,6 +132,14 @@ describe("BacklogServer search endpoint", () => {
 		expect(results[0]?.task?.id).toBe(baseTask.id);
 	});
 
+	it("filters search results by assignee and labels", async () => {
+		const url = "/api/search?type=task&query=Alpha&status=In%20Progress&priority=high&label=search&assignee=%40codex";
+		const results = await fetchJson<Array<{ type: string; task?: Task }>>(url);
+		expect(results).toHaveLength(1);
+		expect(results[0]?.type).toBe("task");
+		expect(results[0]?.task?.id).toBe(baseTask.id);
+	});
+
 	it("filters task listings by priority via the content store", async () => {
 		const tasks = await fetchJson<Task[]>("/api/tasks?priority=high");
 		expect(tasks).toHaveLength(1);

--- a/src/web/components/SideNavigation.tsx
+++ b/src/web/components/SideNavigation.tsx
@@ -7,6 +7,7 @@ import {
 	type Document,
 	type DocumentSearchResult,
 	type SearchResult,
+	type SearchResultType,
 	type Task,
 	type TaskSearchResult,
 } from '../../types';
@@ -15,11 +16,22 @@ import { SidebarSkeleton } from './LoadingSpinner';
 import { sanitizeUrlTitle } from '../utils/urlHelpers';
 import { getWebVersion } from '../utils/version';
 import { apiClient } from '../lib/api';
+import { parseSearchCommandQuery } from '../utils/search-command-query';
 
 // Utility functions for ID transformations
 const stripIdPrefix = (id: string): string => {
 	// Remove any prefix pattern: letters followed by dash (task-, doc-, decision-, JIRA-, etc.)
 	return id.replace(/^[a-zA-Z]+-/, '');
+};
+
+const hasTaskSearchFilters = (parsedQuery: ReturnType<typeof parseSearchCommandQuery>): boolean => {
+	return Boolean(
+		parsedQuery.status ||
+			parsedQuery.priority ||
+			parsedQuery.assignee ||
+			(parsedQuery.labels && parsedQuery.labels.length > 0) ||
+			(parsedQuery.modifiedFiles && parsedQuery.modifiedFiles.length > 0),
+	);
 };
 
 // Icon components for better semantics and performance
@@ -282,7 +294,10 @@ const SideNavigation = memo(function SideNavigation({
 		setSearchError(null);
 		const timeout = setTimeout(async () => {
 			try {
-				const results = await apiClient.search({ query, limit: 15 });
+				const parsedQuery = parseSearchCommandQuery(query);
+				const types: SearchResultType[] | undefined =
+					parsedQuery.types ?? (hasTaskSearchFilters(parsedQuery) ? ['task'] : undefined);
+				const results = await apiClient.search({ ...parsedQuery, types, limit: 15 });
 				if (!cancelled) {
 					setSearchResults(results);
 				}

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -168,6 +168,7 @@ export class ApiClient {
 			types?: SearchResultType[];
 			status?: string | string[];
 			priority?: SearchPriorityFilter | SearchPriorityFilter[];
+			assignee?: string | string[];
 			labels?: string[];
 			modifiedFiles?: string[];
 			limit?: number;
@@ -192,6 +193,14 @@ export class ApiClient {
 			const priorities = Array.isArray(options.priority) ? options.priority : [options.priority];
 			for (const priority of priorities) {
 				params.append("priority", priority);
+			}
+		}
+		if (options.assignee) {
+			const assignees = Array.isArray(options.assignee) ? options.assignee : [options.assignee];
+			for (const assignee of assignees) {
+				if (assignee && assignee.trim().length > 0) {
+					params.append("assignee", assignee.trim());
+				}
 			}
 		}
 		if (options.labels) {

--- a/src/web/utils/search-command-query.ts
+++ b/src/web/utils/search-command-query.ts
@@ -1,0 +1,160 @@
+import type { SearchPriorityFilter, SearchResultType } from "../../types/index.ts";
+
+export interface ParsedSearchCommandQuery {
+	query: string;
+	status?: string | string[];
+	priority?: SearchPriorityFilter | SearchPriorityFilter[];
+	labels?: string[];
+	assignee?: string | string[];
+	types?: SearchResultType[];
+	modifiedFiles?: string[];
+}
+
+interface Token {
+	raw: string;
+	value: string;
+	malformed: boolean;
+}
+
+const PRIORITIES: SearchPriorityFilter[] = ["high", "medium", "low"];
+const RESULT_TYPES: SearchResultType[] = ["task", "document", "decision"];
+
+export function parseSearchCommandQuery(input: string): ParsedSearchCommandQuery {
+	const result: ParsedSearchCommandQuery = { query: "" };
+	const queryParts: string[] = [];
+
+	for (const token of tokenize(input)) {
+		if (!applyToken(token, result)) {
+			queryParts.push(token.raw);
+		}
+	}
+
+	result.query = queryParts.join(" ").trim();
+	return result;
+}
+
+function applyToken(token: Token, result: ParsedSearchCommandQuery): boolean {
+	if (token.malformed) {
+		return false;
+	}
+
+	const colonIndex = token.value.indexOf(":");
+	if (colonIndex <= 0) {
+		return false;
+	}
+
+	const field = token.value.slice(0, colonIndex).toLowerCase();
+	const value = token.value.slice(colonIndex + 1).trim();
+	if (!value) {
+		return false;
+	}
+
+	switch (field) {
+		case "status":
+			result.status = appendFilterValue(result.status, value);
+			return true;
+		case "priority": {
+			const priority = value.toLowerCase();
+			if (!isSearchPriority(priority)) {
+				return false;
+			}
+			result.priority = appendFilterValue(result.priority, priority);
+			return true;
+		}
+		case "label":
+		case "labels":
+			result.labels = [...(result.labels ?? []), value];
+			return true;
+		case "assignee":
+			result.assignee = appendFilterValue(result.assignee, value);
+			return true;
+		case "type":
+		case "types": {
+			const type = value.toLowerCase();
+			if (!isSearchResultType(type)) {
+				return false;
+			}
+			result.types = [...(result.types ?? []), type];
+			return true;
+		}
+		case "modifiedfile":
+		case "modifiedfiles":
+			result.modifiedFiles = [...(result.modifiedFiles ?? []), value];
+			return true;
+		default:
+			return false;
+	}
+}
+
+function tokenize(input: string): Token[] {
+	const tokens: Token[] = [];
+	let index = 0;
+
+	while (index < input.length) {
+		while (index < input.length && /\s/.test(input[index] ?? "")) {
+			index += 1;
+		}
+
+		if (index >= input.length) {
+			break;
+		}
+
+		const start = index;
+		let value = "";
+		let malformed = false;
+
+		while (index < input.length && !/\s/.test(input[index] ?? "")) {
+			const char = input[index];
+			if (char === '"') {
+				index += 1;
+				const quotedStart = index;
+				while (index < input.length && input[index] !== '"') {
+					index += 1;
+				}
+
+				if (index >= input.length) {
+					malformed = true;
+					value += input.slice(quotedStart);
+					break;
+				}
+
+				value += input.slice(quotedStart, index);
+				index += 1;
+				continue;
+			}
+
+			value += char;
+			index += 1;
+		}
+
+		if (malformed) {
+			index = input.length;
+		}
+
+		tokens.push({
+			raw: input.slice(start, index),
+			value,
+			malformed,
+		});
+	}
+
+	return tokens;
+}
+
+function appendFilterValue<T extends string>(current: T | T[] | undefined, value: T): T | T[] {
+	if (!current) {
+		return value;
+	}
+	if (Array.isArray(current)) {
+		return [...current, value];
+	}
+	return [current, value];
+}
+
+function isSearchPriority(value: string): value is SearchPriorityFilter {
+	return PRIORITIES.includes(value as SearchPriorityFilter);
+}
+
+function isSearchResultType(value: string): value is SearchResultType {
+	return RESULT_TYPES.includes(value as SearchResultType);
+}


### PR DESCRIPTION
## Summary
- Rebuilds the stale task-263 PR on current main under BACK-445.
- Parses field:value commands in the web sidebar search and sends structured filters through /api/search.
- Adds centralized assignee filtering alongside existing status, priority, labels, and modified-file filters.

## Related Task
BACK-445 - Add command filters to web search

## Testing
- bun test src/test/search-command-query.test.ts src/test/search-service.test.ts src/test/server-search-endpoint.test.ts
- bunx tsc --noEmit
- bun run check .
- bun test