### PR TITLE
BACK-409 - Clarify acceptance criteria format in task creation guide

### DIFF
--- a/backlog/tasks/back-409 - clarify-acceptance-criteria-format-in-task-creation-guide.md
+++ b/backlog/tasks/back-409 - clarify-acceptance-criteria-format-in-task-creation-guide.md
@@ -1,0 +1,38 @@
+---
+id: BACK-409
+title: clarify acceptance criteria format in task creation guide
+status: Done
+assignee: []
+created_date: '2026-03-26 13:48'
+updated_date: '2026-03-26 13:51'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The task creation guide described acceptance criteria vaguely. Clarify that the `acceptanceCriteria` field expects an array of strings — each item being a specific, testable, and independent condition.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+- Update `src/guidelines/mcp/task-creation.md` line 74: change the acceptance criteria description from "Specific, testable, and independent (the WHAT)" to "An array of strings - specific, testable, and independent items (the WHAT)" to make the expected field type explicit.
+<!-- SECTION:PLAN:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The task creation guide specifies that acceptance criteria is an array of strings
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated `src/guidelines/mcp/task-creation.md` to clarify that the `acceptanceCriteria` field is an array of strings. Change: \"Specific, testable, and independent (the WHAT)\" → \"An array of strings - specific, testable, and independent items (the WHAT)\"."
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-409 - clarify-acceptance-criteria-format-in-task-creation-guide.md
+++ b/backlog/tasks/back-409 - clarify-acceptance-criteria-format-in-task-creation-guide.md
@@ -1,38 +1,50 @@
 ---
 id: BACK-409
-title: clarify acceptance criteria format in task creation guide
+title: Clarify acceptance criteria format in task creation guide
 status: Done
-assignee: []
+assignee:
+  - '@codex'
 created_date: '2026-03-26 13:48'
-updated_date: '2026-03-26 13:51'
-labels: []
+updated_date: '2026-05-03 11:40'
+labels:
+  - bug
+  - docs
+  - mcp
 dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/582'
+  - 'https://github.com/MrLesk/Backlog.md/pull/583'
+modified_files:
+  - src/guidelines/mcp/task-creation.md
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The task creation guide described acceptance criteria vaguely. Clarify that the `acceptanceCriteria` field expects an array of strings — each item being a specific, testable, and independent condition.
+The MCP task creation guide describes acceptance criteria conceptually but does not specify the expected `task_create.acceptanceCriteria` parameter shape. Clarify that `acceptanceCriteria` expects an array of strings so agents do not pass a scalar string and trigger validation errors.
 <!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The task creation guide specifies that `acceptanceCriteria` is an array of strings.
+<!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-- Update `src/guidelines/mcp/task-creation.md` line 74: change the acceptance criteria description from "Specific, testable, and independent (the WHAT)" to "An array of strings - specific, testable, and independent items (the WHAT)" to make the expected field type explicit.
+1. Update `src/guidelines/mcp/task-creation.md` so the acceptance criteria guidance names the expected array-of-strings shape.
+2. Keep the surrounding guidance on atomic, testable criteria unchanged.
+3. Validate formatting/checks for the documentation-only change.
 <!-- SECTION:PLAN:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [x] #1 bun test (or scoped test) passes
+- [x] #1 Documentation change is reflected in the MCP task creation guide.
+- [x] #2 `bun run check .` passes.
 <!-- DOD:END -->
-
-## Acceptance Criteria
-<!-- AC:BEGIN -->
-- [x] #1 The task creation guide specifies that acceptance criteria is an array of strings
-<!-- AC:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Updated `src/guidelines/mcp/task-creation.md` to clarify that the `acceptanceCriteria` field is an array of strings. Change: \"Specific, testable, and independent (the WHAT)\" → \"An array of strings - specific, testable, and independent items (the WHAT)\"."
+Updated `src/guidelines/mcp/task-creation.md` to clarify that the `acceptanceCriteria` field is an array of strings while preserving the existing guidance that each item should be specific, testable, and independent.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -71,7 +71,7 @@ Create all tasks in the same session to maintain consistency and context.
 
 **Title and description**: Explain desired outcome and user value (the WHY). Keep the description focused on outcome and essential handoff context.
 
-**Acceptance criteria**: Specific, testable, and independent (the WHAT)
+**Acceptance criteria**: An array of strings - specific, testable, and independent items (the WHAT)
 - Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S")
 - Include negative or edge scenarios when relevant
 - Capture testing expectations explicitly

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -71,7 +71,7 @@ Create all tasks in the same session to maintain consistency and context.
 
 **Title and description**: Explain desired outcome and user value (the WHY). Keep the description focused on outcome and essential handoff context.
 
-**Acceptance criteria**: An array of strings - specific, testable, and independent items (the WHAT)
+**Acceptance criteria**: `acceptanceCriteria` is an array of strings; each item should be specific, testable, and independent (the WHAT)
 - Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S")
 - Include negative or edge scenarios when relevant
 - Capture testing expectations explicitly


### PR DESCRIPTION
## Summary
- Clarifies the MCP task creation guide so `acceptanceCriteria` is documented as an array of strings
- Keeps the existing guidance that each acceptance criterion should be specific, testable, and independent
- Normalizes the BACK-409 task metadata with issue/PR references and modified files

Closes #582
Closes BACK-409

## Task Checklist
- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Validation
- `bun run check .`
- `bun test src/test/mcp-server.test.ts`
- `git diff --check origin/main...HEAD`