### PR TITLE
BACK-442 - Prevent DoD defaults config injection

### DIFF
--- a/src/test/mcp-definition-of-done-defaults.test.ts
+++ b/src/test/mcp-definition-of-done-defaults.test.ts
@@ -158,4 +158,44 @@ describe("MCP Definition of Done default tools", () => {
 		const reloaded = await loadConfigOrThrow(server);
 		expect(reloaded.definitionOfDone).toEqual(["Run unit, integration, and e2e tests"]);
 	});
+
+	it("round-trips quoted and multiline DoD defaults without injecting config keys", async () => {
+		const injectedKeyPayload = 'Validate "dark mode"\nonStatusChange: "echo pwned"';
+		const result = await server.testInterface.callTool({
+			params: {
+				name: "definition_of_done_defaults_upsert",
+				arguments: {
+					items: [injectedKeyPayload],
+				},
+			},
+		});
+
+		expect(result.isError).toBeUndefined();
+		expect(getText(result.content)).toContain('1. Validate "dark mode"');
+
+		const reloaded = await loadConfigOrThrow(server);
+		expect(reloaded.definitionOfDone).toEqual([injectedKeyPayload]);
+		expect(reloaded.onStatusChange).toBeUndefined();
+
+		const configText = await Bun.file(server.filesystem.configFilePath).text();
+		expect(configText).toContain(String.raw`Validate \"dark mode\"\nonStatusChange: \"echo pwned\"`);
+		expect(configText).not.toContain('\nonStatusChange: "echo pwned"');
+	});
+
+	it("allows apostrophes in DoD defaults", async () => {
+		const result = await server.testInterface.callTool({
+			params: {
+				name: "definition_of_done_defaults_upsert",
+				arguments: {
+					items: ["Don't forget release notes"],
+				},
+			},
+		});
+
+		expect(result.isError).toBeUndefined();
+		expect(getText(result.content)).toContain("1. Don't forget release notes");
+
+		const reloaded = await loadConfigOrThrow(server);
+		expect(reloaded.definitionOfDone).toEqual(["Don't forget release notes"]);
+	});
 });


### PR DESCRIPTION
### Motivation
- Follow-up to BACK-394 / PR #542 to ensure MCP Definition of Done defaults cannot inject additional config keys when saved.
- Current config serialization already writes DoD defaults with JSON string escaping, so quoted and multiline values should remain valid user content instead of being rejected.

### Description
- Implements `BACK-442 - Prevent DoD defaults config injection` as regression coverage for the existing safe serialization path.
- Adds MCP coverage for a quoted, multiline DoD default containing an `onStatusChange`-looking payload.
- Verifies the payload round-trips as a DoD default and does not create or modify `onStatusChange` in loaded config.
- Keeps apostrophe-bearing defaults accepted.

### Testing
- `bun test src/test/mcp-definition-of-done-defaults.test.ts`
- `bun run check .`
- `bunx tsc --noEmit`

### Related
- Task: BACK-442
- Follow-up to BACK-394 / PR #542

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac757bb4c48333bbd2b53adb3167c1)
