### PR TITLE
BACK-461 - Add community tools section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ For the full configuration reference (all options, commands, and detailed notes)
 
 ---
 
+## 🌐 Community Tools
+
+- **[vscode-backlog-md](https://marketplace.visualstudio.com/items?itemName=ysamlan.vscode-backlog-md)** - VS Code extension with issues panel, kanban view, and editing. ([ysamlan/vscode-backlog-md](https://github.com/ysamlan/vscode-backlog-md))
+
+---
+
 ### License
 
 Backlog.md is released under the **MIT License** – do anything, just give credit. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
Adds a small Community Tools section to the README so users can discover community-maintained integrations.

## Related Task
BACK-461

## Changes
- Adds vscode-backlog-md with links to the Visual Studio Marketplace listing and source repository.
- Removes the old conflicting BACK-451 task file from the PR branch; BACK-461 now tracks this work on main.

## Testing
- Original contributor ran bun test and previewed the README in GitHub UI.
- Alex's Agent rebased the PR onto current main and verified the diff is README-only with no whitespace errors.

Closes BACK-461
