### PR TITLE
TASK-335 - Fix CLI to find Backlog.md root from subfolders

### DIFF
--- a/backlog/tasks/task-335 - Fix-CLI-to-find-Backlog.md-root-from-subfolders.md
+++ b/backlog/tasks/task-335 - Fix-CLI-to-find-Backlog.md-root-from-subfolders.md
@@ -1,0 +1,99 @@
+---
+id: task-335
+title: Fix CLI to find Backlog.md root from subfolders
+status: Done
+assignee:
+  - '@claude'
+created_date: '2025-12-04 20:37'
+updated_date: '2025-12-04 20:51'
+labels:
+  - bug
+  - cli
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Running `backlog task list` or other CLI commands from a subfolder of a repository creates a new `backlog/` directory in that subfolder instead of using the one at the repository root.
+
+**Root cause:** The CLI uses `process.cwd()` directly as the project root in all commands. There's no logic to walk up the directory tree to find an existing `backlog.json` or `backlog/` directory.
+
+**Reported in:** https://github.com/MrLesk/Backlog.md/issues/446
+
+**Solution:**
+1. Add a utility function to find the Backlog.md root by walking up the directory tree
+2. Check for `backlog.json` or `backlog/` directory at each level
+3. Fallback to git root via `git rev-parse --show-toplevel`
+4. If no Backlog.md root found, show helpful error: "No Backlog.md project found. Run `backlog init` to initialize."
+5. Don't auto-create `backlog/` structure on read operations (list, view, search) - only `init` should create it
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Running `backlog task list` from a subfolder finds and uses the backlog at repository root
+- [x] #2 Running `backlog task create` from a subfolder creates tasks in the root backlog directory
+- [x] #3 Clear error message shown when no Backlog.md project is found: "No Backlog.md project found. Run `backlog init` to initialize."
+- [x] #4 Read operations (list, view, search) do not auto-create backlog/ directory structure
+- [x] #5 Existing behavior preserved when running from the project root
+- [x] #6 Works correctly in nested git repositories (finds nearest Backlog.md root)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation Plan
+
+### Overview
+Add a `findBacklogRoot()` utility function that walks up the directory tree to find the Backlog.md project root, then use it throughout the CLI instead of raw `process.cwd()`.
+
+### Files to Change
+
+1. **New file: `src/utils/find-backlog-root.ts`**
+   - Create `findBacklogRoot(startDir: string): Promise<string | null>` function
+   - Walk up directory tree checking for `backlog.json` OR `backlog/` directory
+   - Fallback to git root via `git rev-parse --show-toplevel`
+   - Return `null` if no Backlog.md project found
+
+2. **Modify: `src/cli.ts`**
+   - Add helper `getProjectRoot()` that calls `findBacklogRoot()` and handles the error case
+   - Replace ~32 instances of `process.cwd()` with `await getProjectRoot()`
+   - Exception: `init` command should continue using `process.cwd()` (initializes in current directory)
+   - Show clear error: "No Backlog.md project found. Run `backlog init` to initialize."
+
+3. **New file: `src/test/find-backlog-root.test.ts`**
+   - Test finding root from subfolder
+   - Test finding root when at root
+   - Test returning null when no project found
+   - Test nested git repos (finds nearest Backlog.md root)
+
+### Key Design Decisions
+
+1. **Search order**: Check for `backlog/` directory first (more common), then `backlog.json`
+2. **Git fallback**: Only use git root if no `backlog/` or `backlog.json` found walking up
+3. **No auto-creation**: `findBacklogRoot` is read-only; only `init` creates structure
+4. **Caching**: Cache the result within CLI execution to avoid repeated filesystem walks
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Implementation Complete
+
+### Files Created
+- `src/utils/find-backlog-root.ts` - Utility to find Backlog.md project root
+- `src/test/find-backlog-root.test.ts` - 10 tests covering all scenarios
+
+### Files Modified
+- `src/cli.ts` - Added `requireProjectRoot()` helper, replaced 30 `process.cwd()` calls
+
+### Testing Results
+- All 10 new tests pass
+- Manual verification confirms:
+  - `backlog task list` from subfolder finds root correctly
+  - `backlog task create` from subfolder creates in root backlog
+  - Error message shows when no project found
+  - No `backlog/` directory created in subfolders
+- Pre-existing flaky tests in cli-incrementing-ids.test.ts (unrelated)
+<!-- SECTION:NOTES:END -->

--- a/src/test/find-backlog-root.test.ts
+++ b/src/test/find-backlog-root.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+import { clearProjectRootCache, findBacklogRoot } from "../utils/find-backlog-root.ts";
+
+describe("findBacklogRoot", () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		testDir = join(tmpdir(), `backlog-root-test-${Date.now()}`);
+		await mkdir(testDir, { recursive: true });
+		clearProjectRootCache();
+	});
+
+	afterEach(async () => {
+		clearProjectRootCache();
+		try {
+			await rm(testDir, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+	});
+
+	it("should find root when backlog/ directory exists at start dir", async () => {
+		// Create backlog structure at root
+		await mkdir(join(testDir, "backlog", "tasks"), { recursive: true });
+
+		const result = await findBacklogRoot(testDir);
+		expect(result).toBe(testDir);
+	});
+
+	it("should find root when backlog.json exists at start dir", async () => {
+		// Create backlog.json at root
+		await writeFile(join(testDir, "backlog.json"), JSON.stringify({ name: "Test" }));
+
+		const result = await findBacklogRoot(testDir);
+		expect(result).toBe(testDir);
+	});
+
+	it("should find root from a subfolder", async () => {
+		// Create backlog structure at root
+		await mkdir(join(testDir, "backlog", "tasks"), { recursive: true });
+
+		// Create nested subfolder
+		const subfolder = join(testDir, "src", "components", "ui");
+		await mkdir(subfolder, { recursive: true });
+
+		const result = await findBacklogRoot(subfolder);
+		expect(result).toBe(testDir);
+	});
+
+	it("should find root from deeply nested subfolder", async () => {
+		// Create backlog.json at root
+		await writeFile(join(testDir, "backlog.json"), JSON.stringify({ name: "Test" }));
+
+		// Create deeply nested subfolder
+		const deepFolder = join(testDir, "a", "b", "c", "d", "e", "f");
+		await mkdir(deepFolder, { recursive: true });
+
+		const result = await findBacklogRoot(deepFolder);
+		expect(result).toBe(testDir);
+	});
+
+	it("should return null when no backlog project found", async () => {
+		// Create a folder with no backlog setup
+		const emptyFolder = join(testDir, "empty");
+		await mkdir(emptyFolder, { recursive: true });
+
+		const result = await findBacklogRoot(emptyFolder);
+		expect(result).toBeNull();
+	});
+
+	it("should prefer backlog/ directory over git root", async () => {
+		// Initialize git repo
+		await $`git init`.cwd(testDir).quiet();
+
+		// Create backlog in a subfolder (simulating monorepo)
+		const projectFolder = join(testDir, "packages", "my-project");
+		await mkdir(join(projectFolder, "backlog", "tasks"), { recursive: true });
+
+		// Search from within the project
+		const searchDir = join(projectFolder, "src");
+		await mkdir(searchDir, { recursive: true });
+
+		const result = await findBacklogRoot(searchDir);
+		expect(result).toBe(projectFolder);
+	});
+
+	it("should find git root with backlog as fallback", async () => {
+		// Initialize git repo with backlog at root
+		await $`git init`.cwd(testDir).quiet();
+		await mkdir(join(testDir, "backlog", "tasks"), { recursive: true });
+
+		// Create subfolder without its own backlog
+		const subfolder = join(testDir, "packages", "lib");
+		await mkdir(subfolder, { recursive: true });
+
+		const result = await findBacklogRoot(subfolder);
+		expect(result).toBe(testDir);
+	});
+
+	it("should not use git root if it has no backlog setup", async () => {
+		// Initialize git repo WITHOUT backlog
+		await $`git init`.cwd(testDir).quiet();
+
+		// Create subfolder
+		const subfolder = join(testDir, "src");
+		await mkdir(subfolder, { recursive: true });
+
+		const result = await findBacklogRoot(subfolder);
+		expect(result).toBeNull();
+	});
+
+	it("should handle nested git repos - find nearest backlog root", async () => {
+		// Initialize outer git repo with backlog
+		await $`git init`.cwd(testDir).quiet();
+		await mkdir(join(testDir, "backlog", "tasks"), { recursive: true });
+
+		// Create inner project with its own backlog (nested repo scenario)
+		const innerProject = join(testDir, "packages", "inner");
+		await mkdir(innerProject, { recursive: true });
+		await $`git init`.cwd(innerProject).quiet();
+		await mkdir(join(innerProject, "backlog", "tasks"), { recursive: true });
+
+		// Search from within inner project
+		const innerSrc = join(innerProject, "src");
+		await mkdir(innerSrc, { recursive: true });
+
+		const result = await findBacklogRoot(innerSrc);
+		// Should find the inner project's backlog, not the outer one
+		expect(result).toBe(innerProject);
+	});
+
+	it("should handle backlog/ with config.yaml", async () => {
+		// Create backlog structure with config.yaml instead of tasks/
+		await mkdir(join(testDir, "backlog"), { recursive: true });
+		await writeFile(join(testDir, "backlog", "config.yaml"), "name: Test");
+
+		const result = await findBacklogRoot(testDir);
+		expect(result).toBe(testDir);
+	});
+});

--- a/src/utils/find-backlog-root.ts
+++ b/src/utils/find-backlog-root.ts
@@ -1,0 +1,102 @@
+import { stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { $ } from "bun";
+
+/**
+ * Check if a path exists and is a directory
+ */
+async function isDirectory(path: string): Promise<boolean> {
+	try {
+		const s = await stat(path);
+		return s.isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Check if a file exists
+ */
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		const s = await stat(path);
+		return s.isFile();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Finds the Backlog.md project root by walking up the directory tree.
+ *
+ * Search order:
+ * 1. Walk up from startDir looking for `backlog/` directory or `backlog.json` file
+ * 2. If not found, fall back to git repository root (via `git rev-parse --show-toplevel`)
+ * 3. Return null if no Backlog.md project found
+ *
+ * @param startDir - The directory to start searching from (typically process.cwd())
+ * @returns The project root path, or null if no Backlog.md project found
+ */
+export async function findBacklogRoot(startDir: string): Promise<string | null> {
+	let current = startDir;
+
+	// Walk up the directory tree looking for backlog/ or backlog.json
+	while (current !== dirname(current)) {
+		// Check for backlog/ directory
+		const backlogDir = join(current, "backlog");
+		if (await isDirectory(backlogDir)) {
+			return current;
+		}
+
+		// Check for backlog.json file
+		const backlogJson = join(current, "backlog.json");
+		if (await fileExists(backlogJson)) {
+			return current;
+		}
+
+		current = dirname(current);
+	}
+
+	// Fallback: try git repository root
+	try {
+		const result = await $`git rev-parse --show-toplevel`.cwd(startDir).quiet();
+		const gitRoot = result.stdout.toString().trim();
+
+		if (gitRoot) {
+			// Verify the git root has a backlog setup
+			const backlogDir = join(gitRoot, "backlog");
+			const backlogJson = join(gitRoot, "backlog.json");
+
+			if ((await isDirectory(backlogDir)) || (await fileExists(backlogJson))) {
+				return gitRoot;
+			}
+		}
+	} catch {
+		// Not in a git repository or git not available
+	}
+
+	return null;
+}
+
+// Cache for the project root within a single CLI execution
+let cachedProjectRoot: string | null | undefined;
+
+/**
+ * Gets the Backlog.md project root, with caching for performance.
+ * Call clearProjectRootCache() to reset the cache if needed.
+ */
+export async function getProjectRoot(startDir: string): Promise<string | null> {
+	if (cachedProjectRoot !== undefined) {
+		return cachedProjectRoot;
+	}
+
+	cachedProjectRoot = await findBacklogRoot(startDir);
+	return cachedProjectRoot;
+}
+
+/**
+ * Clears the cached project root. Useful for testing.
+ */
+export function clearProjectRootCache(): void {
+	cachedProjectRoot = undefined;
+}


### PR DESCRIPTION
## Summary
- Add `findBacklogRoot()` utility that walks up the directory tree to find the Backlog.md project root
- Fix issue where running CLI commands from subfolders created a new `backlog/` directory instead of using the existing one at the repository root
- Show clear error message when no Backlog.md project is found

## Changes
- Add `src/utils/find-backlog-root.ts` with directory traversal logic
- Add `requireProjectRoot()` helper in CLI that exits with clear error
- Replace 30 `process.cwd()` calls with `requireProjectRoot()`
- Keep `init` command using `process.cwd()` (initializes in current directory)
- Add 10 tests covering all scenarios including nested git repos

## Test plan
- [x] `backlog task list` from subfolder finds root correctly
- [x] `backlog task create` from subfolder creates tasks in root backlog
- [x] Clear error message when no project found: "No Backlog.md project found. Run `backlog init` to initialize."
- [x] No `backlog/` directory created in subfolders
- [x] Existing behavior preserved when running from project root
- [x] Works correctly in nested git repositories

Fixes #446