### PR TITLE
BACK-409 - Add touched-files field to tasks and filename-based search

### DIFF
--- a/backlog/tasks/back-409 - Add-touched-files-field-to-tasks-and-filename-based-search.md
+++ b/backlog/tasks/back-409 - Add-touched-files-field-to-tasks-and-filename-based-search.md
@@ -1,0 +1,32 @@
+---
+id: BACK-409
+title: Add touched-files field to tasks and filename-based search
+status: To Do
+assignee:
+  - '@codex'
+created_date: '2026-04-09 08:44'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add support for tracking which files were touched/modified as part of a task, then make that metadata searchable by filename so users can find all tasks that touched a given file.
+
+This should cover task data model updates, persistence/indexing updates, and CLI/MCP search behavior where applicable.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Tasks include a dedicated field for touched/modified files.
+- [ ] #2 Users can query by filename and get all matching tasks.
+- [ ] #3 Documentation/instructions describe how to set and use the touched-files field.
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [ ] #3 bun test (or scoped test) passes
+<!-- DOD:END -->


### PR DESCRIPTION
### Motivation
- Capture work to add tracking of files touched/modified by a task and enable filename-based search so users can find all tasks that modified a given file.

### Description
- Created `backlog/tasks/back-409 - Add-touched-files-field-to-tasks-and-filename-based-search.md`, adding task `BACK-409` with a description, acceptance criteria for a `touched-files` field and filename query behavior, documentation requirements, and assignment to `@codex`.

### Testing
- No automated tests were run as part of this change; the task file was created and committed, and the task's Definition of Done lists `bunx tsc --noEmit`, `bun run check .`, and `bun test` as verification steps for the eventual implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7666238a48333ba575d7e7a0a5d7e)