### PR TITLE
TASK-284 - Simplify init flow; launch advanced settings via backlog config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,23 +107,20 @@ The web interface provides:
 
 | Action      | Example                                              |
 |-------------|------------------------------------------------------|
-| Initialize project | `backlog init [project-name]` (creates backlog structure with interactive configuration) |
+| Initialize project | `backlog init [project-name]` (creates backlog structure with a minimal interactive flow) |
 | Re-initialize | `backlog init` (preserves existing config, allows updates) |
+| Advanced settings wizard | `backlog config` (no args) — launches the full interactive configuration flow |
 
-The `backlog init` command provides comprehensive project setup with interactive prompts for:
-- **Project name** - identifier for your backlog
-- **Auto-commit** - whether to automatically commit task changes to git
-- **Default editor** - editor command for opening tasks (detects from environment)
-- **Remote operations** - enable/disable fetching tasks from remote branches
-- **Web UI settings** - port and browser auto-open preferences
-- **Agent guidelines** - AI agent instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, Copilot)
-- **Claude Code agent** - optional Backlog.md agent for enhanced task management (defaults to not installed; opt-in during `init` or pass `--install-claude-agent true`)
+`backlog init` keeps first-run setup focused on the essentials:
+- **Project name** – identifier for your backlog (defaults to the current directory on re-run).
+- **Agent instruction files** – pick which AI Agent instruction files to create (CLAUDE.md, AGENTS.md, GEMINI.md, Copilot, or skip).
+- **Advanced settings prompt** – default answer “No” finishes init immediately; choosing “Yes” jumps straight into the advanced wizard documented in [Configuration](#configuration).
+
+You can rerun the wizard anytime with `backlog config`. All existing CLI flags (for example `--defaults`, `--agent-instructions`, or `--install-claude-agent true`) continue to provide fully non-interactive setups, so existing scripts keep working without change.
 
 ### Documentation
 
 - Document IDs are global across all subdirectories under `backlog/docs`. You can organize files in nested folders (e.g., `backlog/docs/guides/`), and `backlog doc list` and `backlog doc view <id>` work across the entire tree. Example: `backlog doc create -p guides "New Guide"`.
-
-When re-initializing an existing project, all current configuration values are preserved and pre-populated in prompts, allowing you to update only what you need.
 
 ### Task Management
 
@@ -274,6 +271,24 @@ Backlog.md merges the following layers (highest → lowest):
 | Bypass git hooks | `backlog config set bypassGitHooks true` |
 | Enable cross-branch check | `backlog config set checkActiveBranches true` |
 | Set active branch days | `backlog config set activeBranchDays 30` |
+
+### Interactive wizard (`backlog config`)
+
+Run `backlog config` with no arguments to launch the full interactive wizard. This is the same experience triggered from `backlog init` when you opt into advanced settings, and it walks through the complete configuration surface:
+- Cross-branch accuracy: `checkActiveBranches`, `remoteOperations`, and `activeBranchDays`.
+- Git workflow: `autoCommit` and `bypassGitHooks`.
+- ID formatting: enable or size `zeroPaddedIds`.
+- Editor integration: pick a `defaultEditor` with availability checks.
+- Web UI defaults: choose `defaultPort` and whether `autoOpenBrowser` should run.
+
+Skipping the wizard (answering “No” during init) applies the safe defaults that ship with Backlog.md:
+- `checkActiveBranches=true`, `remoteOperations=true`, `activeBranchDays=30`.
+- `autoCommit=false`, `bypassGitHooks=false`.
+- `zeroPaddedIds` disabled.
+- `defaultEditor` unset (falls back to your environment).
+- `defaultPort=6420`, `autoOpenBrowser=true`.
+
+Whenever you revisit `backlog init` or rerun `backlog config`, the wizard pre-populates prompts with your current values so you can adjust only what changed.
 
 ### Available Configuration Options
 

--- a/backlog/tasks/task-284 - Simplify-init-flow;-launch-advanced-settings-via-backlog-config.md
+++ b/backlog/tasks/task-284 - Simplify-init-flow;-launch-advanced-settings-via-backlog-config.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2025-10-05 11:17'
-updated_date: '2025-10-05 11:45'
+updated_date: '2025-10-06 19:41'
 labels:
   - cli
   - init
@@ -61,4 +61,9 @@ Init currently prompts for many settings (branch checks, remote, zero-padding, e
 - Simplified `backlog init` interactive flow to project name → agent instructions → advanced confirmation, applying safe defaults when skipped.
 - Updated docs plus added unit coverage for wizard/config flows and CLI summary output.
 - Tests: `bunx tsc --noEmit`, `bun run check .`, `bun test`.
+
+Reopening after Codex review on PR 385 flagged missing `backlog config list` subcommand. Investigating CLI regression to restore list handler while preserving other config commands.
+
+- Restored `backlog config list` CLI coverage and added regression test ensuring list/get/set remain available.
+- Tests: bun test src/test/config-commands.test.ts
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-284 - Simplify-init-flow;-launch-advanced-settings-via-backlog-config.md
+++ b/backlog/tasks/task-284 - Simplify-init-flow;-launch-advanced-settings-via-backlog-config.md
@@ -1,0 +1,64 @@
+---
+id: task-284
+title: Simplify init flow; launch advanced settings via backlog config
+status: Done
+assignee:
+  - '@codex'
+created_date: '2025-10-05 11:17'
+updated_date: '2025-10-05 11:45'
+labels:
+  - cli
+  - init
+  - config
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Goal: Make backlog init minimal and move advanced settings to run under backlog config when opted in.
+
+Summary
+- Keep agent instruction selection in init.
+- After that, ask a single confirm: "Configure advanced settings now? (y/N)".
+- If Yes: immediately run `backlog config` (interactive wizard) and then finish init.
+- If No (default): finish init with safe defaults; no other prompts.
+- Preserve all existing flags and non-interactive behavior for backward compatibility.
+
+Context
+Init currently prompts for many settings (branch checks, remote, zero-padding, editor, web UI, etc.). We want a faster first-run and make advanced choices accessible via a dedicated interactive flow at `backlog config` (no subcommand).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Init prompts only: project name ➜ agent instruction selection ➜ advanced confirm (default No).
+- [x] #2 If user selects Yes, launch `backlog config` interactive wizard immediately and return to complete init.
+- [x] #3 Implement default action for `backlog config` (no args) to run an advanced interactive wizard; keep `config list|get|set` working unchanged.
+- [x] #4 Remove other prompts from init (zero-padding, editor, cross-branch, web UI, git hooks) unless advanced=Yes path is taken (then handled in wizard).
+- [x] #5 Honor all existing init flags and `--defaults` to remain non-interactive and not auto-launch the wizard.
+- [x] #6 Re-init: prefill project name with existing; rerun agent selection; advanced confirm behaves the same; wizard preloads current config values.
+- [x] #7 Post-init summary shows project name and which agent instruction files were created/skipped; no advanced details unless wizard ran.
+- [x] #8 backlog config wizard includes: cross-branch (checkActiveBranches, remoteOperations, activeBranchDays), git behavior (bypassGitHooks, autoCommit), ID formatting (zeroPaddedIds width/disabled), editor (defaultEditor with availability check), web UI (defaultPort, autoOpenBrowser).
+- [x] #9 Defaults when wizard is skipped: checkActiveBranches=true, remoteOperations=true, activeBranchDays=30, bypassGitHooks=false, zeroPaddedIds disabled, defaultEditor unset, defaultPort=6420, autoOpenBrowser=true.
+- [x] #10 Docs: Update README init section and mention `backlog config` for advanced options; update any references in AGENTS.md if needed.
+- [x] #11 Tests: add/adjust tests for new init flow ordering, advanced confirm default=No, and `backlog config` default action; keep existing tests passing (agent files, flags, non-interactive).
+- [x] #12 Backwards compatibility: existing scripts/CI using init flags or `--defaults` continue to work without wizard launch or extra prompts.
+- [x] #13 Code style/quality: Biome passes; type-check passes; no regressions in TUI flows; final summary output remains concise.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Extract the existing advanced init prompts into a reusable helper and wire it as the default `backlog config` wizard.
+2. Rework `backlog init` interactive flow to only ask for project name, agent instructions, and the advanced-settings confirm that launches the wizard when accepted.
+3. Update docs and automated tests to match the new flow, ensuring defaults and flag-based behaviors remain unchanged.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Refactored init advanced prompts into a reusable wizard, reused by `backlog config` and exposed via a new helper.
+- Simplified `backlog init` interactive flow to project name → agent instructions → advanced confirmation, applying safe defaults when skipped.
+- Updated docs plus added unit coverage for wizard/config flows and CLI summary output.
+- Tests: `bunx tsc --noEmit`, `bun run check .`, `bun test`.
+<!-- SECTION:NOTES:END -->

--- a/src/commands/advanced-config-wizard.ts
+++ b/src/commands/advanced-config-wizard.ts
@@ -1,0 +1,242 @@
+import prompts from "prompts";
+import type { BacklogConfig } from "../types/index.ts";
+import { isEditorAvailable } from "../utils/editor.ts";
+
+export type PromptRunner = (...args: Parameters<typeof prompts>) => ReturnType<typeof prompts>;
+
+interface WizardOptions {
+	existingConfig?: BacklogConfig | null;
+	cancelMessage: string;
+	includeClaudePrompt?: boolean;
+	promptImpl?: PromptRunner;
+}
+
+export interface AdvancedConfigWizardResult {
+	config: Partial<BacklogConfig>;
+	installClaudeAgent: boolean;
+}
+
+function handlePromptCancel(message: string) {
+	console.log(message);
+	process.exit(1);
+}
+
+export async function runAdvancedConfigWizard({
+	existingConfig,
+	cancelMessage,
+	includeClaudePrompt = false,
+	promptImpl = prompts,
+}: WizardOptions): Promise<AdvancedConfigWizardResult> {
+	const onCancel = () => handlePromptCancel(cancelMessage);
+	const config = existingConfig ?? null;
+
+	let checkActiveBranches = config?.checkActiveBranches ?? true;
+	let remoteOperations = config?.remoteOperations ?? true;
+	let activeBranchDays = config?.activeBranchDays ?? 30;
+	let bypassGitHooks = config?.bypassGitHooks ?? false;
+	let autoCommit = config?.autoCommit ?? false;
+	let zeroPaddedIds = config?.zeroPaddedIds;
+	let defaultEditor = config?.defaultEditor;
+	let defaultPort = config?.defaultPort ?? 6420;
+	let autoOpenBrowser = config?.autoOpenBrowser ?? true;
+	let installClaudeAgent = false;
+
+	const crossBranchPrompt = await promptImpl(
+		{
+			type: "confirm",
+			name: "checkActiveBranches",
+			message: "Check task states across active branches?",
+			hint: "Ensures accurate task tracking across branches (may impact performance on large repos)",
+			initial: checkActiveBranches,
+		},
+		{ onCancel },
+	);
+	checkActiveBranches = crossBranchPrompt.checkActiveBranches ?? true;
+
+	if (checkActiveBranches) {
+		const remotePrompt = await promptImpl(
+			{
+				type: "confirm",
+				name: "remoteOperations",
+				message: "Check task states in remote branches?",
+				hint: "Required for accessing tasks from feature branches on remote repos",
+				initial: remoteOperations,
+			},
+			{ onCancel },
+		);
+		remoteOperations = remotePrompt.remoteOperations ?? remoteOperations;
+
+		const daysPrompt = await promptImpl(
+			{
+				type: "number",
+				name: "activeBranchDays",
+				message: "How many days should a branch be considered active?",
+				hint: "Lower values improve performance (default: 30 days)",
+				initial: activeBranchDays,
+				min: 1,
+				max: 365,
+			},
+			{ onCancel },
+		);
+		if (typeof daysPrompt.activeBranchDays === "number" && !Number.isNaN(daysPrompt.activeBranchDays)) {
+			activeBranchDays = daysPrompt.activeBranchDays;
+		}
+	} else {
+		remoteOperations = false;
+	}
+
+	const gitHooksPrompt = await promptImpl(
+		{
+			type: "confirm",
+			name: "bypassGitHooks",
+			message: "Bypass git hooks when committing?",
+			hint: "Use --no-verify flag to skip pre-commit hooks",
+			initial: bypassGitHooks,
+		},
+		{ onCancel },
+	);
+	bypassGitHooks = gitHooksPrompt.bypassGitHooks ?? bypassGitHooks;
+
+	const autoCommitPrompt = await promptImpl(
+		{
+			type: "confirm",
+			name: "autoCommit",
+			message: "Enable automatic commits for Backlog operations?",
+			hint: "Creates commits automatically after CLI changes",
+			initial: autoCommit,
+		},
+		{ onCancel },
+	);
+	autoCommit = autoCommitPrompt.autoCommit ?? autoCommit;
+
+	const zeroPaddingPrompt = await promptImpl(
+		{
+			type: "confirm",
+			name: "enableZeroPadding",
+			message: "Enable zero-padded IDs for consistent formatting?",
+			hint: "Example: task-001, doc-001 instead of task-1, doc-1",
+			initial: (zeroPaddedIds ?? 0) > 0,
+		},
+		{ onCancel },
+	);
+
+	if (zeroPaddingPrompt.enableZeroPadding) {
+		const paddingPrompt = await promptImpl(
+			{
+				type: "number",
+				name: "paddingWidth",
+				message: "Number of digits for zero-padding:",
+				hint: "e.g., 3 creates task-001; 4 creates task-0001",
+				initial: zeroPaddedIds ?? 3,
+				min: 1,
+				max: 10,
+			},
+			{ onCancel },
+		);
+		if (typeof paddingPrompt?.paddingWidth === "number" && !Number.isNaN(paddingPrompt.paddingWidth)) {
+			zeroPaddedIds = paddingPrompt.paddingWidth;
+		}
+	} else {
+		zeroPaddedIds = undefined;
+	}
+
+	const editorPrompt = await promptImpl(
+		{
+			type: "text",
+			name: "editor",
+			message: "Default editor command (leave blank to use system default):",
+			hint: "e.g., 'code --wait', 'vim', 'nano'",
+			initial: defaultEditor ?? "",
+		},
+		{ onCancel },
+	);
+
+	let editorResult = String(editorPrompt.editor ?? "").trim();
+	if (editorResult.length > 0) {
+		const isAvailable = await isEditorAvailable(editorResult);
+		if (!isAvailable) {
+			console.warn(`Warning: Editor command '${editorResult}' not found in PATH`);
+			const confirmAnyway = await promptImpl(
+				{
+					type: "confirm",
+					name: "confirm",
+					message: "Editor not found. Set it anyway?",
+					initial: false,
+				},
+				{ onCancel },
+			);
+			if (!confirmAnyway?.confirm) {
+				editorResult = "";
+			}
+		}
+	}
+	defaultEditor = editorResult.length > 0 ? editorResult : undefined;
+
+	const webUIPrompt = await promptImpl(
+		{
+			type: "confirm",
+			name: "configureWebUI",
+			message: "Configure web UI settings now?",
+			hint: "Port and browser auto-open",
+			initial: false,
+		},
+		{ onCancel },
+	);
+
+	if (webUIPrompt.configureWebUI) {
+		const webUIValues = await promptImpl(
+			[
+				{
+					type: "number",
+					name: "defaultPort",
+					message: "Default web UI port:",
+					hint: "Port number for the web interface (1-65535)",
+					initial: defaultPort,
+					min: 1,
+					max: 65535,
+				},
+				{
+					type: "confirm",
+					name: "autoOpenBrowser",
+					message: "Automatically open browser when starting web UI?",
+					hint: "When enabled, 'backlog web' opens your browser",
+					initial: autoOpenBrowser,
+				},
+			],
+			{ onCancel },
+		);
+		if (typeof webUIValues?.defaultPort === "number" && !Number.isNaN(webUIValues.defaultPort)) {
+			defaultPort = webUIValues.defaultPort;
+		}
+		autoOpenBrowser = Boolean(webUIValues?.autoOpenBrowser ?? autoOpenBrowser);
+	}
+
+	if (includeClaudePrompt) {
+		const claudePrompt = await promptImpl(
+			{
+				type: "confirm",
+				name: "installClaudeAgent",
+				message: "Install Claude Code Backlog.md agent?",
+				hint: "Adds configuration under .claude/agents/",
+				initial: false,
+			},
+			{ onCancel },
+		);
+		installClaudeAgent = Boolean(claudePrompt?.installClaudeAgent);
+	}
+
+	return {
+		config: {
+			checkActiveBranches,
+			remoteOperations,
+			activeBranchDays,
+			bypassGitHooks,
+			autoCommit,
+			zeroPaddedIds,
+			defaultEditor,
+			defaultPort,
+			autoOpenBrowser,
+		},
+		installClaudeAgent,
+	};
+}

--- a/src/commands/configure-advanced-settings.ts
+++ b/src/commands/configure-advanced-settings.ts
@@ -1,0 +1,30 @@
+import type { Core } from "../core/backlog.ts";
+import type { BacklogConfig } from "../types/index.ts";
+import { type PromptRunner, runAdvancedConfigWizard } from "./advanced-config-wizard.ts";
+
+interface ConfigureAdvancedOptions {
+	promptImpl?: PromptRunner;
+	cancelMessage?: string;
+}
+
+export async function configureAdvancedSettings(
+	core: Core,
+	{ promptImpl, cancelMessage = "Aborting configuration." }: ConfigureAdvancedOptions = {},
+): Promise<{ mergedConfig: BacklogConfig; installClaudeAgent: boolean }> {
+	const existingConfig = await core.filesystem.loadConfig();
+	if (!existingConfig) {
+		throw new Error("No backlog project found. Initialize one first with: backlog init");
+	}
+
+	const wizardResult = await runAdvancedConfigWizard({
+		existingConfig,
+		cancelMessage,
+		includeClaudePrompt: true,
+		promptImpl,
+	});
+
+	const mergedConfig: BacklogConfig = { ...existingConfig, ...wizardResult.config };
+	await core.filesystem.saveConfig(mergedConfig);
+
+	return { mergedConfig, installClaudeAgent: wizardResult.installClaudeAgent };
+}

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -183,6 +183,22 @@ describe("CLI Integration", () => {
 			expect(output).toContain("Skipping agent instruction files per selection.");
 		});
 
+		it("should print minimal summary when advanced settings are skipped", async () => {
+			await $`git init -b main`.cwd(TEST_DIR).quiet();
+			await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+			await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+			const output = await $`bun ${CLI_PATH} init SummaryProj --defaults --agent-instructions none`
+				.cwd(TEST_DIR)
+				.text();
+
+			expect(output).toContain("Initialization Summary:");
+			expect(output).toContain("Project Name: SummaryProj");
+			expect(output).toContain("Advanced settings: unchanged");
+			expect(output).not.toContain("Remote operations:");
+			expect(output).not.toContain("Zero-padded IDs:");
+		});
+
 		it("should ignore 'none' when other agent instructions are provided", async () => {
 			await $`git init -b main`.cwd(TEST_DIR).quiet();
 			await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
 import { $ } from "bun";
+import type { PromptRunner } from "../commands/advanced-config-wizard.ts";
+import { configureAdvancedSettings } from "../commands/configure-advanced-settings.ts";
 import { Core } from "../core/backlog.ts";
 import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
 
@@ -21,6 +23,85 @@ describe("Config commands", () => {
 
 		core = new Core(TEST_DIR);
 		await core.initializeProject("Test Config Project");
+	});
+
+	function createPromptStub(sequence: Array<Record<string, unknown>>): PromptRunner {
+		const stub: PromptRunner = async () => {
+			return sequence.shift() ?? {};
+		};
+		return stub;
+	}
+
+	it("configureAdvancedSettings keeps defaults when no changes requested", async () => {
+		const promptStub = createPromptStub([
+			{ checkActiveBranches: true },
+			{ remoteOperations: true },
+			{ activeBranchDays: 30 },
+			{ bypassGitHooks: false },
+			{ autoCommit: false },
+			{ enableZeroPadding: false },
+			{ editor: "" },
+			{ configureWebUI: false },
+			{ installClaudeAgent: false },
+		]);
+
+		const { mergedConfig, installClaudeAgent } = await configureAdvancedSettings(core, {
+			promptImpl: promptStub,
+		});
+
+		expect(installClaudeAgent).toBe(false);
+		expect(mergedConfig.checkActiveBranches).toBe(true);
+		expect(mergedConfig.remoteOperations).toBe(true);
+		expect(mergedConfig.activeBranchDays).toBe(30);
+		expect(mergedConfig.bypassGitHooks).toBe(false);
+		expect(mergedConfig.autoCommit).toBe(false);
+		expect(mergedConfig.zeroPaddedIds).toBeUndefined();
+		expect(mergedConfig.defaultEditor).toBeUndefined();
+		expect(mergedConfig.defaultPort).toBe(6420);
+		expect(mergedConfig.autoOpenBrowser).toBe(true);
+
+		const reloadedConfig = await core.filesystem.loadConfig();
+		expect(reloadedConfig?.defaultPort).toBe(6420);
+		expect(reloadedConfig?.autoOpenBrowser).toBe(true);
+	});
+
+	it("configureAdvancedSettings applies wizard selections", async () => {
+		const promptStub = createPromptStub([
+			{ checkActiveBranches: true },
+			{ remoteOperations: false },
+			{ activeBranchDays: 14 },
+			{ bypassGitHooks: true },
+			{ autoCommit: true },
+			{ enableZeroPadding: true },
+			{ paddingWidth: 4 },
+			{ editor: "echo" },
+			{ configureWebUI: true },
+			{ defaultPort: 7007, autoOpenBrowser: false },
+			{ installClaudeAgent: true },
+		]);
+
+		const { mergedConfig, installClaudeAgent } = await configureAdvancedSettings(core, {
+			promptImpl: promptStub,
+		});
+
+		expect(installClaudeAgent).toBe(true);
+		expect(mergedConfig.checkActiveBranches).toBe(true);
+		expect(mergedConfig.remoteOperations).toBe(false);
+		expect(mergedConfig.activeBranchDays).toBe(14);
+		expect(mergedConfig.bypassGitHooks).toBe(true);
+		expect(mergedConfig.autoCommit).toBe(true);
+		expect(mergedConfig.zeroPaddedIds).toBe(4);
+		expect(mergedConfig.defaultEditor).toBe("echo");
+		expect(mergedConfig.defaultPort).toBe(7007);
+		expect(mergedConfig.autoOpenBrowser).toBe(false);
+
+		const reloadedConfig = await core.filesystem.loadConfig();
+		expect(reloadedConfig?.zeroPaddedIds).toBe(4);
+		expect(reloadedConfig?.defaultEditor).toBe("echo");
+		expect(reloadedConfig?.defaultPort).toBe(7007);
+		expect(reloadedConfig?.autoOpenBrowser).toBe(false);
+		expect(reloadedConfig?.bypassGitHooks).toBe(true);
+		expect(reloadedConfig?.autoCommit).toBe(true);
 	});
 
 	afterEach(async () => {

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
 import { $ } from "bun";
 import type { PromptRunner } from "../commands/advanced-config-wizard.ts";
 import { configureAdvancedSettings } from "../commands/configure-advanced-settings.ts";
@@ -7,6 +8,7 @@ import { Core } from "../core/backlog.ts";
 import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
 
 let TEST_DIR: string;
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 
 describe("Config commands", () => {
 	let core: Core;
@@ -102,6 +104,16 @@ describe("Config commands", () => {
 		expect(reloadedConfig?.autoOpenBrowser).toBe(false);
 		expect(reloadedConfig?.bypassGitHooks).toBe(true);
 		expect(reloadedConfig?.autoCommit).toBe(true);
+	});
+
+	it("exposes config list/get/set subcommands", async () => {
+		const listOutput = await $`bun ${CLI_PATH} config list`.cwd(TEST_DIR).text();
+		expect(listOutput).toContain("Configuration:");
+
+		await $`bun ${CLI_PATH} config set defaultPort 7001`.cwd(TEST_DIR).quiet();
+
+		const portOutput = await $`bun ${CLI_PATH} config get defaultPort`.cwd(TEST_DIR).text();
+		expect(portOutput.trim()).toBe("7001");
 	});
 
 	afterEach(async () => {


### PR DESCRIPTION
- Refactored init advanced prompts into a reusable wizard, reused by `backlog config` and exposed via a new helper.
- Simplified `backlog init` interactive flow to project name → agent instructions → advanced confirmation, applying safe defaults when skipped.
- Updated docs plus added unit coverage for wizard/config flows and CLI summary output.
- Tests: `bunx tsc --noEmit`, `bun run check .`, `bun test`.