### PR TITLE
BACK-361 - Add label-based filtering to TUI and web UI task list views

### DIFF
--- a/backlog/tasks/back-361 - Add-label-based-filtering-to-TUI-and-web-UI-task-list-views.md
+++ b/backlog/tasks/back-361 - Add-label-based-filtering-to-TUI-and-web-UI-task-list-views.md
@@ -1,14 +1,18 @@
 ---
 id: BACK-361
 title: Add label-based filtering to TUI and web UI task list views
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@alex-agent'
 created_date: '2026-01-15 20:15'
+updated_date: '2026-04-25 23:39'
 labels:
   - tui
   - web
   - enhancement
 dependencies: []
+modified_files:
+  - src/ui/components/filter-header.ts
 priority: medium
 ---
 
@@ -22,12 +26,39 @@ Reuse the filtering patterns already established for status and priority filters
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 TUI task list view supports filtering by label(s)
-- [ ] #2 Web UI task list view supports filtering by label(s)
-- [ ] #3 Multiple labels can be selected (OR logic - show tasks matching any selected label)
-- [ ] #4 Label filter integrates with existing status and priority filters (filters combine with AND logic)
-- [ ] #5 Available labels are populated from current task set
-- [ ] #6 Filter state is clearly displayed in the footer/UI without overwhelming limited space
-- [ ] #7 Clearing label filter restores full task list
-- [ ] #8 Filter patterns are consistent with existing status/priority filter implementation
+- [x] #1 TUI task list view supports filtering by label(s)
+- [x] #2 Web UI task list view supports filtering by label(s)
+- [x] #3 Multiple labels can be selected (OR logic - show tasks matching any selected label)
+- [x] #4 Label filter integrates with existing status and priority filters (filters combine with AND logic)
+- [x] #5 Available labels are populated from current task set
+- [x] #6 Filter state is clearly displayed in the footer/UI without overwhelming limited space
+- [x] #7 Clearing label filter restores full task list
+- [x] #8 Filter patterns are consistent with existing status/priority filter implementation
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebase PR #499 onto current main and drop stale formatter-only changes from the old branch.
+2. Keep the current shared TUI/Web label filtering implementation on main.
+3. Update the TUI filter header label popup button to show the same concise label summary used by the shared label-filter helper.
+4. Validate with focused label/header tests, typecheck, Biome check, and the full test suite before pushing.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+PR #499 was rebased onto current main. The stale changes in src/cli.ts, src/file-system/operations.ts, src/test/core.test.ts, src/test/filesystem.test.ts, and src/utils/task-path.ts were dropped because current main already contains newer logic there. The remaining code changes import formatLabelSummary in src/ui/components/filter-header.ts, use it for the Labels popup button, and keep popup button content from parsing blessed tags so user-defined labels render literally. Current main already provides the label filtering behavior for the TUI task list, TUI board, Web UI, shared search, available label collection, OR label matching, and AND composition with other filters. Codex review flagged the tag parsing risk on the first rebased push, and the follow-up patch disables tag parsing for these popup buttons.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Prepared PR #499 for current main by rebasing BACK-361 and reducing the patch to the remaining live UI improvement: the TUI filter header now displays a concise selected-label summary via formatLabelSummary. Popup buttons no longer parse blessed tags, so label text containing braces or blessed-style tags is displayed literally instead of affecting terminal styling. The broader label-filtering behavior already exists on main across TUI and Web surfaces, so no stale formatter-only files are changed in the final branch.
+
+Validation passed locally with:
+- bun test src/test/label-filter.test.ts src/test/filter-header-navigation.test.ts
+- bunx tsc --noEmit
+- bun run check .
+- bun test
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/ui/components/filter-header.ts
+++ b/src/ui/components/filter-header.ts
@@ -5,6 +5,7 @@
 
 import type { BoxInterface, ScreenInterface, TextboxInterface } from "neo-neo-bblessed";
 import { box, textbox } from "neo-neo-bblessed";
+import { formatLabelSummary } from "../../utils/label-filter.ts";
 
 export type FilterControlId = "search" | "status" | "priority" | "labels" | "milestone";
 
@@ -531,7 +532,6 @@ export class FilterHeader {
 			left: x,
 			width,
 			height: 1,
-			tags: true,
 			mouse: true,
 			keys: true,
 			style: {
@@ -607,8 +607,8 @@ export class FilterHeader {
 			case "milestone":
 				return this.state.milestone ? `${this.state.milestone} ▼` : "All ▼";
 			case "labels": {
-				const count = this.state.labels.length;
-				return count === 0 ? "All ▼" : `(${count}) ▼`;
+				const summary = formatLabelSummary(this.state.labels).replace(/^Labels:\s*/, "");
+				return `${summary} ▼`;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- rebase BACK-361 onto current main and drop stale formatter-only changes
- keep the existing TUI/Web label-filtering implementation already present on main
- show selected labels in the TUI filter header button using the shared concise label summary helper
- disable blessed tag parsing for popup buttons so label text renders literally

## Testing
- bun test src/test/label-filter.test.ts src/test/filter-header-navigation.test.ts
- bunx tsc --noEmit
- bun run check .
- bun test