### PR TITLE
TASK-326 - Add local branch task discovery to board loading

### DIFF
--- a/backlog/tasks/task-324 - Add-browser-UI-initialization-flow-for-uninitialized-projects.md
+++ b/backlog/tasks/task-324 - Add-browser-UI-initialization-flow-for-uninitialized-projects.md
@@ -4,7 +4,7 @@ title: Add browser UI initialization flow for uninitialized projects
 status: Done
 assignee: []
 created_date: '2025-11-30 14:51'
-updated_date: '2025-11-30 15:12'
+updated_date: '2025-11-30 19:20'
 labels:
   - enhancement
   - browser
@@ -177,5 +177,5 @@ Final: Initialize
 - `src/web/lib/api.ts` - Full options support
 - `src/web/App.tsx` - Init status check
 
-Build passes, tests pass, committed to `tasks/task-324-browser-init-flow` branch.
+Build passes, tests pass.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-326 - Add-local-branch-task-discovery-to-board-loading.md
+++ b/backlog/tasks/task-326 - Add-local-branch-task-discovery-to-board-loading.md
@@ -1,0 +1,60 @@
+---
+id: task-326
+title: Add local branch task discovery to board loading
+status: Done
+assignee: []
+created_date: '2025-11-30 19:20'
+updated_date: '2025-11-30 19:20'
+labels:
+  - bug
+  - task-loading
+  - cross-branch
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Tasks created in other local branches (not pushed to remote) were not visible when viewing the board from a different branch.
+
+## Problem
+
+The task loading architecture only checked:
+1. Filesystem (current branch)
+2. Remote branches (`origin/*`)
+
+Tasks in unpushed local branches were invisible.
+
+## Solution
+
+Added local branch task discovery using the same optimized index-first pattern as remote loading:
+
+**Core changes (`src/core/`):**
+- `task-loader.ts`: Added `buildLocalBranchTaskIndex()` to index tasks from local branches
+- `remote-tasks.ts`: Added `loadLocalBranchTasks()` to discover and hydrate local branch tasks
+- `backlog.ts`: Updated `loadBoardTasks()` and `loadAllTasksForStatistics()` to include local branch discovery
+
+**Web UI changes:**
+- `server/index.ts`: Inject local branch tasks into ContentStore on startup; added `crossBranch` query param to `/api/tasks`
+- `web/lib/api.ts`: Default to `crossBranch=true` for task fetching
+
+**Tests:**
+- `src/test/local-branch-tasks.test.ts`: Coverage for index building, branch filtering, task discovery
+
+## Performance
+
+Uses optimized pattern:
+1. Build cheap index without fetching content
+2. Only hydrate tasks that don't exist locally
+3. Respects `activeBranchDays` config for filtering
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Tasks created in local branches are visible from other branches
+- [x] #2 Performance remains acceptable (use recent branches filtering)
+- [x] #3 Conflict resolution works correctly for tasks in multiple local branches
+- [x] #4 Existing remote task loading continues to work
+- [x] #5 Tests cover local branch task discovery
+<!-- AC:END -->

--- a/src/test/local-branch-tasks.test.ts
+++ b/src/test/local-branch-tasks.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import type { TaskWithMetadata } from "../core/remote-tasks.ts";
+import { loadLocalBranchTasks } from "../core/remote-tasks.ts";
+import { buildLocalBranchTaskIndex } from "../core/task-loader.ts";
+import type { GitOperations } from "../git/operations.ts";
+
+// Mock GitOperations for testing
+class MockGitOperations implements Partial<GitOperations> {
+	private currentBranch = "main";
+
+	async getCurrentBranch(): Promise<string> {
+		return this.currentBranch;
+	}
+
+	async listRecentBranches(_daysAgo: number): Promise<string[]> {
+		return ["main", "feature-a", "feature-b", "origin/main"];
+	}
+
+	async getBranchLastModifiedMap(_ref: string, _dir: string): Promise<Map<string, Date>> {
+		const map = new Map<string, Date>();
+		map.set("backlog/tasks/task-1 - Main Task.md", new Date("2025-06-13"));
+		map.set("backlog/tasks/task-2 - Feature Task.md", new Date("2025-06-13"));
+		map.set("backlog/tasks/task-3 - New Task.md", new Date("2025-06-13"));
+		return map;
+	}
+
+	async listFilesInTree(ref: string, _path: string): Promise<string[]> {
+		// Main branch has task-1 and task-2
+		if (ref === "main") {
+			return ["backlog/tasks/task-1 - Main Task.md", "backlog/tasks/task-2 - Feature Task.md"];
+		}
+		// feature-a has task-1 and task-3 (task-3 is new)
+		if (ref === "feature-a") {
+			return ["backlog/tasks/task-1 - Main Task.md", "backlog/tasks/task-3 - New Task.md"];
+		}
+		// feature-b has task-2
+		if (ref === "feature-b") {
+			return ["backlog/tasks/task-2 - Feature Task.md"];
+		}
+		return [];
+	}
+
+	async showFile(_ref: string, file: string): Promise<string> {
+		if (file.includes("task-1")) {
+			return `---
+id: task-1
+title: Main Task
+status: To Do
+assignee: []
+created_date: 2025-06-13
+labels: []
+dependencies: []
+---\n\n## Description\n\nMain task`;
+		}
+		if (file.includes("task-2")) {
+			return `---
+id: task-2
+title: Feature Task
+status: In Progress
+assignee: []
+created_date: 2025-06-13
+labels: []
+dependencies: []
+---\n\n## Description\n\nFeature task`;
+		}
+		if (file.includes("task-3")) {
+			return `---
+id: task-3
+title: New Task
+status: To Do
+assignee: []
+created_date: 2025-06-13
+labels: []
+dependencies: []
+---\n\n## Description\n\nNew task from feature-a branch`;
+		}
+		return "";
+	}
+}
+
+describe("Local branch task discovery", () => {
+	let consoleDebugSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		consoleDebugSpy = spyOn(console, "debug");
+	});
+
+	afterEach(() => {
+		consoleDebugSpy?.mockRestore();
+	});
+
+	describe("buildLocalBranchTaskIndex", () => {
+		it("should build index from local branches excluding current branch", async () => {
+			const mockGit = new MockGitOperations() as unknown as GitOperations;
+			const branches = ["main", "feature-a", "feature-b", "origin/main"];
+
+			const index = await buildLocalBranchTaskIndex(mockGit, branches, "main", "backlog");
+
+			// Should find task-3 from feature-a (not in main)
+			expect(index.has("task-3")).toBe(true);
+			const task3Entries = index.get("task-3");
+			expect(task3Entries?.length).toBe(1);
+			expect(task3Entries?.[0]?.branch).toBe("feature-a");
+
+			// Should find task-1 and task-2 from other branches
+			expect(index.has("task-1")).toBe(true);
+			expect(index.has("task-2")).toBe(true);
+		});
+
+		it("should exclude origin/ branches", async () => {
+			const mockGit = new MockGitOperations() as unknown as GitOperations;
+			const branches = ["main", "feature-a", "origin/feature-a"];
+
+			const index = await buildLocalBranchTaskIndex(mockGit, branches, "main", "backlog");
+
+			// Should only have entries from feature-a (local), not origin/feature-a
+			const task1Entries = index.get("task-1");
+			expect(task1Entries?.every((e) => e.branch === "feature-a")).toBe(true);
+		});
+
+		it("should exclude current branch", async () => {
+			const mockGit = new MockGitOperations() as unknown as GitOperations;
+			const branches = ["main", "feature-a"];
+
+			const index = await buildLocalBranchTaskIndex(mockGit, branches, "main", "backlog");
+
+			// task-1 should only be from feature-a, not main
+			const task1Entries = index.get("task-1");
+			expect(task1Entries?.every((e) => e.branch !== "main")).toBe(true);
+		});
+	});
+
+	describe("loadLocalBranchTasks", () => {
+		it("should discover tasks from other local branches", async () => {
+			const mockGit = new MockGitOperations() as unknown as GitOperations;
+
+			const progressMessages: string[] = [];
+			const localBranchTasks = await loadLocalBranchTasks(mockGit, null, (msg: string) => {
+				progressMessages.push(msg);
+			});
+
+			// Should find task-3 which only exists in feature-a
+			const task3 = localBranchTasks.find((t) => t.id === "task-3");
+			expect(task3).toBeDefined();
+			expect(task3?.title).toBe("New Task");
+			expect(task3?.source).toBe("local-branch");
+			expect(task3?.branch).toBe("feature-a");
+
+			// Progress should mention other local branches
+			expect(progressMessages.some((msg) => msg.includes("other local branches"))).toBe(true);
+		});
+
+		it("should skip tasks that exist in filesystem when provided", async () => {
+			const mockGit = new MockGitOperations() as unknown as GitOperations;
+
+			// Simulate that task-1 already exists in filesystem
+			const localTasks: TaskWithMetadata[] = [
+				{
+					id: "task-1",
+					title: "Main Task (local)",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-13",
+					labels: [],
+					dependencies: [],
+					source: "local",
+				},
+			];
+
+			const localBranchTasks = await loadLocalBranchTasks(mockGit, null, undefined, localTasks);
+
+			// task-3 should be found (not in local tasks)
+			expect(localBranchTasks.some((t) => t.id === "task-3")).toBe(true);
+
+			// task-1 should not be hydrated since it exists locally
+			// (unless the remote version is newer, which in this mock it's not)
+			// The behavior depends on whether the remote version is newer
+		});
+
+		it("should return empty array when on detached HEAD", async () => {
+			const mockGit = {
+				getCurrentBranch: async () => "",
+			} as unknown as GitOperations;
+
+			const tasks = await loadLocalBranchTasks(mockGit, null);
+			expect(tasks).toEqual([]);
+		});
+
+		it("should return empty when only current branch exists", async () => {
+			const mockGit = {
+				getCurrentBranch: async () => "main",
+				listRecentBranches: async () => ["main"],
+			} as unknown as GitOperations;
+
+			const tasks = await loadLocalBranchTasks(mockGit, null);
+			expect(tasks).toEqual([]);
+		});
+	});
+});

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -129,12 +129,15 @@ export class ApiClient {
 		assignee?: string;
 		parent?: string;
 		priority?: SearchPriorityFilter;
+		crossBranch?: boolean;
 	}): Promise<Task[]> {
 		const params = new URLSearchParams();
 		if (options?.status) params.append("status", options.status);
 		if (options?.assignee) params.append("assignee", options.assignee);
 		if (options?.parent) params.append("parent", options.parent);
 		if (options?.priority) params.append("priority", options.priority);
+		// Default to true for cross-branch loading to match TUI behavior
+		if (options?.crossBranch !== false) params.append("crossBranch", "true");
 
 		const url = `${API_BASE}/tasks${params.toString() ? `?${params.toString()}` : ""}`;
 		return this.fetchJson<Task[]>(url);


### PR DESCRIPTION
- [x] Tasks created in local branches are visible from other branches
- [x] Performance remains acceptable (use recent branches filtering)
- [x] Conflict resolution works correctly for tasks in multiple local branches
- [x] Existing remote task loading continues to work
- [x] Tests cover local branch task discovery