### PR TITLE
TASK-350 - Fix TUI editor launch leaving terminal keypad mode enabled

### DIFF
--- a/backlog/tasks/task-350 - Fix-TUI-editor-launch-leaving-terminal-keypad-mode-enabled.md
+++ b/backlog/tasks/task-350 - Fix-TUI-editor-launch-leaving-terminal-keypad-mode-enabled.md
@@ -1,7 +1,7 @@
 ---
 id: task-350
 title: Fix TUI editor launch leaving terminal keypad mode enabled
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-12-22 19:22'
@@ -19,9 +19,9 @@ Users report that opening an editor from `backlog board` leaves the terminal in 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Opening a task from `backlog board` with E allows arrow-key navigation in common terminal editors the same way as launching the editor directly.
-- [ ] #2 The board UI restores correctly after the editor exits and continues to accept input.
-- [ ] #3 The terminal is not left in an application cursor/keypad mode after launching an editor from the board.
+- [x] #1 Opening a task from `backlog board` with E allows arrow-key navigation in common terminal editors the same way as launching the editor directly.
+- [x] #2 The board UI restores correctly after the editor exits and continues to accept input.
+- [x] #3 The terminal is not left in an application cursor/keypad mode after launching an editor from the board.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,4 +39,12 @@ Add a raw escape-sequence fallback to disable/restore application cursor mode wh
 
 <!-- SECTION:NOTES:BEGIN -->
 Repro: run `TERM=screen-256color ARROW_DUMP_FILE=tmp/arrow-board.txt EDITOR=./tmp/arrow-dump.sh bun run cli board` inside tmux, press E then an arrow key. Before fix the sequence captured was `1b4f41` (application mode); after fix it is `1b5b41` (normal mode).
+
+**Final fix (2026-01-01):** Added SGR reset and cursor visibility sequences to `Core.openEditor` in `src/core/backlog.ts`:
+- `\u001b[0m` - Reset all SGR attributes (fixes white background issue in nano)
+- `\u001b[?25h` - Show cursor (ensure cursor is visible)
+- `\u001b[?1l` - Reset DECCKM (cursor keys send CSI sequences)
+- `\u001b>` - DECKPNM (numeric keypad mode)
+
+Verified with ttyd + Chrome DevTools MCP that cursor is visible and arrow keys work correctly in nano editor.
 <!-- SECTION:NOTES:END -->

--- a/src/types/neo-neo-bblessed.d.ts
+++ b/src/types/neo-neo-bblessed.d.ts
@@ -1,6 +1,16 @@
 declare module "neo-neo-bblessed" {
 	export interface ProgramInterface {
+		disableMouse(): void;
+		enableMouse(): void;
+		hideCursor(): void;
+		showCursor(): void;
+		input: NodeJS.EventEmitter;
 		pause?: () => (() => void) | undefined;
+		flush?: () => void;
+		put?: {
+			keypad_local?: () => void;
+			keypad_xmit?: () => void;
+		};
 	}
 
 	export interface ScreenOptions {
@@ -11,7 +21,7 @@ declare module "neo-neo-bblessed" {
 	}
 
 	export interface ScreenInterface {
-		program?: ProgramInterface;
+		program: ProgramInterface;
 		key(keys: string | string[], callback: (...args: unknown[]) => void): void;
 		on(event: string, callback: (...args: unknown[]) => void): void;
 		append(el: ElementInterface): void;
@@ -22,6 +32,8 @@ declare module "neo-neo-bblessed" {
 		height: number;
 		emit(event: string): void;
 		title?: string;
+		leave(): void;
+		enter(): void;
 	}
 
 	export interface ElementInterface {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -560,14 +560,14 @@ export async function renderBoardTui(
 				columns[currentCol]?.list.focus();
 			});
 
-			contentArea.key(["e", "E"], async () => {
+			contentArea.key(["e", "E", "S-e"], async () => {
 				await openTaskEditor(task);
 			});
 
 			screen.render();
 		});
 
-		screen.key(["e", "E"], async () => {
+		screen.key(["e", "E", "S-e"], async () => {
 			if (popupOpen) return;
 			const column = columns[currentCol];
 			if (!column) return;
@@ -643,7 +643,7 @@ export async function renderBoardTui(
 			renderView();
 		};
 
-		screen.key(["m", "M"], async () => {
+		screen.key(["m", "M", "S-m"], async () => {
 			if (popupOpen) return;
 
 			if (!moveOp) {


### PR DESCRIPTION
- [x] Opening a task from `backlog board` with E allows arrow-key navigation in common terminal editors the same way as launching the editor directly.
- [x] The board UI restores correctly after the editor exits and continues to accept input.
- [x] The terminal is not left in an application cursor/keypad mode after launching an editor from the board.

Fixes #457, fixes #372 