### PR TITLE
BACK-404.1 - Converge task creation into a single canonical core pipeline

### DIFF
--- a/backlog/tasks/back-404.1 - Converge-task-creation-into-a-single-canonical-core-pipeline.md
+++ b/backlog/tasks/back-404.1 - Converge-task-creation-into-a-single-canonical-core-pipeline.md
@@ -1,0 +1,76 @@
+---
+id: BACK-404.1
+title: Converge task creation into a single canonical core pipeline
+status: Done
+assignee:
+  - '@MrLesk'
+created_date: '2026-03-19 23:46'
+updated_date: '2026-03-20 20:02'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/pull/565'
+parent_task_id: BACK-404
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+BACK-404 / PR #565 fixed concurrent ID allocation for create-like operations, but it also made an older architectural problem more visible: Backlog.md still has overlapping task-creation orchestration paths that duplicate semantics and make future behavior changes expensive to maintain. In particular, src/core/backlog.ts currently has multiple create entry points with shared responsibilities (for example createTaskFromData and createTaskFromInput), and the create path still has leftover helper logic outside the canonical core flow.
+
+This follow-up should be a single focused refactor PR whose goal is architectural simplification, not new user-facing behavior. The outcome should be one canonical core task-creation pipeline that owns normalization, validation, default resolution, ID allocation, persistence, and post-write finalization for both regular tasks and drafts.
+
+Required architectural direction:
+- Treat Draft as a reserved task status in domain logic, not as a separate domain kind or flag.
+- Keep the choice of storing a record under tasks vs drafts as a persistence concern derived from the resolved status, not something callers need to model.
+- Prefer deleting or collapsing duplicate orchestration over adding more wrappers or defensive branches.
+- Keep filesystem helpers low-level and persistence-oriented; avoid spreading task-creation business logic across CLI, core, and filesystem layers.
+
+Minimum local context for the implementer:
+- Review the merged locking work in PR #565 and the related task BACK-404 before planning changes.
+- Inspect src/core/backlog.ts, src/cli.ts, src/utils/task-builders.ts, src/file-system/operations.ts, src/mcp/tools/tasks/handlers.ts, and src/server/index.ts to identify which create entry points are still carrying overlapping logic.
+- Preserve all currently supported create semantics unless an explicit follow-up task is approved for behavior changes.
+
+Non-goals:
+- No intended user-facing behavior change.
+- Do not expand this into a broader task lifecycle rewrite; focus on converging the create path only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Core task creation has one canonical orchestration path that owns normalization, validation, default/status resolution, ID allocation, persistence, and post-write finalization for both regular tasks and drafts; any remaining wrappers are thin adapters with no duplicated business logic.
+- [x] #2 The domain create flow models Draft as a reserved status, not as a separate kind/property; persistence decides whether the record is stored under drafts or tasks based on the resolved status.
+- [x] #3 CLI, MCP, and server/web task-creation entry points continue to use the canonical create path and preserve the current behavior shipped after BACK-404, including repo autoCommit handling, cross-branch dependency validation, comma-delimited --ref/--doc parsing, and support for existing create inputs such as description, acceptance criteria, Definition of Done defaults/additions, priority, milestone, ordinal, references, and documentation.
+- [x] #4 The refactor removes or collapses stale/duplicate create-path helpers so the create architecture is materially simpler to maintain than before this task.
+- [x] #5 Automated regression coverage is updated or added for both task and draft creation through the canonical path, and the implementer runs the relevant touched test suites and records the commands/results in the task final summary.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Collapse the overlapping create orchestration in src/core/backlog.ts so one canonical internal create path owns normalization, validation, default/status resolution, ID allocation, persistence, and post-write finalization for both tasks and drafts.
+2. Treat Draft as a reserved status in that shared path, with persistence deciding whether the record is written to tasks or drafts; remove internal duplicate create helpers such as createTaskFromData or createDraft entirely if all in-repo callers can be updated safely.
+3. Remove stale create-path duplication in src/cli.ts and src/utils/task-builders.ts by keeping CLI/MCP/server entry points on core.createTaskFromInput, centralizing list parsing, and deleting dead local helpers such as buildTaskFromOptions and the CLI-local dependency validator.
+4. Add or update focused regressions for task creation and draft creation through the canonical path, plus the existing auto-commit, cross-branch dependency, and refs/docs CLI coverage that protects preserved behavior.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Removed duplicate internal create entry points (`createTaskFromData` and `createDraft`) and migrated in-repo draft callers to `createTaskFromInput` so the canonical path owns draft and task creation.
+
+Verification completed on the clone: targeted create/draft/CLI suites passed (`src/test/core.test.ts`, `src/test/cli.test.ts`, `src/test/cli-plain-output.test.ts`, `src/test/cli-refs-docs.test.ts`, `src/test/auto-commit.test.ts`, `src/test/dependency.test.ts`, `src/test/draft-create-consistency.test.ts`), then broader create-adjacent suites passed (`src/test/acceptance-criteria.test.ts`, `src/test/definition-of-done-cli.test.ts`, `src/test/implementation-plan.test.ts`, `src/test/implementation-notes.test.ts`). `bunx tsc --noEmit` and `bun run check .` both passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Collapsed duplicate create helpers and routed draft creation through the canonical task create pipeline. Removed `createTaskFromData` and `createDraft` from core, updated in-repo draft callers to use `createTaskFromInput({ status: "Draft" })`, and simplified the CLI to share the common dependency/list parsing helpers. Verified with focused create, draft, CLI refs/docs, auto-commit, dependency, acceptance criteria, DoD, implementation plan, and implementation notes suites, plus `bunx tsc --noEmit` and `bun run check .`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ import { hasAnyPrefix } from "./utils/prefix-config.ts";
 import { type RuntimeCwdResolution, resolveRuntimeCwd } from "./utils/runtime-cwd.ts";
 import { formatValidStatuses, getCanonicalStatus, getValidStatuses } from "./utils/status.ts";
 import {
-	normalizeStringList,
+	normalizeDependencies,
 	parseDelimitedStringList,
 	parsePositiveIndexList,
 	processAcceptanceCriteriaOptions,
@@ -1398,122 +1398,6 @@ export async function generateNextDecisionId(core: Core): Promise<string> {
 	return `decision-${nextIdNumber}`;
 }
 
-function normalizeDependencies(dependencies: unknown): string[] {
-	if (!dependencies) return [];
-
-	const normalizeList = (values: string[]): string[] =>
-		values
-			.map((value) => value.trim())
-			.filter((value): value is string => value.length > 0)
-			.map((value) => normalizeTaskId(value));
-
-	if (Array.isArray(dependencies)) {
-		return normalizeList(
-			dependencies.flatMap((dep) =>
-				String(dep)
-					.split(",")
-					.map((d) => d.trim()),
-			),
-		);
-	}
-
-	return normalizeList(String(dependencies).split(","));
-}
-
-async function validateDependencies(
-	dependencies: string[],
-	core: Core,
-): Promise<{ valid: string[]; invalid: string[] }> {
-	const valid: string[] = [];
-	const invalid: string[] = [];
-
-	if (dependencies.length === 0) {
-		return { valid, invalid };
-	}
-
-	// Load both tasks and drafts to validate dependencies
-	const [tasks, drafts] = await Promise.all([core.queryTasks(), core.fs.listDrafts()]);
-
-	const knownIds = [...tasks.map((task) => task.id), ...drafts.map((draft) => draft.id)];
-	for (const dep of dependencies) {
-		const match = knownIds.find((id) => taskIdsEqual(dep, id));
-		if (match) {
-			valid.push(match);
-		} else {
-			invalid.push(dep);
-		}
-	}
-
-	return { valid, invalid };
-}
-
-function buildTaskFromOptions(id: string, title: string, options: Record<string, unknown>): Task {
-	const parentInput = options.parent ? String(options.parent) : undefined;
-	const normalizedParent = parentInput ? normalizeTaskId(parentInput) : undefined;
-
-	const createdDate = new Date().toISOString().slice(0, 16).replace("T", " ");
-
-	// Handle dependencies - they will be validated separately
-	const dependencies = normalizeDependencies(options.dependsOn || options.dep);
-
-	// Handle references (URLs or file paths)
-	const references = normalizeStringList(
-		Array.isArray(options.ref)
-			? options.ref.flatMap((r: string) =>
-					String(r)
-						.split(",")
-						.map((s: string) => s.trim()),
-				)
-			: options.ref
-				? String(options.ref)
-						.split(",")
-						.map((s: string) => s.trim())
-				: [],
-	);
-
-	// Handle documentation (URLs or file paths)
-	const documentation = normalizeStringList(
-		Array.isArray(options.doc)
-			? options.doc.flatMap((d: string) =>
-					String(d)
-						.split(",")
-						.map((s: string) => s.trim()),
-				)
-			: options.doc
-				? String(options.doc)
-						.split(",")
-						.map((s: string) => s.trim())
-				: [],
-	);
-
-	// Validate priority option
-	const priority = options.priority ? String(options.priority).toLowerCase() : undefined;
-	const validPriorities = ["high", "medium", "low"];
-	const validatedPriority =
-		priority && validPriorities.includes(priority) ? (priority as "high" | "medium" | "low") : undefined;
-
-	return {
-		id,
-		title,
-		status: options.status ? String(options.status) : "",
-		assignee: options.assignee ? [String(options.assignee)] : [],
-		createdDate,
-		labels: options.labels
-			? String(options.labels)
-					.split(",")
-					.map((l: string) => l.trim())
-					.filter(Boolean)
-			: [],
-		dependencies,
-		references,
-		documentation,
-		rawContent: "",
-		...(options.description || options.desc ? { description: String(options.description || options.desc) } : {}),
-		...(normalizedParent && { parentTaskId: normalizedParent }),
-		...(validatedPriority && { priority: validatedPriority }),
-	};
-}
-
 const taskCmd = program.command("task").aliases(["tasks"]);
 
 taskCmd
@@ -1617,7 +1501,7 @@ taskCmd
 				references: parseDelimitedStringList(options.ref),
 				documentation: parseDelimitedStringList(options.doc),
 				parentTaskId: options.parent ? String(options.parent) : undefined,
-				priority: options.priority ? String(options.priority).toLowerCase() : undefined,
+				priority: options.priority ? (String(options.priority).toLowerCase() as "high" | "medium" | "low") : undefined,
 				implementationPlan: options.plan ? String(options.plan) : undefined,
 				implementationNotes: options.notes ? String(options.notes) : undefined,
 				finalSummary: options.finalSummary ? String(options.finalSummary) : undefined,
@@ -2278,13 +2162,6 @@ taskCmd
 			return;
 		}
 
-		const parseCommaSeparated = (value: unknown): string[] => {
-			return toStringArray(value)
-				.flatMap((entry) => String(entry).split(","))
-				.map((entry) => entry.trim())
-				.filter((entry) => entry.length > 0);
-		};
-
 		let canonicalStatus: string | undefined;
 		if (options.status) {
 			const canonical = await getCanonicalStatus(String(options.status), core);
@@ -2360,10 +2237,10 @@ taskCmd
 			return;
 		}
 
-		const labelValues = parseCommaSeparated(options.label);
-		const addLabelValues = parseCommaSeparated(options.addLabel);
-		const removeLabelValues = parseCommaSeparated(options.removeLabel);
-		const assigneeValues = parseCommaSeparated(options.assignee);
+		const labelValues = parseDelimitedStringList(options.label) ?? [];
+		const addLabelValues = parseDelimitedStringList(options.addLabel) ?? [];
+		const removeLabelValues = parseDelimitedStringList(options.removeLabel) ?? [];
+		const assigneeValues = parseDelimitedStringList(options.assignee) ?? [];
 		const acceptanceAdditions = processAcceptanceCriteriaOptions(options);
 		const definitionOfDoneAdditions = toStringArray(options.dod)
 			.map((value) => String(value).trim())
@@ -2372,29 +2249,8 @@ taskCmd
 		const combinedDependencies = [...toStringArray(options.dependsOn), ...toStringArray(options.dep)];
 		const dependencyValues = combinedDependencies.length > 0 ? normalizeDependencies(combinedDependencies) : undefined;
 
-		const referenceValues = toStringArray(options.ref);
-		const normalizedReferences =
-			referenceValues.length > 0
-				? normalizeStringList(
-						referenceValues.flatMap((r: string) =>
-							String(r)
-								.split(",")
-								.map((s: string) => s.trim()),
-						),
-					)
-				: undefined;
-
-		const documentationValues = toStringArray(options.doc);
-		const normalizedDocumentation =
-			documentationValues.length > 0
-				? normalizeStringList(
-						documentationValues.flatMap((d: string) =>
-							String(d)
-								.split(",")
-								.map((s: string) => s.trim()),
-						),
-					)
-				: undefined;
+		const normalizedReferences = parseDelimitedStringList(options.ref);
+		const normalizedDocumentation = parseDelimitedStringList(options.doc);
 
 		const notesAppendValues = toStringArray(options.appendNotes);
 		const finalSummaryAppendValues = toStringArray(options.appendFinalSummary);

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -902,68 +902,6 @@ export class Core {
 		return savedTask;
 	}
 
-	// High-level operations that combine filesystem and git
-	async createTaskFromData(
-		taskData: {
-			title: string;
-			status?: string;
-			assignee?: string[];
-			labels?: string[];
-			dependencies?: string[];
-			parentTaskId?: string;
-			priority?: "high" | "medium" | "low";
-			// First-party structured fields from Web UI / CLI
-			description?: string;
-			acceptanceCriteriaItems?: import("../types/index.ts").AcceptanceCriterion[];
-			implementationPlan?: string;
-			implementationNotes?: string;
-			finalSummary?: string;
-			milestone?: string;
-		},
-		autoCommit?: boolean,
-	): Promise<Task> {
-		// Determine entity type before generating ID - drafts get DRAFT-X, tasks get TASK-X
-		const isDraft = taskData.status?.toLowerCase() === "draft";
-		const entityType = isDraft ? EntityType.Draft : EntityType.Task;
-		const config = !isDraft && !taskData.status ? await this.fs.loadConfig() : null;
-		const resolvedStatus = isDraft ? "Draft" : taskData.status || config?.defaultStatus || FALLBACK_STATUS;
-
-		const { task, filepath } = await this.withCreateLock(async () => {
-			const id = await this.generateNextId(entityType, isDraft ? undefined : taskData.parentTaskId);
-
-			const task: Task = {
-				id,
-				title: taskData.title,
-				status: resolvedStatus,
-				assignee: taskData.assignee || [],
-				labels: taskData.labels || [],
-				dependencies: taskData.dependencies || [],
-				rawContent: "",
-				createdDate: new Date().toISOString().slice(0, 16).replace("T", " "),
-				...(taskData.parentTaskId && { parentTaskId: taskData.parentTaskId }),
-				...(taskData.priority && { priority: taskData.priority }),
-				...(typeof taskData.milestone === "string" &&
-					taskData.milestone.trim().length > 0 && {
-						milestone: taskData.milestone.trim(),
-					}),
-				...(typeof taskData.description === "string" && { description: taskData.description }),
-				...(Array.isArray(taskData.acceptanceCriteriaItems) &&
-					taskData.acceptanceCriteriaItems.length > 0 && {
-						acceptanceCriteriaItems: taskData.acceptanceCriteriaItems,
-					}),
-				...(typeof taskData.implementationPlan === "string" && { implementationPlan: taskData.implementationPlan }),
-				...(typeof taskData.implementationNotes === "string" && { implementationNotes: taskData.implementationNotes }),
-				...(typeof taskData.finalSummary === "string" && { finalSummary: taskData.finalSummary }),
-			};
-
-			const filepath = await this.writePreparedTask(task, isDraft);
-			return { task, filepath };
-		});
-
-		await this.finalizeCreatedTask(task, filepath, isDraft, autoCommit);
-		return task;
-	}
-
 	async createTaskFromInput(input: TaskCreateInput, autoCommit?: boolean): Promise<{ task: Task; filePath?: string }> {
 		if (!input.title || input.title.trim().length === 0) {
 			throw new Error("Title is required to create a task.");
@@ -1071,13 +1009,6 @@ export class Core {
 
 		const filepath = await this.writePreparedTask(task, false);
 		await this.finalizeCreatedTask(task, filepath, false, autoCommit);
-
-		return filepath;
-	}
-
-	async createDraft(task: Task, autoCommit?: boolean): Promise<string> {
-		const filepath = await this.writePreparedTask(task, true);
-		await this.finalizeCreatedTask(task, filepath, true, autoCommit);
 
 		return filepath;
 	}

--- a/src/test/auto-commit.test.ts
+++ b/src/test/auto-commit.test.ts
@@ -261,18 +261,14 @@ describe("Auto-commit configuration", () => {
 		});
 
 		it("should respect autoCommit config for draft operations", async () => {
-			const task: Task = {
-				id: "draft-1",
-				title: "Test Draft",
-				status: "Draft",
-				assignee: [],
-				createdDate: "2025-07-07",
-				labels: [],
-				dependencies: [],
-				description: "Test description",
-			};
-
-			await core.createDraft(task);
+			await core.createTaskFromInput(
+				{
+					title: "Test Draft",
+					status: "Draft",
+					description: "Test description",
+				},
+				false,
+			);
 
 			// Check that there are uncommitted changes
 			const git = await core.getGitOps();
@@ -282,20 +278,17 @@ describe("Auto-commit configuration", () => {
 
 		it("should respect autoCommit config for promote draft operations", async () => {
 			// First create a draft with explicit commit
-			const task: Task = {
-				id: "draft-2",
-				title: "Test Draft",
-				status: "Draft",
-				assignee: [],
-				createdDate: "2025-07-07",
-				labels: [],
-				dependencies: [],
-				description: "Test description",
-			};
-			await core.createDraft(task, true);
+			const { task: draft } = await core.createTaskFromInput(
+				{
+					title: "Test Draft",
+					status: "Draft",
+					description: "Test description",
+				},
+				true,
+			);
 
 			// Promote the draft (should not auto-commit)
-			await core.promoteDraft("draft-2");
+			await core.promoteDraft(draft.id);
 
 			// Check that there are uncommitted changes
 			const git = await core.getGitOps();

--- a/src/test/cli-plain-output.test.ts
+++ b/src/test/cli-plain-output.test.ts
@@ -78,16 +78,11 @@ describe("CLI plain output for AI agents", () => {
 			false,
 		);
 
-		// Create a test draft with proper DRAFT-X id format
-		await core.createDraft(
+		// Create a test draft through the canonical create path
+		await core.createTaskFromInput(
 			{
-				id: "draft-1",
 				title: "Test draft for plain output",
 				status: "Draft",
-				assignee: [],
-				createdDate: "2025-06-18",
-				labels: [],
-				dependencies: [],
 				description: "Test draft description",
 			},
 			false,
@@ -194,7 +189,7 @@ describe("CLI plain output for AI agents", () => {
 		// Should contain the formatted draft output
 		expect(result.stdout.toString()).toContain("Task DRAFT-1 - Test draft for plain output");
 		expect(result.stdout.toString()).toContain("Status: ○ Draft");
-		expect(result.stdout.toString()).toContain("Created: 2025-06-18");
+		expect(result.stdout.toString()).toMatch(/Created:\s+\d{4}-\d{2}-\d{2}/);
 		expect(result.stdout.toString()).toContain("Description:");
 		expect(result.stdout.toString()).toContain("Test draft description");
 		expect(result.stdout.toString()).toContain("Definition of Done:");
@@ -224,7 +219,7 @@ describe("CLI plain output for AI agents", () => {
 		// Should contain the formatted draft output
 		expect(result.stdout.toString()).toContain("Task DRAFT-1 - Test draft for plain output");
 		expect(result.stdout.toString()).toContain("Status: ○ Draft");
-		expect(result.stdout.toString()).toContain("Created: 2025-06-18");
+		expect(result.stdout.toString()).toMatch(/Created:\s+\d{4}-\d{2}-\d{2}/);
 		expect(result.stdout.toString()).toContain("Description:");
 		expect(result.stdout.toString()).toContain("Test draft description");
 		expect(result.stdout.toString()).toContain("Definition of Done:");

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1174,28 +1174,24 @@ describe("CLI Integration", () => {
 		it("should promote draft to tasks", async () => {
 			const core = new Core(TEST_DIR);
 
-			// Create a test draft with proper DRAFT-X id
-			await core.createDraft(
+			// Create a test draft through the canonical create path
+			const { task: draft } = await core.createTaskFromInput(
 				{
-					id: "draft-3",
 					title: "Promote Test Draft",
 					status: "Draft",
-					assignee: [],
-					createdDate: "2025-06-08",
 					labels: ["ready"],
-					dependencies: [],
 					rawContent: "Draft ready for promotion",
 				},
 				false,
 			);
 
 			// Promote the draft
-			const success = await core.promoteDraft("draft-3", false);
+			const success = await core.promoteDraft(draft.id, false);
 			expect(success).toBe(true);
 
 			// Verify draft is no longer in drafts directory
-			const draft = await core.filesystem.loadDraft("draft-3");
-			expect(draft).toBeNull();
+			const loadedDraft = await core.filesystem.loadDraft(draft.id);
+			expect(loadedDraft).toBeNull();
 
 			// Verify promoted task has new task- ID
 			const { readdir } = await import("node:fs/promises");
@@ -1210,33 +1206,29 @@ describe("CLI Integration", () => {
 		it("should archive a draft", async () => {
 			const core = new Core(TEST_DIR);
 
-			// Create a test draft with proper DRAFT-X id
-			await core.createDraft(
+			// Create a test draft through the canonical create path
+			const { task: draft } = await core.createTaskFromInput(
 				{
-					id: "draft-4",
 					title: "Archive Test Draft",
 					status: "Draft",
-					assignee: [],
-					createdDate: "2025-06-08",
 					labels: ["cancelled"],
-					dependencies: [],
 					rawContent: "Draft that should be archived",
 				},
 				false,
 			);
 
 			// Archive the draft
-			const success = await core.archiveDraft("draft-4", false);
+			const success = await core.archiveDraft(draft.id, false);
 			expect(success).toBe(true);
 
 			// Verify draft is no longer in drafts directory
-			const draft = await core.filesystem.loadDraft("draft-4");
-			expect(draft).toBeNull();
+			const loadedDraft = await core.filesystem.loadDraft(draft.id);
+			expect(loadedDraft).toBeNull();
 
 			// Verify draft exists in archive
 			const { readdir } = await import("node:fs/promises");
 			const archiveFiles = await readdir(join(TEST_DIR, "backlog", "archive", "drafts"));
-			expect(archiveFiles.some((f) => f.startsWith("draft-4"))).toBe(true);
+			expect(archiveFiles.some((f) => f.startsWith(draft.id.toLowerCase()))).toBe(true);
 		});
 
 		it("should handle promoting non-existent draft", async () => {

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -414,33 +414,35 @@ describe("Core", () => {
 	});
 
 	describe("draft operations", () => {
-		// Drafts now use DRAFT-X id format and draft-x filename prefix
-		const sampleDraft: Task = {
-			id: "draft-1",
-			title: "Draft Task",
-			status: "Draft",
-			assignee: [],
-			createdDate: "2025-06-07",
-			labels: [],
-			dependencies: [],
-			description: "Draft task",
-		};
-
 		beforeEach(async () => {
 			await initializeTestProject(core, "Draft Project", true);
 		});
 
 		it("should create draft without auto-commit", async () => {
-			await core.createDraft(sampleDraft, false);
+			const { task: draft } = await core.createTaskFromInput(
+				{
+					title: "Draft Task",
+					status: "Draft",
+					description: "Draft task",
+				},
+				false,
+			);
 
-			const loaded = await core.filesystem.loadDraft("draft-1");
+			const loaded = await core.filesystem.loadDraft(draft.id);
 			expect(loaded?.id).toBe("DRAFT-1");
 		});
 
 		it("should create draft with auto-commit", async () => {
-			await core.createDraft(sampleDraft, true);
+			const { task: draft } = await core.createTaskFromInput(
+				{
+					title: "Draft Task",
+					status: "Draft",
+					description: "Draft task",
+				},
+				true,
+			);
 
-			const loaded = await core.filesystem.loadDraft("draft-1");
+			const loaded = await core.filesystem.loadDraft(draft.id);
 			expect(loaded?.id).toBe("DRAFT-1");
 
 			const lastCommit = await core.gitOps.getLastCommitMessage();
@@ -449,45 +451,54 @@ describe("Core", () => {
 		});
 
 		it("should promote draft with auto-commit", async () => {
-			await core.createDraft(sampleDraft, true);
+			const { task: draft } = await core.createTaskFromInput(
+				{
+					title: "Draft Task",
+					status: "Draft",
+					description: "Draft task",
+				},
+				true,
+			);
 
-			const promoted = await core.promoteDraft("draft-1", true);
+			const promoted = await core.promoteDraft(draft.id, true);
 			expect(promoted).toBe(true);
 
 			const lastCommit = await core.gitOps.getLastCommitMessage();
-			expect(lastCommit).toContain("backlog: Promote draft DRAFT-1");
+			expect(lastCommit).toContain(`backlog: Promote draft ${draft.id.toUpperCase()}`);
 		});
 
 		it("should archive draft with auto-commit", async () => {
-			await core.createDraft(sampleDraft, true);
+			const { task: draft } = await core.createTaskFromInput(
+				{
+					title: "Draft Task",
+					status: "Draft",
+					description: "Draft task",
+				},
+				true,
+			);
 
-			const archived = await core.archiveDraft("draft-1", true);
+			const archived = await core.archiveDraft(draft.id, true);
 			expect(archived).toBe(true);
 
 			const lastCommit = await core.gitOps.getLastCommitMessage();
-			expect(lastCommit).toContain("backlog: Archive draft DRAFT-1");
+			expect(lastCommit).toContain(`backlog: Archive draft ${draft.id.toUpperCase()}`);
 		});
 
-		it("should normalize assignee for string and array inputs", async () => {
-			const draftString = {
-				...sampleDraft,
-				id: "draft-2",
-				title: "Draft String",
-				assignee: "@erin",
-			} as unknown as Task;
-			await core.createDraft(draftString, false);
-			const loadedString = await core.filesystem.loadDraft("draft-2");
-			expect(loadedString?.assignee).toEqual(["@erin"]);
+		it("should preserve draft metadata through the canonical create path", async () => {
+			const { task: draft } = await core.createTaskFromInput(
+				{
+					title: "Draft Array",
+					status: "Draft",
+					description: "Draft task",
+					assignee: ["@frank"],
+					labels: ["draft"],
+				},
+				false,
+			);
 
-			const draftArray: Task = {
-				...sampleDraft,
-				id: "draft-3",
-				title: "Draft Array",
-				assignee: ["@frank"],
-			};
-			await core.createDraft(draftArray, false);
-			const loadedArray = await core.filesystem.loadDraft("draft-3");
-			expect(loadedArray?.assignee).toEqual(["@frank"]);
+			const loaded = await core.filesystem.loadDraft(draft.id);
+			expect(loaded?.assignee).toEqual(["@frank"]);
+			expect(loaded?.labels).toEqual(["draft"]);
 		});
 	});
 

--- a/src/test/dependency.test.ts
+++ b/src/test/dependency.test.ts
@@ -138,7 +138,15 @@ describe("Task Dependencies", () => {
 			description: "Draft task",
 		};
 
-		await core.createDraft(draftTask, false);
+		await core.createTaskFromInput(
+			{
+				title: draftTask.title,
+				status: "Draft",
+				description: draftTask.description,
+				dependencies: draftTask.dependencies,
+			},
+			false,
+		);
 
 		// Create task that depends on draft
 		const task2: Task = {
@@ -333,11 +341,19 @@ describe("Task Dependencies", () => {
 		};
 
 		await core.createTask(archiveTarget, false);
-		await core.createDraft(draftTask, false);
+		await core.createTaskFromInput(
+			{
+				title: draftTask.title,
+				status: "Draft",
+				description: draftTask.description,
+				dependencies: draftTask.dependencies,
+			},
+			false,
+		);
 		await core.archiveTask("task-1", false);
 
 		const draft = await core.filesystem.loadDraft("draft-1");
-		expect(draft?.dependencies).toEqual(["task-1"]);
+		expect(draft?.dependencies).toEqual(["TASK-1"]);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Removed duplicate internal create helpers in core (`createTaskFromData`, `createDraft`) and kept the canonical create path on `createTaskFromInput`.
- Simplified CLI parsing to use shared helpers for dependencies, refs, and docs.
- Updated in-repo draft callers and regression coverage to use the canonical draft create flow.

## Verification
- `bun test src/test/core.test.ts src/test/cli.test.ts src/test/cli-plain-output.test.ts src/test/cli-refs-docs.test.ts src/test/auto-commit.test.ts src/test/dependency.test.ts src/test/draft-create-consistency.test.ts`
- `bun test src/test/acceptance-criteria.test.ts src/test/definition-of-done-cli.test.ts src/test/implementation-plan.test.ts src/test/implementation-notes.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`