### PR TITLE
BACK-377 - Fix blank-page crash for angle-bracket markdown in web preview

### DIFF
--- a/backlog/tasks/back-377 - Prevent-web-preview-crash-on-angle-bracket-type-strings.md
+++ b/backlog/tasks/back-377 - Prevent-web-preview-crash-on-angle-bracket-type-strings.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-02-09 03:55'
-updated_date: '2026-02-09 03:57'
+updated_date: '2026-02-09 04:02'
 labels:
   - bug
   - web
@@ -32,12 +32,18 @@ Fix blank page in browser task details when markdown contains angle-bracket type
 
 <!-- SECTION:NOTES:BEGIN -->
 Reproduced crash in markdown preview rendering path with `Result<List<MenuItem>>` and confirmed React throws due tag interpretation (`menuitems cannot have children nor dangerouslySetInnerHTML`). Added markdown sanitization in `MermaidMarkdown` to escape tag-like `<...` starts (while preserving angle-bracket autolinks), preventing React from interpreting type notation as HTML tags. Added regression tests for problematic angle-bracket content and normal markdown rendering.
+
+Addressing PR review feedback: preserve non-HTTP autolinks (e.g., `<ftp://...>`, `<foo@example.com>`) while still escaping unsafe tag-like angle-bracket sequences.
+
+Addressed PR feedback by preserving additional CommonMark autolink forms during sanitization: URI schemes beyond HTTP(S) (e.g., ftp) and plain email autolinks.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Fixed web preview blank-page crash for angle-bracket type strings by sanitizing tag-like `<...` sequences before rendering markdown in `MermaidMarkdown`. Added regression test `src/test/mermaid-markdown.test.tsx` to ensure problematic strings no longer throw and normal markdown behavior remains functional.
+
+Follow-up refinement: sanitizer now preserves generic URI/email autolinks while still escaping unsafe tag-like angle-bracket sequences that caused the crash.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/src/test/mermaid-markdown.test.tsx
+++ b/src/test/mermaid-markdown.test.tsx
@@ -21,4 +21,12 @@ describe("MermaidMarkdown", () => {
 		expect(html).toContain("Heading");
 		expect(html).toContain("<strong>markdown</strong>");
 	});
+
+	it("preserves non-http autolinks and email autolinks", () => {
+		const source = "Links: <ftp://example.com/file> and <foo@example.com>";
+		const html = renderToString(<MermaidMarkdown source={source} />);
+
+		expect(html).toContain('href="ftp://example.com/file"');
+		expect(html).toContain('href="mailto:foo@example.com"');
+	});
 });

--- a/src/web/components/MermaidMarkdown.tsx
+++ b/src/web/components/MermaidMarkdown.tsx
@@ -6,8 +6,17 @@ interface Props {
 	source: string;
 }
 
+const URI_AUTOLINK_PREFIX_REGEX = /^<[A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\u0000-\u0020]*>/;
+const EMAIL_AUTOLINK_PREFIX_REGEX = /^<[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+\.[A-Za-z0-9-]+>/;
+
 function sanitizeMarkdownSource(source: string): string {
-	return source.replace(/<(?=[A-Za-z])(?!https?:\/\/)(?!mailto:)/gi, "&lt;");
+	return source.replace(/<(?=[A-Za-z])/g, (match, offset, fullText) => {
+		const remaining = fullText.slice(offset);
+		if (URI_AUTOLINK_PREFIX_REGEX.test(remaining) || EMAIL_AUTOLINK_PREFIX_REGEX.test(remaining)) {
+			return match;
+		}
+		return "&lt;";
+	});
 }
 
 export default function MermaidMarkdown({ source }: Props) {


### PR DESCRIPTION
## Summary
- sanitize markdown preview input in `MermaidMarkdown` so tag-like angle bracket sequences are treated as text instead of HTML tags
- preserve normal preview behavior while preventing React runtime crashes from strings like `Result<List<MenuItem>>`
- add regression tests for problematic angle-bracket content and normal markdown rendering

## Validation
- bun test src/test/mermaid-markdown.test.tsx
- bunx tsc --noEmit
- bun run check .

Closes #504
