### PR TITLE
BACK-369 - Fix web UI acceptance criteria toggle flicker via ContentStore sync

### DIFF
--- a/backlog/tasks/back-369 - Fix-web-UI-acceptance-criteria-toggle-flicker-via-ContentStore-sync.md
+++ b/backlog/tasks/back-369 - Fix-web-UI-acceptance-criteria-toggle-flicker-via-ContentStore-sync.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-01-21 18:57'
-updated_date: '2026-01-21 18:59'
+updated_date: '2026-01-21 19:14'
 labels: []
 dependencies: []
 references:
@@ -50,6 +50,8 @@ Summary:
 - Removed server-layer ContentStore refresh logic now handled in core.
 
 PR: https://github.com/MrLesk/Backlog.md/pull/493
+
+Follow-up: adjusted ContentStore sync to upsert the normalized task loaded from disk after save (avoids overwriting canonical fields like filePath/parentTaskId).
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -753,7 +753,12 @@ export class Core {
 
 		const filepath = await this.fs.saveTask(task);
 		// Keep any in-process ContentStore in sync for immediate UI/search freshness.
-		this.contentStore?.upsertTask(task);
+		if (this.contentStore) {
+			const savedTask = await this.fs.loadTask(task.id);
+			if (savedTask) {
+				this.contentStore.upsertTask(savedTask);
+			}
+		}
 
 		if (await this.shouldAutoCommit(autoCommit)) {
 			await this.git.addAndCommitTaskFile(task.id, filepath, "create");
@@ -791,7 +796,12 @@ export class Core {
 
 		await this.fs.saveTask(task);
 		// Keep any in-process ContentStore in sync for immediate UI/search freshness.
-		this.contentStore?.upsertTask(task);
+		if (this.contentStore) {
+			const savedTask = await this.fs.loadTask(task.id);
+			if (savedTask) {
+				this.contentStore.upsertTask(savedTask);
+			}
+		}
 
 		if (await this.shouldAutoCommit(autoCommit)) {
 			const filePath = await getTaskPath(task.id, this);


### PR DESCRIPTION
## Summary
- sync ContentStore on core task updates for immediate UI/search freshness
- sync ContentStore on task creation for immediate UI/search visibility

## Testing
- bunx tsc --noEmit
- bun test
- bun run check . (failed: existing formatting issues in unrelated files)

Fixes #492 