### PR TITLE
TASK-273.03 - Build core Fuse search service

### DIFF
--- a/backlog/tasks/task-273.03 - 273.03-Build-core-Fuse-search-service.md
+++ b/backlog/tasks/task-273.03 - 273.03-Build-core-Fuse-search-service.md
@@ -1,11 +1,11 @@
 ---
 id: task-273.03
 title: '273.03: Build core Fuse search service'
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-09-19 18:33'
-updated_date: '2025-09-19 18:33'
+updated_date: '2025-09-20 14:52'
 labels:
   - core
   - search
@@ -21,8 +21,18 @@ Implement a reusable search module that consumes the shared content store, build
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Search service indexes tasks/docs/decisions with rawContent + titles using Fuse.js and returns ordered SearchResult objects.
-- [ ] #2 Index automatically refreshes when the content store emits updates without full reloads.
-- [ ] #3 Filtering by status/priority leverages the same service (no separate list filtering logic).
-- [ ] #4 bun run check ., bunx tsc --noEmit, and targeted bun test suites cover search behavior.
+- [x] #1 Search service indexes tasks/docs/decisions with rawContent + titles using Fuse.js and returns ordered SearchResult objects.
+- [x] #2 Index automatically refreshes when the content store emits updates without full reloads.
+- [x] #3 Filtering by status/priority leverages the same service (no separate list filtering logic).
+- [x] #4 bun run check ., bunx tsc --noEmit, and targeted bun test suites cover search behavior.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added Fuse-backed SearchService wired to the ContentStore and unified SearchResult filtering.
+- Extended shared types and Core accessor so CLI/TUI/server can reuse the service.
+- Tests: bunx tsc --noEmit; bun run check .; bun test search-service.test.ts.
+
+- Reset initialization state when ContentStore fails so retries are possible.
+<!-- SECTION:NOTES:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -10,6 +10,7 @@ import { migrateConfig, needsMigration } from "./config-migration.ts";
 import { ContentStore } from "./content-store.ts";
 import { filterTasksByLatestState, getLatestTaskStatesForIds } from "./cross-branch-tasks.ts";
 import { loadRemoteTasks, resolveTaskConflict } from "./remote-tasks.ts";
+import { SearchService } from "./search-service.ts";
 import { computeSequences, planMoveToSequence, planMoveToUnsequenced } from "./sequences.ts";
 
 interface BlessedScreen {
@@ -34,6 +35,7 @@ export class Core {
 	public fs: FileSystem;
 	public git: GitOperations;
 	private contentStore?: ContentStore;
+	private searchService?: SearchService;
 
 	constructor(projectRoot: string) {
 		this.fs = new FileSystem(projectRoot);
@@ -47,6 +49,15 @@ export class Core {
 		}
 		await this.contentStore.ensureInitialized();
 		return this.contentStore;
+	}
+
+	async getSearchService(): Promise<SearchService> {
+		if (!this.searchService) {
+			const store = await this.getContentStore();
+			this.searchService = new SearchService(store);
+		}
+		await this.searchService.ensureInitialized();
+		return this.searchService;
 	}
 
 	// Backward compatibility aliases

--- a/src/core/search-service.ts
+++ b/src/core/search-service.ts
@@ -1,0 +1,360 @@
+import Fuse, { type FuseResult, type FuseResultMatch } from "fuse.js";
+import type {
+	Decision,
+	Document,
+	SearchFilters,
+	SearchMatch,
+	SearchOptions,
+	SearchPriorityFilter,
+	SearchResult,
+	SearchResultType,
+	Task,
+} from "../types/index.ts";
+import type { ContentStore, ContentStoreEvent } from "./content-store.ts";
+
+interface BaseSearchEntity {
+	readonly id: string;
+	readonly type: SearchResultType;
+	readonly title: string;
+	readonly rawContent: string;
+}
+
+interface TaskSearchEntity extends BaseSearchEntity {
+	readonly type: "task";
+	readonly task: Task;
+	readonly statusLower: string;
+	readonly priorityLower?: SearchPriorityFilter;
+}
+
+interface DocumentSearchEntity extends BaseSearchEntity {
+	readonly type: "document";
+	readonly document: Document;
+}
+
+interface DecisionSearchEntity extends BaseSearchEntity {
+	readonly type: "decision";
+	readonly decision: Decision;
+}
+
+type SearchEntity = TaskSearchEntity | DocumentSearchEntity | DecisionSearchEntity;
+
+type NormalizedFilters = {
+	statuses?: string[];
+	priorities?: SearchPriorityFilter[];
+};
+
+export class SearchService {
+	private initialized = false;
+	private initializing: Promise<void> | null = null;
+	private unsubscribe?: () => void;
+	private fuse: Fuse<SearchEntity> | null = null;
+	private tasks: TaskSearchEntity[] = [];
+	private documents: DocumentSearchEntity[] = [];
+	private decisions: DecisionSearchEntity[] = [];
+	private collection: SearchEntity[] = [];
+	private version = 0;
+
+	constructor(private readonly store: ContentStore) {}
+
+	async ensureInitialized(): Promise<void> {
+		if (this.initialized) {
+			return;
+		}
+
+		if (!this.initializing) {
+			this.initializing = this.initialize().catch((error) => {
+				this.initializing = null;
+				throw error;
+			});
+		}
+
+		await this.initializing;
+	}
+
+	dispose(): void {
+		if (this.unsubscribe) {
+			this.unsubscribe();
+			this.unsubscribe = undefined;
+		}
+		this.fuse = null;
+		this.collection = [];
+		this.tasks = [];
+		this.documents = [];
+		this.decisions = [];
+		this.initialized = false;
+		this.initializing = null;
+	}
+
+	search(options: SearchOptions = {}): SearchResult[] {
+		if (!this.initialized) {
+			throw new Error("SearchService not initialized. Call ensureInitialized() first.");
+		}
+
+		const { query = "", limit, types, filters } = options;
+
+		const trimmedQuery = query.trim();
+		const allowedTypes = new Set<SearchResultType>(
+			types && types.length > 0 ? types : ["task", "document", "decision"],
+		);
+		const normalizedFilters = this.normalizeFilters(filters);
+
+		if (trimmedQuery === "") {
+			return this.collectWithoutQuery(allowedTypes, normalizedFilters, limit);
+		}
+
+		const fuse = this.fuse;
+		if (!fuse) {
+			return [];
+		}
+
+		const fuseResults = fuse.search(trimmedQuery);
+		const results: SearchResult[] = [];
+
+		for (const result of fuseResults) {
+			const entity = result.item;
+			if (!allowedTypes.has(entity.type)) {
+				continue;
+			}
+
+			if (entity.type === "task" && !this.matchesTaskFilters(entity, normalizedFilters)) {
+				continue;
+			}
+
+			results.push(this.mapEntityToResult(entity, result));
+			if (limit && results.length >= limit) {
+				break;
+			}
+		}
+
+		return results;
+	}
+
+	private async initialize(): Promise<void> {
+		const snapshot = await this.store.ensureInitialized();
+		this.applySnapshot(snapshot.tasks, snapshot.documents, snapshot.decisions);
+
+		if (!this.unsubscribe) {
+			this.unsubscribe = this.store.subscribe((event) => {
+				this.handleStoreEvent(event);
+			});
+		}
+
+		this.initialized = true;
+		this.initializing = null;
+	}
+
+	private handleStoreEvent(event: ContentStoreEvent): void {
+		if (event.version <= this.version) {
+			return;
+		}
+		this.version = event.version;
+		this.applySnapshot(event.snapshot.tasks, event.snapshot.documents, event.snapshot.decisions);
+	}
+
+	private applySnapshot(tasks: Task[], documents: Document[], decisions: Decision[]): void {
+		this.tasks = tasks.map((task) => ({
+			id: task.id,
+			type: "task",
+			title: task.title,
+			rawContent: task.rawContent ?? "",
+			task,
+			statusLower: task.status.toLowerCase(),
+			priorityLower: task.priority ? (task.priority.toLowerCase() as SearchPriorityFilter) : undefined,
+		}));
+
+		this.documents = documents.map((document) => ({
+			id: document.id,
+			type: "document",
+			title: document.title,
+			rawContent: document.rawContent ?? "",
+			document,
+		}));
+
+		this.decisions = decisions.map((decision) => ({
+			id: decision.id,
+			type: "decision",
+			title: decision.title,
+			rawContent: decision.rawContent ?? "",
+			decision,
+		}));
+
+		this.collection = [...this.tasks, ...this.documents, ...this.decisions];
+		this.rebuildFuse();
+	}
+
+	private rebuildFuse(): void {
+		if (this.collection.length === 0) {
+			this.fuse = null;
+			return;
+		}
+
+		this.fuse = new Fuse(this.collection, {
+			includeScore: true,
+			includeMatches: true,
+			threshold: 0.35,
+			ignoreLocation: true,
+			minMatchCharLength: 2,
+			keys: [
+				{ name: "title", weight: 0.45 },
+				{ name: "rawContent", weight: 0.35 },
+				{ name: "id", weight: 0.2 },
+			],
+		});
+	}
+
+	private collectWithoutQuery(
+		allowedTypes: Set<SearchResultType>,
+		filters: NormalizedFilters,
+		limit?: number,
+	): SearchResult[] {
+		const results: SearchResult[] = [];
+
+		if (allowedTypes.has("task")) {
+			const tasks = this.applyTaskFilters(this.tasks, filters);
+			for (const entity of tasks) {
+				results.push(this.mapEntityToResult(entity));
+				if (limit && results.length >= limit) {
+					return results;
+				}
+			}
+		}
+
+		if (allowedTypes.has("document")) {
+			for (const entity of this.documents) {
+				results.push(this.mapEntityToResult(entity));
+				if (limit && results.length >= limit) {
+					return results;
+				}
+			}
+		}
+
+		if (allowedTypes.has("decision")) {
+			for (const entity of this.decisions) {
+				results.push(this.mapEntityToResult(entity));
+				if (limit && results.length >= limit) {
+					return results;
+				}
+			}
+		}
+
+		return results;
+	}
+
+	private applyTaskFilters(tasks: TaskSearchEntity[], filters: NormalizedFilters): TaskSearchEntity[] {
+		let filtered = tasks;
+		if (filters.statuses && filters.statuses.length > 0) {
+			const allowedStatuses = new Set(filters.statuses);
+			filtered = filtered.filter((task) => allowedStatuses.has(task.statusLower));
+		}
+		if (filters.priorities && filters.priorities.length > 0) {
+			const allowedPriorities = new Set(filters.priorities);
+			filtered = filtered.filter((task) => {
+				if (!task.priorityLower) {
+					return false;
+				}
+				return allowedPriorities.has(task.priorityLower);
+			});
+		}
+		return filtered;
+	}
+
+	private matchesTaskFilters(task: TaskSearchEntity, filters: NormalizedFilters): boolean {
+		if (filters.statuses && filters.statuses.length > 0) {
+			if (!filters.statuses.includes(task.statusLower)) {
+				return false;
+			}
+		}
+
+		if (filters.priorities && filters.priorities.length > 0) {
+			if (!task.priorityLower || !filters.priorities.includes(task.priorityLower)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private normalizeFilters(filters?: SearchFilters): NormalizedFilters {
+		if (!filters) {
+			return {};
+		}
+
+		const statuses = this.normalizeStringArray(filters.status);
+		const priorities = this.normalizePriorityArray(filters.priority);
+
+		return {
+			statuses,
+			priorities,
+		};
+	}
+
+	private normalizeStringArray(value?: string | string[]): string[] | undefined {
+		if (!value) {
+			return undefined;
+		}
+
+		const values = Array.isArray(value) ? value : [value];
+		const normalized = values.map((item) => item.trim().toLowerCase()).filter((item) => item.length > 0);
+
+		return normalized.length > 0 ? normalized : undefined;
+	}
+
+	private normalizePriorityArray(
+		value?: SearchPriorityFilter | SearchPriorityFilter[],
+	): SearchPriorityFilter[] | undefined {
+		if (!value) {
+			return undefined;
+		}
+
+		const values = Array.isArray(value) ? value : [value];
+		const normalized = values
+			.map((item) => item.trim().toLowerCase())
+			.filter((item): item is SearchPriorityFilter => {
+				return item === "high" || item === "medium" || item === "low";
+			});
+
+		return normalized.length > 0 ? normalized : undefined;
+	}
+
+	private mapEntityToResult(entity: SearchEntity, result?: FuseResult<SearchEntity>): SearchResult {
+		const score = result?.score ?? null;
+		const matches = this.mapMatches(result?.matches);
+
+		if (entity.type === "task") {
+			return {
+				type: "task",
+				score,
+				task: entity.task,
+				matches,
+			};
+		}
+
+		if (entity.type === "document") {
+			return {
+				type: "document",
+				score,
+				document: entity.document,
+				matches,
+			};
+		}
+
+		return {
+			type: "decision",
+			score,
+			decision: entity.decision,
+			matches,
+		};
+	}
+
+	private mapMatches(matches?: readonly FuseResultMatch[]): SearchMatch[] | undefined {
+		if (!matches || matches.length === 0) {
+			return undefined;
+		}
+
+		return matches.map((match) => ({
+			key: match.key,
+			indices: match.indices.map(([start, end]) => [start, end] as [number, number]),
+			value: match.value,
+		}));
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { exportKanbanBoardToFile, generateKanbanBoardWithMetadata } from "./boar
 export * from "./constants/index.ts";
 // Core entry point
 export { Core } from "./core/backlog.ts";
+export { SearchService } from "./core/search-service.ts";
 
 // File system operations
 export { FileSystem } from "./file-system/operations.ts";

--- a/src/test/search-service.test.ts
+++ b/src/test/search-service.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { ContentStore } from "../core/content-store.ts";
+import { SearchService } from "../core/search-service.ts";
+import { FileSystem } from "../file-system/operations.ts";
+import type {
+	Decision,
+	DecisionSearchResult,
+	Document,
+	DocumentSearchResult,
+	SearchResult,
+	Task,
+	TaskSearchResult,
+} from "../types/index.ts";
+import { createUniqueTestDir, getPlatformTimeout, safeCleanup, sleep } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+describe("SearchService", () => {
+	let filesystem: FileSystem;
+	let store: ContentStore;
+	let search: SearchService;
+
+	const baseTask: Task = {
+		id: "task-1",
+		title: "Centralized search task",
+		status: "In Progress",
+		assignee: ["@codex"],
+		reporter: "@codex",
+		createdDate: "2025-09-19 09:00",
+		updatedDate: "2025-09-19 09:10",
+		labels: ["search"],
+		dependencies: [],
+		rawContent: "## Description\nImplements Fuse based service",
+		priority: "high",
+	};
+
+	const baseDoc: Document = {
+		id: "doc-1",
+		title: "Search Architecture",
+		type: "guide",
+		createdDate: "2025-09-19",
+		rawContent: "# Search Architecture\nCentralized description",
+	};
+
+	const baseDecision: Decision = {
+		id: "decision-1",
+		title: "Adopt Fuse.js",
+		date: "2025-09-18",
+		status: "accepted",
+		context: "Need consistent search",
+		decision: "Use Fuse.js with centralized store",
+		consequences: "Shared search path",
+		rawContent: "## Context\nNeed consistent search\n\n## Decision\nUse Fuse.js with centralized store",
+	};
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("search-service");
+		filesystem = new FileSystem(TEST_DIR);
+		await filesystem.ensureBacklogStructure();
+		store = new ContentStore(filesystem);
+		search = new SearchService(store);
+	});
+
+	afterEach(async () => {
+		search?.dispose();
+		store?.dispose();
+		try {
+			await safeCleanup(TEST_DIR);
+		} catch {
+			// ignore cleanup errors between tests
+		}
+	});
+
+	it("indexes tasks, documents, and decisions and returns combined results", async () => {
+		await filesystem.saveTask(baseTask);
+		await filesystem.saveDocument(baseDoc);
+		await filesystem.saveDecision(baseDecision);
+
+		await search.ensureInitialized();
+
+		const results = search.search({ query: "centralized" });
+		expect(results).toHaveLength(3);
+
+		const taskResult = results.find(isTaskResult);
+		expect(taskResult).toBeDefined();
+		expect(taskResult?.task.id).toBe("task-1");
+		expect(taskResult?.score).not.toBeNull();
+
+		const docResult = results.find(isDocumentResult);
+		expect(docResult?.document.id).toBe("doc-1");
+		const decisionResult = results.find(isDecisionResult);
+		expect(decisionResult?.decision.id).toBe("decision-1");
+	});
+
+	it("applies status and priority filters without running a text query", async () => {
+		const secondTask: Task = {
+			...baseTask,
+			id: "task-2",
+			title: "Another task",
+			status: "To Do",
+			priority: "low",
+			rawContent: "## Description\nSecondary",
+		};
+
+		const thirdTask: Task = {
+			...baseTask,
+			id: "task-3",
+			title: "In progress medium",
+			priority: "medium",
+			rawContent: "## Description\nMedium priority",
+		};
+
+		await filesystem.saveTask(baseTask);
+		await filesystem.saveTask(secondTask);
+		await filesystem.saveTask(thirdTask);
+
+		await search.ensureInitialized();
+
+		const statusFiltered = search
+			.search({
+				types: ["task"],
+				filters: { status: "In Progress" },
+			})
+			.filter(isTaskResult);
+		expect(statusFiltered.map((result) => result.task.id)).toStrictEqual(["task-1", "task-3"]);
+
+		const priorityFiltered = search
+			.search({
+				types: ["task"],
+				filters: { priority: "high" },
+			})
+			.filter(isTaskResult);
+		expect(priorityFiltered).toHaveLength(1);
+		expect(priorityFiltered[0]?.task.id).toBe("task-1");
+
+		const combinedFiltered = search
+			.search({
+				types: ["task"],
+				filters: { status: ["In Progress"], priority: ["medium"] },
+			})
+			.filter(isTaskResult);
+		expect(combinedFiltered.map((result) => result.task.id)).toStrictEqual(["task-3"]);
+	});
+
+	it("refreshes the index when content changes", async () => {
+		await filesystem.saveTask(baseTask);
+		await search.ensureInitialized();
+
+		const initialResults = search.search({ query: "Fuse", types: ["task"] }).filter(isTaskResult);
+		expect(initialResults).toHaveLength(1);
+
+		await filesystem.saveTask({
+			...baseTask,
+			rawContent: "## Description\nReindexed to new term",
+			title: "Centralized service updated",
+		});
+
+		await waitForSearch(
+			async () => search.search({ query: "Reindexed", types: ["task"] }).filter(isTaskResult),
+			(results) => {
+				return results.length === 1 && results[0]?.task.title === "Centralized service updated";
+			},
+		);
+
+		const staleResults = search.search({ query: "Fuse", types: ["task"] }).filter(isTaskResult);
+		expect(staleResults).toHaveLength(0);
+	});
+});
+
+function isTaskResult(result: SearchResult): result is TaskSearchResult {
+	return result.type === "task";
+}
+
+function isDocumentResult(result: SearchResult): result is DocumentSearchResult {
+	return result.type === "document";
+}
+
+function isDecisionResult(result: SearchResult): result is DecisionSearchResult {
+	return result.type === "decision";
+}
+
+async function waitForSearch<T>(
+	operation: () => Promise<T> | T,
+	predicate: (value: T) => boolean,
+	timeout = getPlatformTimeout(),
+	interval = 50,
+): Promise<T> {
+	const deadline = Date.now() + timeout;
+	let lastValue: T;
+	while (Date.now() < deadline) {
+		lastValue = await operation();
+		if (predicate(lastValue)) {
+			return lastValue;
+		}
+		await sleep(interval);
+	}
+
+	lastValue = await operation();
+	if (predicate(lastValue)) {
+		return lastValue;
+	}
+
+	throw new Error("Timed out waiting for search results to satisfy predicate");
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,51 @@ export interface Document {
 	lastModified?: string;
 }
 
+export type SearchResultType = "task" | "document" | "decision";
+
+export type SearchPriorityFilter = "high" | "medium" | "low";
+
+export interface SearchMatch {
+	key?: string;
+	indices: Array<[number, number]>;
+	value?: unknown;
+}
+
+export interface SearchFilters {
+	status?: string | string[];
+	priority?: SearchPriorityFilter | SearchPriorityFilter[];
+}
+
+export interface SearchOptions {
+	query?: string;
+	limit?: number;
+	types?: SearchResultType[];
+	filters?: SearchFilters;
+}
+
+export interface TaskSearchResult {
+	type: "task";
+	score: number | null;
+	task: Task;
+	matches?: SearchMatch[];
+}
+
+export interface DocumentSearchResult {
+	type: "document";
+	score: number | null;
+	document: Document;
+	matches?: SearchMatch[];
+}
+
+export interface DecisionSearchResult {
+	type: "decision";
+	score: number | null;
+	decision: Decision;
+	matches?: SearchMatch[];
+}
+
+export type SearchResult = TaskSearchResult | DocumentSearchResult | DecisionSearchResult;
+
 export interface Sequence {
 	/** 1-based sequence index */
 	index: number;


### PR DESCRIPTION
- Added Fuse-backed SearchService wired to the ContentStore and unified SearchResult filtering.
- Extended shared types and Core accessor so CLI/TUI/server can reuse the service.
- Tests: bunx tsc --noEmit; bun run check .; bun test search-service.test.ts.
- Reset initialization state when ContentStore fails so retries are possible.