### PR TITLE
TASK-283 - Fix TUI board duplicating cards after external status changes

### DIFF
--- a/backlog/tasks/task-283 - Fix-TUI-board-duplicating-cards-after-external-status-changes.md
+++ b/backlog/tasks/task-283 - Fix-TUI-board-duplicating-cards-after-external-status-changes.md
@@ -1,0 +1,40 @@
+---
+id: task-283
+title: Fix TUI board duplicating cards after external status changes
+status: Done
+assignee:
+  - '@codex'
+created_date: '2025-10-03 19:08'
+updated_date: '2025-10-03 19:16'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Summary
+Fix the TUI Kanban board so that when task statuses are toggled via CLI while the board is open, columns do not visually show duplicate cards.
+
+## Context
+See GitHub issue https://github.com/MrLesk/Backlog.md/issues/383.
+
+## Notes
+- Ensure rendering updates fully replace stale list entries.
+- Validate against toggling tasks between In Progress and Done while the TUI is open.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Reproduce the issue by flipping a task status via CLI while TUI is open and confirm no duplicate cards remain.
+- [x] #2 Add automated coverage or a regression script to guard against stale rows.
+- [x] #3 Document the fix in the task notes.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Adjusted board refresh logic to trigger a full column rebuild whenever task membership or ordering changes, preventing stale rows from lingering in the TUI.
+- Added unit coverage for the new rebuild heuristic to guard regression scenarios.
+- Verified fix manually by flipping task statuses while the TUI runs and ran bun run check ., bunx tsc --noEmit, bun test.
+<!-- SECTION:NOTES:END -->

--- a/src/test/board-render.test.ts
+++ b/src/test/board-render.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "../types/index.ts";
+import { type ColumnData, shouldRebuildColumns } from "../ui/board.ts";
+
+function createTask(id: string, status: string): Task {
+	return {
+		id,
+		title: `Title for ${id}`,
+		status,
+		assignee: [],
+		createdDate: "2025-01-01",
+		labels: [],
+		dependencies: [],
+		rawContent: "",
+	};
+}
+
+function makeColumns(taskIds: string[][], status: string): ColumnData[] {
+	return taskIds.map((ids) => ({
+		status,
+		tasks: ids.map((id) => createTask(id, status)),
+	}));
+}
+
+describe("shouldRebuildColumns", () => {
+	it("returns false when columns and task ordering are unchanged", () => {
+		const previous = makeColumns([["task-1", "task-2"]], "In Progress");
+		const next = makeColumns([["task-1", "task-2"]], "In Progress");
+
+		expect(shouldRebuildColumns(previous, next)).toBe(false);
+	});
+
+	it("returns true when a column loses items", () => {
+		const previous = makeColumns([["task-1", "task-2"]], "In Progress");
+		const next = makeColumns([["task-1"]], "In Progress");
+
+		expect(shouldRebuildColumns(previous, next)).toBe(true);
+	});
+
+	it("returns true when column task ordering changes", () => {
+		const previous = makeColumns([["task-1", "task-2"]], "In Progress");
+		const next = makeColumns([["task-2", "task-1"]], "In Progress");
+
+		expect(shouldRebuildColumns(previous, next)).toBe(true);
+	});
+
+	it("returns true when number of columns changes", () => {
+		const previous = makeColumns([["task-1"]], "In Progress");
+		const next = makeColumns([["task-1"], ["task-2"]], "In Progress");
+
+		expect(shouldRebuildColumns(previous, next)).toBe(true);
+	});
+});


### PR DESCRIPTION
- Adjusted board refresh logic to trigger a full column rebuild whenever task membership or ordering changes, preventing stale rows from lingering in the TUI.
- Added unit coverage for the new rebuild heuristic to guard regression scenarios.
- Verified fix manually by flipping task statuses while the TUI runs and ran bun run check ., bunx tsc --noEmit, bun test.
