### PR TITLE
BACK-444 - Support filesystem-only Backlog projects without Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ bun i -g backlog.md
 # or: npm i -g backlog.md
 # or: brew install backlog-md
 
-# Initialize in any git repo
+# Initialize in any Git repo
 backlog init "My Awesome Project"
+
+# Or initialize without Git for local/non-code projects
+backlog init "Personal Planning" --no-git
 ```
 
 The init wizard will ask how you want to connect AI tools:
@@ -57,7 +60,7 @@ The init wizard will ask how you want to connect AI tools:
 - **CLI commands** — creates instruction files (CLAUDE.md, AGENTS.md, etc.) so agents use Backlog via CLI.
 - **Skip** — no AI setup; use Backlog.md purely as a task manager.
 
-Backlog data is stored in a project-local backlog folder such as `backlog/`, `.backlog/`, or a custom project-relative path configured through `backlog.config.yml`. Tasks remain human-readable Markdown files (e.g. `task-10 - Add core search functionality.md`).
+Backlog data is stored in a project-local backlog folder such as `backlog/`, `.backlog/`, or a custom project-relative path configured through `backlog.config.yml`. Tasks remain human-readable Markdown files (e.g. `task-10 - Add core search functionality.md`). Git is optional: `backlog init --no-git` creates a filesystem-only project and disables cross-branch checks, remote operations, and auto-commit.
 
 ---
 
@@ -256,6 +259,8 @@ Skipping the wizard (answering "No" during init) applies the safe defaults that 
 - `zeroPaddedIds` disabled.
 - `defaultEditor` unset (falls back to your environment).
 - `defaultPort=6420`, `autoOpenBrowser=true`.
+
+For filesystem-only projects, run `backlog init --no-git`. Backlog.md will not run `git init`, and the saved config forces `checkActiveBranches=false`, `remoteOperations=false`, and `autoCommit=false` so CLI, Web, and MCP local-file workflows do not depend on a Git repository.
 
 Whenever you revisit `backlog init` or rerun `backlog config`, the wizard pre-populates prompts with your current values so you can adjust only what changed.
 

--- a/backlog/tasks/back-444 - Support-filesystem-only-Backlog-projects-without-Git.md
+++ b/backlog/tasks/back-444 - Support-filesystem-only-Backlog-projects-without-Git.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-444
 title: Support filesystem-only Backlog projects without Git
-status: To Do
+status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-04-25 23:48'
+updated_date: '2026-04-26 00:01'
 labels:
   - cli
   - init
@@ -25,18 +26,56 @@ This supersedes the outdated TASK-266 PR branch idea. Rebuild the feature from c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Init can run in a non-Git directory with an explicit filesystem-only/no-git option.
-- [ ] #2 Interactive init in a non-Git directory lets the user continue without creating a Git repository.
-- [ ] #3 Filesystem-only projects persist configuration that disables cross-branch checks, remote operations, and auto-commit.
-- [ ] #4 Core task, draft, document, decision, milestone, CLI, MCP, and Web flows keep working for local files when no Git repository exists.
-- [ ] #5 Git-only behavior is skipped gracefully when Git is unavailable or disabled, without noisy stack traces for normal local workflows.
-- [ ] #6 Documentation explains Git-backed and filesystem-only initialization paths.
-- [ ] #7 Regression tests cover init and representative local commands in a non-Git project.
+- [x] #1 Init can run in a non-Git directory with an explicit filesystem-only/no-git option.
+- [x] #2 Interactive init in a non-Git directory lets the user continue without creating a Git repository.
+- [x] #3 Filesystem-only projects persist configuration that disables cross-branch checks, remote operations, and auto-commit.
+- [x] #4 Core task, draft, document, decision, milestone, CLI, MCP, and Web flows keep working for local files when no Git repository exists.
+- [x] #5 Git-only behavior is skipped gracefully when Git is unavailable or disabled, without noisy stack traces for normal local workflows.
+- [x] #6 Documentation explains Git-backed and filesystem-only initialization paths.
+- [x] #7 Regression tests cover init and representative local commands in a non-Git project.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add an explicit filesystem-only init path (`backlog init --no-git`) and interactive no-git choice when init runs outside a Git repository.
+2. Persist no-git projects with `checkActiveBranches=false`, `remoteOperations=false`, and `autoCommit=false` from the shared initializer so CLI/Web/MCP-created projects use the same config semantics.
+3. Harden Git operation boundaries so task, draft, document, decision, milestone, cleanup, CLI, Web, and MCP local-file flows skip Git work gracefully when no repository is present.
+4. Add focused regression tests for no-git init and representative local commands in a non-Git project.
+5. Update documentation, mark acceptance criteria/DoD, and retitle/update PR #354 once the branch is ready.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started from current main instead of carrying the old PR #354 diff. The old branch intent is preserved, but the implementation will be rebuilt around the current shared initializer and Git operation abstraction.
+
+Implemented filesystem-only mode with a persisted filesystem_only config flag so Git helpers skip parent repositories too. Codex follow-ups fixed lazy Core paths so fresh GitOperations instances load config before repository/path-context checks, and made the server init endpoint parse optional boolean init flags without truthy string coercion. Validation passed: bun test src/test/cli-init-no-git.test.ts; targeted no-git/git/offline/core/server suites; bunx tsc --noEmit; bun run check .; full bun test.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented filesystem-only Backlog projects from current main.
+
+Summary:
+- Added `backlog init --no-git` and an interactive no-Git choice when init runs outside a Git repository.
+- Persisted filesystem-only mode with `filesystem_only: true` plus Git-disabled config defaults (`check_active_branches=false`, `remote_operations=false`, `auto_commit=false`).
+- Hardened Git operations so filesystem-only projects skip Git work even when located under a parent Git repository, while preserving existing Git-backed behavior.
+- Added lazy config loading for Git operation boundaries so fresh Core instances respect filesystem-only mode before explicit config loading.
+- Tightened Web/API init boolean parsing so string `"false"` does not accidentally enable filesystem-only mode.
+- Added no-Git regression coverage for init plus task, draft, document, decision, milestone, and local loading flows.
+- Documented Git-backed and filesystem-only init paths in README.
+
+Validation:
+- `bunx tsc --noEmit`
+- `bun run check .`
+- `bun test`
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -413,7 +413,7 @@ program
 
 program
 	.command("init [projectName]")
-	.description("initialize backlog project in the current repository")
+	.description("initialize backlog project in the current directory")
 	.option(
 		"--agent-instructions <instructions>",
 		"comma-separated agent instructions to create. Valid: claude, agents, gemini, copilot, cursor (alias of agents), none. Use 'none' to skip; when combined with others, 'none' is ignored.",
@@ -431,6 +431,7 @@ program
 	.option("--backlog-dir <path>", "backlog folder for init: backlog, .backlog, or a custom project-relative path")
 	.option("--config-location <location>", "config location for init: folder or root")
 	.option("--task-prefix <prefix>", "custom task prefix, letters only (default: task)")
+	.option("--no-git", "initialize without Git integration")
 	.option("--defaults", "use default values for all prompts")
 	.action(
 		async (
@@ -450,6 +451,7 @@ program
 				backlogDir?: string;
 				configLocation?: string;
 				taskPrefix?: string;
+				git?: boolean;
 				defaults?: boolean;
 			},
 		) => {
@@ -457,22 +459,34 @@ program
 				// init command uses process.cwd() directly - it initializes in the current directory
 				const cwd = process.cwd();
 				const isRepo = await isGitRepository(cwd);
+				let filesystemOnly = options.git === false;
 
-				if (!isRepo) {
-					const initializeRepo = await clack.confirm({
-						message: "No git repository found. Initialize one here?",
-						initialValue: false,
+				if (!isRepo && !filesystemOnly) {
+					const repositoryMode = await clack.select({
+						message: "No git repository found. How should Backlog.md initialize this project?",
+						initialValue: "git",
+						options: [
+							{
+								label: "Initialize a Git repository",
+								value: "git",
+								hint: "Use the standard Git-backed workflow",
+							},
+							{
+								label: "Continue without Git",
+								value: "filesystem",
+								hint: "Use local Markdown files only",
+							},
+						],
 					});
-					if (clack.isCancel(initializeRepo)) {
+					if (clack.isCancel(repositoryMode)) {
 						abortInitialization();
 						return;
 					}
 
-					if (initializeRepo) {
+					if (repositoryMode === "git") {
 						await initializeGitRepository(cwd);
 					} else {
-						abortInitialization();
-						return;
+						filesystemOnly = true;
 					}
 				}
 
@@ -536,7 +550,8 @@ program
 					options.integrationMode ||
 					options.backlogDir ||
 					options.configLocation ||
-					options.taskPrefix
+					options.taskPrefix ||
+					options.git === false
 				);
 
 				// Get project name
@@ -1079,6 +1094,15 @@ program
 						advancedConfigured = true;
 					}
 				}
+				if (filesystemOnly) {
+					advancedConfig = {
+						...advancedConfig,
+						checkActiveBranches: false,
+						remoteOperations: false,
+						bypassGitHooks: false,
+						autoCommit: false,
+					};
+				}
 				// Call shared core init function
 				const initResult = await initializeProject(core, {
 					projectName: name,
@@ -1103,9 +1127,11 @@ program
 						taskPrefix: taskPrefix || undefined,
 					},
 					existingConfig,
+					filesystemOnly,
 				});
 
 				const config = initResult.config;
+				const gitIntegrationDisabled = Boolean(config.filesystemOnly);
 
 				// Show configuration summary
 				const supportsColor = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
@@ -1142,6 +1168,9 @@ program
 				summaryLines.push(
 					`${label("Config location:")} ${configLocation === "root" ? DEFAULT_FILES.ROOT_CONFIG : "folder config.yml"}`,
 				);
+				summaryLines.push(
+					`${label("Git integration:")} ${gitIntegrationDisabled ? muted("disabled (filesystem-only)") : good("enabled")}`,
+				);
 				if (integrationMode === "cli") {
 					summaryLines.push(`${label("AI Integration:")} ${muted("CLI commands (legacy)")}`);
 					if (agentFiles.length > 0) {
@@ -1172,7 +1201,7 @@ program
 					completionSummary = muted("not configured");
 				}
 				summaryLines.push(`${label("Shell completions:")} ${completionSummary}`);
-				if (advancedConfigured) {
+				if (advancedConfigured || gitIntegrationDisabled) {
 					summaryLines.push(label("Advanced settings:"));
 					summaryLines.push(`  ${label("Check active branches:")} ${boolValue(Boolean(config.checkActiveBranches))}`);
 					summaryLines.push(`  ${label("Remote operations:")} ${boolValue(Boolean(config.remoteOperations))}`);
@@ -3333,6 +3362,9 @@ configCmd
 				case "autoCommit":
 					console.log(config.autoCommit?.toString() || "");
 					break;
+				case "filesystemOnly":
+					console.log(config.filesystemOnly?.toString() || "false");
+					break;
 				case "bypassGitHooks":
 					console.log(config.bypassGitHooks?.toString() || "");
 					break;
@@ -3348,7 +3380,7 @@ configCmd
 				default:
 					console.error(`Unknown config key: ${key}`);
 					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, remoteOperations, autoCommit, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
+						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
 					);
 					process.exit(1);
 			}
@@ -3449,6 +3481,22 @@ configCmd
 					}
 					break;
 				}
+				case "filesystemOnly": {
+					const boolValue = value.toLowerCase();
+					if (boolValue === "true" || boolValue === "1" || boolValue === "yes") {
+						config.filesystemOnly = true;
+						config.checkActiveBranches = false;
+						config.remoteOperations = false;
+						config.autoCommit = false;
+						config.bypassGitHooks = false;
+					} else if (boolValue === "false" || boolValue === "0" || boolValue === "no") {
+						config.filesystemOnly = false;
+					} else {
+						console.error("filesystemOnly must be true or false");
+						process.exit(1);
+					}
+					break;
+				}
 				case "bypassGitHooks": {
 					const boolValue = value.toLowerCase();
 					if (boolValue === "true" || boolValue === "1" || boolValue === "yes") {
@@ -3523,7 +3571,7 @@ configCmd
 				default:
 					console.error(`Unknown config key: ${key}`);
 					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, dateFormat, maxColumnWidth, autoOpenBrowser, defaultPort, remoteOperations, autoCommit, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
+						"Available keys: defaultEditor, projectName, defaultStatus, dateFormat, maxColumnWidth, autoOpenBrowser, defaultPort, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
 					);
 					process.exit(1);
 			}
@@ -3565,6 +3613,7 @@ configCmd
 			console.log(`  defaultPort: ${config.defaultPort ?? "(not set)"}`);
 			console.log(`  remoteOperations: ${config.remoteOperations ?? "(not set)"}`);
 			console.log(`  autoCommit: ${config.autoCommit ?? "(not set)"}`);
+			console.log(`  filesystemOnly: ${config.filesystemOnly ?? "false"}`);
 			console.log(`  bypassGitHooks: ${config.bypassGitHooks ?? "(not set)"}`);
 			console.log(`  zeroPaddedIds: ${config.zeroPaddedIds ?? "(disabled)"}`);
 			console.log(`  taskPrefix: ${config.prefixes?.task || "task"} (read-only)`);
@@ -3591,6 +3640,7 @@ program
 				console.error("No backlog project found. Initialize one first with: backlog init");
 				process.exit(1);
 			}
+			core.gitOps.setConfig(config);
 
 			// Get all Done tasks
 			const tasks = await core.queryTasks();
@@ -3682,7 +3732,8 @@ program
 			}
 
 			// If autoCommit is disabled, stage the moves so Git recognizes them
-			if (successCount > 0 && !shouldAutoCommit) {
+			const hasGitRepository = await core.gitOps.isRepository();
+			if (successCount > 0 && !shouldAutoCommit && hasGitRepository) {
 				console.log("Staging file moves for Git...");
 				for (const { fromPath, toPath } of movedTasks) {
 					try {
@@ -3694,7 +3745,7 @@ program
 			}
 
 			console.log(`Successfully moved ${successCount} of ${tasksToMove.length} tasks to completed folder.`);
-			if (successCount > 0 && !shouldAutoCommit) {
+			if (successCount > 0 && !shouldAutoCommit && hasGitRepository) {
 				console.log("Files have been staged. To commit: git commit -m 'cleanup: Move completed tasks'");
 			}
 		} catch (err) {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -65,6 +65,7 @@ export const DEFAULT_INIT_CONFIG = {
 	activeBranchDays: 30,
 	bypassGitHooks: false,
 	autoCommit: false,
+	filesystemOnly: false,
 	zeroPaddedIds: undefined as number | undefined,
 	defaultEditor: undefined as string | undefined,
 	defaultPort: 6420,

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -158,7 +158,7 @@ export class Core {
 
 	constructor(projectRoot: string, options?: { enableWatchers?: boolean }) {
 		this.fs = new FileSystem(projectRoot);
-		this.git = new GitOperations(projectRoot);
+		this.git = new GitOperations(projectRoot, null, () => this.fs.loadConfig());
 		// Disable watchers by default for CLI commands (non-interactive)
 		// Interactive modes (TUI, browser, MCP) should explicitly pass enableWatchers: true
 		this.enableWatchers = options?.enableWatchers ?? false;
@@ -399,6 +399,8 @@ export class Core {
 
 		// Check config for remote operations
 		const config = await this.fs.loadConfig();
+		if (config?.checkActiveBranches === false) return null;
+
 		const sinceDays = config?.activeBranchDays ?? 30;
 		const taskPrefix = config?.prefixes?.task ?? "task";
 
@@ -461,7 +463,7 @@ export class Core {
 		this.disposeSearchService();
 		this.disposeContentStore();
 		this.fs = new FileSystem(projectRoot);
-		this.git = new GitOperations(projectRoot);
+		this.git = new GitOperations(projectRoot, null, () => this.fs.loadConfig());
 	}
 
 	disposeSearchService(): void {
@@ -504,12 +506,16 @@ export class Core {
 	}
 
 	async shouldAutoCommit(overrideValue?: boolean): Promise<boolean> {
+		const config = await this.fs.loadConfig();
+		this.git.setConfig(config);
+		if (config?.filesystemOnly) {
+			return false;
+		}
 		// If override is explicitly provided, use it
 		if (overrideValue !== undefined) {
 			return overrideValue;
 		}
 		// Otherwise, check config (default to false for safety)
-		const config = await this.fs.loadConfig();
 		return config?.autoCommit ?? false;
 	}
 

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -25,6 +25,7 @@ export interface InitializeProjectOptions {
 	mcpClients?: McpClient[];
 	agentInstructions?: AgentInstructionFile[];
 	installClaudeAgent?: boolean;
+	filesystemOnly?: boolean;
 	advancedConfig?: {
 		checkActiveBranches?: boolean;
 		remoteOperations?: boolean;
@@ -87,13 +88,24 @@ export async function initializeProject(
 		installClaudeAgent: installClaudeAgentFlag = false,
 		advancedConfig = {},
 		existingConfig,
+		filesystemOnly = false,
 	} = options;
 
 	const isReInitialization = !!existingConfig;
 	const projectRoot = core.filesystem.rootDir;
-	const hasDefaultEditorOverride = Object.hasOwn(advancedConfig, "defaultEditor");
-	const hasZeroPaddedIdsOverride = Object.hasOwn(advancedConfig, "zeroPaddedIds");
-	const hasDefinitionOfDoneOverride = Object.hasOwn(advancedConfig, "definitionOfDone");
+	const effectiveFilesystemOnly = filesystemOnly || existingConfig?.filesystemOnly === true;
+	const normalizedAdvancedConfig = effectiveFilesystemOnly
+		? {
+				...advancedConfig,
+				checkActiveBranches: false,
+				remoteOperations: false,
+				bypassGitHooks: false,
+				autoCommit: false,
+			}
+		: advancedConfig;
+	const hasDefaultEditorOverride = Object.hasOwn(normalizedAdvancedConfig, "defaultEditor");
+	const hasZeroPaddedIdsOverride = Object.hasOwn(normalizedAdvancedConfig, "zeroPaddedIds");
+	const hasDefinitionOfDoneOverride = Object.hasOwn(normalizedAdvancedConfig, "definitionOfDone");
 
 	// Build config, preserving existing values for re-initialization.
 	// Re-init should be idempotent for fields that init does not explicitly manage.
@@ -105,56 +117,64 @@ export async function initializeProject(
 		defaultStatus: "To Do",
 		dateFormat: "yyyy-mm-dd",
 		maxColumnWidth: 20,
-		autoCommit: advancedConfig.autoCommit ?? existingConfig?.autoCommit ?? d.autoCommit,
-		remoteOperations: advancedConfig.remoteOperations ?? existingConfig?.remoteOperations ?? d.remoteOperations,
-		bypassGitHooks: advancedConfig.bypassGitHooks ?? existingConfig?.bypassGitHooks ?? d.bypassGitHooks,
+		filesystemOnly: effectiveFilesystemOnly || d.filesystemOnly,
+		autoCommit: normalizedAdvancedConfig.autoCommit ?? existingConfig?.autoCommit ?? d.autoCommit,
+		remoteOperations:
+			normalizedAdvancedConfig.remoteOperations ?? existingConfig?.remoteOperations ?? d.remoteOperations,
+		bypassGitHooks: normalizedAdvancedConfig.bypassGitHooks ?? existingConfig?.bypassGitHooks ?? d.bypassGitHooks,
 		checkActiveBranches:
-			advancedConfig.checkActiveBranches ?? existingConfig?.checkActiveBranches ?? d.checkActiveBranches,
-		activeBranchDays: advancedConfig.activeBranchDays ?? existingConfig?.activeBranchDays ?? d.activeBranchDays,
-		defaultPort: advancedConfig.defaultPort ?? existingConfig?.defaultPort ?? d.defaultPort,
-		autoOpenBrowser: advancedConfig.autoOpenBrowser ?? existingConfig?.autoOpenBrowser ?? d.autoOpenBrowser,
+			normalizedAdvancedConfig.checkActiveBranches ?? existingConfig?.checkActiveBranches ?? d.checkActiveBranches,
+		activeBranchDays:
+			normalizedAdvancedConfig.activeBranchDays ?? existingConfig?.activeBranchDays ?? d.activeBranchDays,
+		defaultPort: normalizedAdvancedConfig.defaultPort ?? existingConfig?.defaultPort ?? d.defaultPort,
+		autoOpenBrowser: normalizedAdvancedConfig.autoOpenBrowser ?? existingConfig?.autoOpenBrowser ?? d.autoOpenBrowser,
 		taskResolutionStrategy: existingConfig?.taskResolutionStrategy || "most_recent",
 		// Preserve existing prefixes on re-init, or use custom prefix if provided during first init
 		prefixes: existingConfig?.prefixes || {
-			task: advancedConfig.taskPrefix || "task",
+			task: normalizedAdvancedConfig.taskPrefix || "task",
 		},
 	};
 	const config: BacklogConfig = {
 		...baseConfig,
 		...(existingConfig ?? {}),
 		projectName,
-		autoCommit: advancedConfig.autoCommit ?? existingConfig?.autoCommit ?? d.autoCommit,
-		remoteOperations: advancedConfig.remoteOperations ?? existingConfig?.remoteOperations ?? d.remoteOperations,
-		bypassGitHooks: advancedConfig.bypassGitHooks ?? existingConfig?.bypassGitHooks ?? d.bypassGitHooks,
+		filesystemOnly: effectiveFilesystemOnly || d.filesystemOnly,
+		autoCommit: normalizedAdvancedConfig.autoCommit ?? existingConfig?.autoCommit ?? d.autoCommit,
+		remoteOperations:
+			normalizedAdvancedConfig.remoteOperations ?? existingConfig?.remoteOperations ?? d.remoteOperations,
+		bypassGitHooks: normalizedAdvancedConfig.bypassGitHooks ?? existingConfig?.bypassGitHooks ?? d.bypassGitHooks,
 		checkActiveBranches:
-			advancedConfig.checkActiveBranches ?? existingConfig?.checkActiveBranches ?? d.checkActiveBranches,
-		activeBranchDays: advancedConfig.activeBranchDays ?? existingConfig?.activeBranchDays ?? d.activeBranchDays,
-		defaultPort: advancedConfig.defaultPort ?? existingConfig?.defaultPort ?? d.defaultPort,
-		autoOpenBrowser: advancedConfig.autoOpenBrowser ?? existingConfig?.autoOpenBrowser ?? d.autoOpenBrowser,
+			normalizedAdvancedConfig.checkActiveBranches ?? existingConfig?.checkActiveBranches ?? d.checkActiveBranches,
+		activeBranchDays:
+			normalizedAdvancedConfig.activeBranchDays ?? existingConfig?.activeBranchDays ?? d.activeBranchDays,
+		defaultPort: normalizedAdvancedConfig.defaultPort ?? existingConfig?.defaultPort ?? d.defaultPort,
+		autoOpenBrowser: normalizedAdvancedConfig.autoOpenBrowser ?? existingConfig?.autoOpenBrowser ?? d.autoOpenBrowser,
 		prefixes: existingConfig?.prefixes || {
-			task: advancedConfig.taskPrefix || "task",
+			task: normalizedAdvancedConfig.taskPrefix || "task",
 		},
-		...(hasDefaultEditorOverride && advancedConfig.defaultEditor
-			? { defaultEditor: advancedConfig.defaultEditor }
+		...(hasDefaultEditorOverride && normalizedAdvancedConfig.defaultEditor
+			? { defaultEditor: normalizedAdvancedConfig.defaultEditor }
 			: {}),
-		...(hasZeroPaddedIdsOverride && typeof advancedConfig.zeroPaddedIds === "number" && advancedConfig.zeroPaddedIds > 0
-			? { zeroPaddedIds: advancedConfig.zeroPaddedIds }
+		...(hasZeroPaddedIdsOverride &&
+		typeof normalizedAdvancedConfig.zeroPaddedIds === "number" &&
+		normalizedAdvancedConfig.zeroPaddedIds > 0
+			? { zeroPaddedIds: normalizedAdvancedConfig.zeroPaddedIds }
 			: {}),
-		...(hasDefinitionOfDoneOverride && Array.isArray(advancedConfig.definitionOfDone)
-			? { definitionOfDone: [...advancedConfig.definitionOfDone] }
+		...(hasDefinitionOfDoneOverride && Array.isArray(normalizedAdvancedConfig.definitionOfDone)
+			? { definitionOfDone: [...normalizedAdvancedConfig.definitionOfDone] }
 			: {}),
 	};
 	// Preserve all non-init-managed fields, but allow init-managed optional fields to be explicitly cleared.
-	if (hasDefaultEditorOverride && !advancedConfig.defaultEditor) {
+	if (hasDefaultEditorOverride && !normalizedAdvancedConfig.defaultEditor) {
 		delete config.defaultEditor;
 	}
 	if (
 		hasZeroPaddedIdsOverride &&
-		!(typeof advancedConfig.zeroPaddedIds === "number" && advancedConfig.zeroPaddedIds > 0)
+		!(typeof normalizedAdvancedConfig.zeroPaddedIds === "number" && normalizedAdvancedConfig.zeroPaddedIds > 0)
 	) {
 		delete config.zeroPaddedIds;
 	}
-	if (hasDefinitionOfDoneOverride && !Array.isArray(advancedConfig.definitionOfDone)) {
+	if (hasDefinitionOfDoneOverride && !Array.isArray(normalizedAdvancedConfig.definitionOfDone)) {
 		delete config.definitionOfDone;
 	}
 

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1384,6 +1384,10 @@ ${description || `Milestone: ${title}`}`,
 				case "auto_commit":
 					config.autoCommit = value.toLowerCase() === "true";
 					break;
+				case "filesystem_only":
+				case "filesystemOnly":
+					config.filesystemOnly = value.toLowerCase() === "true";
+					break;
 				case "zero_padded_ids":
 					config.zeroPaddedIds = Number.parseInt(value, 10);
 					break;
@@ -1426,6 +1430,7 @@ ${description || `Milestone: ${title}`}`,
 			defaultPort: config.defaultPort,
 			remoteOperations: config.remoteOperations,
 			autoCommit: config.autoCommit,
+			filesystemOnly: config.filesystemOnly,
 			zeroPaddedIds: config.zeroPaddedIds,
 			bypassGitHooks: config.bypassGitHooks,
 			checkActiveBranches: config.checkActiveBranches,
@@ -1455,6 +1460,7 @@ ${description || `Milestone: ${title}`}`,
 			...(config.defaultPort ? [`default_port: ${config.defaultPort}`] : []),
 			...(typeof config.remoteOperations === "boolean" ? [`remote_operations: ${config.remoteOperations}`] : []),
 			...(typeof config.autoCommit === "boolean" ? [`auto_commit: ${config.autoCommit}`] : []),
+			...(typeof config.filesystemOnly === "boolean" ? [`filesystem_only: ${config.filesystemOnly}`] : []),
 			...(typeof config.zeroPaddedIds === "number" ? [`zero_padded_ids: ${config.zeroPaddedIds}`] : []),
 			...(typeof config.bypassGitHooks === "boolean" ? [`bypass_git_hooks: ${config.bypassGitHooks}`] : []),
 			...(typeof config.checkActiveBranches === "boolean"

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -8,23 +8,49 @@ type GitPathContext = {
 	relativePath: string;
 };
 
+type GitConfigLoader = () => Promise<BacklogConfig | null>;
+
 export class GitOperations {
 	private projectRoot: string;
 	private config: BacklogConfig | null = null;
+	private readonly configLoader?: GitConfigLoader;
 
-	constructor(projectRoot: string, config: BacklogConfig | null = null) {
+	constructor(projectRoot: string, config: BacklogConfig | null = null, configLoader?: GitConfigLoader) {
 		this.projectRoot = projectRoot;
 		this.config = config;
+		this.configLoader = configLoader;
 	}
 
 	setConfig(config: BacklogConfig | null): void {
 		this.config = config;
 	}
 
+	private async loadConfigIfNeeded(): Promise<void> {
+		if (this.config || !this.configLoader) {
+			return;
+		}
+		try {
+			this.config = await this.configLoader();
+		} catch {
+			this.config = null;
+		}
+	}
+
+	async isRepository(cwd = this.projectRoot): Promise<boolean> {
+		await this.loadConfigIfNeeded();
+		if (this.config?.filesystemOnly) {
+			return false;
+		}
+		return await isGitRepository(cwd);
+	}
+
 	async addFile(filePath: string): Promise<void> {
 		const context = await this.getPathContext(filePath);
 		if (context) {
 			await this.execGit(["add", context.relativePath], { cwd: context.repoRoot });
+			return;
+		}
+		if (!(await this.isRepository())) {
 			return;
 		}
 
@@ -34,6 +60,9 @@ export class GitOperations {
 	}
 
 	async addFiles(filePaths: string[]): Promise<void> {
+		if (filePaths.length === 0 || !(await this.isRepository())) {
+			return;
+		}
 		// Convert absolute paths to relative paths from project root to avoid Windows encoding issues
 		const relativePaths = filePaths.map((filePath) => relative(this.projectRoot, filePath).replace(/\\/g, "/"));
 		await this.execGit(["add", ...relativePaths]);
@@ -46,10 +75,16 @@ export class GitOperations {
 			args.push("--no-verify");
 		}
 		const repoRoot = filePath ? (await this.getPathContext(filePath))?.repoRoot : undefined;
+		if (!(await this.isRepository(repoRoot ?? this.projectRoot))) {
+			return;
+		}
 		await this.execGit(args, { cwd: repoRoot });
 	}
 
 	async commitChanges(message: string, repoRoot?: string | null): Promise<void> {
+		if (!(await this.isRepository(repoRoot ?? this.projectRoot))) {
+			return;
+		}
 		const args = ["commit", "-m", message];
 		if (this.config?.bypassGitHooks) {
 			args.push("--no-verify");
@@ -65,6 +100,9 @@ export class GitOperations {
 
 		const resolvedRepoRoot =
 			repoRoot ?? (await this.getPathContext(uniqueFilePaths[0] ?? ""))?.repoRoot ?? this.projectRoot;
+		if (!(await this.isRepository(resolvedRepoRoot))) {
+			return;
+		}
 		const relativePaths: string[] = [];
 		for (const filePath of uniqueFilePaths) {
 			const relativePath = await this.getRelativePathForRepo(filePath, resolvedRepoRoot);
@@ -95,6 +133,9 @@ export class GitOperations {
 	}
 
 	async resetIndex(repoRoot?: string | null): Promise<void> {
+		if (!(await this.isRepository(repoRoot ?? this.projectRoot))) {
+			return;
+		}
 		// Reset the staging area without affecting working directory
 		await this.execGit(["reset", "HEAD"], { cwd: repoRoot ?? undefined });
 	}
@@ -107,6 +148,9 @@ export class GitOperations {
 
 		const resolvedRepoRoot =
 			repoRoot ?? (await this.getPathContext(uniqueFilePaths[0] ?? ""))?.repoRoot ?? this.projectRoot;
+		if (!(await this.isRepository(resolvedRepoRoot))) {
+			return;
+		}
 		const relativePaths: string[] = [];
 		for (const filePath of uniqueFilePaths) {
 			const relativePath = await this.getRelativePathForRepo(filePath, resolvedRepoRoot);
@@ -121,6 +165,9 @@ export class GitOperations {
 	}
 
 	async commitStagedChanges(message: string, repoRoot?: string | null): Promise<void> {
+		if (!(await this.isRepository(repoRoot ?? this.projectRoot))) {
+			return;
+		}
 		// Check if there are any staged changes before committing
 		const { stdout: status } = await this.execGit(["status", "--porcelain"], { cwd: repoRoot ?? undefined });
 		const hasStagedChanges = status.split("\n").some((line) => line.match(/^[AMDRC]/));
@@ -166,6 +213,9 @@ export class GitOperations {
 	}
 
 	async getStatus(): Promise<string> {
+		if (!(await this.isRepository())) {
+			return "";
+		}
 		const { stdout } = await this.execGit(["status", "--porcelain"], { readOnly: true });
 		return stdout;
 	}
@@ -176,6 +226,9 @@ export class GitOperations {
 	}
 
 	async getCurrentBranch(): Promise<string> {
+		if (!(await this.isRepository())) {
+			return "";
+		}
 		const { stdout } = await this.execGit(["branch", "--show-current"], { readOnly: true });
 		return stdout.trim();
 	}
@@ -185,6 +238,9 @@ export class GitOperations {
 	}
 
 	async getLastCommitMessage(): Promise<string> {
+		if (!(await this.isRepository())) {
+			return "";
+		}
 		const { stdout } = await this.execGit(["log", "-1", "--pretty=format:%s"], { readOnly: true });
 		return stdout.trim();
 	}
@@ -256,6 +312,9 @@ export class GitOperations {
 
 		const context = await this.getPathContext(filePath);
 		const repoRoot = context?.repoRoot ?? this.projectRoot;
+		if (!(await this.isRepository(repoRoot))) {
+			return;
+		}
 		const pathForAdd = context?.relativePath ?? relative(this.projectRoot, filePath).replace(/\\/g, "/");
 
 		// Retry git operations to handle transient failures
@@ -278,28 +337,34 @@ export class GitOperations {
 			await this.execGit(["add", pathForAdd], { cwd: context.repoRoot });
 			return context.repoRoot;
 		}
+		if (!(await this.isRepository())) {
+			return null;
+		}
 
 		await this.execGit(["add", `${backlogDir}/`]);
 		return null;
 	}
 	async stageFileMove(fromPath: string, toPath: string): Promise<string | null> {
 		const toContext = await this.getPathContext(toPath);
-		const repoRoot = toContext?.repoRoot;
-		const relativeFrom = repoRoot ? await this.getRelativePathForRepo(fromPath, repoRoot) : null;
-		const relativeTo = toContext?.relativePath ?? null;
+		const repoRoot = toContext?.repoRoot ?? this.projectRoot;
+		if (!(await this.isRepository(repoRoot))) {
+			return null;
+		}
+		const relativeFrom = await this.getRelativePathForRepo(fromPath, repoRoot);
+		const relativeTo = toContext?.relativePath ?? (await this.getRelativePathForRepo(toPath, repoRoot));
 
 		// Stage the deletion of the old file and addition of the new file
 		// Git will automatically detect this as a rename if the content is similar enough
 		try {
 			// First try to stage the removal of the old file (if it still exists)
-			await this.execGit(["add", "--all", relativeFrom ?? fromPath], { cwd: repoRoot ?? undefined });
+			await this.execGit(["add", "--all", relativeFrom ?? fromPath], { cwd: repoRoot });
 		} catch {
 			// If the old file doesn't exist, that's okay - it was already moved
 		}
 
 		// Always stage the new file location
-		await this.execGit(["add", relativeTo ?? toPath], { cwd: repoRoot ?? undefined });
-		return repoRoot ?? null;
+		await this.execGit(["add", relativeTo ?? toPath], { cwd: repoRoot });
+		return repoRoot === this.projectRoot ? null : repoRoot;
 	}
 
 	async listRemoteBranches(remote = "origin"): Promise<string[]> {
@@ -353,6 +418,9 @@ export class GitOperations {
 	}
 
 	async listRecentBranches(daysAgo: number): Promise<string[]> {
+		if (!(await this.isRepository())) {
+			return [];
+		}
 		try {
 			// Get all branches with their last commit date
 			// Using for-each-ref which is more efficient than multiple branch commands
@@ -396,6 +464,9 @@ export class GitOperations {
 	}
 
 	async listLocalBranches(): Promise<string[]> {
+		if (!(await this.isRepository())) {
+			return [];
+		}
 		try {
 			const { stdout } = await this.execGit(["branch", "--format=%(refname:short)"], { readOnly: true });
 			return stdout
@@ -408,6 +479,9 @@ export class GitOperations {
 	}
 
 	async listAllBranches(_remote = "origin"): Promise<string[]> {
+		if (!(await this.isRepository())) {
+			return [];
+		}
 		try {
 			// Use -a flag only if remote operations are enabled
 			const branchArgs =
@@ -430,6 +504,9 @@ export class GitOperations {
 	 * Returns true if the current repository has any remotes configured
 	 */
 	async hasAnyRemote(): Promise<boolean> {
+		if (!(await this.isRepository())) {
+			return false;
+		}
 		try {
 			const { stdout } = await this.execGit(["remote"], { readOnly: true });
 			return (
@@ -447,6 +524,9 @@ export class GitOperations {
 	 * Returns true if a specific remote exists (default: origin)
 	 */
 	async hasRemote(remote = "origin"): Promise<boolean> {
+		if (!(await this.isRepository())) {
+			return false;
+		}
 		try {
 			const { stdout } = await this.execGit(["remote"], { readOnly: true });
 			return stdout.split("\n").some((r) => r.trim() === remote);
@@ -456,10 +536,16 @@ export class GitOperations {
 	}
 
 	async listFilesInTree(ref: string, path: string): Promise<string[]> {
+		if (!(await this.isRepository())) {
+			return [];
+		}
 		const { stdout } = await this.execGit(["ls-tree", "-r", "--name-only", "-z", ref, "--", path], { readOnly: true });
 		return stdout.split("\0").filter(Boolean);
 	}
 	async showFile(ref: string, filePath: string): Promise<string> {
+		if (!(await this.isRepository())) {
+			return "";
+		}
 		const { stdout } = await this.execGit(["show", `${ref}:${filePath}`], { readOnly: true });
 		return stdout;
 	}
@@ -470,6 +556,9 @@ export class GitOperations {
 	 */
 	async getBranchLastModifiedMap(ref: string, dir: string, sinceDays?: number): Promise<Map<string, Date>> {
 		const out = new Map<string, Date>();
+		if (!(await this.isRepository())) {
+			return out;
+		}
 
 		try {
 			// Build args with optional --since filter
@@ -526,6 +615,9 @@ export class GitOperations {
 	}
 
 	async getFileLastModifiedBranch(filePath: string): Promise<string | null> {
+		if (!(await this.isRepository())) {
+			return null;
+		}
 		try {
 			// Get the hash of the last commit that touched the file
 			const { stdout: commitHash } = await this.execGit(["log", "-1", "--format=%H", "--", filePath], {
@@ -613,6 +705,10 @@ export class GitOperations {
 	}
 
 	private async resolveRepoRoot(startDir: string): Promise<string | null> {
+		await this.loadConfigIfNeeded();
+		if (this.config?.filesystemOnly) {
+			return null;
+		}
 		try {
 			const { stdout } = await this.execGit(["rev-parse", "--show-toplevel"], { readOnly: true, cwd: startDir });
 			const root = stdout.trim();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -71,6 +71,18 @@ function findTaskByLooseId(tasks: Task[], inputId: string): Task | undefined {
 	});
 }
 
+function parseOptionalBoolean(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") {
+		return value;
+	}
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (normalized === "true") return true;
+		if (normalized === "false") return false;
+	}
+	return undefined;
+}
+
 // @ts-expect-error
 import favicon from "../web/favicon.png" with { type: "file" };
 import indexHtml from "../web/index.html";
@@ -1675,7 +1687,8 @@ export class BacklogServer {
 			const integrationMode = body.integrationMode as "mcp" | "cli" | "none" | undefined;
 			const mcpClients = Array.isArray(body.mcpClients) ? body.mcpClients : [];
 			const agentInstructions = Array.isArray(body.agentInstructions) ? body.agentInstructions : [];
-			const installClaudeAgentFlag = Boolean(body.installClaudeAgent);
+			const installClaudeAgentFlag = parseOptionalBoolean(body.installClaudeAgent) ?? false;
+			const filesystemOnly = parseOptionalBoolean(body.filesystemOnly) ?? false;
 			const advancedConfig = body.advancedConfig || {};
 
 			// Input validation (browser layer responsibility)
@@ -1699,6 +1712,7 @@ export class BacklogServer {
 				mcpClients,
 				agentInstructions,
 				installClaudeAgent: installClaudeAgentFlag,
+				filesystemOnly,
 				advancedConfig,
 				existingConfig: null,
 			});

--- a/src/test/cli-init-no-git.test.ts
+++ b/src/test/cli-init-no-git.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { initializeProject } from "../core/init.ts";
+import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
+
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+
+let TEST_DIR: string;
+
+async function pathExists(path: string): Promise<boolean> {
+	try {
+		await stat(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function initFilesystemOnlyProject(projectName = "No Git Project"): Promise<Core> {
+	const result = await $`bun ${CLI_PATH} init ${projectName} --no-git --defaults --integration-mode none`
+		.cwd(TEST_DIR)
+		.quiet();
+	expect(result.exitCode).toBe(0);
+	return new Core(TEST_DIR);
+}
+
+describe("CLI init without Git", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-cli-init-no-git");
+		await mkdir(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(async () => {
+		try {
+			await safeCleanup(TEST_DIR);
+		} catch {
+			// Ignore cleanup errors - the unique directory names prevent conflicts
+		}
+	});
+
+	test("initializes a filesystem-only project without creating a Git repository", async () => {
+		const result = await $`bun ${CLI_PATH} init "Filesystem Project" --no-git --defaults --integration-mode none`
+			.cwd(TEST_DIR)
+			.quiet();
+
+		expect(result.exitCode).toBe(0);
+		expect(await pathExists(join(TEST_DIR, ".git"))).toBe(false);
+
+		const core = new Core(TEST_DIR);
+		const config = await core.filesystem.loadConfig();
+
+		expect(config?.projectName).toBe("Filesystem Project");
+		expect(config?.checkActiveBranches).toBe(false);
+		expect(config?.remoteOperations).toBe(false);
+		expect(config?.autoCommit).toBe(false);
+		expect(config?.bypassGitHooks).toBe(false);
+		expect(config?.filesystemOnly).toBe(true);
+		expect(result.stdout.toString()).toContain("Git integration: disabled (filesystem-only)");
+	});
+
+	test("shared init enforces Git-disabled config when filesystemOnly is requested", async () => {
+		const core = new Core(TEST_DIR);
+
+		await initializeProject(core, {
+			projectName: "Core Filesystem Project",
+			integrationMode: "none",
+			filesystemOnly: true,
+			advancedConfig: {
+				checkActiveBranches: true,
+				remoteOperations: true,
+				autoCommit: true,
+				bypassGitHooks: true,
+			},
+		});
+
+		const config = await core.filesystem.loadConfig();
+
+		expect(config?.checkActiveBranches).toBe(false);
+		expect(config?.remoteOperations).toBe(false);
+		expect(config?.autoCommit).toBe(false);
+		expect(config?.bypassGitHooks).toBe(false);
+		expect(config?.filesystemOnly).toBe(true);
+		expect(await pathExists(join(TEST_DIR, ".git"))).toBe(false);
+	});
+
+	test("local task, draft, document, decision, milestone, and list flows work without Git", async () => {
+		const core = await initFilesystemOnlyProject();
+
+		expect(await core.gitOps.listAllBranches()).toEqual([]);
+		expect(await core.gitOps.listRecentBranches(30)).toEqual([]);
+		expect(await core.gitOps.hasAnyRemote()).toBe(false);
+
+		const taskResult = await $`bun ${CLI_PATH} task create "No Git Task" --plain`.cwd(TEST_DIR).quiet();
+		expect(taskResult.exitCode).toBe(0);
+		expect(taskResult.stdout.toString()).toContain("Task TASK-1 - No Git Task");
+
+		const draftResult = await $`bun ${CLI_PATH} draft create "No Git Draft"`.cwd(TEST_DIR).quiet();
+		expect(draftResult.exitCode).toBe(0);
+		expect(draftResult.stdout.toString()).toContain("Created draft DRAFT-1");
+
+		const docResult = await $`bun ${CLI_PATH} doc create "No Git Doc"`.cwd(TEST_DIR).quiet();
+		expect(docResult.exitCode).toBe(0);
+		expect(docResult.stdout.toString()).toContain("Created document doc-1");
+
+		const decisionResult = await $`bun ${CLI_PATH} decision create "No Git Decision"`.cwd(TEST_DIR).quiet();
+		expect(decisionResult.exitCode).toBe(0);
+		expect(decisionResult.stdout.toString()).toContain("Created decision decision-1");
+
+		const promotedResult = await $`bun ${CLI_PATH} draft promote draft-1`.cwd(TEST_DIR).quiet();
+		expect(promotedResult.exitCode).toBe(0);
+		expect(promotedResult.stdout.toString()).toContain("Promoted draft draft-1");
+
+		const milestone = await core.filesystem.createMilestone("No Git Milestone");
+		const archiveMilestoneResult = await core.archiveMilestone(milestone.id, true);
+		expect(archiveMilestoneResult.success).toBe(true);
+
+		const tasks = await core.loadTasks();
+		const documents = await core.filesystem.listDocuments();
+		const decisions = await core.filesystem.listDecisions();
+		const archivedMilestones = await core.filesystem.listArchivedMilestones();
+
+		expect(tasks.map((task) => task.title)).toContain("No Git Task");
+		expect(tasks.map((task) => task.title)).toContain("No Git Draft");
+		expect(documents.map((doc) => doc.title)).toContain("No Git Doc");
+		expect(decisions.map((decision) => decision.title)).toContain("No Git Decision");
+		expect(archivedMilestones.map((item) => item.title)).toContain("No Git Milestone");
+		expect(await core.gitOps.getStatus()).toBe("");
+	});
+
+	test("filesystem-only mode ignores stale Git branches before explicit config loading", async () => {
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await Bun.write(join(TEST_DIR, "README.md"), "parent repo\n");
+		await $`git add README.md`.cwd(TEST_DIR).quiet();
+		await $`git commit -m initial`.cwd(TEST_DIR).quiet();
+
+		await $`git checkout -b stale-backlog`.cwd(TEST_DIR).quiet();
+		await mkdir(join(TEST_DIR, "backlog", "docs"), { recursive: true });
+		await mkdir(join(TEST_DIR, "backlog", "decisions"), { recursive: true });
+		await Bun.write(join(TEST_DIR, "backlog", "docs", "doc-8 - stale.md"), "# stale\n");
+		await Bun.write(join(TEST_DIR, "backlog", "decisions", "decision-8 - stale.md"), "# stale\n");
+		await $`git add backlog`.cwd(TEST_DIR).quiet();
+		await $`git commit -m "add stale backlog ids"`.cwd(TEST_DIR).quiet();
+		await $`git checkout main`.cwd(TEST_DIR).quiet();
+
+		const core = await initFilesystemOnlyProject("Nested No Git Project");
+
+		expect(await core.gitOps.listAllBranches()).toEqual([]);
+		expect(await core.gitOps.listRecentBranches(30)).toEqual([]);
+
+		const docResult = await $`bun ${CLI_PATH} doc create "Fresh Doc"`.cwd(TEST_DIR).quiet();
+		expect(docResult.exitCode).toBe(0);
+		expect(docResult.stdout.toString()).toContain("Created document doc-1");
+
+		const decisionResult = await $`bun ${CLI_PATH} decision create "Fresh Decision"`.cwd(TEST_DIR).quiet();
+		expect(decisionResult.exitCode).toBe(0);
+		expect(decisionResult.stdout.toString()).toContain("Created decision decision-1");
+	});
+});

--- a/src/test/server-init.test.ts
+++ b/src/test/server-init.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Core } from "../core/backlog.ts";
+import { BacklogServer } from "../server/index.ts";
+import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+type InitHandler = {
+	handleInit(req: Request): Promise<Response>;
+};
+
+function initRequest(body: Record<string, unknown>): Request {
+	return new Request("http://127.0.0.1/api/init", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({
+			projectName: "Server Init",
+			integrationMode: "none",
+			...body,
+		}),
+	});
+}
+
+describe("BacklogServer init endpoint", () => {
+	beforeEach(() => {
+		TEST_DIR = createUniqueTestDir("server-init");
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("parses string false filesystemOnly without enabling filesystem-only mode", async () => {
+		const server = new BacklogServer(TEST_DIR) as unknown as InitHandler;
+		const response = await server.handleInit(initRequest({ filesystemOnly: "false" }));
+
+		expect(response.status).toBe(200);
+
+		const config = await new Core(TEST_DIR).filesystem.loadConfig();
+		expect(config?.filesystemOnly).toBe(false);
+		expect(config?.remoteOperations).toBe(true);
+		expect(config?.checkActiveBranches).toBe(true);
+	});
+
+	it("accepts string true filesystemOnly for loose init callers", async () => {
+		const server = new BacklogServer(TEST_DIR) as unknown as InitHandler;
+		const response = await server.handleInit(initRequest({ filesystemOnly: "true" }));
+
+		expect(response.status).toBe(200);
+
+		const config = await new Core(TEST_DIR).filesystem.loadConfig();
+		expect(config?.filesystemOnly).toBe(true);
+		expect(config?.remoteOperations).toBe(false);
+		expect(config?.checkActiveBranches).toBe(false);
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -276,6 +276,8 @@ export interface BacklogConfig {
 	defaultPort?: number;
 	remoteOperations?: boolean;
 	autoCommit?: boolean;
+	/** Disable all Git integration for filesystem-only projects. */
+	filesystemOnly?: boolean;
 	zeroPaddedIds?: number;
 	includeDateTimeInDates?: boolean; // Whether to include time in new dates
 	bypassGitHooks?: boolean;

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -529,6 +529,7 @@ export class ApiClient {
 		mcpClients?: ("claude" | "codex" | "gemini" | "kiro" | "guide")[];
 		agentInstructions?: ("CLAUDE.md" | "AGENTS.md" | "GEMINI.md" | ".github/copilot-instructions.md")[];
 		installClaudeAgent?: boolean;
+		filesystemOnly?: boolean;
 		advancedConfig?: {
 			checkActiveBranches?: boolean;
 			remoteOperations?: boolean;


### PR DESCRIPTION
## Summary
- Rebuilt the old TASK-266 idea from current `main` instead of carrying the outdated/conflicting diff.
- Adds `backlog init --no-git` plus an interactive no-Git init choice for directories without Git.
- Persists filesystem-only mode in config and skips Git operations for CLI, core, Web API, and MCP local-file flows.
- Adds regression coverage for no-Git init and local task/draft/doc/decision/milestone workflows.

## Task
BACK-444 - Support filesystem-only Backlog projects without Git

## Testing
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test`