### PR TITLE
BACK-440 - Handle cancel in agents update prompt

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3125,12 +3125,12 @@ agentsCmd
 					{ label: "Copilot (GitHub Copilot)", value: ".github/copilot-instructions.md" },
 				],
 			});
-			const files: AgentInstructionFile[] = clack.isCancel(selected)
-				? []
-				: Array.isArray(selected)
-					? (selected as AgentInstructionFile[])
-					: [];
+			if (clack.isCancel(selected)) {
+				clack.log.info("Agent instruction update cancelled.");
+				return;
+			}
 
+			const files: AgentInstructionFile[] = Array.isArray(selected) ? (selected as AgentInstructionFile[]) : [];
 			if (files.length > 0) {
 				// Get autoCommit setting from config
 				const config = await core.filesystem.loadConfig();


### PR DESCRIPTION
## Problem
Issue #192 reports confusing behavior around instruction updates and init flows. In the interactive `backlog agents --update-instructions` flow, cancelling the multiselect prompt was handled the same as an empty selection path.

## Root Cause
The code converted a cancelled prompt result directly into an empty `files` array, so command flow continued instead of treating cancel as an explicit abort.

## Solution
Added explicit cancel handling in `src/cli.ts`:
- detect `clack.isCancel(selected)`
- log a clear cancellation message
- return early from the command action

Then process selected files only for non-cancelled responses.

## Related Tasks
- Closes BACK-440
- Refs #192

## Task Checklist
- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Validation
- Reproduced current-main behavior with `/usr/bin/expect` against a real pseudo-terminal: Escape at the multiselect exits via `No files selected for update.`
- Verified this PR branch with `/usr/bin/expect`: Escape prints `Agent instruction update cancelled.` and does not create instruction files.
- Verified Enter with no selection still prints `No files selected for update.`
- Verified Space+Enter still updates `CLAUDE.md`.
- `bun test src/test/cli-agents.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
