### PR TITLE
BACK-449 - Document task image handling and docs management in agent guidelines

### DIFF
--- a/backlog/tasks/back-449 - Document-task-image-handling-and-docs-management-in-agent-guidelines.md
+++ b/backlog/tasks/back-449 - Document-task-image-handling-and-docs-management-in-agent-guidelines.md
@@ -1,12 +1,16 @@
 ---
 id: BACK-449
 title: Document task image handling and docs management in agent guidelines
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-04-26 13:05'
+updated_date: '2026-04-26 13:17'
 labels:
   - documentation
 dependencies: []
+modified_files:
+  - src/guidelines/agent-guidelines.md
 priority: low
 ---
 
@@ -18,14 +22,38 @@ Document agent-facing guidance for task image assets and the document-management
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Agent guidelines document task image asset storage, supported formats, Markdown references, and browser serving behavior.
-- [ ] #2 Agent guidelines document the current docs-management public surface without telling agents to rely on stale or source-only behavior.
-- [ ] #3 Guidance matches the recent document cleanup: docs paths are relative to backlog/docs, unsafe paths are rejected, CLI supports doc create/list/view, and MCP/Web provide document update behavior.
+- [x] #1 Agent guidelines document task image asset storage, supported formats, Markdown references, and browser serving behavior.
+- [x] #2 Agent guidelines document the current docs-management public surface without telling agents to rely on stale or source-only behavior.
+- [x] #3 Guidance matches the recent document cleanup: docs paths are relative to backlog/docs, unsafe paths are rejected, CLI supports doc create/list/view, and MCP/Web provide document update behavior.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Rebased PR #598 onto current main after BACK-436/BACK-610 document-management cleanup. Removed the fork-created BACK-448 task because task IDs must be created on main; this PR now uses BACK-449, which was created directly on main.
+
+Kept the useful task-image guidance, corrected asset path wording, and replaced the stale long Docs Management section with concise guidance aligned to the current public surface: CLI doc create/list/view, MCP document_create/document_update, docs-relative paths, unsafe path rejection, and supported document types.
+
+Validation passed: `bun run check .`, `bunx tsc --noEmit`, and `bun test src/test/server-assets.test.ts`.
+
+Confirmed the CLI surface after the user question about `doc update`: `backlog doc --help` and `src/cli.ts` expose only `doc create`, `doc list`, and `doc view`; document updates are currently MCP/Web only. Added an explicit guideline sentence so agents do not infer a nonexistent CLI update command.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated agent guidelines for task image assets and current document-management APIs.
+
+Changes:
+- Documented local task image storage under backlog/assets and Markdown references using assets/<relative-path>.
+- Replaced stale docs CLI guidance with the current public contract from the recent docs cleanup: CLI create/list/view, MCP/Web update, docs-relative paths, unsafe path rejection, and supported document types.
+- Explicitly called out that the CLI does not currently expose `doc update`, so agents should use MCP or Web UI for document updates.
+- Removed the fork-created BACK-448 task and completed BACK-449 from main for this PR.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -600,6 +600,70 @@ Tests:
 - bun test src/test/cli-final-summary.test.ts
 ```
 
+### Task Images (Local Assets)
+
+Tasks may include images for screenshots, diagrams, or visual references. Local images are served automatically when using `backlog browser`.
+
+**Storage location:**
+- Place image files under the `assets/` folder inside your backlog directory (e.g., `backlog/assets/images/screenshot.png`)
+
+**Supported formats:**
+- png, jpg, jpeg, gif, svg, webp, avif (served with correct Content-Type)
+
+**Markdown syntax in tasks:**
+```markdown
+![example](assets/images/screenshot.png)
+```
+
+**Workflow when adding images to tasks:**
+1. Move or copy the image file into the `assets/` folder inside your backlog directory (e.g., `backlog/assets/images/screenshot.png`)
+2. Then add or edit the task content via CLI, referencing the image using the `assets/<relative-path>` path
+
+**Key points:**
+- The path in Markdown starts with `assets/` and maps to the backlog directory's `assets/` folder; do **not** include the backlog directory name itself
+- When `backlog browser` is running, these files are automatically available at `assets/<relative-path>`
+- You can add images to descriptions, implementation notes, or final summaries using the standard CLI commands
+
+### Document Management
+
+> Docs are used for long-term project reference information, such as development standards, configuration guides, architecture documentation, etc. They differ from `tasks/` (specific tasks), `decisions/` (decision records), and `drafts/` (drafts).
+
+Use Backlog.md public interfaces for document creation and updates so IDs, frontmatter, paths, and search metadata stay consistent.
+
+#### CLI Usage
+
+The CLI currently supports creating, listing, and viewing documents. Use MCP or the Web UI for document updates.
+
+```bash
+# Create a new doc (saved under backlog/docs/ by default)
+backlog doc create "API Guidelines"
+
+# Create in a subdirectory (nested paths supported)
+backlog doc create "Setup Guide" -p guides/setup
+
+# Specify type at creation time
+backlog doc create "Architecture" -t guide
+
+# List all docs (searched globally across subdirectories)
+backlog doc list
+
+# View a specific doc
+backlog doc view doc-1
+```
+
+#### MCP / API Usage
+
+- Use `document_create` to create documents with title, content, optional type/tags, and optional docs-directory-relative path.
+- Use `document_update` to update document content, title, type, tags, or path while preserving document metadata.
+- Document responses include the persisted docs-relative file path so agents can reference the created file without scanning source internals.
+
+#### Key Rules
+
+- Document paths are relative to `backlog/docs/`; absolute paths and `..` traversal are rejected.
+- Supported document types are `readme`, `guide`, `specification`, and `other`.
+- Document IDs are global across the entire docs tree, including nested subfolders.
+- Prefer CLI, MCP, or Web document APIs over ad-hoc file writes so frontmatter and metadata remain valid.
+
 ### Task Operations
 
 | Action             | Command                                      |


### PR DESCRIPTION
## Summary
- Rebased the contribution onto current `main` after the BACK-436 document-management cleanup.
- Kept and corrected the task-image asset guidance for agents.
- Replaced stale docs CLI guidance with the current public document contract: CLI create/list/view, MCP/Web update, docs-relative paths, unsafe path rejection, and supported document types.
- Explicitly verified that `backlog doc update` is not currently exposed by the CLI, so the guidance points agents to MCP/Web for updates.
- Uses `BACK-449`, created on `main`, instead of the fork-created `BACK-448` task ID.

## Testing
- `bun run check .`
- `bunx tsc --noEmit`
- `bun test src/test/server-assets.test.ts`
- `bun run cli doc --help` / `bun run cli doc update --help`