### PR TITLE
TASK-281 - Fix backlog init skip option

### DIFF
--- a/backlog/tasks/task-281 - Fix-backlog-init-skip-option.md
+++ b/backlog/tasks/task-281 - Fix-backlog-init-skip-option.md
@@ -1,10 +1,11 @@
 ---
 id: task-281
 title: Fix backlog init skip option
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-09-27 16:32'
+updated_date: '2025-09-27 17:07'
 labels:
   - bug
 dependencies: []
@@ -30,7 +31,24 @@ When the skip option is chosen, the wizard should accept the choice and proceed 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Interactive backlog init accepts the skip option without showing a validation error.
-- [ ] #2 Interactive backlog init still requires a retry when no option is chosen or when only the placeholder row is highlighted.
-- [ ] #3 Automated coverage verifies that selecting only the skip option results in initialization continuing with zero agent instruction files.
+- [x] #1 Interactive backlog init accepts the skip option without showing a validation error.
+- [x] #2 Interactive backlog init still requires a retry when no option is chosen or when only the placeholder row is highlighted.
+- [x] #3 Automated coverage verifies that selecting only the skip option results in initialization continuing with zero agent instruction files.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update `processAgentSelection` to treat a lone "none" selection as an explicit skip (no retry) while still deduping/ignoring placeholders, and surface a skip indicator alongside the files array.
+2. Adjust the `backlog init` agent-instruction prompt handling to honor the skip outcome without forcing the retry loop, keeping existing behavior for other selections and fallbacks.
+3. Strengthen coverage by extending `agent-selection` unit tests for the skip case and adding an integration regression test that proves `backlog init` proceeds with zero agent instruction files when the skip option is chosen.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Updated `processAgentSelection` to treat a lone "none" selection as an explicit skip and return a skip flag for callers.
+- Updated the `backlog init` agent selection flow to honor skip outcomes and log that instructions were skipped instead of forcing a retry.
+- Added regression coverage for the skip path in `agent-selection` and CLI integration tests to ensure no agent instruction files are produced when skipping.
+- Tests: `bunx tsc --noEmit`, `bun test`, `bun run check .`
+<!-- SECTION:NOTES:END -->

--- a/src/test/agent-selection.test.ts
+++ b/src/test/agent-selection.test.ts
@@ -10,18 +10,21 @@ describe("processAgentSelection", () => {
 		const result = processAgentSelection({ selected: [AGENTS_MD, CLAUDE_MD] });
 		expect(result.needsRetry).toBe(false);
 		expect(result.files).toEqual([AGENTS_MD, CLAUDE_MD]);
+		expect(result.skipped).toBe(false);
 	});
 
 	it("auto-selects highlighted item when none selected and fallback enabled", () => {
 		const result = processAgentSelection({ selected: [], highlighted: GEMINI_MD, useHighlightFallback: true });
 		expect(result.needsRetry).toBe(false);
 		expect(result.files).toEqual([GEMINI_MD]);
+		expect(result.skipped).toBe(false);
 	});
 
 	it("does not auto-select highlight when fallback disabled", () => {
 		const result = processAgentSelection({ selected: [], highlighted: CLAUDE_MD });
 		expect(result.needsRetry).toBe(true);
 		expect(result.files).toEqual([]);
+		expect(result.skipped).toBe(false);
 	});
 
 	it("ignores placeholder highlight even when fallback enabled", () => {
@@ -32,24 +35,28 @@ describe("processAgentSelection", () => {
 		});
 		expect(result.needsRetry).toBe(true);
 		expect(result.files).toEqual([]);
+		expect(result.skipped).toBe(false);
 	});
 
 	it("requires retry when nothing highlighted or selected", () => {
 		const result = processAgentSelection({ selected: [] });
 		expect(result.needsRetry).toBe(true);
 		expect(result.files).toEqual([]);
+		expect(result.skipped).toBe(false);
 	});
 
 	it("filters out 'none' when combined with other selections", () => {
 		const result = processAgentSelection({ selected: ["none", AGENTS_MD] as AgentSelectionValue[] });
 		expect(result.needsRetry).toBe(false);
 		expect(result.files).toEqual([AGENTS_MD]);
+		expect(result.skipped).toBe(false);
 	});
 
-	it("requires retry when only 'none' is selected", () => {
+	it("reports skip when only 'none' is selected", () => {
 		const result = processAgentSelection({ selected: ["none"] });
-		expect(result.needsRetry).toBe(true);
+		expect(result.needsRetry).toBe(false);
 		expect(result.files).toEqual([]);
+		expect(result.skipped).toBe(true);
 	});
 
 	it("dedupes selections while preserving order", () => {
@@ -58,5 +65,6 @@ describe("processAgentSelection", () => {
 		});
 		expect(result.needsRetry).toBe(false);
 		expect(result.files).toEqual([AGENTS_MD, CLAUDE_MD]);
+		expect(result.skipped).toBe(false);
 	});
 });

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -174,12 +174,13 @@ describe("CLI Integration", () => {
 			await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
 			await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
 
-			await $`bun ${CLI_PATH} init TestProj --defaults --agent-instructions none`.cwd(TEST_DIR).quiet();
+			const output = await $`bun ${CLI_PATH} init TestProj --defaults --agent-instructions none`.cwd(TEST_DIR).text();
 
 			const agentsFile = await Bun.file(join(TEST_DIR, "AGENTS.md")).exists();
 			const claudeFile = await Bun.file(join(TEST_DIR, "CLAUDE.md")).exists();
 			expect(agentsFile).toBe(false);
 			expect(claudeFile).toBe(false);
+			expect(output).toContain("Skipping agent instruction files per selection.");
 		});
 
 		it("should ignore 'none' when other agent instructions are provided", async () => {

--- a/src/utils/agent-selection.ts
+++ b/src/utils/agent-selection.ts
@@ -13,6 +13,7 @@ export interface AgentSelectionInput {
 export interface AgentSelectionOutcome {
 	files: AgentInstructionFile[];
 	needsRetry: boolean;
+	skipped: boolean;
 }
 
 function uniqueOrder(values: AgentSelectionValue[]): AgentSelectionValue[] {
@@ -48,10 +49,11 @@ export function processAgentSelection({
 	const agentFiles = ordered.filter(
 		(value): value is AgentInstructionFile => value !== "none" && value !== PLACEHOLDER_AGENT_VALUE,
 	);
+	const skipSelected = ordered.includes("none") && agentFiles.length === 0;
 
-	if (agentFiles.length === 0) {
-		return { files: [], needsRetry: true };
+	if (agentFiles.length === 0 && !skipSelected) {
+		return { files: [], needsRetry: true, skipped: false };
 	}
 
-	return { files: agentFiles, needsRetry: false };
+	return { files: agentFiles, needsRetry: false, skipped: skipSelected };
 }


### PR DESCRIPTION
- Updated `processAgentSelection` to treat a lone "none" selection as an explicit skip and return a skip flag for callers.
- Updated the `backlog init` agent selection flow to honor skip outcomes and log that instructions were skipped instead of forcing a retry.
- Added regression coverage for the skip path in `agent-selection` and CLI integration tests to ensure no agent instruction files are produced when skipping.
- Tests: `bunx tsc --noEmit`, `bun test`, `bun run check .`