### PR TITLE
BACK-409 - Add Cursor to MCP initialization (CLI, web, core)

### DIFF
--- a/backlog/tasks/back-409 - Add-Cursor-to-MCP-initialization-CLI-web-core.md
+++ b/backlog/tasks/back-409 - Add-Cursor-to-MCP-initialization-CLI-web-core.md
@@ -1,0 +1,52 @@
+---
+id: BACK-409
+title: 'Add Cursor to MCP initialization (CLI, web, core)'
+status: Done
+assignee: []
+created_date: '2026-03-21 16:35'
+updated_date: '2026-03-21 16:44'
+labels:
+  - init
+  - mcp
+  - cursor
+dependencies: []
+documentation:
+  - src/core/init.ts
+  - src/cli.ts
+  - src/web/components/InitializationScreen.tsx
+  - src/agent-instructions.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Users who pick MCP integration should see Cursor as an explicit option alongside other clients.
+
+When Cursor is selected, the implementation should use Cursor’s current, documented project-level MCP mechanism to create or merge the Backlog MCP server entry where the runtime reliably supports it. If automation is not possible or is unreliable, the flow must degrade gracefully with clear user-visible feedback and a documented fallback (for example pointing to the setup guide).
+
+Cursor must also follow the same pattern as other MCP clients that rely on AGENTS.md: ensure MCP workflow guidelines are present in AGENTS.md when Cursor is selected.
+
+Relevant code areas: src/core/init.ts (MCP client loop), src/cli.ts (interactive MCP multiselect and handler), src/web/components/InitializationScreen.tsx and src/web/lib/api.ts (wizard + types), src/server/index.ts (init API). Tests: extend src/test/cli.test.ts and any init/server tests as appropriate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Core: initializeProject accepts a new MCP client id for Cursor; when selected, ensure AGENTS.md MCP guidelines via existing helpers and perform Cursor MCP config merge/create per current Cursor docs where supported, or set mcpResults with a clear success vs fallback message.
+- [x] #2 CLI: Interactive MCP multiselect lists Cursor; document or align any non-interactive init path if applicable.
+- [x] #3 Web: MCP step in the initialization wizard includes Cursor; API, types, and server validation accept the new client value end-to-end.
+- [x] #4 Quality: Automated tests cover the new behavior; bun test and bunx tsc --noEmit pass for touched code.
+- [x] #5 Docs/copy: Wizard text, CLI summary, or other user-facing init messaging reflects Cursor and matches actual fallback behavior.
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Cursor as an MCP client across core, CLI, and web init: `configureCursorProjectMcp` writes/merges `.cursor/mcp.json` (stdio `backlog mcp start`), with `mergeCursorMcpProjectJson` for unit tests and `BACKLOG_TEST_CURSOR_MCP_RELATIVE_DIR` only for sandbox-safe file tests. `initializeProject` runs Cursor setup plus `ensureMcpGuidelines` for AGENTS.md. CLI multiselect and MCP_CLIENT_INSTRUCTION_MAP include Cursor; web wizard and API types include `cursor`. Updated `src/guidelines/mcp/init-required.md`. Added `src/test/cursor-mcp-init.test.ts`. Verified with `bun test` on cursor + enhanced-init tests, `tsc --noEmit`, and Biome on touched files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import { configureAdvancedSettings } from "./commands/configure-advanced-setting
 import { registerMcpCommand } from "./commands/mcp.ts";
 import { pickTaskForEditWizard, runTaskCreateWizard, runTaskEditWizard } from "./commands/task-wizard.ts";
 import { DEFAULT_DIRECTORIES, DEFAULT_FILES } from "./constants/index.ts";
-import { initializeProject } from "./core/init.ts";
+import { configureCursorProjectMcp, initializeProject } from "./core/init.ts";
 import { buildMilestoneBuckets, collectArchivedMilestoneKeys, milestoneKey } from "./core/milestones.ts";
 import { computeSequences } from "./core/sequences.ts";
 import { formatTaskPlainText } from "./formatters/task-plain-text.ts";
@@ -112,6 +112,7 @@ const MCP_CLIENT_INSTRUCTION_MAP: Record<string, AgentInstructionFile> = {
 	codex: "AGENTS.md",
 	gemini: "GEMINI.md",
 	kiro: "AGENTS.md",
+	cursor: "AGENTS.md",
 	guide: "AGENTS.md",
 };
 
@@ -907,6 +908,7 @@ program
 									{ label: "OpenAI Codex", value: "codex" },
 									{ label: "Gemini CLI", value: "gemini" },
 									{ label: "Kiro", value: "kiro" },
+									{ label: "Cursor", value: "cursor" },
 									{ label: "Other (open setup guide)", value: "guide" },
 								],
 								required: true,
@@ -997,6 +999,20 @@ program
 										"mcp,start",
 									]);
 									results.push(result);
+									await recordGuidelinesForClient(client);
+									continue;
+								}
+								if (client === "cursor") {
+									console.log("    Configuring Cursor...");
+									try {
+										const result = await configureCursorProjectMcp(cwd);
+										console.log(`    ✓ ${result}`);
+										results.push(result);
+									} catch (error) {
+										const message = error instanceof Error ? error.message : String(error);
+										console.warn(`    ⚠️ Unable to configure Cursor automatically (${message}).`);
+										results.push(`Cursor (${message})`);
+									}
 									await recordGuidelinesForClient(client);
 									continue;
 								}

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { spawn } from "bun";
 import {
 	type AgentInstructionFile,
@@ -14,7 +17,7 @@ export const MCP_SERVER_NAME = "backlog";
 export const MCP_GUIDE_URL = "https://github.com/MrLesk/Backlog.md#-mcp-integration-model-context-protocol";
 
 export type IntegrationMode = "mcp" | "cli" | "none";
-export type McpClient = "claude" | "codex" | "gemini" | "kiro" | "guide";
+export type McpClient = "claude" | "codex" | "gemini" | "kiro" | "cursor" | "guide";
 
 export interface InitializeProjectOptions {
 	projectName: string;
@@ -69,6 +72,70 @@ async function runMcpClientCommand(label: string, command: string, args: string[
 			`Unable to configure ${label} automatically (${message}). Run manually: ${command} ${args.join(" ")}`,
 		);
 	}
+}
+
+/**
+ * Merge parsed Cursor `mcp.json` root with the canonical Backlog MCP server entry.
+ * Used by `configureCursorProjectMcp` and unit-tested without filesystem I/O.
+ */
+export function mergeCursorMcpProjectJson(base: Record<string, unknown>): Record<string, unknown> {
+	const existingServers = base.mcpServers;
+	let mcpServers: Record<string, unknown>;
+	if (existingServers === undefined) {
+		mcpServers = {};
+	} else if (existingServers !== null && typeof existingServers === "object" && !Array.isArray(existingServers)) {
+		mcpServers = { ...(existingServers as Record<string, unknown>) };
+	} else {
+		throw new Error(`Cursor MCP config has an invalid mcpServers value. Manual setup: ${MCP_GUIDE_URL}`);
+	}
+
+	mcpServers[MCP_SERVER_NAME] = {
+		type: "stdio",
+		command: "backlog",
+		args: ["mcp", "start"],
+	};
+
+	return { ...base, mcpServers };
+}
+
+function cursorMcpConfigDir(projectRoot: string): string {
+	/** Test-only: write under a non-`.cursor` folder when sandbox blocks `.cursor` mkdir (see tests). */
+	const rel = process.env.BACKLOG_TEST_CURSOR_MCP_RELATIVE_DIR ?? ".cursor";
+	return join(projectRoot, rel);
+}
+
+/**
+ * Merge or create Cursor project MCP config at `.cursor/mcp.json` (see Cursor docs).
+ * Preserves other `mcpServers` entries and other top-level keys when valid.
+ */
+export async function configureCursorProjectMcp(projectRoot: string): Promise<string> {
+	const cursorDir = cursorMcpConfigDir(projectRoot);
+	const mcpPath = join(cursorDir, "mcp.json");
+	const displayPath = ".cursor/mcp.json";
+	await mkdir(cursorDir, { recursive: true });
+
+	let base: Record<string, unknown> = {};
+	if (existsSync(mcpPath)) {
+		const raw = await readFile(mcpPath, "utf-8");
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			throw new Error(
+				`Existing Cursor MCP config is not valid JSON (${displayPath}). Fix or remove the file, then retry. Manual setup: ${MCP_GUIDE_URL}`,
+			);
+		}
+		if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			throw new Error(
+				`Existing Cursor MCP config must be a JSON object (${displayPath}). Manual setup: ${MCP_GUIDE_URL}`,
+			);
+		}
+		base = { ...(parsed as Record<string, unknown>) };
+	}
+
+	const out = mergeCursorMcpProjectJson(base);
+	await writeFile(mcpPath, `${JSON.stringify(out, null, "\t")}\n`, "utf-8");
+	return `Added Backlog MCP server to Cursor (${displayPath})`;
 }
 
 /**
@@ -258,6 +325,10 @@ export async function initializeProject(
 						"mcp,start",
 					]);
 					mcpResults.kiro = result;
+					await ensureMcpGuidelines(projectRoot, "AGENTS.md");
+				} else if (client === "cursor") {
+					const result = await configureCursorProjectMcp(projectRoot);
+					mcpResults.cursor = result;
 					await ensureMcpGuidelines(projectRoot, "AGENTS.md");
 				} else if (client === "guide") {
 					mcpResults.guide = `Setup guide: ${MCP_GUIDE_URL}`;

--- a/src/guidelines/mcp/init-required.md
+++ b/src/guidelines/mcp/init-required.md
@@ -18,7 +18,7 @@ Backlog.md is a task management system that uses markdown files to track feature
 
 1. Run `backlog init` in your project directory
 2. Follow the interactive setup prompts
-3. Choose your preferred AI agent integration (Claude Code, Codex, Gemini CLI, or Kiro)
+3. Choose your preferred AI agent integration (Claude Code, Codex, Gemini CLI, Kiro, or Cursor)
 4. Start creating and managing tasks!
 
 For more information, visit: https://backlog.md

--- a/src/test/cursor-mcp-init.test.ts
+++ b/src/test/cursor-mcp-init.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Core } from "../core/backlog.ts";
+import {
+	configureCursorProjectMcp,
+	initializeProject,
+	MCP_SERVER_NAME,
+	mergeCursorMcpProjectJson,
+} from "../core/init.ts";
+
+/** Sandbox environments may forbid mkdir `.cursor`; production always uses `.cursor`. */
+const TEST_CURSOR_DIR = "cursor-mcp-test";
+
+describe("Cursor MCP init", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "cursor-mcp-init-"));
+		process.env.BACKLOG_TEST_CURSOR_MCP_RELATIVE_DIR = TEST_CURSOR_DIR;
+	});
+
+	afterEach(async () => {
+		delete process.env.BACKLOG_TEST_CURSOR_MCP_RELATIVE_DIR;
+		try {
+			await rm(tmpDir, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+	});
+
+	test("mergeCursorMcpProjectJson adds backlog server and preserves peers", () => {
+		const merged = mergeCursorMcpProjectJson({
+			mcpServers: {
+				other: { type: "stdio", command: "echo", args: ["hi"] },
+			},
+		});
+		expect(merged.mcpServers).toEqual({
+			other: { type: "stdio", command: "echo", args: ["hi"] },
+			[MCP_SERVER_NAME]: {
+				type: "stdio",
+				command: "backlog",
+				args: ["mcp", "start"],
+			},
+		});
+	});
+
+	test("mergeCursorMcpProjectJson rejects invalid mcpServers", () => {
+		expect(() => mergeCursorMcpProjectJson({ mcpServers: "nope" as unknown as Record<string, unknown> })).toThrow();
+	});
+
+	test("configureCursorProjectMcp creates mcp.json with backlog stdio server", async () => {
+		await configureCursorProjectMcp(tmpDir);
+		const raw = await readFile(join(tmpDir, TEST_CURSOR_DIR, "mcp.json"), "utf-8");
+		const parsed: { mcpServers: Record<string, unknown> } = JSON.parse(raw);
+		expect(parsed.mcpServers[MCP_SERVER_NAME]).toEqual({
+			type: "stdio",
+			command: "backlog",
+			args: ["mcp", "start"],
+		});
+	});
+
+	test("configureCursorProjectMcp merges with existing mcpServers", async () => {
+		await mkdir(join(tmpDir, TEST_CURSOR_DIR), { recursive: true });
+		await writeFile(
+			join(tmpDir, TEST_CURSOR_DIR, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					other: { type: "stdio", command: "echo", args: ["hi"] },
+				},
+			}),
+			"utf-8",
+		);
+		await configureCursorProjectMcp(tmpDir);
+		const parsed: { mcpServers: Record<string, unknown> } = JSON.parse(
+			await readFile(join(tmpDir, TEST_CURSOR_DIR, "mcp.json"), "utf-8"),
+		);
+		expect(parsed.mcpServers.other).toEqual({
+			type: "stdio",
+			command: "echo",
+			args: ["hi"],
+		});
+		expect(parsed.mcpServers[MCP_SERVER_NAME]).toEqual({
+			type: "stdio",
+			command: "backlog",
+			args: ["mcp", "start"],
+		});
+	});
+
+	test("configureCursorProjectMcp rejects invalid JSON", async () => {
+		await mkdir(join(tmpDir, TEST_CURSOR_DIR), { recursive: true });
+		await writeFile(join(tmpDir, TEST_CURSOR_DIR, "mcp.json"), "not json", "utf-8");
+		await expect(configureCursorProjectMcp(tmpDir)).rejects.toThrow(/valid JSON/);
+	});
+
+	test("initializeProject with cursor writes mcp config and mcpResults", async () => {
+		const core = new Core(tmpDir);
+		const result = await initializeProject(core, {
+			projectName: "Cursor MCP Project",
+			integrationMode: "mcp",
+			mcpClients: ["cursor"],
+			advancedConfig: { autoCommit: false },
+		});
+		expect(result.success).toBe(true);
+		expect(result.mcpResults?.cursor).toContain(".cursor/mcp.json");
+		const raw = await readFile(join(tmpDir, TEST_CURSOR_DIR, "mcp.json"), "utf-8");
+		expect(JSON.parse(raw).mcpServers[MCP_SERVER_NAME].command).toBe("backlog");
+	});
+});

--- a/src/web/components/InitializationScreen.tsx
+++ b/src/web/components/InitializationScreen.tsx
@@ -3,7 +3,15 @@ import { DEFAULT_INIT_CONFIG } from "../../constants/index.ts";
 import { apiClient } from "../lib/api";
 
 type IntegrationMode = "mcp" | "cli" | "none";
-type McpClient = "claude" | "codex" | "gemini" | "guide";
+type McpClient = "claude" | "codex" | "gemini" | "cursor" | "guide";
+
+const MCP_CLIENT_DISPLAY_LABELS: Record<McpClient, string> = {
+	claude: "Claude Code",
+	codex: "OpenAI Codex",
+	gemini: "Gemini CLI",
+	cursor: "Cursor",
+	guide: "Manual Setup Guide",
+};
 type AgentFile = "CLAUDE.md" | "AGENTS.md" | "GEMINI.md" | ".github/copilot-instructions.md";
 type BacklogDirectoryChoice = "backlog" | ".backlog" | "custom";
 type ConfigLocationChoice = "folder" | "root";
@@ -353,6 +361,11 @@ const InitializationScreen: React.FC<InitializationScreenProps> = ({ onInitializ
 					{ id: "claude" as McpClient, label: "Claude Code", description: "Anthropic's Claude Code editor" },
 					{ id: "codex" as McpClient, label: "OpenAI Codex", description: "OpenAI's Codex CLI" },
 					{ id: "gemini" as McpClient, label: "Gemini CLI", description: "Google's Gemini Code Assist CLI" },
+					{
+						id: "cursor" as McpClient,
+						label: "Cursor",
+						description: "Cursor editor (writes project .cursor/mcp.json)",
+					},
 					{
 						id: "guide" as McpClient,
 						label: "Manual Setup Guide",
@@ -844,7 +857,7 @@ const InitializationScreen: React.FC<InitializationScreenProps> = ({ onInitializ
 					<div className="flex justify-between">
 						<span className="text-gray-600 dark:text-gray-400">MCP Clients:</span>
 						<span className="font-medium text-gray-900 dark:text-gray-100">
-							{selectedMcpClients.join(", ")}
+							{selectedMcpClients.map((id) => MCP_CLIENT_DISPLAY_LABELS[id]).join(", ")}
 						</span>
 					</div>
 				)}
@@ -883,7 +896,7 @@ const InitializationScreen: React.FC<InitializationScreenProps> = ({ onInitializ
 					<h3 className="text-sm font-medium text-blue-800 dark:text-blue-300 mb-2">Setup Progress:</h3>
 					{Object.entries(mcpSetupResults).map(([client, result]) => (
 						<div key={client} className="text-sm text-blue-700 dark:text-blue-400">
-							{client}: {result}
+							{MCP_CLIENT_DISPLAY_LABELS[client as McpClient] ?? client}: {result}
 						</div>
 					))}
 				</div>

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -482,7 +482,7 @@ export class ApiClient {
 		backlogDirectorySource?: "backlog" | ".backlog" | "custom";
 		configLocation?: "folder" | "root";
 		integrationMode: "mcp" | "cli" | "none";
-		mcpClients?: ("claude" | "codex" | "gemini" | "kiro" | "guide")[];
+		mcpClients?: ("claude" | "codex" | "gemini" | "kiro" | "cursor" | "guide")[];
 		agentInstructions?: ("CLAUDE.md" | "AGENTS.md" | "GEMINI.md" | ".github/copilot-instructions.md")[];
 		installClaudeAgent?: boolean;
 		advancedConfig?: {


### PR DESCRIPTION
## Summary

This PR implements [BACK-409](https://github.com/MrLesk/Backlog.md/blob/main/backlog/tasks/back-409%20-%20Add-Cursor-to-MCP-initialization-CLI-web-core.md): Cursor appears as an explicit MCP client during init (CLI, web, and shared core).

## Changes

- **Core:** `configureCursorProjectMcp` creates or merges project `.cursor/mcp.json` with the canonical stdio Backlog MCP entry; `mergeCursorMcpProjectJson` supports unit tests; optional `BACKLOG_TEST_CURSOR_MCP_RELATIVE_DIR` for tests in environments that block creating `.cursor`.
- **CLI:** Multiselect includes Cursor; uses the shared helper and AGENTS.md guideline updates.
- **Web:** Initialization wizard lists Cursor; API types include the `cursor` client id.
- **Docs:** `init-required` MCP resource copy mentions Cursor.
- **Tests:** `src/test/cursor-mcp-init.test.ts`.

## Verification

- `bun test src/test/cursor-mcp-init.test.ts src/test/enhanced-init.test.ts`
- `bunx tsc --noEmit`
- Biome on touched files


Made with [Cursor](https://cursor.com)