### PR TITLE
BACK-376 - Fix milestone loss when creating tasks from web UI

### DIFF
--- a/backlog/tasks/back-376 - Fix-web-task-creation-dropping-selected-milestone.md
+++ b/backlog/tasks/back-376 - Fix-web-task-creation-dropping-selected-milestone.md
@@ -1,0 +1,49 @@
+---
+id: BACK-376
+title: Fix web task creation dropping selected milestone
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-02-08 23:41'
+updated_date: '2026-02-08 23:42'
+labels:
+  - bug
+  - web
+  - api
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/506'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate and fix issue where creating a task from the web UI with a selected milestone results in the task being created without milestone assignment (appears under Unassigned). Ensure server task-creation path preserves milestone and add regression test coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Creating a task via web API with a milestone persists that milestone on the created task.
+- [x] #2 A regression test covers the server create-task flow with milestone input.
+- [x] #3 Existing create/edit task behavior remains unchanged for requests without milestone.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: server `POST /api/tasks` did not forward `milestone` into `createTaskFromInput`, while update flow did. Added milestone mapping in `handleCreateTask` with string guard and added regression coverage in server API tests to verify milestone is preserved on create and retrievable via `/api/task/:id`.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Web task creation now preserves selected milestone by forwarding `milestone` in server create-task payload mapping. Added regression test `persists milestone when creating tasks via POST` in `src/test/server-search-endpoint.test.ts` to prevent recurrence.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -668,6 +668,7 @@ export class BacklogServer {
 				description: payload.description,
 				status: payload.status,
 				priority: payload.priority,
+				milestone: typeof payload.milestone === "string" ? payload.milestone : undefined,
 				labels: payload.labels,
 				assignee: payload.assignee,
 				dependencies: payload.dependencies,

--- a/src/test/server-search-endpoint.test.ts
+++ b/src/test/server-search-endpoint.test.ts
@@ -180,6 +180,25 @@ describe("BacklogServer search endpoint", () => {
 		expect(fetched.title).toBe("Immediate fetch");
 	});
 
+	it("persists milestone when creating tasks via POST", async () => {
+		const createResponse = await fetch(`http://127.0.0.1:${serverPort}/api/tasks`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Milestone create",
+				status: "To Do",
+				milestone: "m-2",
+			}),
+		});
+		expect(createResponse.ok).toBe(true);
+		const created = (await createResponse.json()) as Task;
+		expect(created.milestone).toBe("m-2");
+
+		const shortId = created.id.replace(/^task-/i, "");
+		const fetched = await fetchJson<Task>(`/api/task/${shortId}`);
+		expect(fetched.milestone).toBe("m-2");
+	});
+
 	it("rebuilds the Fuse index when markdown content changes", async () => {
 		await filesystem.saveDocument({
 			...baseDoc,


### PR DESCRIPTION
## Summary
- preserve `milestone` in `POST /api/tasks` by forwarding it to `createTaskFromInput`
- keep create-path behavior unchanged when no milestone is provided
- add regression coverage for create-task milestone persistence in the server API tests

## Validation
- bun test src/test/server-search-endpoint.test.ts
- bunx tsc --noEmit
- bun run check .

Closes #506
