### PR TITLE
BACK-378 - Fix timezone docs and task modal local date display

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,6 @@ Whenever you revisit `backlog init` or rerun `backlog config`, the wizard pre-po
 | `definition_of_done` | Default DoD checklist items for new tasks | `(not set)` |
 | `statuses`        | Board columns      | `[To Do, In Progress, Done]`  |
 | `dateFormat`      | Date/time format   | `yyyy-mm-dd hh:mm`            |
-| `timezonePreference` | Timezone for dates | `UTC`                     |
 | `includeDatetimeInDates` | Add time to new dates | `true`              |
 | `defaultEditor`   | Editor for 'E' key | Platform default (nano/notepad) |
 | `defaultPort`     | Web UI port        | `6420`                        |

--- a/backlog/tasks/back-378 - Fix-timezone-configuration-docs-and-local-date-display-in-task-modal.md
+++ b/backlog/tasks/back-378 - Fix-timezone-configuration-docs-and-local-date-display-in-task-modal.md
@@ -1,0 +1,49 @@
+---
+id: BACK-378
+title: Fix timezone configuration docs and local date display in task modal
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-02-09 06:22'
+updated_date: '2026-02-09 06:24'
+labels:
+  - bug
+  - web
+  - docs
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/508'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve issue #508 by removing stale timezonePreference configuration documentation and fixing task details modal to display created/updated dates in local time instead of raw stored UTC strings.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 README no longer documents unsupported `timezonePreference` config key.
+- [x] #2 Task details modal displays created/updated dates using local timezone formatting rather than raw storage strings.
+- [x] #3 Regression tests cover date parsing/formatting behavior for stored UTC datetime strings used by the web UI.
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Removed stale `timezonePreference` documentation and type definition to match current supported config surface. Added web utility functions to parse stored UTC date strings (`YYYY-MM-DD HH:mm` and date-only) and format for local display. Updated `TaskDetailsModal` created/updated display to use local formatting instead of raw storage strings.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Issue #508 resolved by removing unsupported `timezonePreference` config docs/type and fixing task details modal date rendering to display local timezone values from stored UTC strings. Added regression tests in `src/web/utils/date-display.test.ts` for parse/format behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -270,7 +270,6 @@ export interface BacklogConfig {
 	remoteOperations?: boolean;
 	autoCommit?: boolean;
 	zeroPaddedIds?: number;
-	timezonePreference?: string; // e.g., 'UTC', 'America/New_York', or 'local'
 	includeDateTimeInDates?: boolean; // Whether to include time in new dates
 	bypassGitHooks?: boolean;
 	checkActiveBranches?: boolean; // Check task states across active branches (default: true)

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -8,6 +8,7 @@ import AcceptanceCriteriaEditor from "./AcceptanceCriteriaEditor";
 import MermaidMarkdown from './MermaidMarkdown';
 import ChipInput from "./ChipInput";
 import DependencyInput from "./DependencyInput";
+import { formatStoredUtcDateForDisplay } from "../utils/date-display";
 
 interface Props {
   task?: Task; // Optional for create mode
@@ -789,14 +790,14 @@ export const TaskDetailsModal: React.FC<Props> = ({
         {/* Sidebar */}
         <div className="md:col-span-1 space-y-4">
           {/* Dates */}
-          {task && (
-            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 text-xs text-gray-600 dark:text-gray-300 space-y-1">
-              <div><span className="font-semibold text-gray-800 dark:text-gray-100">Created:</span> <span className="text-gray-700 dark:text-gray-200">{task.createdDate}</span></div>
-              {task.updatedDate && (
-                <div><span className="font-semibold text-gray-800 dark:text-gray-100">Updated:</span> <span className="text-gray-700 dark:text-gray-200">{task.updatedDate}</span></div>
-              )}
-            </div>
-          )}
+	          {task && (
+	            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 text-xs text-gray-600 dark:text-gray-300 space-y-1">
+	              <div><span className="font-semibold text-gray-800 dark:text-gray-100">Created:</span> <span className="text-gray-700 dark:text-gray-200">{formatStoredUtcDateForDisplay(task.createdDate)}</span></div>
+	              {task.updatedDate && (
+	                <div><span className="font-semibold text-gray-800 dark:text-gray-100">Updated:</span> <span className="text-gray-700 dark:text-gray-200">{formatStoredUtcDateForDisplay(task.updatedDate)}</span></div>
+	              )}
+	            </div>
+	          )}
           {/* Title (editable for existing tasks) */}
           {task && (
             <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">

--- a/src/web/utils/date-display.test.ts
+++ b/src/web/utils/date-display.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { formatStoredUtcDateForDisplay, parseStoredUtcDate } from "./date-display";
+
+describe("parseStoredUtcDate", () => {
+	it("parses stored UTC datetime strings", () => {
+		const parsed = parseStoredUtcDate("2026-02-09 06:01");
+		expect(parsed).not.toBeNull();
+		expect(parsed?.toISOString()).toBe("2026-02-09T06:01:00.000Z");
+	});
+
+	it("parses date-only strings as UTC midnight", () => {
+		const parsed = parseStoredUtcDate("2026-02-09");
+		expect(parsed).not.toBeNull();
+		expect(parsed?.toISOString()).toBe("2026-02-09T00:00:00.000Z");
+	});
+
+	it("returns null for invalid date values", () => {
+		expect(parseStoredUtcDate("2026-02-31 06:01")).toBeNull();
+		expect(parseStoredUtcDate("not-a-date")).toBeNull();
+	});
+});
+
+describe("formatStoredUtcDateForDisplay", () => {
+	it("formats datetime values in local timezone", () => {
+		const expected = new Date(Date.UTC(2026, 1, 9, 6, 1, 0)).toLocaleString(undefined, {
+			dateStyle: "medium",
+			timeStyle: "short",
+		});
+		expect(formatStoredUtcDateForDisplay("2026-02-09 06:01")).toBe(expected);
+	});
+
+	it("formats date-only values as local dates", () => {
+		const expected = new Date(Date.UTC(2026, 1, 9, 0, 0, 0)).toLocaleDateString();
+		expect(formatStoredUtcDateForDisplay("2026-02-09")).toBe(expected);
+	});
+
+	it("falls back to original value when parsing fails", () => {
+		expect(formatStoredUtcDateForDisplay("not-a-date")).toBe("not-a-date");
+	});
+});

--- a/src/web/utils/date-display.ts
+++ b/src/web/utils/date-display.ts
@@ -1,0 +1,73 @@
+const DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
+const DATE_TIME_REGEX = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})$/;
+
+function parseIntStrict(value: string): number {
+	return Number.parseInt(value, 10);
+}
+
+export function parseStoredUtcDate(dateStr: string): Date | null {
+	const normalized = dateStr.trim();
+	if (!normalized) return null;
+
+	const dateTimeMatch = normalized.match(DATE_TIME_REGEX);
+	if (dateTimeMatch) {
+		const y = dateTimeMatch[1];
+		const m = dateTimeMatch[2];
+		const d = dateTimeMatch[3];
+		const hh = dateTimeMatch[4];
+		const mm = dateTimeMatch[5];
+		if (!y || !m || !d || !hh || !mm) return null;
+		const year = parseIntStrict(y);
+		const month = parseIntStrict(m);
+		const day = parseIntStrict(d);
+		const hours = parseIntStrict(hh);
+		const minutes = parseIntStrict(mm);
+		const date = new Date(Date.UTC(year, month - 1, day, hours, minutes, 0));
+
+		if (
+			date.getUTCFullYear() !== year ||
+			date.getUTCMonth() !== month - 1 ||
+			date.getUTCDate() !== day ||
+			date.getUTCHours() !== hours ||
+			date.getUTCMinutes() !== minutes
+		) {
+			return null;
+		}
+
+		return date;
+	}
+
+	const dateOnlyMatch = normalized.match(DATE_ONLY_REGEX);
+	if (dateOnlyMatch) {
+		const y = dateOnlyMatch[1];
+		const m = dateOnlyMatch[2];
+		const d = dateOnlyMatch[3];
+		if (!y || !m || !d) return null;
+		const year = parseIntStrict(y);
+		const month = parseIntStrict(m);
+		const day = parseIntStrict(d);
+		const date = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+
+		if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+			return null;
+		}
+
+		return date;
+	}
+
+	return null;
+}
+
+export function formatStoredUtcDateForDisplay(dateStr: string): string {
+	const parsed = parseStoredUtcDate(dateStr);
+	if (!parsed) return dateStr;
+
+	if (DATE_TIME_REGEX.test(dateStr.trim())) {
+		return parsed.toLocaleString(undefined, {
+			dateStyle: "medium",
+			timeStyle: "short",
+		});
+	}
+
+	return parsed.toLocaleDateString();
+}


### PR DESCRIPTION
## Summary
- remove stale `timezonePreference` from public configuration docs and config typings
- add shared web date helpers to parse stored UTC date strings and format them for local display
- update `TaskDetailsModal` created/updated metadata display to use local timezone formatting instead of raw storage strings
- add regression tests for UTC date parsing/formatting used by the web UI

## Validation
- bun test src/web/utils/date-display.test.ts
- bunx tsc --noEmit
- bun run check .

Closes #508
