### PR TITLE
BACK-413 - Fix browser labels filter dropdown stacking over task table header

### DIFF
--- a/backlog/tasks/back-413 - Fix-browser-labels-filter-dropdown-stacking-over-task-table-header.md
+++ b/backlog/tasks/back-413 - Fix-browser-labels-filter-dropdown-stacking-over-task-table-header.md
@@ -1,0 +1,66 @@
+---
+id: BACK-413
+title: Fix browser labels filter dropdown stacking over task table header
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-04-13 16:05'
+updated_date: '2026-04-13 16:10'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/592'
+  - 'https://github.com/MrLesk/Backlog.md/issues/592#issuecomment-4204881606'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix the browser task list so the Labels filter dropdown remains fully visible and readable when opened above the task table. This addresses GitHub issue #592, where the dropdown is rendered behind the sticky table header and options become partially hidden.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Opening the Labels filter in the browser task list renders the dropdown above the sticky task table header so all options remain visible and readable.
+- [x] #2 The labels filter remains usable after the fix, including selecting labels and clearing the filter.
+- [x] #3 A regression test covers the browser task list labels filter stacking behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update the browser task list labels filter popover in src/web/components/TaskList.tsx so it stacks above the sticky task table header while keeping the existing labels selection and clear-filter behavior intact.
+2. Add a focused web regression test that renders TaskList, opens the labels menu, and verifies the popover uses a higher stacking level than the sticky header and still exposes label options.
+3. Run validation for the change set with a scoped web test, bunx tsc --noEmit, and bun run check .; capture results and finalize the task if all acceptance criteria are met.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Raised the TaskList labels popover above the sticky table header by increasing the menu stacking level and added explicit menu accessibility attributes on the trigger and popover.
+
+Added a focused JSDOM regression test for the TaskList labels menu that verifies the popover stacks above the sticky header and that a preselected label filter can be cleared through the UI.
+
+Validation: `bun test src/test/web-task-list-labels-menu.test.tsx` passed and `bunx tsc --noEmit` passed. `bun run check .` still fails on an unrelated existing `package.json` formatting issue in the repository baseline.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Raised the browser TaskList labels filter popover above the sticky task table header by changing the popover to a higher z-index and adding explicit menu accessibility attributes to the labels filter trigger and menu. Added a focused JSDOM regression test that opens the labels menu, verifies it stacks above the sticky header, and confirms a preselected label filter can be cleared through the UI.
+
+Validation run:
+- `bun test src/test/web-task-list-labels-menu.test.tsx`
+- `bunx tsc --noEmit`
+
+Known validation caveat:
+- `bun run check .` still fails because `package.json` is not formatted to the current Biome style in the existing repository baseline; this issue is unrelated to the TaskList fix.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-413 - Fix-browser-labels-filter-dropdown-stacking-over-task-table-header.md
+++ b/backlog/tasks/back-413 - Fix-browser-labels-filter-dropdown-stacking-over-task-table-header.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-13 16:05'
-updated_date: '2026-04-13 16:12'
+updated_date: '2026-04-13 17:31'
 labels: []
 dependencies: []
 references:
@@ -30,9 +30,9 @@ Fix the browser task list so the Labels filter dropdown remains fully visible an
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Update the browser task list labels filter popover in src/web/components/TaskList.tsx so it stacks above the sticky task table header while keeping the existing labels selection and clear-filter behavior intact.
-2. Add a focused web regression test that renders TaskList, opens the labels menu, and verifies the popover uses a higher stacking level than the sticky header and still exposes label options.
-3. Run validation for the change set with a scoped web test, bunx tsc --noEmit, and bun run check .; capture results and finalize the task if all acceptance criteria are met.
+1. Remove the mismatched ARIA menu semantics from the browser TaskList labels popover in src/web/components/TaskList.tsx while preserving the stacking fix and the existing checkbox/button interaction model.
+2. Update the focused TaskList labels popover regression test to assert the popover remains above the sticky header and stays role-neutral instead of exposing menu semantics.
+3. Re-run the focused test and TypeScript validation, then push the follow-up commit to the existing PR #594.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -45,6 +45,10 @@ Added a focused JSDOM regression test for the TaskList labels menu that verifies
 Validation: `bun test src/test/web-task-list-labels-menu.test.tsx` passed and `bunx tsc --noEmit` passed. `bun run check .` still fails on an unrelated existing `package.json` formatting issue in the repository baseline.
 
 Opened PR #594 for this fix: https://github.com/MrLesk/Backlog.md/pull/594
+
+Addressed PR review feedback on `src/web/components/TaskList.tsx` by removing the added ARIA menu semantics from the labels popover. The control remains a role-neutral popover containing native checkboxes and a button, which matches its actual interaction model.
+
+Follow-up validation after the accessibility fix: `bun test src/test/web-task-list-labels-menu.test.tsx` passed and `bunx tsc --noEmit` passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -58,6 +62,8 @@ Validation run:
 
 Known validation caveat:
 - `bun run check .` still fails because `package.json` is not formatted to the current Biome style in the existing repository baseline; this issue is unrelated to the TaskList fix.
+
+Follow-up review fix: removed mismatched `aria-haspopup="menu"` and `role="menu"` semantics from the labels popover so assistive technology sees the existing native form-control pattern instead of an unsupported ARIA menu model.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-413 - Fix-browser-labels-filter-dropdown-stacking-over-task-table-header.md
+++ b/backlog/tasks/back-413 - Fix-browser-labels-filter-dropdown-stacking-over-task-table-header.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-13 16:05'
-updated_date: '2026-04-13 16:10'
+updated_date: '2026-04-13 16:12'
 labels: []
 dependencies: []
 references:
@@ -43,6 +43,8 @@ Raised the TaskList labels popover above the sticky table header by increasing t
 Added a focused JSDOM regression test for the TaskList labels menu that verifies the popover stacks above the sticky header and that a preselected label filter can be cleared through the UI.
 
 Validation: `bun test src/test/web-task-list-labels-menu.test.tsx` passed and `bunx tsc --noEmit` passed. `bun run check .` still fails on an unrelated existing `package.json` formatting issue in the repository baseline.
+
+Opened PR #594 for this fix: https://github.com/MrLesk/Backlog.md/pull/594
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import type { Task } from "../types/index.ts";
+import TaskList from "../web/components/TaskList.tsx";
+
+const createTask = (overrides: Partial<Task>): Task => ({
+	id: "task-1",
+	title: "Task",
+	status: "To Do",
+	assignee: [],
+	labels: [],
+	dependencies: [],
+	createdDate: "2026-01-01",
+	...overrides,
+});
+
+const tasks: Task[] = [
+	createTask({ id: "task-101", title: "Fix labels dropdown", labels: ["bug"] }),
+	createTask({ id: "task-102", title: "Ship docs", labels: ["docs"] }),
+];
+
+let activeRoot: Root | null = null;
+const originalFetch = globalThis.fetch;
+
+const setupDom = () => {
+	const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { url: "http://localhost" });
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = dom.window as unknown as Window & typeof globalThis;
+	globalThis.document = dom.window.document as unknown as Document;
+	globalThis.navigator = dom.window.navigator as unknown as Navigator;
+	globalThis.localStorage = dom.window.localStorage as unknown as Storage;
+
+	if (!window.matchMedia) {
+		window.matchMedia = () =>
+			({
+				matches: false,
+				media: "",
+				onchange: null,
+				addListener: () => {},
+				removeListener: () => {},
+				addEventListener: () => {},
+				removeEventListener: () => {},
+				dispatchEvent: () => false,
+			}) as MediaQueryList;
+	}
+
+	const htmlElementPrototype = window.HTMLElement.prototype as unknown as {
+		attachEvent?: () => void;
+		detachEvent?: () => void;
+	};
+	if (typeof htmlElementPrototype.attachEvent !== "function") {
+		htmlElementPrototype.attachEvent = () => {};
+	}
+	if (typeof htmlElementPrototype.detachEvent !== "function") {
+		htmlElementPrototype.detachEvent = () => {};
+	}
+};
+
+const renderTaskList = (initialEntries?: string[]): HTMLElement => {
+	setupDom();
+	const container = document.getElementById("root");
+	expect(container).toBeTruthy();
+	activeRoot = createRoot(container as HTMLElement);
+	act(() => {
+		activeRoot?.render(
+			<MemoryRouter initialEntries={initialEntries}>
+				<TaskList
+					tasks={tasks}
+					availableStatuses={["To Do", "In Progress", "Done"]}
+					availableLabels={["bug", "docs"]}
+					availableMilestones={[]}
+					milestoneEntities={[]}
+					archivedMilestones={[]}
+					onEditTask={() => {}}
+					onNewTask={() => {}}
+				/>
+			</MemoryRouter>,
+		);
+	});
+	return container as HTMLElement;
+};
+
+const clickElement = async (element: Element) => {
+	await act(async () => {
+		element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+		await Promise.resolve();
+	});
+};
+
+const waitFor = async (predicate: () => boolean) => {
+	for (let attempt = 0; attempt < 10; attempt += 1) {
+		if (predicate()) {
+			return;
+		}
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+	}
+};
+
+const getLabelsButton = (container: HTMLElement): HTMLButtonElement => {
+	const button = container.querySelector("button[aria-controls='task-list-labels-menu']");
+	expect(button).toBeTruthy();
+	return button as HTMLButtonElement;
+};
+
+const getZIndexClass = (element: Element): number | null => {
+	const match = element.className.match(/\bz-(\d+)\b/);
+	const value = match?.[1];
+	return value ? Number.parseInt(value, 10) : null;
+};
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	if (activeRoot) {
+		act(() => {
+			activeRoot?.unmount();
+		});
+		activeRoot = null;
+	}
+});
+
+describe("TaskList labels filter menu", () => {
+	it("renders the labels menu above the sticky table header", async () => {
+		const container = renderTaskList();
+		const labelsButton = getLabelsButton(container);
+
+		await clickElement(labelsButton);
+
+		const labelsMenu = container.querySelector("#task-list-labels-menu");
+		const stickyHeader = container.querySelector("div.sticky");
+
+		expect(labelsMenu).toBeTruthy();
+		expect(stickyHeader).toBeTruthy();
+		expect(labelsMenu?.textContent).toContain("bug");
+		expect(getZIndexClass(labelsMenu as Element)).toBeGreaterThan(getZIndexClass(stickyHeader as Element) ?? 0);
+	});
+
+	it("allows selecting and clearing a label filter", async () => {
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			expect(url).toContain("/api/search");
+			expect(url).toContain("label=bug");
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () => [{ type: "task", score: 0, task: tasks[0] }],
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(["/?label=bug"]);
+		const labelsButton = getLabelsButton(container);
+		await waitFor(() => fetchCalls.length === 1);
+
+		expect(labelsButton.textContent).toContain("bug");
+		expect(fetchCalls).toHaveLength(1);
+
+		await clickElement(labelsButton);
+
+		const clearButton = Array.from(container.querySelectorAll("button")).find((button) =>
+			button.textContent?.includes("Clear label filter"),
+		);
+		expect(clearButton).toBeTruthy();
+		await clickElement(clearButton as HTMLButtonElement);
+
+		expect(labelsButton.textContent).toContain("All");
+		expect(container.querySelector("#task-list-labels-menu")).toBeNull();
+	});
+});

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -136,6 +136,8 @@ describe("TaskList labels filter menu", () => {
 		expect(labelsMenu).toBeTruthy();
 		expect(stickyHeader).toBeTruthy();
 		expect(labelsMenu?.textContent).toContain("bug");
+		expect(labelsButton.getAttribute("aria-haspopup")).toBeNull();
+		expect(labelsMenu?.getAttribute("role")).toBeNull();
 		expect(getZIndexClass(labelsMenu as Element)).toBeGreaterThan(getZIndexClass(stickyHeader as Element) ?? 0);
 	});
 

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -716,6 +716,9 @@ const TaskList: React.FC<TaskListProps> = ({
 							type="button"
 							ref={labelsButtonRef}
 							onClick={() => setShowLabelsMenu((open) => !open)}
+							aria-haspopup="menu"
+							aria-expanded={showLabelsMenu}
+							aria-controls="task-list-labels-menu"
 							className="min-w-[200px] py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200 text-left"
 						>
 							<div className="flex items-center justify-between gap-2">
@@ -731,8 +734,10 @@ const TaskList: React.FC<TaskListProps> = ({
 						</button>
 						{showLabelsMenu && (
 							<div
+								id="task-list-labels-menu"
 								ref={labelsMenuRef}
-								className="absolute z-10 mt-2 w-[220px] max-h-56 overflow-y-auto rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg"
+								role="menu"
+								className="absolute z-50 mt-2 w-[220px] max-h-56 overflow-y-auto rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg"
 							>
 								{mergedAvailableLabels.length === 0 ? (
 									<div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No labels</div>

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -716,7 +716,6 @@ const TaskList: React.FC<TaskListProps> = ({
 							type="button"
 							ref={labelsButtonRef}
 							onClick={() => setShowLabelsMenu((open) => !open)}
-							aria-haspopup="menu"
 							aria-expanded={showLabelsMenu}
 							aria-controls="task-list-labels-menu"
 							className="min-w-[200px] py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200 text-left"
@@ -736,7 +735,6 @@ const TaskList: React.FC<TaskListProps> = ({
 							<div
 								id="task-list-labels-menu"
 								ref={labelsMenuRef}
-								role="menu"
 								className="absolute z-50 mt-2 w-[220px] max-h-56 overflow-y-auto rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg"
 							>
 								{mergedAvailableLabels.length === 0 ? (


### PR DESCRIPTION
## Summary
- raise the browser TaskList labels popover above the sticky task table header so the dropdown is fully readable when opened
- add explicit menu accessibility attributes for the labels filter trigger and popover
- add a focused JSDOM regression test for the labels menu stacking and clear-filter behavior

## Root Cause
The labels filter menu used the same `z-10` stacking level as the sticky table header in the task list. Because the header establishes its own stacking context later in the layout, the dropdown could render underneath it and partially hide options.

## Related Task
- BACK-413

## Issue
Closes #592

## Task Checklist
- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Testing
- `bun test src/test/web-task-list-labels-menu.test.tsx`
- `bunx tsc --noEmit`

## Validation Note
- `bun run check .` currently fails on an unrelated existing `package.json` Biome formatting issue in the repository baseline; this PR does not modify `package.json`.
