### PR TITLE
BACK-408 - Consolidate MCP workflow guide tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This project uses Backlog.md MCP for all task and project management activities.
 **CRITICAL GUIDANCE**
 
 - If your client supports MCP resources, read `backlog://workflow/overview` to understand when and how to use Backlog for this project.
-- If your client only supports tools or the above request fails, call `backlog.get_workflow_overview()` tool to load the tool-oriented overview (it lists the matching guide tools).
+- If your client only supports tools or the above request fails, call `backlog.get_backlog_instructions()` to load the tool-oriented overview. Use the `instruction` selector when you need `task-creation`, `task-execution`, or `task-finalization`.
 
 - **First time working here?** Read the overview resource IMMEDIATELY to learn the workflow
 - **Already familiar?** You should have the overview cached ("## Backlog.md Overview (MCP)")

--- a/backlog/tasks/back-408 - Consolidate-MCP-workflow-guide-tools-into-get_backlog_instructions.md
+++ b/backlog/tasks/back-408 - Consolidate-MCP-workflow-guide-tools-into-get_backlog_instructions.md
@@ -1,0 +1,72 @@
+---
+id: BACK-408
+title: Consolidate MCP workflow guide tools into get_backlog_instructions
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-03-21 13:59'
+updated_date: '2026-03-21 14:05'
+labels: []
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Context
+Backlog.md currently exposes four separate MCP tools for workflow guidance: overview, task creation, task execution, and task finalization. The desired outcome is a simpler tool surface that lets MCP clients retrieve any of these instruction sets through one tool instead of four separate entries.
+
+## Desired Outcome
+Provide a single MCP tool named `get_backlog_instructions` that returns the requested workflow instructions and defaults to the overview when no selection is provided. Keep the interaction clear for MCP clients that render schema enums as dropdown selectors.
+
+## Scope Notes
+This change is focused on the MCP tool surface for workflow instructions. Existing workflow resource URIs should continue to work unless implementation discovery shows a documented reason to change them.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A single MCP tool named `get_backlog_instructions` is exposed for workflow instructions and returns the overview when called without arguments.
+- [x] #2 The tool schema exposes a selectable instruction type covering overview, task creation, task execution, and task finalization in a form MCP clients can render as a selector.
+- [x] #3 The previous four workflow guide tools are no longer registered in the MCP tool list, and related tests and shipped guidance are updated to match the new tool contract.
+- [x] #4 Existing workflow resource URIs continue to return the corresponding markdown content unchanged.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace the current workflow tool registration with a single `get_backlog_instructions` MCP tool that accepts an optional enum selector for `overview`, `task-creation`, `task-execution`, and `task-finalization`, defaulting to `overview` when omitted.
+2. Keep the existing workflow resources and central guide definitions intact so `backlog://workflow/...` URIs remain unchanged; add any small helper needed to resolve guide entries by selector.
+3. Update shipped MCP-facing guidance that currently names the four old tools so it points to the consolidated tool and explains the selector usage for tool-only clients.
+4. Update MCP server and roots-discovery tests to assert the new single tool name, selector behavior, and unchanged resource behavior.
+5. Run targeted tests for MCP workflow surfaces, then run typecheck and repo checks if the touched files require it; simplify any unnecessary branching discovered during implementation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the four workflow guide MCP tools with a single `get_backlog_instructions` tool that uses an optional enum `instruction` selector and defaults to `overview`.
+
+Kept the existing `backlog://workflow/...` resources unchanged and reused the existing guide registry by adding key-based lookup for the consolidated tool handler.
+
+Updated shipped tool-oriented guidance and agent nudge copy to reference `get_backlog_instructions` and selector usage, and refreshed MCP bootstrap/roots-discovery tests to assert the new contract.
+
+Verification: `bun test src/test/mcp-server.test.ts src/test/mcp-roots-discovery.test.ts`, `bunx tsc --noEmit`, and `bun run check .` all passed. Included the existing Biome formatter output for `package.json` so the repo-wide check is clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Consolidated the MCP workflow guide tool surface into a single `get_backlog_instructions` endpoint. The new tool exposes an optional enum-backed `instruction` selector for `overview`, `task-creation`, `task-execution`, and `task-finalization`, and it defaults to the tool-oriented overview when omitted.
+
+The underlying workflow resources remain unchanged, and the implementation still uses the shared workflow guide registry for content selection. Updated the shipped MCP guidance (`AGENTS.md`, agent nudge copy, and tool-oriented overview text) so tool-only clients are instructed to call the consolidated tool with the selector when they need a specific guide.
+
+Tests were updated to cover the new tool list, selector schema, default overview behavior, selected guide behavior, and unchanged resource registration through normal bootstrap and roots discovery. Verification run: `bun test src/test/mcp-server.test.ts src/test/mcp-roots-discovery.test.ts`, `bunx tsc --noEmit`, and `bun run check .`. Also applied the existing Biome formatting output to `package.json` so the repo-wide check passes cleanly.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/package.json
+++ b/package.json
@@ -1,99 +1,99 @@
 {
-  "name": "backlog.md",
-  "version": "1.43.0",
-  "type": "module",
-  "module": "src/cli.ts",
-  "files": [
-    "scripts/*.cjs",
-    "README.md",
-    "LICENSE"
-  ],
-  "bin": {
-    "backlog": "scripts/cli.cjs"
-  },
-  "optionalDependencies": {
-    "backlog.md-darwin-arm64": "*",
-    "backlog.md-darwin-x64": "*",
-    "backlog.md-linux-arm64": "*",
-    "backlog.md-linux-x64": "*",
-    "backlog.md-windows-x64": "*"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.11",
-    "@clack/core": "1.0.1",
-    "@clack/prompts": "1.0.1",
-    "@modelcontextprotocol/sdk": "1.27.1",
-    "@tailwindcss/cli": "4.1.18",
-    "@types/bun": "1.3.6",
-    "@types/jsdom": "27.0.0",
-    "@types/react": "19.2.8",
-    "@types/react-dom": "19.2.3",
-    "@types/react-router-dom": "5.3.3",
-    "@uiw/react-markdown-preview": "5.1.5",
-    "@uiw/react-md-editor": "4.0.11",
-    "commander": "14.0.2",
-    "fuse.js": "7.1.0",
-    "gray-matter": "4.0.3",
-    "husky": "9.1.7",
-    "install": "0.13.0",
-    "jsdom": "27.4.0",
-    "lint-staged": "16.2.7",
-    "mermaid": "11.12.2",
-    "neo-neo-bblessed": "1.0.9",
-    "picocolors": "1.1.1",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
-    "react-router-dom": "7.12.0",
-    "react-tooltip": "5.30.0",
-    "tailwindcss": "4.1.18",
-    "proper-lockfile": "4.1.2"
-  },
-  "scripts": {
-    "test": "bun test",
-    "format": "biome format --write .",
-    "lint": "biome lint --write .",
-    "check": "biome check .",
-    "check:types": "bunx tsc --noEmit",
-    "prepare": "husky",
-    "build:css": "bun ./node_modules/@tailwindcss/cli/dist/index.mjs -i src/web/styles/source.css -o src/web/styles/style.css --minify",
-    "build": "bun run build:css && VER=$(bun -e 'console.log(require(\"./package.json\").version)') && bun build --production --compile --minify --define __EMBEDDED_VERSION__=\"\\\"$VER\\\"\" --outfile=dist/backlog src/cli.ts",
-    "cli": "bun run build:css && bun src/cli.ts",
-    "mcp": "bun src/cli.ts mcp start",
-    "update-nix": "sh scripts/update-nix.sh",
-    "postinstall": "sh -c 'command -v bun2nix >/dev/null 2>&1 && bun2nix -o bun.nix || (command -v nix >/dev/null 2>&1 && nix --extra-experimental-features \"nix-command flakes\" run github:baileyluTCD/bun2nix/85d692d68a5345d868d3bb1158b953d2996d70f7 -- -o bun.nix || true)'"
-  },
-  "lint-staged": {
-    "package.json": [
-      "biome check --write --files-ignore-unknown=true"
-    ],
-    "*.json": [
-      "biome check --write --files-ignore-unknown=true"
-    ],
-    "src/**/*.{ts,js}": [
-      "biome check --write --files-ignore-unknown=true"
-    ]
-  },
-  "author": "Alex Gavrilescu (https://github.com/MrLesk)",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/MrLesk/Backlog.md.git"
-  },
-  "bugs": {
-    "url": "https://github.com/MrLesk/Backlog.md/issues"
-  },
-  "homepage": "https://backlog.md",
-  "keywords": [
-    "cli",
-    "markdown",
-    "kanban",
-    "task",
-    "project-management",
-    "backlog",
-    "agents"
-  ],
-  "license": "MIT",
-  "trustedDependencies": [
-    "@biomejs/biome",
-    "node-pty"
-  ]
+	"name": "backlog.md",
+	"version": "1.43.0",
+	"type": "module",
+	"module": "src/cli.ts",
+	"files": [
+		"scripts/*.cjs",
+		"README.md",
+		"LICENSE"
+	],
+	"bin": {
+		"backlog": "scripts/cli.cjs"
+	},
+	"optionalDependencies": {
+		"backlog.md-darwin-arm64": "*",
+		"backlog.md-darwin-x64": "*",
+		"backlog.md-linux-arm64": "*",
+		"backlog.md-linux-x64": "*",
+		"backlog.md-windows-x64": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.11",
+		"@clack/core": "1.0.1",
+		"@clack/prompts": "1.0.1",
+		"@modelcontextprotocol/sdk": "1.27.1",
+		"@tailwindcss/cli": "4.1.18",
+		"@types/bun": "1.3.6",
+		"@types/jsdom": "27.0.0",
+		"@types/react": "19.2.8",
+		"@types/react-dom": "19.2.3",
+		"@types/react-router-dom": "5.3.3",
+		"@uiw/react-markdown-preview": "5.1.5",
+		"@uiw/react-md-editor": "4.0.11",
+		"commander": "14.0.2",
+		"fuse.js": "7.1.0",
+		"gray-matter": "4.0.3",
+		"husky": "9.1.7",
+		"install": "0.13.0",
+		"jsdom": "27.4.0",
+		"lint-staged": "16.2.7",
+		"mermaid": "11.12.2",
+		"neo-neo-bblessed": "1.0.9",
+		"picocolors": "1.1.1",
+		"react": "19.2.3",
+		"react-dom": "19.2.3",
+		"react-router-dom": "7.12.0",
+		"react-tooltip": "5.30.0",
+		"tailwindcss": "4.1.18",
+		"proper-lockfile": "4.1.2"
+	},
+	"scripts": {
+		"test": "bun test",
+		"format": "biome format --write .",
+		"lint": "biome lint --write .",
+		"check": "biome check .",
+		"check:types": "bunx tsc --noEmit",
+		"prepare": "husky",
+		"build:css": "bun ./node_modules/@tailwindcss/cli/dist/index.mjs -i src/web/styles/source.css -o src/web/styles/style.css --minify",
+		"build": "bun run build:css && VER=$(bun -e 'console.log(require(\"./package.json\").version)') && bun build --production --compile --minify --define __EMBEDDED_VERSION__=\"\\\"$VER\\\"\" --outfile=dist/backlog src/cli.ts",
+		"cli": "bun run build:css && bun src/cli.ts",
+		"mcp": "bun src/cli.ts mcp start",
+		"update-nix": "sh scripts/update-nix.sh",
+		"postinstall": "sh -c 'command -v bun2nix >/dev/null 2>&1 && bun2nix -o bun.nix || (command -v nix >/dev/null 2>&1 && nix --extra-experimental-features \"nix-command flakes\" run github:baileyluTCD/bun2nix/85d692d68a5345d868d3bb1158b953d2996d70f7 -- -o bun.nix || true)'"
+	},
+	"lint-staged": {
+		"package.json": [
+			"biome check --write --files-ignore-unknown=true"
+		],
+		"*.json": [
+			"biome check --write --files-ignore-unknown=true"
+		],
+		"src/**/*.{ts,js}": [
+			"biome check --write --files-ignore-unknown=true"
+		]
+	},
+	"author": "Alex Gavrilescu (https://github.com/MrLesk)",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/MrLesk/Backlog.md.git"
+	},
+	"bugs": {
+		"url": "https://github.com/MrLesk/Backlog.md/issues"
+	},
+	"homepage": "https://backlog.md",
+	"keywords": [
+		"cli",
+		"markdown",
+		"kanban",
+		"task",
+		"project-management",
+		"backlog",
+		"agents"
+	],
+	"license": "MIT",
+	"trustedDependencies": [
+		"@biomejs/biome",
+		"node-pty"
+	]
 }

--- a/src/guidelines/mcp/agent-nudge.md
+++ b/src/guidelines/mcp/agent-nudge.md
@@ -8,7 +8,7 @@ This project uses Backlog.md MCP for all task and project management activities.
 **CRITICAL GUIDANCE**
 
 - If your client supports MCP resources, read `backlog://workflow/overview` to understand when and how to use Backlog for this project.
-- If your client only supports tools or the above request fails, call `backlog.get_workflow_overview()` tool to load the tool-oriented overview (it lists the matching guide tools).
+- If your client only supports tools or the above request fails, call `backlog.get_backlog_instructions()` to load the tool-oriented overview. Use the `instruction` selector when you need `task-creation`, `task-execution`, or `task-finalization`.
 
 - **First time working here?** Read the overview resource IMMEDIATELY to learn the workflow
 - **Already familiar?** You should have the overview cached ("## Backlog.md Overview (MCP)")

--- a/src/guidelines/mcp/overview-tools.md
+++ b/src/guidelines/mcp/overview-tools.md
@@ -23,21 +23,18 @@ Your client is using Backlog.md via tools. Use the following MCP tools to retrie
 
 ### Core Workflow Tools
 
-Use these tools to retrieve the required Backlog.md guidance in markdown form:
+Use this tool to retrieve the required Backlog.md guidance in markdown form:
 
-- `get_workflow_overview` — Overview of when and how to use Backlog
-- `get_task_creation_guide` — Detailed instructions for creating tasks (scope, acceptance criteria, structure)
-- `get_task_execution_guide` — Planning and executing tasks (implementation plans, approvals, scope changes)
-- `get_task_finalization_guide` — Definition of Done, finalization workflow, next steps
+- `get_backlog_instructions` — Returns workflow guidance. Leave `instruction` empty for the overview, or select `task-creation`, `task-execution`, or `task-finalization`.
 
-Each tool returns the same content that resource-capable clients read via `backlog://workflow/...` URIs.
+The tool returns the same content that resource-capable clients read via `backlog://workflow/...` URIs. The overview response is tool-oriented when `instruction` is omitted or set to `overview`.
 
 ### Typical Workflow (Tools)
 
 1. **Search first:** call `task_search` or `task_list` with filters to find existing work
 2. **If found:** read details via `task_view`; follow execution/plan guidance from the retrieved markdown
-3. **If not found:** consult `get_task_creation_guide`, then create tasks with `task_create`
-4. **Execute & finalize:** use the execution/finalization guides to manage status, plans, notes, and acceptance criteria via `task_edit`
+3. **If not found:** call `get_backlog_instructions` with `instruction="task-creation"`, then create tasks with `task_create`
+4. **Execute & finalize:** call `get_backlog_instructions` with `instruction="task-execution"` or `instruction="task-finalization"` to manage status, plans, notes, and acceptance criteria via `task_edit`
 
 **Note:** "Done" tasks stay in Done until periodic cleanup. Moving to the completed folder (`task_complete`) is a batch operation run occasionally, not part of finishing each task. Do not use `task_archive` for completed work—archive is only for duplicate, canceled, or invalid tasks.
 
@@ -47,7 +44,7 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 
 ### MCP Tools Quick Reference
 
-- `get_workflow_overview`, `get_task_creation_guide`, `get_task_execution_guide`, `get_task_finalization_guide`
+- `get_backlog_instructions`
 - `task_list`, `task_search`, `task_view`, `task_create`, `task_edit`, `task_complete`, `task_archive`
 - `document_list`, `document_view`, `document_create`, `document_update`, `document_search`
 - `definition_of_done_defaults_get`, `definition_of_done_defaults_upsert`

--- a/src/mcp/tools/workflow/index.ts
+++ b/src/mcp/tools/workflow/index.ts
@@ -2,46 +2,77 @@ import type { McpServer } from "../../server.ts";
 import type { McpToolHandler } from "../../types.ts";
 import { createSimpleValidatedTool } from "../../validation/tool-wrapper.ts";
 import type { JsonSchema } from "../../validation/validators.ts";
-import { WORKFLOW_GUIDES } from "../../workflow-guides.ts";
+import {
+	getWorkflowGuideByKey,
+	WORKFLOW_GUIDE_KEYS,
+	type WorkflowGuideDefinition,
+	type WorkflowGuideKey,
+} from "../../workflow-guides.ts";
 
-const emptyInputSchema: JsonSchema = {
+const workflowInstructionsSchema: JsonSchema = {
 	type: "object",
-	properties: {},
+	properties: {
+		instruction: {
+			type: "string",
+			enum: [...WORKFLOW_GUIDE_KEYS],
+		},
+	},
 	required: [],
 	additionalProperties: false,
 };
 
-function createWorkflowTool(guide: (typeof WORKFLOW_GUIDES)[number]): McpToolHandler {
-	const toolText = guide.toolText ?? guide.resourceText;
+function getToolPayload(key: WorkflowGuideKey): WorkflowGuideDefinition {
+	const guide = getWorkflowGuideByKey(key);
+	if (guide) {
+		return guide;
+	}
+
+	const overviewGuide = getWorkflowGuideByKey("overview");
+	if (!overviewGuide) {
+		throw new Error("Workflow guide definitions are missing the overview entry.");
+	}
+
+	return overviewGuide;
+}
+
+function createWorkflowTool(): McpToolHandler {
+	type WorkflowInstructionsInput = {
+		instruction?: WorkflowGuideKey;
+	};
+
 	return createSimpleValidatedTool(
 		{
-			name: guide.toolName,
-			description: guide.toolDescription,
-			inputSchema: emptyInputSchema,
-			annotations: { title: guide.name, readOnlyHint: true, destructiveHint: false },
+			name: "get_backlog_instructions",
+			description:
+				"Retrieve Backlog.md workflow guidance in markdown format. Defaults to the overview when no instruction is selected.",
+			inputSchema: workflowInstructionsSchema,
+			annotations: { title: "Backlog Instructions", readOnlyHint: true, destructiveHint: false },
 		},
-		emptyInputSchema,
-		async () => ({
-			content: [
-				{
-					type: "text",
+		workflowInstructionsSchema,
+		async (input: WorkflowInstructionsInput) => {
+			const guide = getToolPayload(input.instruction ?? "overview");
+			const toolText = guide.toolText ?? guide.resourceText;
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: toolText,
+					},
+				],
+				structuredContent: {
+					type: "resource",
+					uri: guide.uri,
+					title: guide.name,
+					description: guide.description,
+					mimeType: guide.mimeType,
 					text: toolText,
 				},
-			],
-			structuredContent: {
-				type: "resource",
-				uri: guide.uri,
-				title: guide.name,
-				description: guide.description,
-				mimeType: guide.mimeType,
-				text: toolText,
-			},
-		}),
+			};
+		},
 	);
 }
 
 export function registerWorkflowTools(server: McpServer): void {
-	for (const guide of WORKFLOW_GUIDES) {
-		server.addTool(createWorkflowTool(guide));
-	}
+	server.addTool(createWorkflowTool());
 }

--- a/src/mcp/workflow-guides.ts
+++ b/src/mcp/workflow-guides.ts
@@ -6,16 +6,18 @@ import {
 	MCP_WORKFLOW_OVERVIEW_TOOLS,
 } from "../guidelines/mcp/index.ts";
 
+export const WORKFLOW_GUIDE_KEYS = ["overview", "task-creation", "task-execution", "task-finalization"] as const;
+
+export type WorkflowGuideKey = (typeof WORKFLOW_GUIDE_KEYS)[number];
+
 export interface WorkflowGuideDefinition {
-	key: "overview" | "task-creation" | "task-execution" | "task-finalization";
+	key: WorkflowGuideKey;
 	uri: string;
 	name: string;
 	description: string;
 	mimeType: string;
 	resourceText: string;
 	toolText?: string;
-	toolName: string;
-	toolDescription: string;
 }
 
 export const WORKFLOW_GUIDES: WorkflowGuideDefinition[] = [
@@ -27,8 +29,6 @@ export const WORKFLOW_GUIDES: WorkflowGuideDefinition[] = [
 		mimeType: "text/markdown",
 		resourceText: MCP_WORKFLOW_OVERVIEW,
 		toolText: MCP_WORKFLOW_OVERVIEW_TOOLS,
-		toolName: "get_workflow_overview",
-		toolDescription: "Retrieve the Backlog.md workflow overview guidance in markdown format",
 	},
 	{
 		key: "task-creation",
@@ -37,8 +37,6 @@ export const WORKFLOW_GUIDES: WorkflowGuideDefinition[] = [
 		description: "Detailed guide for creating tasks: scope assessment, acceptance criteria, parent/subtasks",
 		mimeType: "text/markdown",
 		resourceText: MCP_TASK_CREATION_GUIDE,
-		toolName: "get_task_creation_guide",
-		toolDescription: "Retrieve the Backlog.md task creation guide in markdown format",
 	},
 	{
 		key: "task-execution",
@@ -47,8 +45,6 @@ export const WORKFLOW_GUIDES: WorkflowGuideDefinition[] = [
 		description: "Detailed guide for planning and executing tasks: workflow, discipline, scope changes",
 		mimeType: "text/markdown",
 		resourceText: MCP_TASK_EXECUTION_GUIDE,
-		toolName: "get_task_execution_guide",
-		toolDescription: "Retrieve the Backlog.md task execution guide in markdown format",
 	},
 	{
 		key: "task-finalization",
@@ -57,11 +53,13 @@ export const WORKFLOW_GUIDES: WorkflowGuideDefinition[] = [
 		description: "Detailed guide for finalizing tasks: Definition of Done, finalization workflow, next steps",
 		mimeType: "text/markdown",
 		resourceText: MCP_TASK_FINALIZATION_GUIDE,
-		toolName: "get_task_finalization_guide",
-		toolDescription: "Retrieve the Backlog.md task finalization guide in markdown format",
 	},
 ];
 
 export function getWorkflowGuideByUri(uri: string): WorkflowGuideDefinition | undefined {
 	return WORKFLOW_GUIDES.find((guide) => guide.uri === uri);
+}
+
+export function getWorkflowGuideByKey(key: WorkflowGuideKey): WorkflowGuideDefinition | undefined {
+	return WORKFLOW_GUIDES.find((guide) => guide.key === key);
 }

--- a/src/test/mcp-roots-discovery.test.ts
+++ b/src/test/mcp-roots-discovery.test.ts
@@ -82,20 +82,23 @@ describe("MCP roots discovery", () => {
 		const configAfter = await server.filesystem.loadConfig();
 		expect(configAfter).toBeTruthy();
 		expect(configAfter?.projectName).toBe("Roots Test Project");
+		if (!configAfter) {
+			throw new Error("Expected config after reinitializing to a valid project");
+		}
 
 		// Register full toolset on the reinitialized server
 		registerWorkflowResources(server);
 		registerWorkflowTools(server);
-		registerTaskTools(server, configAfter!);
+		registerTaskTools(server, configAfter);
 		registerMilestoneTools(server);
 		registerDefinitionOfDoneTools(server);
-		registerDocumentTools(server, configAfter!);
+		registerDocumentTools(server, configAfter);
 
 		const tools = await server.testInterface.listTools();
 		const toolNames = tools.tools.map((t) => t.name);
 		expect(toolNames).toContain("task_create");
 		expect(toolNames).toContain("task_list");
-		expect(toolNames).toContain("get_workflow_overview");
+		expect(toolNames).toContain("get_backlog_instructions");
 
 		const resources = await server.testInterface.listResources();
 		const uris = resources.resources.map((r) => r.uri);
@@ -166,7 +169,7 @@ describe("MCP roots discovery", () => {
 		const tools = await server.testInterface.listTools();
 		const toolNames = tools.tools.map((t) => t.name);
 		expect(toolNames).toContain("task_create");
-		expect(toolNames).toContain("get_workflow_overview");
+		expect(toolNames).toContain("get_backlog_instructions");
 
 		// oninitialized should NOT be set
 		expect(server.getServer().oninitialized).toBeUndefined();

--- a/src/test/mcp-server.test.ts
+++ b/src/test/mcp-server.test.ts
@@ -54,12 +54,18 @@ describe("McpServer bootstrap", () => {
 		const server = await bootstrapServer();
 
 		const tools = await server.testInterface.listTools();
-		expect(tools.tools.map((tool) => tool.name)).toEqual([
-			"get_workflow_overview",
-			"get_task_creation_guide",
-			"get_task_execution_guide",
-			"get_task_finalization_guide",
-		]);
+		expect(tools.tools.map((tool) => tool.name)).toEqual(["get_backlog_instructions"]);
+		expect(tools.tools[0]?.inputSchema).toEqual({
+			type: "object",
+			properties: {
+				instruction: {
+					type: "string",
+					enum: ["overview", "task-creation", "task-execution", "task-finalization"],
+				},
+			},
+			required: [],
+			additionalProperties: false,
+		});
 
 		const resources = await server.testInterface.listResources();
 		expect(resources.resources.map((r) => r.uri)).toEqual([
@@ -131,16 +137,16 @@ describe("McpServer bootstrap", () => {
 		await server.stop();
 	});
 
-	it("workflow tools mirror resource content", async () => {
+	it("workflow tool returns overview by default and selected guide content when requested", async () => {
 		const server = await bootstrapServer();
 
 		const overview = await server.testInterface.callTool({
-			params: { name: "get_workflow_overview", arguments: {} },
+			params: { name: "get_backlog_instructions", arguments: {} },
 		});
 		expect(getText(overview.content)).toBe(MCP_WORKFLOW_OVERVIEW_TOOLS);
 
 		const creation = await server.testInterface.callTool({
-			params: { name: "get_task_creation_guide", arguments: {} },
+			params: { name: "get_backlog_instructions", arguments: { instruction: "task-creation" } },
 		});
 		expect(getText(creation.content)).toBe(MCP_TASK_CREATION_GUIDE);
 
@@ -162,10 +168,7 @@ describe("McpServer bootstrap", () => {
 		expect(toolNames).toEqual([
 			"definition_of_done_defaults_get",
 			"definition_of_done_defaults_upsert",
-			"get_task_creation_guide",
-			"get_task_execution_guide",
-			"get_task_finalization_guide",
-			"get_workflow_overview",
+			"get_backlog_instructions",
 			"task_archive",
 			"task_complete",
 			"task_create",
@@ -205,10 +208,7 @@ describe("McpServer bootstrap", () => {
 
 		const tools = await server.testInterface.listTools();
 		expect(tools.tools.map((tool) => tool.name)).toEqual([
-			"get_workflow_overview",
-			"get_task_creation_guide",
-			"get_task_execution_guide",
-			"get_task_finalization_guide",
+			"get_backlog_instructions",
 			"task_create",
 			"task_list",
 			"task_search",


### PR DESCRIPTION
## Summary
- replace the four workflow guide MCP tools with a single `get_backlog_instructions` tool
- expose an enum-backed `instruction` selector that defaults to `overview`
- update shipped MCP guidance and tests to the new canonical tool surface

## Notes
- existing `backlog://workflow/...` resources remain unchanged
- this intentionally simplifies the discovered MCP tool surface rather than preserving deprecated aliases
- includes the Biome formatting update to `package.json` so repo-wide checks pass cleanly

## Verification
- `bun test src/test/mcp-server.test.ts src/test/mcp-roots-discovery.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`