### PR TITLE
BACK-351 - Strengthen MCP task creation guidance for standalone tasks

### DIFF
--- a/backlog/tasks/back-351 - Strengthen-MCP-task-creation-guidance-for-standalone-tasks.md
+++ b/backlog/tasks/back-351 - Strengthen-MCP-task-creation-guidance-for-standalone-tasks.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-351
 title: Strengthen MCP task creation guidance for standalone tasks
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2025-12-25 20:04'
-updated_date: '2025-12-26 17:40'
+updated_date: '2026-01-16 18:44'
 labels: []
 dependencies: []
 ---
@@ -44,11 +45,30 @@ This prevents agents from creating tightly-coupled task batches that only make s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 task-creation.md includes 'Agent Lifecycle Reality' section explaining agents won't work on all tasks they create
-- [ ] #2 task-creation.md guidance requires tasks be written as work orders for strangers with full context
-- [ ] #3 overview.md includes 'Execution Model' statement about independent agent sessions
+- [x] #1 task-creation.md includes 'Agent Lifecycle Reality' section explaining agents won't work on all tasks they create
+- [x] #2 task-creation.md guidance requires tasks be written as work orders for strangers with full context
+- [x] #3 overview.md includes 'Execution Model' statement about independent agent sessions
 
-- [ ] #4 task-execution.md strengthens language about agent replacement/interruption and handoff
-- [ ] #5 Task-creation guidance requires tests and documentation expectations per task (no deferring to later tasks)
-- [ ] #6 Guide includes anti-pattern example (deferred tests/docs) vs correct example (standalone tasks)
+- [x] #4 task-execution.md strengthens language about agent replacement/interruption and handoff
+- [x] #5 Task-creation guidance requires tests and documentation expectations per task (no deferring to later tasks)
+- [x] #6 Guide includes anti-pattern example (deferred tests/docs) vs correct example (standalone tasks)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update src/guidelines/mcp/task-creation.md with an "Agent Lifecycle Reality" section after scope assessment, covering independent agent sessions, writing tasks as work orders for strangers, explicit dependency outputs, and linking relevant code/docs.
+2. Strengthen task-creation guidance to require per-task testing/documentation expectations and add an anti-pattern vs correct example for deferred tests/docs.
+3. Add an "Execution Model" statement in src/guidelines/mcp/overview.md under Core Principle to emphasize independent agent sessions and standalone task context.
+4. Tighten handoff/replacement language in src/guidelines/mcp/task-execution.md to stress tasks as the permanent record when agents are replaced or interrupted.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Summary: added Agent Lifecycle Reality guidance to task-creation workflow, including explicit dependency/context rules and standalone tests/docs expectations with anti-pattern vs correct examples.
+
+Summary: added Execution Model statement in overview and strengthened task-execution handoff language to stress agent replacement.
+
+Tests: not run (documentation-only changes).
+<!-- SECTION:NOTES:END -->

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -48,6 +48,8 @@ These guides contain critical workflows you need to follow for proper task manag
 
 Backlog tracks **commitments** (what will be built). Use your judgment to distinguish between "help me understand X" (no tracking) vs "add feature Y" (track in Backlog).
 
+**Execution Model:** Tasks are executed by independent AI agents in separate sessions. Each agent only sees its assigned task, not prior conversation history, so tasks must include enough context for a developer with no prior knowledge to start immediately.
+
 ### MCP Tools Quick Reference
 
 **Note:** "Done" tasks stay in the Done column until periodic cleanup moves them to the completed folder. Don't use `task_complete` immediately after finishing—it's for batch cleanup, not per-task workflow.

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -27,6 +27,15 @@ Use `task_view` to read full context of related tasks.
 
 If the work requires multiple tasks, proceed to choose the appropriate task structure (subtasks vs separate tasks).
 
+### Agent Lifecycle Reality
+
+**Assume the agent who creates tasks will NOT execute them.** Each task is handled by an independent agent session with no memory of prior conversations or other tasks.
+
+- Write tasks as work orders for strangers: include all required context inside the task
+- Never reference "what we discussed" without restating the essential decisions and constraints
+- Dependencies must explicitly state what the other task provides (e.g., output, schema, artifact)
+- Include links to relevant code, docs, or references directly in the task description
+
 ### Step 3: Choose task structure
 
 **When to use subtasks vs separate tasks:**
@@ -62,6 +71,7 @@ Create all tasks in the same session to maintain consistency and context.
 - Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S")
 - Include negative or edge scenarios when relevant
 - Capture testing expectations explicitly
+- Include documentation expectations in the same task (no deferring to follow-up tasks)
 
 **Never embed implementation details** in title, description, or acceptance criteria
 
@@ -78,12 +88,15 @@ After creation, show the user each new task's ID, title, description, and accept
 - Creating a single task called "Build desktop application" with 10+ acceptance criteria
 - Adding implementation steps to acceptance criteria
 - Creating a task before understanding if it needs to be split
+- Deferring tests or documentation to "later tasks" (e.g., "Add tests/docs in a follow-up")
 
 ### Correct Pattern
 
 "This request spans electron setup, IPC bridge, UI adaptation, and packaging. I'll create 4 separate tasks to break this down properly."
 
 Then create the tasks and report what was created.
+
+**Standalone task example (includes tests/docs):** "Add API endpoint for bulk updates" with acceptance criteria that include required tests and documentation updates in the same task.
 
 ### Additional Context Gathering
 

--- a/src/guidelines/mcp/task-execution.md
+++ b/src/guidelines/mcp/task-execution.md
@@ -10,9 +10,9 @@
 4. **Present plan to user** - Show your proposed implementation approach
 5. **Wait for explicit approval** - Do not start coding until user confirms or asks you to skip review
 6. **Record approved plan** - Use `task_edit` with planSet or planAppend to capture the agreed approach in the task
-7. **Document the agreed breakdown** - In the parent task's plan, capture the final list of subtasks, owners, and sequencing so future agents see the structure the user approved
+7. **Document the agreed breakdown** - In the parent task's plan, capture the final list of subtasks, owners, and sequencing so a replacement agent can resume with the approved structure
 
-**IMPORTANT:** Use tasks as a permanent storage for everything related to the work. Implementation plan and notes are essential to resume work in case of interruptions or handoffs.
+**IMPORTANT:** Use tasks as permanent storage for everything related to the work. You may be interrupted or replaced at any point, so the task record must contain everything needed for a clean handoff.
 
 ### Planning Guidelines
 


### PR DESCRIPTION
- Added “Agent Lifecycle Reality” guidance, standalone
    tests/docs expectations, and anti‑pattern vs correct
    example in src/guidelines/mcp/task-creation.md.
 - Added an “Execution Model” statement in src/guidelines/
    mcp/overview.md.
 - Strengthened handoff/replacement language in src/
    guidelines/mcp/task-execution.md.