### PR TITLE
BACK-365 - Fix acceptance criteria insertion adding blank lines

### DIFF
--- a/backlog/tasks/back-365 - Fix-acceptance-criteria-insertion-adding-blank-lines.md
+++ b/backlog/tasks/back-365 - Fix-acceptance-criteria-insertion-adding-blank-lines.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-365
 title: Fix acceptance criteria insertion adding blank lines
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-01-15 21:42'
+updated_date: '2026-01-16 17:04'
 labels: []
 dependencies: []
 ---
@@ -16,7 +18,43 @@ Users report that adding a new acceptance criteria always inserts an empty line 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Adding a new acceptance criteria does not insert an extra empty line above the new entry.
-- [ ] #2 Existing acceptance criteria lists remain unchanged unless the user explicitly adds blank lines.
-- [ ] #3 Adding multiple acceptance criteria in sequence results in a contiguous list without blank lines by default.
+- [x] #1 Adding a new acceptance criteria does not insert an extra empty line above the new entry.
+- [x] #2 Existing acceptance criteria lists remain unchanged unless the user explicitly adds blank lines.
+- [x] #3 Adding multiple acceptance criteria in sequence results in a contiguous list without blank lines by default.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Root Cause
+When extracting existing AC body from markdown, the regex captures a trailing newline before `<!-- AC:END -->`. When split by `\n`, this produces an empty string at the end of `sourceLines`. The loop preserves non-checkbox lines (including this empty string), causing a blank line before newly added criteria.
+
+## Fix
+Add `.trimEnd()` to existingBody before splitting in `composeAcceptanceCriteriaBody()` (line 386 of structured-sections.ts):
+```typescript
+const sourceLines = existingBody ? existingBody.replace(/\r\n/g, "\n").trimEnd().split("\n") : [];
+```
+
+## Testing
+1. Add test case for blank line bug
+2. Verify existing AC tests pass
+3. Clean up test task BACK-367
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Implementation Summary
+
+**Root Cause**: The `composeAcceptanceCriteriaBody()` function in `src/markdown/structured-sections.ts` was splitting the existingBody without trimming trailing newlines. This caused empty strings to appear at the end of `sourceLines` array, which were then preserved as blank lines when adding new criteria.
+
+**Fix**: Added `.trimEnd()` to the existingBody before splitting (line 387):
+```typescript
+const sourceLines = existingBody ? existingBody.replace(/\r\n/g, "\n").trimEnd().split("\n") : [];
+```
+
+**Testing**:
+- Added unit test in `acceptance-criteria-manager.test.ts` that verifies no blank lines are inserted when adding new criteria
+- Manually verified fix works with fresh tasks
+- All related AC tests pass (31/36 - 5 failures are pre-existing unrelated issues)
+<!-- SECTION:NOTES:END -->

--- a/src/markdown/structured-sections.ts
+++ b/src/markdown/structured-sections.ts
@@ -383,7 +383,8 @@ export class AcceptanceCriteriaManager {
 		const queue = [...sorted];
 		const lines: string[] = [];
 		let nextNumber = 1;
-		const sourceLines = existingBody ? existingBody.replace(/\r\n/g, "\n").split("\n") : [];
+		// trimEnd() removes trailing newlines from regex capture that would create empty sourceLines entries
+		const sourceLines = existingBody ? existingBody.replace(/\r\n/g, "\n").trimEnd().split("\n") : [];
 
 		if (sourceLines.length > 0) {
 			for (const line of sourceLines) {

--- a/src/test/acceptance-criteria-manager.test.ts
+++ b/src/test/acceptance-criteria-manager.test.ts
@@ -2,6 +2,39 @@ import { describe, expect, it } from "bun:test";
 import { AcceptanceCriteriaManager } from "../markdown/structured-sections.ts";
 
 describe("AcceptanceCriteriaManager", () => {
+	it("does not insert blank lines when adding new criteria (BACK-365)", () => {
+		// Start with existing content that has 2 criteria
+		const existingContent = `## Description
+
+Some description
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 First criterion
+- [ ] #2 Second criterion
+<!-- AC:END -->
+`;
+		// Add a third criterion
+		const updatedCriteria = [
+			{ checked: false, text: "First criterion", index: 1 },
+			{ checked: false, text: "Second criterion", index: 2 },
+			{ checked: false, text: "Third criterion", index: 3 },
+		];
+		const result = AcceptanceCriteriaManager.updateContent(existingContent, updatedCriteria);
+
+		// Extract the AC section and verify no blank lines between criteria
+		const acSection = result.match(/<!-- AC:BEGIN -->([\s\S]*?)<!-- AC:END -->/)?.[1] || "";
+		const lines = acSection.split("\n").filter((line) => line.trim() !== "");
+
+		expect(lines).toHaveLength(3);
+		expect(lines[0]).toBe("- [ ] #1 First criterion");
+		expect(lines[1]).toBe("- [ ] #2 Second criterion");
+		expect(lines[2]).toBe("- [ ] #3 Third criterion");
+
+		// Also verify no double newlines in the AC section (which would indicate blank lines)
+		expect(acSection).not.toContain("\n\n");
+	});
+
 	it("removes a single criterion without affecting other sections", () => {
 		const base = AcceptanceCriteriaManager.formatAcceptanceCriteria([
 			{ checked: false, text: "First", index: 1 },


### PR DESCRIPTION
Root cause: composeAcceptanceCriteriaBody() was splitting existingBody without trimming trailing newlines, causing empty strings in sourceLines that were preserved as blank lines between criteria.

Fix: Added .trimEnd() before splitting to remove trailing newlines from regex capture while preserving intentional blank lines in the middle.

Added test in acceptance-criteria-manager.test.ts to verify no blank lines are inserted when adding new criteria.