### PR TITLE
BACK-439 - Allow backdrop click to close task modal

### DIFF
--- a/backlog/tasks/back-439 - Allow-backdrop-click-to-close-task-modal.md
+++ b/backlog/tasks/back-439 - Allow-backdrop-click-to-close-task-modal.md
@@ -1,0 +1,46 @@
+---
+id: BACK-439
+title: Allow backdrop click to close task modal
+status: Done
+assignee:
+  - '@eyanq'
+created_date: '2026-03-23 09:40'
+updated_date: '2026-04-25 23:41'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Allow mouse users to close Task Details modal by clicking outside modal content, matching Escape behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Backdrop click closes modal in preview mode
+- [x] #2 Backdrop click is disabled whenever Escape-close is disabled
+- [x] #3 Modal content click does not close modal
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update shared web Modal backdrop to trigger close on outside click.
+2. Keep inner panel click propagation stopped.
+3. Gate backdrop close with same disableEscapeClose condition used for Escape.
+4. Verify behavior in preview and edit/create modes.
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added backdrop-click close behavior to the shared Web UI modal using the same `disableEscapeClose` guard as Escape handling. Clicking inside modal content still stops propagation, so preview-mode task modals can close from the backdrop while edit/create flows remain protected from accidental dismissal.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/web/components/Modal.tsx
+++ b/src/web/components/Modal.tsx
@@ -6,7 +6,7 @@ interface ModalProps {
 	title: string;
 	children: React.ReactNode;
 	maxWidthClass?: string; // e.g., "max-w-4xl"
-	disableEscapeClose?: boolean; // when true, Escape won't close the modal (child can handle it)
+	disableEscapeClose?: boolean; // when true, Escape and backdrop click won't close (child can handle it)
 	actions?: React.ReactNode; // optional actions rendered in header before close
 }
 
@@ -36,8 +36,18 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, maxWidt
 	if (!isOpen) return null;
 
 	return (
-		<div className="fixed inset-0 bg-black/40 dark:bg-black/60 flex items-center justify-center z-50 p-4">
-			<div className={`bg-white dark:bg-gray-800 rounded-lg shadow-2xl ${maxWidthClass} w-full max-h-[94vh] overflow-y-auto transition-colors duration-200`} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-labelledby="modal-title">
+		<div
+			className="fixed inset-0 bg-black/40 dark:bg-black/60 flex items-center justify-center z-50 p-4"
+			onClick={disableEscapeClose ? undefined : onClose}
+			role="presentation"
+		>
+			<div
+				className={`bg-white dark:bg-gray-800 rounded-lg shadow-2xl ${maxWidthClass} w-full max-h-[94vh] overflow-y-auto transition-colors duration-200`}
+				onClick={(e) => e.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="modal-title"
+			>
 				<div className="sticky top-0 z-10 flex items-center justify-between px-6 pt-4 pb-3 border-b border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur supports-[backdrop-filter]:bg-white/75 supports-[backdrop-filter]:dark:bg-gray-800/75">
 					<h2 id="modal-title" className="text-base font-semibold text-gray-900 dark:text-gray-100">{title}</h2>
 					<div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
This pull request adds backdrop-click-to-close for the task details modal in the Web UI. It aligns mouse behavior with existing Escape behavior so users can dismiss the modal by clicking outside when it is safe to close.

## Related Tasks
- Closes BACK-439
- Issue #576

## Task Checklist
- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Testing
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test src/test/web-task-details-modal-final-summary.test.tsx src/test/web-task-details-modal-documentation.test.tsx`

## Maintainer Follow-up
- Rebased on current `main`.
- Renumbered the task from conflicting `BACK-409` to `BACK-439`.
- Marked the task Done and filled the final summary / Definition of Done.
