### PR TITLE
fix: update config.yml and milestone file on milestone_rename

### DIFF
--- a/src/mcp/tools/milestones/handlers.ts
+++ b/src/mcp/tools/milestones/handlers.ts
@@ -187,6 +187,24 @@ export class MilestoneHandlers {
 			updatedTaskIds = updatedTaskIds.sort((a, b) => a.localeCompare(b));
 		}
 
+		// Update config.yml milestones array
+		const config = await this.core.filesystem.loadConfig();
+		if (config?.milestones) {
+			const idx = config.milestones.indexOf(fromName);
+			if (idx >= 0) {
+				config.milestones[idx] = toName;
+				await this.core.filesystem.saveConfig(config);
+			}
+		}
+
+		// Update milestone file's title frontmatter
+		const milestoneMatch = (await this.listFileMilestones()).find(
+			(m) => milestoneKey(m.title) === milestoneKey(fromName),
+		);
+		if (milestoneMatch) {
+			await this.core.filesystem.updateMilestoneTitle(milestoneMatch.id, toName);
+		}
+
 		const targetSummary = targetMilestone === toName ? `"${toName}"` : `"${toName}" (stored as "${targetMilestone}")`;
 		const summaryLines: string[] = [`Renamed milestone "${fromName}" → ${targetSummary}.`];
 		if (shouldUpdateTasks) {


### PR DESCRIPTION
## Summary

Fixes #521

`milestone_rename` only updated task files but left `config.yml` milestones array and milestone file frontmatter title unchanged, causing the browser UI to show tasks under the wrong milestone.

## Changes

In `src/mcp/tools/milestones/handlers.ts` → `renameMilestone()`:

1. **Update config.yml**: Find the old milestone name in `config.milestones` array and replace it with the new name
2. **Update milestone file**: Find the matching milestone file and update its `title` frontmatter via `updateMilestoneTitle()`

Both use existing filesystem methods — no new APIs needed.

## Diff

1 file changed, +18 lines