### PR TITLE
BACK-405 - Restore package.json version sync in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -500,7 +500,7 @@ jobs:
           files: binaries/*
 
   sync-version:
-    needs: build
+    needs: [github-release, npm-publish, install-sanity]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,3 +498,22 @@ jobs:
       - uses: softprops/action-gh-release@v1
         with:
           files: binaries/*
+
+  sync-version:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Sync version to tag
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF##refs/tags/v}"
+          jq ".version = \"$TAG\"" package.json > tmp.json && mv tmp.json package.json
+      - name: Commit version bump
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: sync package.json version to ${{ github.ref_name }} [skip ci]"
+          branch: main
+          file_pattern: package.json

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "backlog.md",
-      "dependencies": {
-        "proper-lockfile": "^4.1.2",
-      },
       "devDependencies": {
         "@biomejs/biome": "2.3.11",
         "@clack/core": "1.0.1",
@@ -30,6 +27,7 @@
         "mermaid": "11.12.2",
         "neo-neo-bblessed": "1.0.9",
         "picocolors": "1.1.1",
+        "proper-lockfile": "4.1.2",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-router-dom": "7.12.0",

--- a/bun.nix
+++ b/bun.nix
@@ -3153,6 +3153,12 @@
     url = "https://registry.npmjs.org/process/-/process-0.11.10.tgz";
     hash = "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==";
   };
+  "proper-lockfile" = {
+    out_path = "proper-lockfile";
+    name = "proper-lockfile@4.1.2";
+    url = "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz";
+    hash = "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==";
+  };
   "property-information" = {
     out_path = "property-information";
     name = "property-information@7.1.0";
@@ -3369,6 +3375,18 @@
     url = "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz";
     hash = "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==";
   };
+  "restore-cursor/signal-exit" = {
+    out_path = "restore-cursor/node_modules/signal-exit";
+    name = "signal-exit@4.1.0";
+    url = "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz";
+    hash = "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==";
+  };
+  "retry" = {
+    out_path = "retry";
+    name = "retry@0.12.0";
+    url = "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz";
+    hash = "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==";
+  };
   "rfdc" = {
     out_path = "rfdc";
     name = "rfdc@1.4.1";
@@ -3497,9 +3515,9 @@
   };
   "signal-exit" = {
     out_path = "signal-exit";
-    name = "signal-exit@4.1.0";
-    url = "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz";
-    hash = "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==";
+    name = "signal-exit@3.0.7";
+    url = "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz";
+    hash = "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==";
   };
   "simple-xml-to-json" = {
     out_path = "simple-xml-to-json";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "backlog.md",
-	"version": "1.35.7",
+	"version": "1.42.0",
 	"type": "module",
 	"module": "src/cli.ts",
 	"files": [
@@ -45,7 +45,8 @@
 		"react-dom": "19.2.3",
 		"react-router-dom": "7.12.0",
 		"react-tooltip": "5.30.0",
-		"tailwindcss": "4.1.18"
+		"tailwindcss": "4.1.18",
+		"proper-lockfile": "4.1.2"
 	},
 	"scripts": {
 		"test": "bun test",
@@ -94,8 +95,5 @@
 	"trustedDependencies": [
 		"@biomejs/biome",
 		"node-pty"
-	],
-	"dependencies": {
-		"proper-lockfile": "^4.1.2"
-	}
+	]
 }


### PR DESCRIPTION
## Summary

- Re-add `sync-version` job to `release.yml` that commits the tag version back to `package.json` on `main` after each release. This was accidentally removed in BACK-383 when the README board export was deleted.
- Bump `package.json` from `1.35.7` to `1.42.0` to match the current latest release.
- Update `bun.lock` and regenerate `bun.nix` after dependency restructuring.

## Test plan

- [ ] Verify the `sync-version` job syntax is valid by reviewing the workflow YAML
- [ ] Confirm next release tag triggers the job and commits the version back to `main`

Fixes https://github.com/MrLesk/Backlog.md/issues/567