### PR TITLE
Fix case sensitivity bug in reorderTask

### DIFF
--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1271,7 +1271,7 @@ export class Core {
 		const validTasks = loadedTasks.filter((t): t is Task => t !== null);
 
 		// Verify the moved task itself exists
-		const movedTask = validTasks.find((t) => t.id === taskId);
+		const movedTask = validTasks.find((t) => taskIdsEqual(t.id, taskId));
 		if (!movedTask) {
 			throw new Error(`Task ${taskId} not found while reordering`);
 		}
@@ -1292,7 +1292,7 @@ export class Core {
 					: undefined;
 
 		// Calculate target index within the valid tasks list
-		const validOrderedIds = orderedTaskIds.filter((id) => validTasks.some((t) => t.id === id));
+		const validOrderedIds = orderedTaskIds.filter((id) => validTasks.some((t) => taskIdsEqual(t.id, id)));
 		const targetIndex = validOrderedIds.indexOf(taskId);
 
 		if (targetIndex === -1) {


### PR DESCRIPTION
## Summary

Fixes #481

The `reorderTask` function in `src/core/backlog.ts` fails with "Task TASK-11 not found while reordering" even when the task exists due to a case sensitivity mismatch.

**Root cause:** Task IDs are normalized to uppercase via `normalizeTaskId()`, but then compared against loaded task IDs (which are lowercase from task files) using strict equality (`===`).

**Fix:** Use the existing `taskIdsEqual()` function which handles case-insensitive comparison.

## Changes

- Line 1274: `t.id === taskId` → `taskIdsEqual(t.id, taskId)`
- Line 1295: `t.id === id` → `taskIdsEqual(t.id, id)`

## Test plan

1. Create tasks with lowercase IDs (e.g., `task-3`, `task-5`, `task-11`)
2. Call the reorder API:
```bash
curl 'http://localhost:6420/api/tasks/reorder' \
  -X 'POST' \
  -H 'Content-Type: application/json' \
  --data-raw '{"taskId":"task-11","targetStatus":"To Do","orderedTaskIds":["task-3","task-11","task-5"]}'
```
3. Verify reorder succeeds (previously returned 400 error)