### PR TITLE
BACK-460 - Fix TUI selected-row readability in board and task list

### DIFF
--- a/backlog/tasks/back-460 - Fix-TUI-selected-row-readability-in-board-and-task-list.md
+++ b/backlog/tasks/back-460 - Fix-TUI-selected-row-readability-in-board-and-task-list.md
@@ -1,0 +1,49 @@
+---
+id: BACK-460
+title: Fix TUI selected-row readability in board and task list
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-04-01 09:28'
+updated_date: '2026-05-03 12:13'
+labels:
+  - bug
+  - tui
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/pull/587'
+modified_files:
+  - src/test/generic-list-selection.test.ts
+  - src/test/strip-tags.test.ts
+  - src/ui/board.ts
+  - src/ui/components/generic-list.ts
+  - src/ui/utils/strip-tags.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Selected rows in the terminal UI become hard to read in Catppuccin because inline blessed foreground tags override the list widget's selected-row foreground styling. The fix should be limited to TUI selected rows and avoid changing non-selected rendering or web/plain-text behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Selected rows in the board view remain readable when item text contains inline blessed foreground color tags
+- [x] #2 Selected rows in the task list view remain readable without changing non-selected row formatting
+- [x] #3 The fix is covered by focused automated tests and does not change web or plain-text output paths
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a small TUI utility that strips blessed foreground color tags while preserving structural tags.
+2. Use the utility only for actively selected rows in the board and GenericList paths.
+3. Preserve rich formatting for non-selected rows.
+4. Add focused tests for tag stripping and board item preservation.
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented a TUI-only selected-row readability fix by stripping inline blessed foreground tags only for the active row in the board and GenericList paths. Added focused tests for tag stripping, board item preservation, and mouse-driven GenericList selection changes; validated the related TUI/task-viewer test suites, ran typecheck, and addressed Codex review feedback.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/generic-list-selection.test.ts
+++ b/src/test/generic-list-selection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import type { ListInterface, ScreenInterface } from "neo-neo-bblessed";
+import { GenericList } from "../ui/components/generic-list.ts";
+import { createScreen } from "../ui/tui.ts";
+
+type RenderedList = ListInterface & {
+	ritems: string[];
+};
+
+function withTtyScreen(run: (screen: ScreenInterface) => void): void {
+	const originalIsTTY = process.stdout.isTTY;
+	if (process.stdout.isTTY === false) {
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+	}
+	const screen = createScreen({ smartCSR: false });
+	try {
+		run(screen);
+	} finally {
+		if (process.stdout.isTTY !== originalIsTTY) {
+			Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, configurable: true });
+		}
+		screen.destroy();
+	}
+}
+
+describe("GenericList selection rendering", () => {
+	it("syncs highlighted content when the blessed list selection changes", () => {
+		withTtyScreen((screen) => {
+			const highlighted: number[] = [];
+			const list = new GenericList({
+				parent: screen,
+				items: [{ id: "TASK-1" }, { id: "TASK-2" }],
+				itemRenderer: (item) => `{cyan-fg}${item.id}{/}`,
+				onHighlight: (_item, index) => {
+					highlighted.push(index);
+				},
+				showHelp: false,
+			});
+
+			const listBox = list.getListBox() as RenderedList;
+			expect(listBox.ritems[0]).toBe("TASK-1");
+			expect(listBox.ritems[1]).toBe("{cyan-fg}TASK-2{/}");
+
+			listBox.select(1);
+
+			expect(listBox.ritems[0]).toBe("{cyan-fg}TASK-1{/}");
+			expect(listBox.ritems[1]).toBe("TASK-2");
+			expect(list.getSelectedIndex()).toBe(1);
+			expect(highlighted.at(-1)).toBe(1);
+
+			list.destroy();
+		});
+	});
+});

--- a/src/test/strip-tags.test.ts
+++ b/src/test/strip-tags.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "../types/index.ts";
+import { formatTaskListItem } from "../ui/board.ts";
+import { stripBlessedFgTags } from "../ui/utils/strip-tags.ts";
+
+describe("stripBlessedFgTags", () => {
+	it("returns the original string when no blessed tags are present", () => {
+		expect(stripBlessedFgTags("plain text")).toBe("plain text");
+	});
+
+	it("removes foreground color tags that use generic closing tags", () => {
+		expect(stripBlessedFgTags("{cyan-fg}@dev{/}")).toBe("@dev");
+	});
+
+	it("removes foreground color tags that use explicit closing tags", () => {
+		expect(stripBlessedFgTags("{yellow-fg}[bug]{/yellow-fg}")).toBe("[bug]");
+	});
+
+	it("preserves structural tags while removing nested foreground wrappers", () => {
+		expect(stripBlessedFgTags("{gray-fg}{bold}TASK-1{/bold}{/}")).toBe("{bold}TASK-1{/bold}");
+	});
+
+	it("removes multiple nested foreground tags while keeping text content", () => {
+		expect(stripBlessedFgTags("{magenta-fg}► {bold}TASK-1{/bold} {cyan-fg}@dev{/}{/}")).toBe(
+			"► {bold}TASK-1{/bold} @dev",
+		);
+	});
+
+	it("preserves stack state when an explicit closing tag does not match the opener", () => {
+		expect(stripBlessedFgTags("{bold}TASK{/cyan-fg}{/bold}")).toBe("{bold}TASK{/cyan-fg}{/bold}");
+	});
+
+	it("keeps empty strings unchanged", () => {
+		expect(stripBlessedFgTags("")).toBe("");
+	});
+});
+
+describe("formatTaskListItem", () => {
+	it("retains all task content after stripping foreground color tags", () => {
+		const task = {
+			id: "TASK-24.4.5.1",
+			title: "Simplify highlighted task contrast",
+			status: "To Do",
+			assignee: ["jay"],
+			createdDate: "2026-04-01",
+			labels: ["ui", "tui"],
+			dependencies: [],
+			branch: "tasks/back-409-highlight-contrast",
+		} satisfies Task & { branch: string };
+
+		const stripped = stripBlessedFgTags(formatTaskListItem(task));
+		expect(stripped).toContain("{bold}TASK-24.4.5.1{/bold}");
+		expect(stripped).toContain("Simplify highlighted task contrast");
+		expect(stripped).toContain("@jay");
+		expect(stripped).toContain("[ui, tui]");
+		expect(stripped).toContain("(tasks/back-409-highlight-contrast)");
+		expect(stripped).not.toContain("{cyan-fg}");
+		expect(stripped).not.toContain("{yellow-fg}");
+		expect(stripped).not.toContain("{green-fg}");
+		expect(stripped).not.toContain("{gray-fg}");
+	});
+});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -22,10 +22,16 @@ import {
 	shouldMoveFromListBoundaryToSearch,
 } from "./task-viewer-with-search.ts";
 import { createScreen } from "./tui.ts";
+import { stripBlessedFgTags } from "./utils/strip-tags.ts";
 
 export type ColumnData = {
 	status: string;
 	tasks: Task[];
+};
+
+type MutableList = ListInterface & {
+	selected?: number;
+	setItem?: (index: number, content: string) => void;
 };
 
 type ColumnView = {
@@ -33,6 +39,9 @@ type ColumnView = {
 	tasks: Task[];
 	list: ListInterface;
 	box: BoxInterface;
+	richItems: string[];
+	plainItems: string[];
+	highlightedIndex?: number;
 };
 
 function isDoneStatus(status: string): boolean {
@@ -100,7 +109,7 @@ function prepareBoardColumns(tasks: Task[], statuses: string[]): ColumnData[] {
 	});
 }
 
-function formatTaskListItem(task: Task, isMoving = false): string {
+export function formatTaskListItem(task: Task, isMoving = false): string {
 	const assignee = task.assignee?.[0]
 		? ` {cyan-fg}${task.assignee[0].startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
 		: "";
@@ -117,6 +126,14 @@ function formatTaskListItem(task: Task, isMoving = false): string {
 		return `{gray-fg}${content}{/}`;
 	}
 	return content;
+}
+
+function buildRenderedTaskListItems(tasks: Task[], movingTaskId?: string): { rich: string[]; plain: string[] } {
+	const rich = tasks.map((task) => formatTaskListItem(task, movingTaskId === task.id));
+	return {
+		rich,
+		plain: rich.map((item) => stripBlessedFgTags(item)),
+	};
 }
 
 function formatColumnLabel(status: string, count: number): string {
@@ -223,6 +240,7 @@ export async function renderBoardTui(
 		let currentFocus: "board" | "filters" = "board";
 		let filterPopupOpen = false;
 		let pendingSearchWrap: "to-first" | "to-last" | null = null;
+		let programmaticColumnSelection = false;
 		const sharedFilters = {
 			searchQuery: options?.filters?.searchQuery ?? "",
 			priorityFilter: options?.filters?.priorityFilter ?? "",
@@ -338,8 +356,48 @@ export async function renderBoardTui(
 
 		const columnWidthFor = (count: number) => Math.max(1, Math.floor(100 / Math.max(1, count)));
 
+		const getSelectedRowIndex = (column: ColumnView): number => {
+			const selected = (column.list as MutableList).selected ?? 0;
+			return Math.max(0, Math.min(selected, Math.max(0, column.tasks.length - 1)));
+		};
+
+		const setColumnItemContent = (column: ColumnView, index: number, usePlain: boolean) => {
+			if (index < 0 || index >= column.tasks.length) return;
+			const content = usePlain ? column.plainItems[index] : column.richItems[index];
+			if (!content) return;
+			(column.list as MutableList).setItem?.(index, content);
+		};
+
+		const syncColumnSelectionDisplay = (column: ColumnView | undefined, active: boolean) => {
+			if (!column) return;
+			const nextHighlightedIndex = active && column.tasks.length > 0 ? getSelectedRowIndex(column) : undefined;
+			if (column.highlightedIndex !== undefined && column.highlightedIndex !== nextHighlightedIndex) {
+				setColumnItemContent(column, column.highlightedIndex, false);
+			}
+			if (nextHighlightedIndex !== undefined) {
+				setColumnItemContent(column, nextHighlightedIndex, true);
+			}
+			column.highlightedIndex = nextHighlightedIndex;
+		};
+
+		const selectColumnRow = (column: ColumnView, index: number, active: boolean) => {
+			if (column.tasks.length === 0) {
+				syncColumnSelectionDisplay(column, false);
+				return;
+			}
+			const nextIndex = Math.max(0, Math.min(index, column.tasks.length - 1));
+			programmaticColumnSelection = true;
+			try {
+				column.list.select(nextIndex);
+			} finally {
+				programmaticColumnSelection = false;
+			}
+			(column.list as MutableList).selected = nextIndex;
+			syncColumnSelectionDisplay(column, active);
+		};
+
 		const getFormattedItems = (tasks: Task[]) => {
-			return tasks.map((task) => formatTaskListItem(task, moveOp?.taskId === task.id));
+			return buildRenderedTaskListItems(tasks, moveOp?.taskId);
 		};
 
 		const createColumnViews = (data: ColumnData[]) => {
@@ -373,8 +431,32 @@ export async function renderBoardTui(
 					style: { selected: { fg: "white" } },
 				});
 
-				taskList.setItems(getFormattedItems(columnData.tasks));
-				columns.push({ status: columnData.status, tasks: columnData.tasks, list: taskList, box: columnBox });
+				const renderedItems = getFormattedItems(columnData.tasks);
+				taskList.setItems(renderedItems.rich);
+				columns.push({
+					status: columnData.status,
+					tasks: columnData.tasks,
+					list: taskList,
+					box: columnBox,
+					richItems: renderedItems.rich,
+					plainItems: renderedItems.plain,
+				});
+
+				taskList.on("select item", (_item: unknown, selected: unknown) => {
+					if (programmaticColumnSelection || popupOpen || filterPopupOpen) return;
+					const column = columns[idx];
+					if (!column) return;
+					if (currentCol !== idx) {
+						setColumnActiveState(columns[currentCol], false);
+						currentCol = idx;
+					}
+					(column.list as MutableList).selected = typeof selected === "number" ? selected : getSelectedRowIndex(column);
+					currentFocus = "board";
+					setColumnActiveState(column, true);
+					filterHeader?.setBorderColor("cyan");
+					updateFooter();
+					screen.render();
+				});
 
 				taskList.on("focus", () => {
 					if (popupOpen || filterPopupOpen) return;
@@ -398,6 +480,7 @@ export async function renderBoardTui(
 			if (listStyle.selected) listStyle.selected.bg = moveOp && active ? "green" : active ? "blue" : undefined;
 			const boxStyle = column.box.style as { border?: { fg?: string } };
 			if (boxStyle.border) boxStyle.border.fg = active ? "yellow" : "gray";
+			syncColumnSelectionDisplay(column, active);
 		};
 
 		const getSelectedTaskId = (): string | undefined => {
@@ -421,7 +504,7 @@ export async function renderBoardTui(
 			if (total > 0) {
 				const previousSelected = typeof previous?.list.selected === "number" ? previous.list.selected : 0;
 				const target = preferredRow !== undefined ? preferredRow : Math.min(previousSelected, total - 1);
-				current.list.select(Math.max(0, target));
+				selectColumnRow(current, target, activate);
 			}
 
 			if (activate) {
@@ -459,7 +542,11 @@ export async function renderBoardTui(
 				if (!column) return;
 				column.status = columnData.status;
 				column.tasks = columnData.tasks;
-				column.list.setItems(getFormattedItems(columnData.tasks));
+				const renderedItems = getFormattedItems(columnData.tasks);
+				column.richItems = renderedItems.rich;
+				column.plainItems = renderedItems.plain;
+				column.highlightedIndex = undefined;
+				column.list.setItems(renderedItems.rich);
 				column.box.setLabel?.(formatColumnLabel(columnData.status, columnData.tasks.length));
 			});
 			restoreSelection(selectedTaskId);
@@ -706,10 +793,10 @@ export async function renderBoardTui(
 		const firstColumn = columns[0];
 		if (firstColumn) {
 			currentCol = 0;
-			setColumnActiveState(firstColumn, true);
 			if (firstColumn.tasks.length > 0) {
-				firstColumn.list.select(0);
+				selectColumnRow(firstColumn, 0, true);
 			}
+			setColumnActiveState(firstColumn, true);
 			firstColumn.list.focus();
 		}
 
@@ -842,7 +929,7 @@ export async function renderBoardTui(
 					return;
 				}
 				const nextIndex = selected - 1;
-				listWidget.select(nextIndex);
+				selectColumnRow(column, nextIndex, true);
 				screen.render();
 			}
 		});
@@ -879,7 +966,7 @@ export async function renderBoardTui(
 					return;
 				}
 				const nextIndex = selected + 1;
-				listWidget.select(nextIndex);
+				selectColumnRow(column, nextIndex, true);
 				screen.render();
 			}
 		});

--- a/src/ui/components/generic-list.ts
+++ b/src/ui/components/generic-list.ts
@@ -8,6 +8,7 @@ import type { ElementInterface, ListInterface, ScreenInterface } from "neo-neo-b
 import { list } from "neo-neo-bblessed";
 import { formatHeading } from "../heading.ts";
 import { createScreen } from "../tui.ts";
+import { stripBlessedFgTags } from "../utils/strip-tags.ts";
 
 export interface GenericListItem {
 	id: string;
@@ -76,6 +77,12 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 	private searchTerm = "";
 	private isSearchMode = false;
 	private options: GenericListOptions<T>;
+	private displayIndexByFilteredIndex = new Map<number, number>();
+	private filteredIndexByDisplayIndex = new Map<number, number>();
+	private normalDisplayByFilteredIndex = new Map<number, string>();
+	private highlightedDisplayByFilteredIndex = new Map<number, string>();
+	private highlightedIndex: number | null = null;
+	private updatingListSelection = false;
 
 	constructor(options: GenericListOptions<T>) {
 		this.options = options;
@@ -104,6 +111,17 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 		}
 
 		this.createListComponent();
+	}
+
+	private buildDisplayContent(item: T, index: number, grouped: boolean): { normal: string; highlighted: string } {
+		const isSelected = this.isMultiSelect ? this.selectedIndices.has(index) : false;
+		const rendered = this.itemRenderer(item, index, isSelected);
+		const prefix = this.isMultiSelect ? (isSelected ? "[✓] " : "[ ] ") : grouped ? "  " : "";
+		const normal = prefix + rendered;
+		return {
+			normal,
+			highlighted: stripBlessedFgTags(normal),
+		};
 	}
 
 	private handleNonTTY(): void {
@@ -176,51 +194,57 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 
 		// Build display items
 		const displayItems: string[] = [];
-		const itemMap = new Map<number, T | null>();
-		let index = 0;
+		this.displayIndexByFilteredIndex.clear();
+		this.filteredIndexByDisplayIndex.clear();
+		this.normalDisplayByFilteredIndex.clear();
+		this.highlightedDisplayByFilteredIndex.clear();
+		let displayIndex = 0;
+
+		if (this.options.searchable && this.isSearchMode) {
+			displayItems.push(`{cyan-fg}Search: ${this.searchTerm}_{/}`);
+			displayIndex += 1;
+		}
 
 		if (this.groupBy) {
 			// Group items
-			const groups = new Map<string, T[]>();
-			for (const item of this.filteredItems) {
+			const groups = new Map<string, Array<{ item: T; filteredIndex: number }>>();
+			for (const [filteredIndex, item] of this.filteredItems.entries()) {
 				const group = this.groupBy(item);
 				if (!groups.has(group)) {
 					groups.set(group, []);
 				}
 				const groupList = groups.get(group);
 				if (groupList) {
-					groupList.push(item);
+					groupList.push({ item, filteredIndex });
 				}
 			}
 
 			// Render groups
 			for (const [group, groupItems] of groups) {
 				displayItems.push(formatHeading(group || "No Group", 2));
-				itemMap.set(index++, null); // Group header
-				for (const item of groupItems) {
-					const isSelected = this.isMultiSelect ? this.selectedIndices.has(index) : false;
-					const rendered = this.itemRenderer(item, index, isSelected);
-					const prefix = this.isMultiSelect ? (isSelected ? "[✓] " : "[ ] ") : "  ";
-					displayItems.push(prefix + rendered);
-					itemMap.set(index++, item);
+				displayIndex += 1;
+				for (const { item, filteredIndex } of groupItems) {
+					const content = this.buildDisplayContent(item, filteredIndex, true);
+					displayItems.push(content.normal);
+					this.displayIndexByFilteredIndex.set(filteredIndex, displayIndex);
+					this.filteredIndexByDisplayIndex.set(displayIndex, filteredIndex);
+					this.normalDisplayByFilteredIndex.set(filteredIndex, content.normal);
+					this.highlightedDisplayByFilteredIndex.set(filteredIndex, content.highlighted);
+					displayIndex += 1;
 				}
 			}
 		} else {
 			// Render flat list
-			for (let i = 0; i < this.filteredItems.length; i++) {
-				const item = this.filteredItems[i];
+			for (const [filteredIndex, item] of this.filteredItems.entries()) {
 				if (!item) continue;
-				const isSelected = this.isMultiSelect ? this.selectedIndices.has(i) : false;
-				const rendered = this.itemRenderer(item, i, isSelected);
-				const prefix = this.isMultiSelect ? (isSelected ? "[✓] " : "[ ] ") : "";
-				displayItems.push(prefix + rendered);
-				itemMap.set(index++, item);
+				const content = this.buildDisplayContent(item, filteredIndex, false);
+				displayItems.push(content.normal);
+				this.displayIndexByFilteredIndex.set(filteredIndex, displayIndex);
+				this.filteredIndexByDisplayIndex.set(displayIndex, filteredIndex);
+				this.normalDisplayByFilteredIndex.set(filteredIndex, content.normal);
+				this.highlightedDisplayByFilteredIndex.set(filteredIndex, content.highlighted);
+				displayIndex += 1;
 			}
-		}
-
-		// Add search indicator
-		if (this.options.searchable && this.isSearchMode) {
-			displayItems.unshift(`{cyan-fg}Search: ${this.searchTerm}_{/}`);
 		}
 
 		// Add help text
@@ -230,6 +254,12 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 		}
 
 		this.listBox.setItems(displayItems);
+		this.highlightedIndex = null;
+		if (this.filteredItems.length === 0) {
+			return;
+		}
+		const clampedIndex = Math.max(0, Math.min(this.selectedIndex, this.filteredItems.length - 1));
+		this.setHighlightedIndex(clampedIndex, { emitHighlight: false });
 	}
 
 	private buildHelpText(): string {
@@ -267,11 +297,7 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 			if (sel <= 0 && this.options.onBoundaryNavigation?.("up", sel, total)) {
 				return;
 			}
-			const nextIndex = sel > 0 ? sel - 1 : total - 1;
-			this.listBox.select(nextIndex);
-			this.selectedIndex = nextIndex;
-			this.onHighlight?.(this.filteredItems[nextIndex] ?? null, nextIndex);
-			this.getScreen()?.render?.();
+			this.setHighlightedIndex(sel > 0 ? sel - 1 : total - 1, { render: true });
 		};
 
 		const moveDown = () => {
@@ -281,20 +307,26 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 			if (sel >= total - 1 && this.options.onBoundaryNavigation?.("down", sel, total)) {
 				return;
 			}
-			const nextIndex = sel < total - 1 ? sel + 1 : 0;
-			this.listBox.select(nextIndex);
-			this.selectedIndex = nextIndex;
-			this.onHighlight?.(this.filteredItems[nextIndex] ?? null, nextIndex);
-			this.getScreen()?.render?.();
+			this.setHighlightedIndex(sel < total - 1 ? sel + 1 : 0, { render: true });
 		};
 
 		this.listBox.key(["up", "k"], moveUp);
 		this.listBox.key(["down", "j"], moveDown);
 
+		this.listBox.on("select item", (_item: unknown, displayIndex: unknown) => {
+			if (this.updatingListSelection) return;
+			if (typeof displayIndex !== "number") return;
+			const filteredIndex = this.filteredIndexByDisplayIndex.get(displayIndex);
+			if (filteredIndex === undefined) return;
+			this.setHighlightedIndex(filteredIndex, { selectList: false, render: true });
+		});
+
 		// Selection/Toggle
 		if (this.isMultiSelect) {
 			this.listBox.key(keys.toggle || ["space"], () => {
-				this.toggleSelection(this.listBox.selected ?? 0);
+				const filteredIndex = this.getFilteredIndexFromSelection();
+				if (filteredIndex === null) return;
+				this.toggleSelection(filteredIndex);
 			});
 
 			this.listBox.key(keys.select || ["enter"], () => {
@@ -302,7 +334,9 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 			});
 		} else {
 			this.listBox.key(keys.select || ["enter"], () => {
-				this.selectedIndex = this.listBox.selected ?? 0;
+				const filteredIndex = this.getFilteredIndexFromSelection();
+				if (filteredIndex === null) return;
+				this.selectedIndex = filteredIndex;
 				this.triggerSelection();
 			});
 		}
@@ -345,11 +379,7 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 	private selectInitialItem(): void {
 		if (this.filteredItems.length > 0) {
 			const validIndex = Math.min(this.selectedIndex, this.filteredItems.length - 1);
-			this.listBox.select(validIndex);
-			this.selectedIndex = validIndex;
-			// Emit initial highlight so hosts can synchronize detail panes
-			this.onHighlight?.(this.filteredItems[validIndex] ?? null, validIndex);
-			// For multi-select, keep internal selectedIndex aligned with highlight
+			this.setHighlightedIndex(validIndex);
 		}
 	}
 
@@ -362,10 +392,10 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 		// Update just the current item's display without full refresh
 		const item = this.filteredItems[index];
 		if (item) {
-			const isSelected = this.selectedIndices.has(index);
-			const rendered = this.itemRenderer(item, index, isSelected);
-			const prefix = isSelected ? "[✓] " : "[ ] ";
-			(this.listBox as { setItem?: (i: number, content: string) => void }).setItem?.(index, prefix + rendered);
+			const content = this.buildDisplayContent(item, index, Boolean(this.groupBy));
+			this.normalDisplayByFilteredIndex.set(index, content.normal);
+			this.highlightedDisplayByFilteredIndex.set(index, content.highlighted);
+			this.setDisplayContent(index, index === this.selectedIndex);
 			this.getScreen()?.render?.();
 		}
 	}
@@ -429,17 +459,7 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 			return;
 		}
 		const clamped = Math.max(0, Math.min(index, this.filteredItems.length - 1));
-		if (this.selectedIndex === clamped) {
-			// Still emit highlight to ensure host state stays synchronized
-			this.onHighlight?.(this.filteredItems[clamped] ?? null, clamped);
-			return;
-		}
-		this.selectedIndex = clamped;
-		this.listBox.select(clamped);
-		const listWithSelected = this.listBox as ListInterface & { selected?: number };
-		listWithSelected.selected = clamped;
-		this.onHighlight?.(this.filteredItems[clamped] ?? null, clamped);
-		this.getScreen()?.render?.();
+		this.setHighlightedIndex(clamped, { render: true });
 	}
 
 	public updateItems(items: T[]): void {
@@ -471,6 +491,64 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 		if (this.screen) return this.screen;
 		const maybeHasScreen = this.listBox as unknown as { screen?: ScreenInterface };
 		return maybeHasScreen?.screen;
+	}
+
+	private getFilteredIndexFromSelection(): number | null {
+		const displayIndex = (this.listBox as ListInterface & { selected?: number }).selected ?? 0;
+		return this.filteredIndexByDisplayIndex.get(displayIndex) ?? null;
+	}
+
+	private selectFilteredIndex(index: number): void {
+		const displayIndex = this.displayIndexByFilteredIndex.get(index);
+		if (displayIndex === undefined) {
+			return;
+		}
+		this.listBox.select(displayIndex);
+		(this.listBox as ListInterface & { selected?: number }).selected = displayIndex;
+	}
+
+	private setHighlightedIndex(
+		index: number,
+		options: { selectList?: boolean; emitHighlight?: boolean; render?: boolean } = {},
+	): void {
+		if (!this.listBox || index < 0 || index >= this.filteredItems.length) {
+			return;
+		}
+		const { selectList = true, emitHighlight = true, render = false } = options;
+		if (this.highlightedIndex !== null && this.highlightedIndex !== index) {
+			this.setDisplayContent(this.highlightedIndex, false);
+		}
+		this.selectedIndex = index;
+		if (selectList) {
+			this.updatingListSelection = true;
+			try {
+				this.selectFilteredIndex(index);
+			} finally {
+				this.updatingListSelection = false;
+			}
+		}
+		this.setDisplayContent(index, true);
+		this.highlightedIndex = index;
+		if (emitHighlight) {
+			this.onHighlight?.(this.filteredItems[index] ?? null, index);
+		}
+		if (render) {
+			this.getScreen()?.render?.();
+		}
+	}
+
+	private setDisplayContent(index: number, highlighted: boolean): void {
+		const displayIndex = this.displayIndexByFilteredIndex.get(index);
+		if (displayIndex === undefined) {
+			return;
+		}
+		const content = highlighted
+			? this.highlightedDisplayByFilteredIndex.get(index)
+			: this.normalDisplayByFilteredIndex.get(index);
+		if (!content) {
+			return;
+		}
+		(this.listBox as { setItem?: (itemIndex: number, content: string) => void }).setItem?.(displayIndex, content);
 	}
 }
 

--- a/src/ui/utils/strip-tags.ts
+++ b/src/ui/utils/strip-tags.ts
@@ -1,0 +1,81 @@
+type TagState = {
+	name: string;
+	strip: boolean;
+};
+
+function parseOpenTag(tag: string): string | null {
+	if (!tag.startsWith("{") || !tag.endsWith("}") || tag.startsWith("{/")) {
+		return null;
+	}
+
+	return tag.slice(1, -1).trim() || null;
+}
+
+function parseCloseTag(tag: string): string | null {
+	if (tag === "{/}") {
+		return "";
+	}
+
+	if (!tag.startsWith("{/") || !tag.endsWith("}")) {
+		return null;
+	}
+
+	return tag.slice(2, -1).trim();
+}
+
+function isForegroundTag(name: string): boolean {
+	return name.endsWith("-fg");
+}
+
+export function stripBlessedFgTags(value: string): string {
+	if (!value.includes("{")) {
+		return value;
+	}
+
+	const tagPattern = /\{\/?[^{}]+\}|\{\/\}/g;
+	const stack: TagState[] = [];
+	let cursor = 0;
+	let output = "";
+
+	for (const match of value.matchAll(tagPattern)) {
+		const tag = match[0];
+		const start = match.index ?? 0;
+		output += value.slice(cursor, start);
+		cursor = start + tag.length;
+
+		const closeTag = parseCloseTag(tag);
+		if (closeTag !== null) {
+			const openTag = stack.pop();
+			if (!openTag) {
+				output += tag;
+				continue;
+			}
+
+			if (closeTag && closeTag !== openTag.name) {
+				stack.push(openTag);
+				output += tag;
+				continue;
+			}
+
+			if (!openTag.strip) {
+				output += tag;
+			}
+			continue;
+		}
+
+		const openTagName = parseOpenTag(tag);
+		if (!openTagName) {
+			output += tag;
+			continue;
+		}
+
+		const strip = isForegroundTag(openTagName);
+		stack.push({ name: openTagName, strip });
+		if (!strip) {
+			output += tag;
+		}
+	}
+
+	output += value.slice(cursor);
+	return output;
+}


### PR DESCRIPTION
## Summary
- Rebased the stale PR onto current `main` and removed the obsolete lockfile delta.
- Reassigned the task from the stale `BACK-409` ID to `BACK-460` and updated the PR title/task metadata.
- Preserved rich blessed foreground formatting for normal rows while stripping those foreground tags only from the active selected row in board and GenericList views.
- Synced selected-row rendering when blessed changes selection directly, including mouse-driven selection changes.

## Validation
- `bun test src/test/generic-list-selection.test.ts src/test/strip-tags.test.ts src/test/board-ui.test.ts src/test/board-render.test.ts src/test/board-ui-selection.test.ts`
- `bun test src/test/filter-header-navigation.test.ts src/test/tab-switching.test.ts src/test/task-viewer-boundary-navigation.test.ts src/test/task-viewer-milestone-filter-model.test.ts src/test/unified-view-filters.test.ts src/test/unified-view-loading.test.ts src/test/view-switcher.test.ts`
- `bun test src/test/cli-agents.test.ts src/test/task-viewer-boundary-navigation.test.ts src/test/tui-interactive-editor-handoff.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `git diff --check origin/main...HEAD`
- TTY smoke with `expect`: launched `bun src/cli.ts board`, observed `Backlog Board`, exited with `q`

Closes BACK-460

Co-authored-by: Alex's Agent <bot@local>
