### PR TITLE
BACK-375 - Fix inconsistent draft IDs for task create --draft

### DIFF
--- a/backlog/tasks/back-375 - Fix-inconsistent-draft-IDs-for-`task-create-draft`.md
+++ b/backlog/tasks/back-375 - Fix-inconsistent-draft-IDs-for-`task-create-draft`.md
@@ -1,0 +1,48 @@
+---
+id: BACK-375
+title: Fix inconsistent draft IDs for `task create --draft`
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-02-08 21:43'
+updated_date: '2026-02-08 21:45'
+labels:
+  - bug
+  - cli
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/507'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix mismatch between `draft create` and `task create --draft` where the latter creates `draft-task-*` files and prints TASK IDs. Ensure both commands produce consistent DRAFT IDs and add regression test coverage for CLI path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `backlog task create --draft <title>` creates a draft file with `draft-<n>` filename pattern (no `draft-task-` prefix).
+- [x] #2 CLI output for `task create --draft` reports the created draft ID using DRAFT prefix.
+- [x] #3 A regression test covers the `task create --draft` CLI path so this bug is caught in CI.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause was in `task create` CLI flow generating a Task ID unconditionally before draft creation, which produced `draft-task-*` filenames after draft normalization. Updated `task create` to generate Draft IDs when `--draft` is set and to report `task.id` consistently in output. Added CLI regression tests that exercise the exact failing path (`draft create` followed by `task create --draft`) and plain output behavior.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed inconsistent draft identity handling for `task create --draft` by generating Draft IDs in the CLI path and reporting the normalized created ID in output. Added regression coverage in `src/test/draft-create-consistency.test.ts` to verify filename prefix, ID sequencing, and `--plain` output for draft creation.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1299,7 +1299,11 @@ taskCmd
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		await core.ensureConfigLoaded();
-		const id = await core.generateNextId(EntityType.Task, options.parent);
+		const createAsDraft = Boolean(options.draft);
+		const id = await core.generateNextId(
+			createAsDraft ? EntityType.Draft : EntityType.Task,
+			createAsDraft ? undefined : options.parent,
+		);
 		const task = buildTaskFromOptions(id, title, options);
 
 		// Normalize and validate status if provided (case-insensitive)
@@ -1363,13 +1367,13 @@ taskCmd
 		// Workaround for bun compile issue with commander options
 		const isPlainFlag = options.plain || process.argv.includes("--plain");
 
-		if (options.draft) {
+		if (createAsDraft) {
 			const filepath = await core.createDraft(task);
 			if (isPlainFlag) {
 				console.log(formatTaskPlainText(task, { filePathOverride: filepath }));
 				return;
 			}
-			console.log(`Created draft ${id}`);
+			console.log(`Created draft ${task.id}`);
 			console.log(`File: ${filepath}`);
 		} else {
 			const filepath = await core.createTask(task);
@@ -1377,7 +1381,7 @@ taskCmd
 				console.log(formatTaskPlainText(task, { filePathOverride: filepath }));
 				return;
 			}
-			console.log(`Created task ${id}`);
+			console.log(`Created task ${task.id}`);
 			console.log(`File: ${filepath}`);
 		}
 	});

--- a/src/test/draft-create-consistency.test.ts
+++ b/src/test/draft-create-consistency.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, readdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+
+describe("Draft creation consistency", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-draft-create-consistency");
+		try {
+			await rm(TEST_DIR, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+		await mkdir(TEST_DIR, { recursive: true });
+
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email "test@example.com"`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await core.initializeProject("Draft Consistency Test Project");
+	});
+
+	afterEach(async () => {
+		try {
+			await safeCleanup(TEST_DIR);
+		} catch {
+			// Ignore cleanup errors - the unique directory names prevent conflicts
+		}
+	});
+
+	it("keeps IDs and filenames consistent between draft create and task create --draft", async () => {
+		const first = await $`bun ${CLI_PATH} draft create "Hallo"`.cwd(TEST_DIR).quiet();
+		const second = await $`bun ${CLI_PATH} task create --draft "Goodbye"`.cwd(TEST_DIR).quiet();
+
+		expect(first.stdout.toString()).toContain("Created draft DRAFT-1");
+		expect(second.stdout.toString()).toContain("Created draft DRAFT-2");
+		expect(second.stdout.toString()).toContain("draft-2 - Goodbye.md");
+		expect(second.stdout.toString()).not.toContain("draft-task-");
+
+		const draftFiles = await readdir(join(TEST_DIR, "backlog", "drafts"));
+		expect(draftFiles).toContain("draft-1 - Hallo.md");
+		expect(draftFiles).toContain("draft-2 - Goodbye.md");
+		expect(draftFiles.some((file) => file.startsWith("draft-task-"))).toBe(false);
+
+		const core = new Core(TEST_DIR);
+		const secondDraft = await core.filesystem.loadDraft("draft-2");
+		expect(secondDraft).not.toBeNull();
+		expect(secondDraft?.id).toBe("DRAFT-2");
+	});
+
+	it("uses DRAFT IDs in plain output for task create --draft", async () => {
+		const result = await $`bun ${CLI_PATH} task create --draft "Plain sample" --plain`.cwd(TEST_DIR).quiet();
+		const output = result.stdout.toString();
+
+		expect(output).toContain("draft-1 - Plain-sample.md");
+		expect(output).toContain("Task DRAFT-1 - Plain sample");
+		expect(output).not.toContain("Task TASK-1");
+	});
+});


### PR DESCRIPTION
## Summary
- generate Draft IDs when `backlog task create --draft` is used instead of precomputing a Task ID
- align create output with the saved entity by printing `task.id` after creation
- add regression tests for the inconsistent path (`draft create` then `task create --draft`) and `--plain` output

## Validation
- bun test src/test/draft-create-consistency.test.ts
- bunx tsc --noEmit
- bun run check .

Closes #507
