### PR TITLE
BACK-347 - Add milestone editing in Web UI

### DIFF
--- a/backlog/tasks/back-347 - Add-milestone-editing-in-Web-UI.md
+++ b/backlog/tasks/back-347 - Add-milestone-editing-in-Web-UI.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-347
 title: Add milestone editing in Web UI
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@alex-agent'
 created_date: '2025-12-17 19:29'
-updated_date: '2025-12-17 22:11'
+updated_date: '2026-04-25 20:53'
 labels:
   - milestones
   - web-ui
@@ -33,3 +34,60 @@ Add milestone editing capabilities to the Milestones page:
 - task-344 added MCP milestone management (list/add/rename/remove)
 - Should reuse the same core logic for consistency
 <!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Context level: L2 (server API + shared milestone mutation logic + React Web UI + tests).
+
+Reviewed context:
+- Existing Web Milestones page in `src/web/components/MilestonesPage.tsx` already supports add, search, drag/drop assignment, and archive-only card action.
+- Existing Web API in `src/server/index.ts` exposes milestone list/get/create/archive but not rename/remove.
+- Existing MCP milestone implementation in `src/mcp/tools/milestones/handlers.ts` has the canonical rename/remove behavior: duplicate alias validation, task milestone updates, clear/reassign/keep handling, rollback, and auto-commit support.
+- Existing API client methods live in `src/web/lib/api.ts`; milestone tests live under `src/test/*web-milestones*` and server milestone API coverage is currently in `src/test/server-search-endpoint.test.ts`.
+
+Implementation plan:
+1. Reuse the existing MCP milestone mutation handler from the Web server by relaxing its constructor dependency from `McpServer` to the shared `Core` type, so MCP and Web routes use the same rename/remove behavior.
+2. Add Web API routes: `PUT /api/milestones/:id` for rename/update and `DELETE /api/milestones/:id` for removal with `taskHandling=clear|reassign|keep` and optional `reassignTo`; return JSON errors with 400/404/500 based on the shared handler error code.
+3. Add API client methods for updating and removing milestones.
+4. Update `MilestonesPage` with an Edit action/modal and a Remove confirmation modal. Rename validates empty/duplicate names before submit and server remains authoritative; remove lets users clear task milestones or reassign to another active milestone.
+5. Add focused server and Web component tests for rename/remove flows and UI affordances.
+6. Run targeted tests and type/check commands as appropriate, then simplify after implementation if anything duplicated remains.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Started implementation as @codex. Initial scope: add milestone edit/delete support in the Web UI, reusing existing core milestone logic where possible.
+
+Implemented milestone rename/remove in the Web UI using the existing MCP milestone mutation handler so duplicate validation, local task updates, clear/reassign semantics, rollback, and auto-commit behavior stay consistent. Added a regression test ensuring milestone rename commit failures are not masked by rollback rename failures. Validation passed for targeted Web/server/MCP tests, task-scoped Biome checks, and `bunx tsc --noEmit`. Full `bun run check .` still reports unrelated dirty-worktree formatting for `.codex/hooks.json` and `package.json`.
+
+Review follow-up completed: milestone mutation request parsing now treats an empty body as optional/default input but returns `VALIDATION_ERROR` for malformed JSON and non-object JSON bodies. Added Web API regression coverage for malformed DELETE bodies, non-object DELETE payloads, PUT not-found, and DELETE not-found. Removed the machine-local `.codex/hooks.json` from the worktree, ignored it via `.codex/.gitignore`, formatted `package.json`, and verified `bun run check .` now passes.
+
+PR #604 merge-readiness pass: rebased the branch onto current origin/main, kept the newer package dependency set, restored the separate Web UI milestone Archive action while keeping Remove, fixed the Web API title-alias rename response to return the renamed milestone, and added Web component submit-path tests for edit/remove API calls plus refresh behavior.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented Web UI milestone editing/removal for BACK-347.
+
+Changes:
+- Added `PUT /api/milestones/:id` and `DELETE /api/milestones/:id` Web API routes backed by the existing MCP milestone handler, so rename/remove behavior reuses the canonical duplicate validation, task updates, clear/reassign handling, rollback, and auto-commit paths.
+- Added request-body validation for milestone mutation routes: empty bodies remain optional, malformed JSON and non-object JSON now return `VALIDATION_ERROR` instead of falling through to destructive defaults.
+- Added API client methods for milestone update/remove.
+- Updated the Milestones page with card-level Edit and Remove actions, an edit modal for renaming, and a remove confirmation modal that can leave tasks unassigned or reassign them to another milestone.
+- Added server/API tests for rename/remove behavior, malformed/non-object DELETE bodies, PUT/DELETE not-found responses, Web component tests for the new controls/modals, and a rollback regression test for milestone rename auto-commit failure handling.
+- Removed the machine-local `.codex/hooks.json` from the worktree by ignoring it in `.codex/.gitignore` and formatted `package.json`.
+
+Validation:
+- `bun test src/test/server-search-endpoint.test.ts src/test/mcp-milestones.test.ts src/test/web-milestones-page-search.test.tsx`
+- `bunx tsc --noEmit`
+- `bun run check .`
+
+Merge-readiness follow-up on PR #604:
+- Rebased onto current main and preserved the newer dependency/package bump state.
+- Restored the separate Web UI Archive action so adding Remove no longer removes existing archive behavior.
+- Fixed `PUT /api/milestones/:id` to return the renamed milestone when the route parameter is a title alias instead of the canonical milestone ID.
+- Added regression coverage for title-alias Web API renames and Web component edit/remove submit wiring.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/board.ts
+++ b/src/board.ts
@@ -146,7 +146,7 @@ Project: ${projectName}
 	for (let taskIdx = 0; taskIdx < maxTasks; taskIdx++) {
 		const row = orderedStatuses.map((_, cIdx) => {
 			const task = columns[cIdx]?.[taskIdx];
-			if (!task || !task.id || !task.title) return "";
+			if (!task?.id || !task.title) return "";
 
 			// Check if this is a subtask
 			const isSubtask = task.parentTaskId;

--- a/src/completions/helper.ts
+++ b/src/completions/helper.ts
@@ -57,7 +57,7 @@ export function parseCompletionContext(line: string, point: number): CompletionC
 		} else {
 			// Count positional arguments
 			const prevWord = completedWords[i - 1];
-			if (!prevWord || !prevWord.startsWith("-")) {
+			if (!prevWord?.startsWith("-")) {
 				argPosition++;
 			}
 		}

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2040,7 +2040,11 @@ export class Core {
 			} catch (error) {
 				await this.git.resetPaths(commitPaths, repoRoot);
 				const rollbackTitle = result.previousTitle ?? title;
-				await this.fs.renameMilestone(result.milestone?.id ?? identifier, rollbackTitle);
+				try {
+					await this.fs.renameMilestone(result.milestone?.id ?? identifier, rollbackTitle);
+				} catch {
+					// Ignore rollback failure and propagate original commit error.
+				}
 				throw error;
 			}
 		}

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -385,7 +385,7 @@ export class ContentStore {
 		const decisionsDir = this.filesystem.decisionsDir;
 		const watcher: FSWatcher = watch(decisionsDir, { recursive: false }, (eventType, filename) => {
 			const file = this.normalizeFilename(filename);
-			if (!file || !file.startsWith("decision-") || !file.endsWith(".md")) {
+			if (!file?.startsWith("decision-") || !file.endsWith(".md")) {
 				this.enqueue(async () => {
 					await this.refreshDecisionsFromDisk();
 				});

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -562,7 +562,7 @@ export class FileSystem {
 			return await this.withCreateLock(async () => {
 				// Load the draft
 				const draft = await this.loadDraft(draftId);
-				if (!draft || !draft.filePath) return false;
+				if (!draft?.filePath) return false;
 
 				// Get task prefix from config (default: "task")
 				const config = await this.loadConfig();
@@ -604,7 +604,7 @@ export class FileSystem {
 			return await this.withCreateLock(async () => {
 				// Load the task
 				const task = await this.loadTask(taskId);
-				if (!task || !task.filePath) return false;
+				if (!task?.filePath) return false;
 
 				// Get existing draft IDs to generate next ID
 				// Draft prefix is always "draft" (not configurable like task prefix)

--- a/src/markdown/structured-sections.ts
+++ b/src/markdown/structured-sections.ts
@@ -376,7 +376,7 @@ function parseOldChecklistFormat(content: string, definition: ChecklistSectionDe
 	const src = content.replace(/\r\n/g, "\n");
 	const criteriaRegex = new RegExp(`${escapeForRegex(definition.sectionHeader)}\\s*\\n([\\s\\S]*?)(?=\\n## |$)`, "i");
 	const match = src.match(criteriaRegex);
-	if (!match || !match[1]) {
+	if (!match?.[1]) {
 		return [];
 	}
 	const lines = match[1].split("\n").filter((line) => line.trim());

--- a/src/mcp/tools/milestones/handlers.ts
+++ b/src/mcp/tools/milestones/handlers.ts
@@ -1,7 +1,7 @@
 import { rename as moveFile } from "node:fs/promises";
+import type { Core } from "../../../core/backlog.ts";
 import type { Milestone, Task } from "../../../types/index.ts";
 import { BacklogToolError } from "../../errors/mcp-errors.ts";
-import type { McpServer } from "../../server.ts";
 import type { CallToolResult } from "../../types.ts";
 import {
 	buildMilestoneMatchKeys,
@@ -212,7 +212,7 @@ function resolveMilestoneValueForReporting(
 }
 
 export class MilestoneHandlers {
-	constructor(private readonly core: McpServer) {}
+	constructor(private readonly core: Core) {}
 
 	private async listLocalTasks(): Promise<Task[]> {
 		return await this.core.queryTasks({ includeCrossBranch: false });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,8 @@ import { initializeProject } from "../core/init.ts";
 import type { SearchService } from "../core/search-service.ts";
 import { getTaskStatistics } from "../core/statistics.ts";
 import { isCreateLockError } from "../file-system/operations.ts";
+import { BacklogToolError } from "../mcp/errors/mcp-errors.ts";
+import { MilestoneHandlers } from "../mcp/tools/milestones/handlers.ts";
 import type { SearchPriorityFilter, SearchResultType, Task, TaskUpdateInput } from "../types/index.ts";
 import { watchConfig } from "../utils/config-watcher.ts";
 import { getVersion } from "../utils/version.ts";
@@ -373,6 +375,10 @@ export class BacklogServer {
 					},
 					"/api/milestones/:id": {
 						GET: async (req: Request & { params: { id: string } }) => await this.handleGetMilestone(req.params.id),
+						PUT: async (req: Request & { params: { id: string } }) =>
+							await this.handleUpdateMilestone(req, req.params.id),
+						DELETE: async (req: Request & { params: { id: string } }) =>
+							await this.handleRemoveMilestone(req, req.params.id),
 					},
 					"/api/milestones/:id/archive": {
 						POST: async (req: Request & { params: { id: string } }) => await this.handleArchiveMilestone(req.params.id),
@@ -1225,6 +1231,52 @@ export class BacklogServer {
 	}
 
 	// Milestone handlers
+	private async readOptionalJsonBody(req: Request): Promise<Record<string, unknown>> {
+		const text = await req.text();
+		if (!text.trim()) {
+			return {};
+		}
+
+		let body: unknown;
+		try {
+			body = JSON.parse(text);
+		} catch {
+			throw new BacklogToolError("Request body must be valid JSON.", "VALIDATION_ERROR");
+		}
+
+		if (!body || typeof body !== "object" || Array.isArray(body)) {
+			throw new BacklogToolError("Request body must be a JSON object.", "VALIDATION_ERROR");
+		}
+
+		return body as Record<string, unknown>;
+	}
+
+	private getMilestoneMutationMessage(result: { content: Array<{ type: string; text?: string }> }): string {
+		return result.content
+			.filter((item) => item.type === "text" && typeof item.text === "string")
+			.map((item) => item.text)
+			.join("\n");
+	}
+
+	private milestoneMutationErrorResponse(error: unknown, context: string): Response {
+		const status =
+			error instanceof BacklogToolError
+				? error.code === "NOT_FOUND"
+					? 404
+					: error.code === "VALIDATION_ERROR"
+						? 400
+						: 500
+				: 500;
+		const message = error instanceof Error ? error.message : context;
+		if (status === 500) {
+			console.error(context, error);
+		}
+		return Response.json(
+			{ error: message, code: error instanceof BacklogToolError ? error.code : "INTERNAL_ERROR" },
+			{ status },
+		);
+	}
+
 	private async handleListMilestones(): Promise<Response> {
 		try {
 			const milestones = await this.core.filesystem.listMilestones();
@@ -1309,6 +1361,67 @@ export class BacklogServer {
 		} catch (error) {
 			console.error("Error creating milestone:", error);
 			return Response.json({ error: "Failed to create milestone" }, { status: 500 });
+		}
+	}
+
+	private async handleUpdateMilestone(req: Request, milestoneId: string): Promise<Response> {
+		try {
+			const body = await this.readOptionalJsonBody(req);
+			const title = typeof body.title === "string" ? body.title.trim() : "";
+			const updateTasks = typeof body.updateTasks === "boolean" ? body.updateTasks : true;
+
+			if (!title) {
+				return Response.json({ error: "Milestone title is required" }, { status: 400 });
+			}
+
+			const sourceMilestone = await this.core.filesystem.loadMilestone(milestoneId);
+			const result = await new MilestoneHandlers(this.core).renameMilestone({
+				from: milestoneId,
+				to: title,
+				updateTasks,
+			});
+			const milestone =
+				(await this.core.filesystem.loadMilestone(sourceMilestone?.id ?? milestoneId)) ??
+				(await this.core.filesystem.loadMilestone(title));
+			this.broadcastTasksUpdated();
+			return Response.json({
+				success: true,
+				milestone: milestone ?? null,
+				message: this.getMilestoneMutationMessage(result),
+			});
+		} catch (error) {
+			return this.milestoneMutationErrorResponse(error, "Error updating milestone");
+		}
+	}
+
+	private async handleRemoveMilestone(req: Request, milestoneId: string): Promise<Response> {
+		try {
+			const body = await this.readOptionalJsonBody(req);
+			const rawTaskHandling = body.taskHandling;
+			const taskHandling =
+				rawTaskHandling === undefined
+					? "clear"
+					: rawTaskHandling === "clear" || rawTaskHandling === "keep" || rawTaskHandling === "reassign"
+						? rawTaskHandling
+						: null;
+			const reassignTo = typeof body.reassignTo === "string" ? body.reassignTo : undefined;
+
+			if (!taskHandling) {
+				return Response.json({ error: "taskHandling must be clear, keep, or reassign" }, { status: 400 });
+			}
+
+			const result = await new MilestoneHandlers(this.core).removeMilestone({
+				name: milestoneId,
+				taskHandling,
+				reassignTo,
+			});
+			this.broadcastTasksUpdated();
+			return Response.json({
+				success: true,
+				message: this.getMilestoneMutationMessage(result),
+			});
+		} catch (error) {
+			return this.milestoneMutationErrorResponse(error, "Error removing milestone");
 		}
 	}
 

--- a/src/test/markdown-test-helpers.ts
+++ b/src/test/markdown-test-helpers.ts
@@ -100,7 +100,7 @@ export function parseSequenceCreateMarkdown(markdown: string) {
 				}
 			}
 		}
-		if (inUnsequenced && line && line.startsWith("## ") && line !== "## Unsequenced Tasks") {
+		if (inUnsequenced && line?.startsWith("## ") && line !== "## Unsequenced Tasks") {
 			inUnsequenced = false;
 		}
 	}
@@ -203,7 +203,7 @@ export function parseSequencePlanMarkdown(markdown: string) {
 		}
 
 		// Match task lines like "- **task-1** - Foundation Task (To Do)"
-		if (currentPhase && inPhaseTasks && line && line.match(/^- \*\*(.+?)\*\* - (.+?) \((.+?)\)(.*)$/)) {
+		if (currentPhase && inPhaseTasks && line?.match(/^- \*\*(.+?)\*\* - (.+?) \((.+?)\)(.*)$/)) {
 			const taskMatch = line.match(/^- \*\*(.+?)\*\* - (.+?) \((.+?)\)(.*)$/);
 			if (taskMatch) {
 				const [, id, title, status, extra] = taskMatch;
@@ -227,7 +227,7 @@ export function parseSequencePlanMarkdown(markdown: string) {
 		}
 
 		// Check for dependency lines
-		if (currentPhase && inPhaseTasks && line && line.match(/^\s+- Dependencies: (.+)$/)) {
+		if (currentPhase && inPhaseTasks && line?.match(/^\s+- Dependencies: (.+)$/)) {
 			const depMatch = line.match(/^\s+- Dependencies: (.+)$/);
 			if (depMatch?.[1] && currentPhase.tasks.length > 0) {
 				const lastTask = currentPhase.tasks[currentPhase.tasks.length - 1];
@@ -270,7 +270,7 @@ export function parseSequencePlanMarkdown(markdown: string) {
 				unsequenced.push({ id, title, status, reason });
 			}
 		}
-		if (inUnsequenced && line && line.startsWith("## ") && line !== "## Unsequenced Tasks") {
+		if (inUnsequenced && line?.startsWith("## ") && line !== "## Unsequenced Tasks") {
 			inUnsequenced = false;
 		}
 	}

--- a/src/test/mcp-milestones.test.ts
+++ b/src/test/mcp-milestones.test.ts
@@ -412,6 +412,48 @@ describe("MCP milestone tools", () => {
 		expect(lastCommit).toContain("backlog: Rename milestone m-0");
 	});
 
+	it("preserves the original commit error when milestone rename rollback fails", async () => {
+		await server.testInterface.callTool({
+			params: { name: "milestone_add", arguments: { name: "Release 1.0" } },
+		});
+		const config = await loadConfigOrThrow(server);
+		config.autoCommit = true;
+		await server.filesystem.saveConfig(config);
+		await server.ensureConfigLoaded();
+
+		await $`git add .`.cwd(TEST_DIR).quiet();
+		await $`git commit -m "baseline"`.cwd(TEST_DIR).quiet();
+
+		const originalCommitFiles = server.git.commitFiles.bind(server.git);
+		const originalResetPaths = server.git.resetPaths.bind(server.git);
+		const originalRenameMilestone = server.filesystem.renameMilestone.bind(server.filesystem);
+		const commitError = new Error("simulated commit failure");
+		let renameCalls = 0;
+
+		server.git.commitFiles = (async () => {
+			throw commitError;
+		}) as typeof server.git.commitFiles;
+		server.git.resetPaths = (async () => {}) as typeof server.git.resetPaths;
+		server.filesystem.renameMilestone = (async (...args: Parameters<typeof server.filesystem.renameMilestone>) => {
+			renameCalls += 1;
+			if (renameCalls === 1) {
+				return await originalRenameMilestone(...args);
+			}
+			throw new Error("simulated rollback failure");
+		}) as typeof server.filesystem.renameMilestone;
+
+		try {
+			await expect(server.renameMilestone("Release 1.0", "Release 2.0", true)).rejects.toThrow(
+				"simulated commit failure",
+			);
+			expect(renameCalls).toBe(2);
+		} finally {
+			server.git.commitFiles = originalCommitFiles;
+			server.git.resetPaths = originalResetPaths;
+			server.filesystem.renameMilestone = originalRenameMilestone;
+		}
+	});
+
 	it("only rewrites the default description section when renaming milestones", async () => {
 		await server.testInterface.callTool({
 			params: { name: "milestone_add", arguments: { name: "Release 1.0" } },

--- a/src/test/server-search-endpoint.test.ts
+++ b/src/test/server-search-endpoint.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { join } from "node:path";
 import { FileSystem } from "../file-system/operations.ts";
 import { BacklogServer } from "../server/index.ts";
-import type { Decision, Document, Task } from "../types/index.ts";
+import type { Decision, Document, Milestone, Task } from "../types/index.ts";
 import { createUniqueTestDir, retry, safeCleanup } from "./test-utils.ts";
 
 let TEST_DIR: string;
@@ -422,6 +422,175 @@ Milestone: m-0
 		expect(numericAliasConflict.status).toBe(400);
 	});
 
+	it("renames milestones via the Web API and keeps tasks on the canonical milestone ID", async () => {
+		const sourceCreate = await fetch(`http://127.0.0.1:${serverPort}/api/milestones`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Release Source" }),
+		});
+		expect(sourceCreate.status).toBe(201);
+		const source = (await sourceCreate.json()) as Milestone;
+
+		const targetCreate = await fetch(`http://127.0.0.1:${serverPort}/api/milestones`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Release Target" }),
+		});
+		expect(targetCreate.status).toBe(201);
+		const target = (await targetCreate.json()) as Milestone;
+
+		const taskCreate = await fetch(`http://127.0.0.1:${serverPort}/api/tasks`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Rename milestone task",
+				status: "To Do",
+				milestone: source.title,
+			}),
+		});
+		expect(taskCreate.status).toBe(201);
+		const task = (await taskCreate.json()) as Task;
+		expect(task.milestone).toBe(source.id);
+
+		const renameResponse = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${source.id}`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Release Source Prime" }),
+		});
+		expect(renameResponse.status).toBe(200);
+		const renamed = (await renameResponse.json()) as { milestone?: Milestone | null; message?: string };
+		expect(renamed.milestone?.id).toBe(source.id);
+		expect(renamed.milestone?.title).toBe("Release Source Prime");
+		expect(renamed.message).toContain("Renamed milestone");
+
+		const fetchedTask = await fetchJson<Task>(`/api/task/${task.id}`);
+		expect(fetchedTask.milestone).toBe(source.id);
+
+		const titleAliasRenameResponse = await fetch(
+			`http://127.0.0.1:${serverPort}/api/milestones/${encodeURIComponent("Release Source Prime")}`,
+			{
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title: "Release Source Final" }),
+			},
+		);
+		expect(titleAliasRenameResponse.status).toBe(200);
+		const titleAliasRenamed = (await titleAliasRenameResponse.json()) as { milestone?: Milestone | null };
+		expect(titleAliasRenamed.milestone?.id).toBe(source.id);
+		expect(titleAliasRenamed.milestone?.title).toBe("Release Source Final");
+
+		const duplicateRename = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${source.id}`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: target.id }),
+		});
+		expect(duplicateRename.status).toBe(400);
+	});
+
+	it("removes milestones via the Web API and clears or reassigns matching tasks", async () => {
+		const createMilestone = async (title: string): Promise<Milestone> => {
+			const response = await fetch(`http://127.0.0.1:${serverPort}/api/milestones`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title }),
+			});
+			expect(response.status).toBe(201);
+			return (await response.json()) as Milestone;
+		};
+		const createTaskWithMilestone = async (title: string, milestone: string): Promise<Task> => {
+			const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title, status: "To Do", milestone }),
+			});
+			expect(response.status).toBe(201);
+			return (await response.json()) as Task;
+		};
+
+		const clearSource = await createMilestone("Clear Source");
+		const clearTask = await createTaskWithMilestone("Clear milestone task", clearSource.id);
+		const clearResponse = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${clearSource.id}`, {
+			method: "DELETE",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ taskHandling: "clear" }),
+		});
+		expect(clearResponse.status).toBe(200);
+		const clearedTask = await fetchJson<Task>(`/api/task/${clearTask.id}`);
+		expect(clearedTask.milestone).toBeUndefined();
+
+		const reassignSource = await createMilestone("Reassign Source");
+		const reassignTarget = await createMilestone("Reassign Target");
+		const reassignTask = await createTaskWithMilestone("Reassign milestone task", reassignSource.id);
+		const reassignResponse = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${reassignSource.id}`, {
+			method: "DELETE",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ taskHandling: "reassign", reassignTo: reassignTarget.id }),
+		});
+		expect(reassignResponse.status).toBe(200);
+		const reassignedTask = await fetchJson<Task>(`/api/task/${reassignTask.id}`);
+		expect(reassignedTask.milestone).toBe(reassignTarget.id);
+
+		const removedMilestone = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${reassignSource.id}`);
+		expect(removedMilestone.status).toBe(404);
+	});
+
+	it("rejects malformed and non-object milestone DELETE bodies without changing tasks", async () => {
+		const source = await createMilestoneViaApi("Invalid Delete Source");
+		const task = await createTaskWithMilestoneViaApi("Invalid delete task", source.id);
+
+		const malformedResponse = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${source.id}`, {
+			method: "DELETE",
+			headers: { "Content-Type": "application/json" },
+			body: "{",
+		});
+		expect(malformedResponse.status).toBe(400);
+		const malformedPayload = (await malformedResponse.json()) as { error?: string; code?: string };
+		expect(malformedPayload.code).toBe("VALIDATION_ERROR");
+		expect(malformedPayload.error).toContain("valid JSON");
+
+		const afterMalformedMilestone = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${source.id}`);
+		expect(afterMalformedMilestone.status).toBe(200);
+		const afterMalformedTask = await fetchJson<Task>(`/api/task/${task.id}`);
+		expect(afterMalformedTask.milestone).toBe(source.id);
+
+		const arrayResponse = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${source.id}`, {
+			method: "DELETE",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify([]),
+		});
+		expect(arrayResponse.status).toBe(400);
+		const arrayPayload = (await arrayResponse.json()) as { error?: string; code?: string };
+		expect(arrayPayload.code).toBe("VALIDATION_ERROR");
+		expect(arrayPayload.error).toContain("JSON object");
+
+		const afterArrayMilestone = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/${source.id}`);
+		expect(afterArrayMilestone.status).toBe(200);
+		const afterArrayTask = await fetchJson<Task>(`/api/task/${task.id}`);
+		expect(afterArrayTask.milestone).toBe(source.id);
+	});
+
+	it("returns not found for missing milestone mutation targets", async () => {
+		const renameMissing = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/m-999`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Missing Rename Target" }),
+		});
+		expect(renameMissing.status).toBe(404);
+		const renamePayload = (await renameMissing.json()) as { error?: string; code?: string };
+		expect(renamePayload.code).toBe("NOT_FOUND");
+		expect(renamePayload.error).toContain("Milestone not found");
+
+		const removeMissing = await fetch(`http://127.0.0.1:${serverPort}/api/milestones/m-999`, {
+			method: "DELETE",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ taskHandling: "clear" }),
+		});
+		expect(removeMissing.status).toBe(404);
+		const removePayload = (await removeMissing.json()) as { error?: string; code?: string };
+		expect(removePayload.code).toBe("NOT_FOUND");
+		expect(removePayload.error).toContain("Milestone not found");
+	});
+
 	it("rebuilds the Fuse index when markdown content changes", async () => {
 		await filesystem.saveDocument({
 			...baseDoc,
@@ -448,4 +617,24 @@ async function fetchJson<T>(path: string): Promise<T> {
 		throw new Error(`Request failed: ${response.status}`);
 	}
 	return response.json();
+}
+
+async function createMilestoneViaApi(title: string): Promise<Milestone> {
+	const response = await fetch(`http://127.0.0.1:${serverPort}/api/milestones`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ title }),
+	});
+	expect(response.status).toBe(201);
+	return (await response.json()) as Milestone;
+}
+
+async function createTaskWithMilestoneViaApi(title: string, milestone: string): Promise<Task> {
+	const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ title, status: "To Do", milestone }),
+	});
+	expect(response.status).toBe(201);
+	return (await response.json()) as Task;
 }

--- a/src/test/web-milestones-page-search.test.tsx
+++ b/src/test/web-milestones-page-search.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import type { Milestone, Task } from "../types/index.ts";
 import MilestonesPage from "../web/components/MilestonesPage.tsx";
+import { apiClient } from "../web/lib/api.ts";
 
 const createTask = (overrides: Partial<Task>): Task => ({
 	id: "task-1",
@@ -40,6 +41,8 @@ const baseTasks: Task[] = [
 ];
 
 let activeRoot: Root | null = null;
+const originalUpdateMilestone = apiClient.updateMilestone.bind(apiClient);
+const originalRemoveMilestone = apiClient.removeMilestone.bind(apiClient);
 
 const setupDom = () => {
 	const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { url: "http://localhost" });
@@ -75,7 +78,12 @@ const setupDom = () => {
 	}
 };
 
-const renderPage = (tasks: Task[] = baseTasks): HTMLElement => {
+const renderPage = (
+	tasks: Task[] = baseTasks,
+	options: {
+		onRefreshData?: () => Promise<void>;
+	} = {},
+): HTMLElement => {
 	setupDom();
 	const container = document.getElementById("root");
 	expect(container).toBeTruthy();
@@ -89,6 +97,7 @@ const renderPage = (tasks: Task[] = baseTasks): HTMLElement => {
 					milestoneEntities={milestoneEntities}
 					archivedMilestones={[]}
 					onEditTask={() => {}}
+					onRefreshData={options.onRefreshData}
 				/>
 			</MemoryRouter>,
 		);
@@ -116,6 +125,29 @@ const clickElement = (element: Element) => {
 	});
 };
 
+const setInputValue = (input: HTMLInputElement, value: string) => {
+	act(() => {
+		const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+		valueSetter?.call(input, value);
+		input.dispatchEvent(new window.Event("input", { bubbles: true }));
+		input.dispatchEvent(new window.Event("change", { bubbles: true }));
+	});
+};
+
+const submitForm = async (form: HTMLFormElement) => {
+	await act(async () => {
+		form.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+		await Promise.resolve();
+	});
+};
+
+const clickElementAsync = async (element: Element) => {
+	await act(async () => {
+		element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+		await Promise.resolve();
+	});
+};
+
 afterEach(() => {
 	if (activeRoot) {
 		act(() => {
@@ -123,6 +155,8 @@ afterEach(() => {
 		});
 		activeRoot = null;
 	}
+	apiClient.updateMilestone = originalUpdateMilestone;
+	apiClient.removeMilestone = originalRemoveMilestone;
 });
 
 describe("Web milestones page search", () => {
@@ -185,5 +219,118 @@ describe("Web milestones page search", () => {
 		expect(noMatchText).toContain("Release 1");
 		expect(noMatchText).toContain("Release 2");
 		expect(noMatchText).toContain("Unassigned tasks");
+	});
+
+	it("opens an edit modal from each milestone card", () => {
+		const container = renderPage();
+		const editButtons = Array.from(container.querySelectorAll("button")).filter((button) =>
+			button.textContent?.includes("Edit"),
+		);
+		expect(editButtons.length).toBeGreaterThanOrEqual(2);
+
+		clickElement(editButtons[0] as HTMLButtonElement);
+
+		expect(container.textContent).toContain("Edit milestone");
+		const input = container.querySelector("#edit-milestone-name") as HTMLInputElement | null;
+		expect(input).toBeTruthy();
+		expect(input?.value).toBe("Release 2");
+	});
+
+	it("opens a remove confirmation with clear and reassign choices", () => {
+		const container = renderPage();
+		const removeButtons = Array.from(container.querySelectorAll("button")).filter((button) =>
+			button.textContent?.includes("Remove"),
+		);
+		expect(removeButtons.length).toBeGreaterThanOrEqual(2);
+
+		clickElement(removeButtons[0] as HTMLButtonElement);
+
+		const text = container.textContent ?? "";
+		expect(text).toContain("Remove milestone");
+		expect(text).toContain("Leave tasks unassigned");
+		expect(text).toContain("Reassign tasks");
+
+		const select = container.querySelector("select") as HTMLSelectElement | null;
+		expect(select).toBeTruthy();
+		expect(Array.from(select?.options ?? []).map((option) => option.value)).toContain("m-1");
+	});
+
+	it("submits milestone edits through the API and refreshes data", async () => {
+		let updateArgs: [string, string] | undefined;
+		let refreshCount = 0;
+		apiClient.updateMilestone = async (id: string, title: string) => {
+			updateArgs = [id, title];
+			return { success: true, milestone: { ...milestoneEntities[1]!, title } };
+		};
+
+		const container = renderPage(baseTasks, {
+			onRefreshData: async () => {
+				refreshCount += 1;
+			},
+		});
+		const editButtons = Array.from(container.querySelectorAll("button")).filter((button) =>
+			button.textContent?.includes("Edit"),
+		);
+		clickElement(editButtons[0] as HTMLButtonElement);
+
+		const input = container.querySelector("#edit-milestone-name") as HTMLInputElement | null;
+		expect(input).toBeTruthy();
+		setInputValue(input as HTMLInputElement, "Release 2.1");
+		await submitForm(input?.closest("form") as HTMLFormElement);
+
+		expect(updateArgs?.[0]).toBe("m-2");
+		expect(updateArgs?.[1]).toBe("Release 2.1");
+		expect(refreshCount).toBe(1);
+	});
+
+	it("submits milestone removal with reassign options through the API", async () => {
+		let removeArgs: [
+			string,
+			{ taskHandling?: "clear" | "keep" | "reassign"; reassignTo?: string } | undefined,
+		] | undefined;
+		let refreshCount = 0;
+		apiClient.removeMilestone = async (id, options) => {
+			removeArgs = [id, options];
+			return { success: true };
+		};
+
+		const container = renderPage(baseTasks, {
+			onRefreshData: async () => {
+				refreshCount += 1;
+			},
+		});
+		const removeButtons = Array.from(container.querySelectorAll("button")).filter((button) =>
+			button.textContent?.includes("Remove"),
+		);
+		clickElement(removeButtons[0] as HTMLButtonElement);
+
+		const reassignRadio = container.querySelector("input[value='reassign']") as HTMLInputElement | null;
+		expect(reassignRadio).toBeTruthy();
+		clickElement(reassignRadio as HTMLInputElement);
+		const select = container.querySelector("select") as HTMLSelectElement | null;
+		expect(select).toBeTruthy();
+		act(() => {
+			if (select) {
+				select.value = "m-1";
+				select.dispatchEvent(new window.Event("change", { bubbles: true }));
+			}
+		});
+		const submitButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent === "Remove milestone",
+		);
+		expect(submitButton).toBeTruthy();
+		await clickElementAsync(submitButton as HTMLButtonElement);
+
+		expect(removeArgs?.[0]).toBe("m-2");
+		expect(removeArgs?.[1]).toEqual({ taskHandling: "reassign", reassignTo: "m-1" });
+		expect(refreshCount).toBe(1);
+	});
+
+	it("keeps milestone archive available as a separate action", () => {
+		const container = renderPage();
+		const archiveButtons = Array.from(container.querySelectorAll("button")).filter((button) =>
+			button.textContent?.includes("Archive"),
+		);
+		expect(archiveButtons.length).toBeGreaterThanOrEqual(2);
 	});
 });

--- a/src/utils/task-path.ts
+++ b/src/utils/task-path.ts
@@ -91,7 +91,7 @@ function extractTaskBody(value: string, prefix: string = DEFAULT_TASK_PREFIX): s
 function extractTaskIdFromFilename(filename: string, prefix: string = DEFAULT_TASK_PREFIX): string | null {
 	const regex = buildFilenameIdRegex(prefix);
 	const match = filename.match(regex);
-	if (!match || !match[1]) return null;
+	if (!match?.[1]) return null;
 	return normalizeTaskId(`${prefix}-${match[1]}`, prefix);
 }
 
@@ -268,7 +268,7 @@ function draftIdsMatchLoosely(inputId: string, filename: string): boolean {
 function extractDraftIdFromFilename(filename: string): string | null {
 	const regex = buildFilenameIdRegex(DEFAULT_DRAFT_PREFIX);
 	const match = filename.match(regex);
-	if (!match || !match[1]) return null;
+	if (!match?.[1]) return null;
 	return normalizeDraftId(`${DEFAULT_DRAFT_PREFIX}-${match[1]}`);
 }
 

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useCallback } from "react";
 import { Link } from "react-router-dom";
 import Fuse from "fuse.js";
 import { apiClient } from "../lib/api";
-import { buildMilestoneBuckets, collectArchivedMilestoneKeys, isDoneStatus } from "../utils/milestones";
+import { buildMilestoneBuckets, collectArchivedMilestoneKeys, isDoneStatus, milestoneKey } from "../utils/milestones";
 import { type Milestone, type MilestoneBucket, type Task } from "../../types";
 import MilestoneTaskRow from "./MilestoneTaskRow";
 import Modal from "./Modal";
@@ -11,6 +11,8 @@ interface MilestoneSearchEntry {
 	id: string;
 	title: string;
 }
+
+type RemoveTaskHandling = "clear" | "reassign";
 
 const rebuildFilteredBucket = (
 	bucket: MilestoneBucket,
@@ -67,6 +69,14 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 	const [showAllUnassigned, setShowAllUnassigned] = useState(false);
 	const [showCompleted, setShowCompleted] = useState(false);
 	const [archivingMilestoneKey, setArchivingMilestoneKey] = useState<string | null>(null);
+	const [savingMilestoneKey, setSavingMilestoneKey] = useState<string | null>(null);
+	const [removingMilestoneKey, setRemovingMilestoneKey] = useState<string | null>(null);
+	const [editingBucket, setEditingBucket] = useState<MilestoneBucket | null>(null);
+	const [editMilestoneName, setEditMilestoneName] = useState("");
+	const [removingBucket, setRemovingBucket] = useState<MilestoneBucket | null>(null);
+	const [removeTaskHandling, setRemoveTaskHandling] = useState<RemoveTaskHandling>("clear");
+	const [removeReassignTo, setRemoveReassignTo] = useState("");
+	const [modalError, setModalError] = useState<string | null>(null);
 	const [searchQuery, setSearchQuery] = useState("");
 
 	const archivedMilestoneIds = useMemo(
@@ -154,6 +164,12 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 			completedMilestones: sortedCompleted,
 		};
 	}, [visibleBuckets]);
+	const removeReassignOptions = useMemo(() => {
+		const currentMilestoneId = removingBucket?.milestone;
+		return milestoneEntities.filter(
+			(milestone) => !currentMilestoneId || milestoneKey(milestone.id) !== milestoneKey(currentMilestoneId),
+		);
+	}, [milestoneEntities, removingBucket]);
 
 	// Drag and drop handlers
 	const handleDragStart = useCallback((e: React.DragEvent, task: Task) => {
@@ -279,6 +295,135 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		[onRefreshData],
 	);
 
+	const findDuplicateMilestone = (title: string, currentMilestoneId?: string): Milestone | undefined => {
+		const titleKey = milestoneKey(title);
+		if (!titleKey) return undefined;
+		return milestoneEntities.find((milestone) => {
+			if (currentMilestoneId && milestoneKey(milestone.id) === milestoneKey(currentMilestoneId)) {
+				return false;
+			}
+			return milestoneKey(milestone.title) === titleKey || milestoneKey(milestone.id) === titleKey;
+		});
+	};
+
+	const openEditModal = (bucket: MilestoneBucket) => {
+		if (!bucket.milestone) return;
+		setEditingBucket(bucket);
+		setEditMilestoneName(bucket.label || bucket.milestone);
+		setModalError(null);
+		setError(null);
+		setSuccess(null);
+	};
+
+	const closeEditModal = () => {
+		setEditingBucket(null);
+		setEditMilestoneName("");
+		setModalError(null);
+	};
+
+	const handleEditMilestoneNameChange = (value: string) => {
+		setEditMilestoneName(value);
+		if (modalError) setModalError(null);
+		if (error) setError(null);
+		if (success) setSuccess(null);
+	};
+
+	const handleUpdateMilestone = async (event?: React.FormEvent<HTMLFormElement>) => {
+		event?.preventDefault();
+		const bucket = editingBucket;
+		if (!bucket?.milestone) return;
+
+		const value = editMilestoneName.trim();
+		if (!value) {
+			setModalError("Milestone name cannot be empty.");
+			return;
+		}
+
+		const duplicate = findDuplicateMilestone(value, bucket.milestone);
+		if (duplicate) {
+			setModalError(`Milestone "${duplicate.title}" already exists.`);
+			return;
+		}
+
+		const previousLabel = bucket.label || bucket.milestone;
+		setSavingMilestoneKey(bucket.key);
+		setModalError(null);
+		setError(null);
+		setSuccess(null);
+		try {
+			await apiClient.updateMilestone(bucket.milestone, value);
+			closeEditModal();
+			setSuccess(`Renamed milestone "${previousLabel}" to "${value}"`);
+			if (onRefreshData) {
+				await onRefreshData();
+			}
+			setTimeout(() => setSuccess(null), 3000);
+		} catch (err) {
+			console.error("Failed to update milestone:", err);
+			setModalError(err instanceof Error ? err.message : "Failed to update milestone.");
+		} finally {
+			setSavingMilestoneKey(null);
+		}
+	};
+
+	const openRemoveModal = (bucket: MilestoneBucket) => {
+		if (!bucket.milestone) return;
+		const fallbackMilestone = milestoneEntities.find(
+			(milestone) => milestoneKey(milestone.id) !== milestoneKey(bucket.milestone),
+		);
+		setRemovingBucket(bucket);
+		setRemoveTaskHandling("clear");
+		setRemoveReassignTo(fallbackMilestone?.id ?? "");
+		setModalError(null);
+		setError(null);
+		setSuccess(null);
+	};
+
+	const closeRemoveModal = () => {
+		setRemovingBucket(null);
+		setRemoveTaskHandling("clear");
+		setRemoveReassignTo("");
+		setModalError(null);
+	};
+
+	const handleRemoveMilestone = async () => {
+		const bucket = removingBucket;
+		if (!bucket?.milestone) return;
+		const selectedTaskHandling = removeTaskHandling;
+		const selectedReassignTo = removeReassignTo.trim();
+		if (selectedTaskHandling === "reassign" && !selectedReassignTo) {
+			setModalError("Choose a milestone to reassign tasks to.");
+			return;
+		}
+
+		const label = bucket.label || bucket.milestone;
+		setRemovingMilestoneKey(bucket.key);
+		setModalError(null);
+		setError(null);
+		setSuccess(null);
+		try {
+			await apiClient.removeMilestone(bucket.milestone, {
+				taskHandling: selectedTaskHandling,
+				reassignTo: selectedTaskHandling === "reassign" ? selectedReassignTo : undefined,
+			});
+			closeRemoveModal();
+			setSuccess(
+				selectedTaskHandling === "reassign"
+					? `Removed milestone "${label}" and reassigned its tasks`
+					: `Removed milestone "${label}" and left its tasks unassigned`,
+			);
+			if (onRefreshData) {
+				await onRefreshData();
+			}
+			setTimeout(() => setSuccess(null), 3000);
+		} catch (err) {
+			console.error("Failed to remove milestone:", err);
+			setModalError(err instanceof Error ? err.message : "Failed to remove milestone.");
+		} finally {
+			setRemovingMilestoneKey(null);
+		}
+	};
+
 	const getStatusBadgeClass = (status?: string | null) => {
 		const normalized = (status ?? "").toLowerCase();
 		if (normalized.includes("done") || normalized.includes("complete")) {
@@ -342,6 +487,8 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		const isDropTarget = dropTargetKey === bucket.key;
 		const isDragging = draggedTask !== null;
 		const isArchiving = archivingMilestoneKey === bucket.key;
+		const isSavingMilestone = savingMilestoneKey === bucket.key;
+		const isRemoving = removingMilestoneKey === bucket.key;
 
 		return (
 			<div
@@ -425,9 +572,31 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 							</Link>
 							<button
 								type="button"
-								onClick={() => handleArchiveMilestone(bucket)}
-								disabled={isArchiving}
+								onClick={() => openEditModal(bucket)}
+								disabled={isArchiving || isSavingMilestone || isRemoving}
+								className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-60"
+							>
+								<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+								</svg>
+								{isSavingMilestone ? "Saving..." : "Edit"}
+							</button>
+							<button
+								type="button"
+								onClick={() => openRemoveModal(bucket)}
+								disabled={isArchiving || isSavingMilestone || isRemoving}
 								className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-red-200 dark:border-red-800 text-red-600 dark:text-red-300 bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors disabled:opacity-60"
+							>
+								<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7h6m2 0H7m3 0V5a2 2 0 012-2h0a2 2 0 012 2v2" />
+								</svg>
+								{isRemoving ? "Removing..." : "Remove"}
+							</button>
+							<button
+								type="button"
+								onClick={() => handleArchiveMilestone(bucket)}
+								disabled={isArchiving || isSavingMilestone || isRemoving}
+								className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200 bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/40 transition-colors disabled:opacity-60"
 							>
 								<svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
@@ -589,6 +758,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 	const hasSearchMatches = visibleBuckets.some((bucket) => bucket.total > 0);
 	const showSearchNoMatchHint = isSearchActive && !hasSearchMatches;
 	const noMilestones = !isSearchActive && activeMilestones.length === 0 && completedMilestones.length === 0;
+	const canReassignRemovedMilestone = removeReassignOptions.length > 0;
 
 	return (
 		<div className="container mx-auto px-4 py-8 transition-colors duration-200">
@@ -757,6 +927,128 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 						</button>
 					</div>
 				</form>
+			</Modal>
+
+			{/* Edit modal */}
+			<Modal isOpen={editingBucket !== null} onClose={closeEditModal} title="Edit milestone" maxWidthClass="max-w-md">
+				<form onSubmit={handleUpdateMilestone} className="space-y-4">
+					<div className="space-y-2">
+						<label htmlFor="edit-milestone-name" className="text-sm font-medium text-gray-900 dark:text-gray-100">
+							Milestone name
+						</label>
+						<input
+							id="edit-milestone-name"
+							type="text"
+							value={editMilestoneName}
+							onInput={(event) => handleEditMilestoneNameChange((event.target as HTMLInputElement).value)}
+							autoFocus
+							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
+						<p className="text-xs text-gray-500 dark:text-gray-400">
+							Renaming updates local tasks that reference this milestone.
+						</p>
+						{modalError && <p className="text-xs text-red-600 dark:text-red-400">{modalError}</p>}
+					</div>
+					<div className="flex justify-end gap-2">
+						<button
+							type="button"
+							onClick={closeEditModal}
+							className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							disabled={savingMilestoneKey !== null || !editMilestoneName.trim()}
+							className="px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-60 transition-colors"
+						>
+							{savingMilestoneKey ? "Saving..." : "Save"}
+						</button>
+					</div>
+				</form>
+			</Modal>
+
+			{/* Remove modal */}
+			<Modal isOpen={removingBucket !== null} onClose={closeRemoveModal} title="Remove milestone" maxWidthClass="max-w-md">
+				<div className="space-y-4">
+					<p className="text-sm text-gray-600 dark:text-gray-300">
+						Remove milestone &quot;{removingBucket?.label ?? ""}&quot; and choose what happens to its tasks.
+					</p>
+					<div className="space-y-3">
+						<label className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 dark:border-gray-700 px-3 py-3 text-sm text-gray-700 dark:text-gray-200">
+							<input
+								type="radio"
+								name="remove-milestone-task-handling"
+								value="clear"
+								checked={removeTaskHandling === "clear"}
+								onChange={() => {
+									setRemoveTaskHandling("clear");
+									setModalError(null);
+								}}
+								className="mt-0.5"
+							/>
+							<span>
+								<span className="block font-medium text-gray-900 dark:text-gray-100">Leave tasks unassigned</span>
+								<span className="block text-xs text-gray-500 dark:text-gray-400">
+									Clear this milestone from matching local tasks.
+								</span>
+							</span>
+						</label>
+						<label className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 dark:border-gray-700 px-3 py-3 text-sm text-gray-700 dark:text-gray-200">
+							<input
+								type="radio"
+								name="remove-milestone-task-handling"
+								value="reassign"
+								checked={removeTaskHandling === "reassign"}
+								disabled={!canReassignRemovedMilestone}
+								onChange={() => {
+									setRemoveTaskHandling("reassign");
+									setModalError(null);
+								}}
+								className="mt-0.5"
+							/>
+							<span className="flex-1">
+								<span className="block font-medium text-gray-900 dark:text-gray-100">Reassign tasks</span>
+								<span className="block text-xs text-gray-500 dark:text-gray-400">
+									Move matching local tasks to another milestone.
+								</span>
+								<select
+									value={removeReassignTo}
+									onChange={(event) => {
+										setRemoveReassignTo(event.target.value);
+										setModalError(null);
+									}}
+									disabled={removeTaskHandling !== "reassign" || !canReassignRemovedMilestone}
+									className="mt-2 w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 disabled:opacity-60"
+								>
+									{removeReassignOptions.map((milestone) => (
+										<option key={milestone.id} value={milestone.id}>
+											{milestone.title}
+										</option>
+									))}
+								</select>
+							</span>
+						</label>
+					</div>
+					{modalError && <p className="text-xs text-red-600 dark:text-red-400">{modalError}</p>}
+					<div className="flex justify-end gap-2">
+						<button
+							type="button"
+							onClick={closeRemoveModal}
+							className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							onClick={handleRemoveMilestone}
+							disabled={removingMilestoneKey !== null || (removeTaskHandling === "reassign" && !removeReassignTo)}
+							className="px-4 py-2 rounded-md text-sm font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-60 transition-colors"
+						>
+							{removingMilestoneKey ? "Removing..." : "Remove milestone"}
+						</button>
+					</div>
+				</div>
 			</Modal>
 		</div>
 	);

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -461,6 +461,42 @@ export class ApiClient {
 		return response.json();
 	}
 
+	async updateMilestone(
+		id: string,
+		title: string,
+	): Promise<{ success: boolean; milestone?: Milestone | null; message?: string }> {
+		const response = await fetch(`${API_BASE}/milestones/${encodeURIComponent(id)}`, {
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ title }),
+		});
+		if (!response.ok) {
+			const data = await response.json().catch(() => ({}));
+			throw new Error(data.error || "Failed to update milestone");
+		}
+		return response.json();
+	}
+
+	async removeMilestone(
+		id: string,
+		options: { taskHandling?: "clear" | "keep" | "reassign"; reassignTo?: string } = {},
+	): Promise<{ success: boolean; message?: string }> {
+		const response = await fetch(`${API_BASE}/milestones/${encodeURIComponent(id)}`, {
+			method: "DELETE",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(options),
+		});
+		if (!response.ok) {
+			const data = await response.json().catch(() => ({}));
+			throw new Error(data.error || "Failed to remove milestone");
+		}
+		return response.json();
+	}
+
 	async archiveMilestone(id: string): Promise<{ success: boolean; milestone?: Milestone | null }> {
 		const response = await fetch(`${API_BASE}/milestones/${encodeURIComponent(id)}/archive`, {
 			method: "POST",


### PR DESCRIPTION
## Summary
- add Web API routes for milestone rename/remove and route them through the shared milestone mutation handler
- add Milestones page edit/remove flows with duplicate validation and clear/reassign removal options
- add regression coverage for Web API behavior, UI controls, and milestone rename rollback error handling
- format `package.json` without including unrelated dependency version changes

## Validation
- `bun test src/test/server-search-endpoint.test.ts src/test/mcp-milestones.test.ts src/test/web-milestones-page-search.test.tsx`
- `bunx tsc --noEmit`
- `bun run check .`

## Notes
- `bun run check .` passed with one Biome schema-version info message because the installed Biome CLI is 2.4.12 while this PR intentionally leaves the tracked schema at 2.3.11.