### PR TITLE
TASK-327 - Fix loadTaskById to search remote branches

### DIFF
--- a/backlog/tasks/task-327 - Fix-loadTaskById-to-search-remote-branches.md
+++ b/backlog/tasks/task-327 - Fix-loadTaskById-to-search-remote-branches.md
@@ -1,0 +1,63 @@
+---
+id: task-327
+title: Fix loadTaskById to search remote branches
+status: Done
+assignee: []
+created_date: '2025-11-30 20:46'
+updated_date: '2025-11-30 20:46'
+labels:
+  - bug
+  - task-loading
+  - cross-branch
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+When viewing a task with `task view <id>`, if the task exists in a remote branch (e.g., `origin/test`) but not in the local filesystem, it would show "Task not found" even though the task is visible in the board and web UI.
+
+This was because `loadTaskById()` only checked the local filesystem via `fs.loadTask()`, while `loadBoardTasks()` properly loads from remote and local branches.
+
+## Root Cause
+
+The `loadTaskById` function in `src/core/backlog.ts` was only checking the local filesystem:
+
+```typescript
+async loadTaskById(taskId: string): Promise<Task | null> {
+  const canonicalId = normalizeTaskId(taskId);
+  return await this.fs.loadTask(canonicalId);
+}
+```
+
+## Solution
+
+Updated `loadTaskById` to search in order:
+1. Local filesystem (current branch)
+2. Other local branches (using `findTaskInLocalBranches`)
+3. Remote branches (using `findTaskInRemoteBranches`)
+
+Added two new helper functions to `task-loader.ts`:
+- `findTaskInRemoteBranches()` - finds and hydrates a task from remote branches
+- `findTaskInLocalBranches()` - finds and hydrates a task from other local branches
+
+Both functions use the same optimized index-first, hydrate-later pattern as `loadRemoteTasks()`.
+
+## Files Changed
+
+- `src/core/task-loader.ts`: Added `findTaskInRemoteBranches()` and `findTaskInLocalBranches()`
+- `src/core/backlog.ts`: Updated `loadTaskById()` to use branch search functions
+- `src/test/find-task-in-branches.test.ts`: Added tests for new functions
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Tasks in remote branches are viewable via `task view <id>`
+- [x] #2 Tasks in other local branches are viewable via `task view <id>`
+- [x] #3 Respects remoteOperations config setting
+- [x] #4 Uses activeBranchDays config for branch filtering
+- [x] #5 Tests cover the new functions
+<!-- AC:END -->

--- a/src/test/find-task-in-branches.test.ts
+++ b/src/test/find-task-in-branches.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+import { findTaskInLocalBranches, findTaskInRemoteBranches } from "../core/task-loader.ts";
+
+describe("findTaskInRemoteBranches", () => {
+	it("should return null when git has no remotes", async () => {
+		const mockGit = {
+			hasAnyRemote: async () => false,
+		};
+		const result = await findTaskInRemoteBranches(mockGit as any, "task-999");
+		expect(result).toBeNull();
+	});
+
+	it("should return null when no branches exist", async () => {
+		const mockGit = {
+			hasAnyRemote: async () => true,
+			listRecentRemoteBranches: async () => [],
+		};
+		const result = await findTaskInRemoteBranches(mockGit as any, "task-999");
+		expect(result).toBeNull();
+	});
+
+	it("should return null when task is not in any branch", async () => {
+		const mockGit = {
+			hasAnyRemote: async () => true,
+			listRecentRemoteBranches: async () => ["main"],
+			listFilesInTree: async () => ["backlog/tasks/task-1 - some task.md"],
+			getBranchLastModifiedMap: async () => new Map([["backlog/tasks/task-1 - some task.md", new Date()]]),
+		};
+		const result = await findTaskInRemoteBranches(mockGit as any, "task-999");
+		expect(result).toBeNull();
+	});
+
+	it("should find and load task from remote branch", async () => {
+		const mockTaskContent = `---
+id: task-123
+title: Test Task
+status: To Do
+assignee: []
+created_date: '2025-01-01 12:00'
+labels: []
+dependencies: []
+---
+
+## Description
+
+Test description
+`;
+		const mockGit = {
+			hasAnyRemote: async () => true,
+			listRecentRemoteBranches: async () => ["feature"],
+			listFilesInTree: async () => ["backlog/tasks/task-123 - Test Task.md"],
+			getBranchLastModifiedMap: async () =>
+				new Map([["backlog/tasks/task-123 - Test Task.md", new Date("2025-01-01")]]),
+			showFile: async () => mockTaskContent,
+		};
+
+		const result = await findTaskInRemoteBranches(mockGit as any, "task-123");
+		expect(result).not.toBeNull();
+		expect(result?.id).toBe("task-123");
+		expect(result?.source).toBe("remote");
+		expect(result?.branch).toBe("feature");
+	});
+});
+
+describe("findTaskInLocalBranches", () => {
+	it("should return null when on detached HEAD", async () => {
+		const mockGit = {
+			getCurrentBranch: async () => null,
+		};
+		const result = await findTaskInLocalBranches(mockGit as any, "task-999");
+		expect(result).toBeNull();
+	});
+
+	it("should return null when only current branch exists", async () => {
+		const mockGit = {
+			getCurrentBranch: async () => "main",
+			listRecentBranches: async () => ["main"],
+		};
+		const result = await findTaskInLocalBranches(mockGit as any, "task-999");
+		expect(result).toBeNull();
+	});
+
+	it("should find and load task from another local branch", async () => {
+		const mockTaskContent = `---
+id: task-456
+title: Local Branch Task
+status: In Progress
+assignee: []
+created_date: '2025-01-01 12:00'
+labels: []
+dependencies: []
+---
+
+## Description
+
+From local branch
+`;
+		const mockGit = {
+			getCurrentBranch: async () => "main",
+			listRecentBranches: async () => ["main", "feature-branch"],
+			listFilesInTree: async () => ["backlog/tasks/task-456 - Local Branch Task.md"],
+			getBranchLastModifiedMap: async () =>
+				new Map([["backlog/tasks/task-456 - Local Branch Task.md", new Date("2025-01-01")]]),
+			showFile: async () => mockTaskContent,
+		};
+
+		const result = await findTaskInLocalBranches(mockGit as any, "task-456");
+		expect(result).not.toBeNull();
+		expect(result?.id).toBe("task-456");
+		expect(result?.source).toBe("local-branch");
+		expect(result?.branch).toBe("feature-branch");
+	});
+});


### PR DESCRIPTION
- [x] Tasks in remote branches are viewable via `task view <id>`
- [x] Tasks in other local branches are viewable via `task view <id>`
- [x] Respects remoteOperations config setting
- [x] Uses activeBranchDays config for branch filtering
- [x] Tests cover the new functions