### PR TITLE
BACK-432 - Parse definition_of_done with standard YAML semantics

### DIFF
--- a/backlog/tasks/back-432 - Parse-definition_of_done-with-standard-YAML-semantics.md
+++ b/backlog/tasks/back-432 - Parse-definition_of_done-with-standard-YAML-semantics.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-432
 title: Parse definition_of_done with standard YAML semantics
-status: To Do
+status: In Progress
 assignee:
   - '@alex-agent'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-04-25 12:23'
 labels:
   - config
   - bug
@@ -22,15 +23,36 @@ Track GitHub issue #599: config loading misparses definition_of_done values cont
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Quoted commas in flow-style definition_of_done entries are preserved as part of one checklist item.
-- [ ] #2 Block-style definition_of_done sequences parse consistently, including empty or blank-line-adjacent lists.
-- [ ] #3 CLI, MCP, and Web settings use the same config parse behavior.
-- [ ] #4 Regression tests cover the issue's repro config examples.
+- [x] #1 Quoted commas in flow-style definition_of_done entries are preserved as part of one checklist item.
+- [x] #2 Block-style definition_of_done sequences parse consistently, including empty or blank-line-adjacent lists.
+- [x] #3 CLI, MCP, and Web settings use the same config parse behavior.
+- [x] #4 Regression tests cover the issue's repro config examples.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Context-hunter classification: L2 shared config semantics.
+
+Implementation plan:
+1. Keep the fix in the shared FileSystem config loader so CLI, MCP, and Web all consume the same parsed definitionOfDone values.
+2. Parse definition_of_done with YAML semantics, preserving quoted commas and supporting block-style sequences, while keeping the existing config shape and normalization behavior.
+3. Remove the temporary MCP comma rejection now that save/load can round-trip comma-bearing defaults.
+4. Add focused regression tests for the issue #599 flow-style and block-style repros, including task creation from parsed defaults and MCP upsert with commas.
+5. Run targeted tests first, then type-check and Biome check.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Discovery: issue #599 reproduces in FileSystem.parseConfig, which manually splits flow arrays by comma and ignores block-style definition_of_done. CLI, MCP, and Web read config through FileSystem.loadConfig(), so the fix belongs there. MCP had a comma rejection added as a corruption guard; that should be removed once YAML parsing is fixed.
+
+Verification: focused DoD regression tests pass, full bun test passes, and bunx tsc --noEmit passes. Targeted Biome check on changed TypeScript files passes. Project-wide bun run check . currently fails on pre-existing package.json formatting from origin/main, so DoD #2 remains unchecked and unrelated package formatting was intentionally left out of this PR.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
 - [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1,5 +1,6 @@
 import { mkdir, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import matter from "gray-matter";
 import lockfile from "proper-lockfile";
 import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES } from "../constants/index.ts";
 import { parseDecision, parseDocument, parseMilestone, parseTask } from "../markdown/parser.ts";
@@ -1301,6 +1302,7 @@ ${description || `Milestone: ${title}`}`,
 
 	private parseConfig(content: string): BacklogConfig {
 		const config: Partial<BacklogConfig> = {};
+		const parsedDefinitionOfDone = this.parseDefinitionOfDone(content);
 		const lines = content.split("\n");
 
 		for (const line of lines) {
@@ -1337,12 +1339,8 @@ ${description || `Milestone: ${title}`}`,
 					}
 					break;
 				case "definition_of_done":
-					if (value.startsWith("[") && value.endsWith("]")) {
-						const arrayContent = value.slice(1, -1);
-						config.definitionOfDone = arrayContent
-							.split(",")
-							.map((item) => item.trim().replace(/['"]/g, ""))
-							.filter(Boolean);
+					if (parsedDefinitionOfDone !== undefined) {
+						config.definitionOfDone = parsedDefinitionOfDone;
 					}
 					break;
 				case "date_format":
@@ -1428,7 +1426,7 @@ ${description || `Milestone: ${title}`}`,
 			`statuses: [${config.statuses.map((s) => `"${s}"`).join(", ")}]`,
 			`labels: [${config.labels.map((l) => `"${l}"`).join(", ")}]`,
 			...(Array.isArray(normalizedDefinitionOfDone)
-				? [`definition_of_done: [${normalizedDefinitionOfDone.map((item) => `"${item}"`).join(", ")}]`]
+				? [`definition_of_done: [${normalizedDefinitionOfDone.map((item) => JSON.stringify(item)).join(", ")}]`]
 				: []),
 			`date_format: ${config.dateFormat}`,
 			...(config.maxColumnWidth ? [`max_column_width: ${config.maxColumnWidth}`] : []),
@@ -1449,6 +1447,65 @@ ${description || `Milestone: ${title}`}`,
 		];
 
 		return `${lines.join("\n")}\n`;
+	}
+
+	private parseDefinitionOfDone(content: string): string[] | undefined {
+		const parsedFromDocument = this.parseDefinitionOfDoneFromYaml(content);
+		if (parsedFromDocument !== undefined) {
+			return parsedFromDocument;
+		}
+
+		// Some legacy config values are accepted by the line parser but are not valid YAML.
+		const definitionOfDoneYaml = this.extractDefinitionOfDoneYaml(content);
+		return definitionOfDoneYaml ? this.parseDefinitionOfDoneFromYaml(definitionOfDoneYaml) : undefined;
+	}
+
+	private parseDefinitionOfDoneFromYaml(content: string): string[] | undefined {
+		try {
+			const data = matter(`---\n${content.trimEnd()}\n---\n`).data as Record<string, unknown>;
+			if (!Object.hasOwn(data, "definition_of_done")) {
+				return undefined;
+			}
+
+			const definitionOfDone = data.definition_of_done;
+			if (definitionOfDone === null) {
+				return [];
+			}
+
+			return this.normalizeDefinitionOfDone(definitionOfDone);
+		} catch {
+			return undefined;
+		}
+	}
+
+	private extractDefinitionOfDoneYaml(content: string): string | undefined {
+		const lines = content.split(/\r?\n/);
+		const keyPattern = /^(\s*)definition_of_done\s*:/;
+		const topLevelKeyPattern = /^\s*[A-Za-z_][A-Za-z0-9_]*\s*:/;
+		const startIndex = lines.findIndex((line) => keyPattern.test(line));
+		if (startIndex === -1) {
+			return undefined;
+		}
+
+		const startLine = lines[startIndex];
+		const startIndent = startLine?.match(keyPattern)?.[1]?.length ?? 0;
+		const collected: string[] = [];
+
+		for (let index = startIndex; index < lines.length; index++) {
+			const line = lines[index] ?? "";
+			const trimmed = line.trim();
+			const indent = line.length - line.trimStart().length;
+			const isNextTopLevelKey =
+				index > startIndex && trimmed.length > 0 && indent <= startIndent && topLevelKeyPattern.test(line);
+
+			if (isNextTopLevelKey) {
+				break;
+			}
+
+			collected.push(line);
+		}
+
+		return collected.join("\n");
 	}
 
 	private normalizeDefinitionOfDone(definitionOfDone: unknown): string[] | undefined {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1450,13 +1450,23 @@ ${description || `Milestone: ${title}`}`,
 	}
 
 	private parseDefinitionOfDone(content: string): string[] | undefined {
+		const definitionOfDoneYaml = this.extractDefinitionOfDoneYaml(content);
+		const legacyEscapedDefinitionOfDoneYaml = definitionOfDoneYaml
+			? this.escapeLegacyDefinitionOfDoneBackslashes(definitionOfDoneYaml)
+			: undefined;
+		if (legacyEscapedDefinitionOfDoneYaml) {
+			const parsedLegacyDefinitionOfDone = this.parseDefinitionOfDoneFromYaml(legacyEscapedDefinitionOfDoneYaml);
+			if (parsedLegacyDefinitionOfDone !== undefined) {
+				return parsedLegacyDefinitionOfDone;
+			}
+		}
+
 		const parsedFromDocument = this.parseDefinitionOfDoneFromYaml(content);
 		if (parsedFromDocument !== undefined) {
 			return parsedFromDocument;
 		}
 
 		// Some legacy config values are accepted by the line parser but are not valid YAML.
-		const definitionOfDoneYaml = this.extractDefinitionOfDoneYaml(content);
 		return definitionOfDoneYaml ? this.parseDefinitionOfDoneFromYaml(definitionOfDoneYaml) : undefined;
 	}
 
@@ -1506,6 +1516,58 @@ ${description || `Milestone: ${title}`}`,
 		}
 
 		return collected.join("\n");
+	}
+
+	private escapeLegacyDefinitionOfDoneBackslashes(content: string): string | undefined {
+		let escaped = "";
+		let quote: "'" | '"' | undefined;
+		let changed = false;
+
+		for (let index = 0; index < content.length; index++) {
+			const char = content[index];
+
+			if (quote) {
+				if (quote === '"' && char === "\\") {
+					let slashCount = 1;
+					while (content[index + slashCount] === "\\") {
+						slashCount++;
+					}
+
+					const nextChar = content[index + slashCount];
+					if (nextChar === '"' && slashCount % 2 === 1) {
+						escaped += "\\".repeat(slashCount);
+						escaped += nextChar;
+						index += slashCount;
+						continue;
+					}
+
+					const escapedSlashCount = slashCount % 2 === 1 ? slashCount + 1 : slashCount;
+					escaped += "\\".repeat(escapedSlashCount);
+					changed ||= escapedSlashCount !== slashCount;
+					index += slashCount - 1;
+					continue;
+				}
+
+				if (char === quote) {
+					escaped += char;
+					quote = undefined;
+					continue;
+				}
+
+				escaped += char;
+				continue;
+			}
+
+			if (char === "'" || char === '"') {
+				escaped += char;
+				quote = char;
+				continue;
+			}
+
+			escaped += char;
+		}
+
+		return changed ? escaped : undefined;
 	}
 
 	private normalizeDefinitionOfDone(definitionOfDone: unknown): string[] | undefined {

--- a/src/mcp/tools/definition-of-done/handlers.ts
+++ b/src/mcp/tools/definition-of-done/handlers.ts
@@ -10,10 +10,6 @@ function normalizeDefinitionOfDoneDefaults(items: string[]): string[] {
 	return items.map((item) => item.trim()).filter((item) => item.length > 0);
 }
 
-function findDelimiterSensitiveItem(items: string[]): string | undefined {
-	return items.find((item) => item.includes(","));
-}
-
 function formatDefinitionOfDoneDefaults(items: string[]): string {
 	if (items.length === 0) {
 		return "Project Definition of Done defaults (0):\n  (none)";
@@ -54,13 +50,6 @@ export class DefinitionOfDoneHandlers {
 	async upsertDefaults(args: DefinitionOfDoneDefaultsUpsertArgs): Promise<CallToolResult> {
 		const config = await this.loadConfigOrThrow();
 		const nextDefaults = normalizeDefinitionOfDoneDefaults(args.items);
-		const commaSensitiveItem = findDelimiterSensitiveItem(nextDefaults);
-		if (commaSensitiveItem) {
-			throw new BacklogToolError(
-				`Definition of Done defaults cannot contain commas (invalid item: "${commaSensitiveItem}").`,
-				"VALIDATION_ERROR",
-			);
-		}
 
 		await this.core.filesystem.saveConfig({
 			...config,

--- a/src/test/definition-of-done.test.ts
+++ b/src/test/definition-of-done.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -10,6 +10,11 @@ let TEST_DIR: string;
 const readConfigFile = async (root: string): Promise<string> => {
 	const configPath = join(root, "backlog", "config.yml");
 	return await readFile(configPath, "utf8");
+};
+
+const writeConfigFile = async (root: string, content: string): Promise<void> => {
+	const configPath = join(root, "backlog", "config.yml");
+	await writeFile(configPath, content);
 };
 
 describe("Definition of Done", () => {
@@ -83,6 +88,77 @@ describe("Definition of Done", () => {
 
 		const rawConfig = await readConfigFile(TEST_DIR);
 		expect(rawConfig).toContain('definition_of_done: ["First item", "Second item"]');
+	});
+
+	it("preserves quoted commas in flow-style definition_of_done entries", async () => {
+		await writeConfigFile(
+			TEST_DIR,
+			[
+				'project_name: "DoD Test Project"',
+				'definition_of_done: ["simple item", "item with, a comma, inside"]',
+				'statuses: ["To Do", "In Progress", "Done"]',
+				"labels: []",
+				"date_format: yyyy-mm-dd",
+				"",
+			].join("\n"),
+		);
+
+		const core = new Core(TEST_DIR);
+		const config = await core.filesystem.loadConfig();
+		expect(config?.definitionOfDone).toEqual(["simple item", "item with, a comma, inside"]);
+
+		const { task } = await core.createTaskFromInput({ title: "Flow DoD task" });
+		const saved = await core.filesystem.loadTask(task.id);
+		const body = saved?.rawContent ?? "";
+		expect(body).toContain("- [ ] #1 simple item");
+		expect(body).toContain("- [ ] #2 item with, a comma, inside");
+	});
+
+	it("parses block-style definition_of_done entries with adjacent blank lines", async () => {
+		await writeConfigFile(
+			TEST_DIR,
+			[
+				'project_name: "DoD Test Project"',
+				"definition_of_done:",
+				"",
+				"  - Tests pass",
+				"",
+				"  - Documentation updated",
+				'statuses: ["To Do", "In Progress", "Done"]',
+				"labels: []",
+				"date_format: yyyy-mm-dd",
+				"",
+			].join("\n"),
+		);
+
+		const core = new Core(TEST_DIR);
+		const config = await core.filesystem.loadConfig();
+		expect(config?.definitionOfDone).toEqual(["Tests pass", "Documentation updated"]);
+
+		const { task } = await core.createTaskFromInput({ title: "Block DoD task" });
+		const saved = await core.filesystem.loadTask(task.id);
+		const body = saved?.rawContent ?? "";
+		expect(body).toContain("- [ ] #1 Tests pass");
+		expect(body).toContain("- [ ] #2 Documentation updated");
+	});
+
+	it("treats an empty block-style definition_of_done key as an empty defaults list", async () => {
+		await writeConfigFile(
+			TEST_DIR,
+			[
+				'project_name: "DoD Test Project"',
+				"definition_of_done:",
+				"",
+				'statuses: ["To Do", "In Progress", "Done"]',
+				"labels: []",
+				"date_format: yyyy-mm-dd",
+				"",
+			].join("\n"),
+		);
+
+		const core = new Core(TEST_DIR);
+		const config = await core.filesystem.loadConfig();
+		expect(config?.definitionOfDone).toEqual([]);
 	});
 
 	it("applies Definition of Done defaults on create", async () => {

--- a/src/test/definition-of-done.test.ts
+++ b/src/test/definition-of-done.test.ts
@@ -90,6 +90,24 @@ describe("Definition of Done", () => {
 		expect(rawConfig).toContain('definition_of_done: ["First item", "Second item"]');
 	});
 
+	it("round-trips saved definition_of_done entries with backslashes", async () => {
+		const core = new Core(TEST_DIR);
+		const config = await core.filesystem.loadConfig();
+		const windowsCheck = String.raw`Run .\scripts\check.ps1`;
+		expect(config).toBeTruthy();
+
+		if (config) {
+			config.definitionOfDone = [windowsCheck];
+			await core.filesystem.saveConfig(config);
+		}
+
+		const rawConfig = await readConfigFile(TEST_DIR);
+		expect(rawConfig).toContain(String.raw`definition_of_done: ["Run .\\scripts\\check.ps1"]`);
+
+		const reloaded = await core.filesystem.loadConfig();
+		expect(reloaded?.definitionOfDone).toEqual([windowsCheck]);
+	});
+
 	it("preserves quoted commas in flow-style definition_of_done entries", async () => {
 		await writeConfigFile(
 			TEST_DIR,
@@ -112,6 +130,32 @@ describe("Definition of Done", () => {
 		const body = saved?.rawContent ?? "";
 		expect(body).toContain("- [ ] #1 simple item");
 		expect(body).toContain("- [ ] #2 item with, a comma, inside");
+	});
+
+	it("preserves legacy flow-style definition_of_done entries with unescaped backslashes", async () => {
+		const scriptCheck = String.raw`Run .\scripts\check.ps1`;
+		const tempTasks = String.raw`Run C:\temp\tasks`;
+		await writeConfigFile(
+			TEST_DIR,
+			[
+				'project_name: "DoD Test Project"',
+				String.raw`definition_of_done: ["Run .\scripts\check.ps1", "Run C:\temp\tasks"]`,
+				'statuses: ["To Do", "In Progress", "Done"]',
+				"labels: []",
+				"date_format: yyyy-mm-dd",
+				"",
+			].join("\n"),
+		);
+
+		const core = new Core(TEST_DIR);
+		const config = await core.filesystem.loadConfig();
+		expect(config?.definitionOfDone).toEqual([scriptCheck, tempTasks]);
+
+		const { task } = await core.createTaskFromInput({ title: "Legacy Windows DoD task" });
+		const saved = await core.filesystem.loadTask(task.id);
+		const body = saved?.rawContent ?? "";
+		expect(body).toContain(`- [ ] #1 ${scriptCheck}`);
+		expect(body).toContain(`- [ ] #2 ${tempTasks}`);
 	});
 
 	it("parses block-style definition_of_done entries with adjacent blank lines", async () => {

--- a/src/test/mcp-definition-of-done-defaults.test.ts
+++ b/src/test/mcp-definition-of-done-defaults.test.ts
@@ -133,7 +133,7 @@ describe("MCP Definition of Done default tools", () => {
 		expect(withoutDefaultsText).not.toContain("Run tests");
 	});
 
-	it("rejects delimiter-sensitive DoD defaults (commas) to prevent config corruption", async () => {
+	it("round-trips comma-bearing DoD defaults", async () => {
 		await server.testInterface.callTool({
 			params: {
 				name: "definition_of_done_defaults_upsert",
@@ -152,10 +152,10 @@ describe("MCP Definition of Done default tools", () => {
 			},
 		});
 
-		expect(result.isError).toBe(true);
-		expect(getText(result.content)).toContain("cannot contain commas");
+		expect(result.isError).toBeUndefined();
+		expect(getText(result.content)).toContain("1. Run unit, integration, and e2e tests");
 
 		const reloaded = await loadConfigOrThrow(server);
-		expect(reloaded.definitionOfDone).toEqual(["Run tests", "Update docs"]);
+		expect(reloaded.definitionOfDone).toEqual(["Run unit, integration, and e2e tests"]);
 	});
 });


### PR DESCRIPTION
## Summary

- Parse `definition_of_done` through YAML semantics in the shared config loader so quoted commas remain part of a single item and block-style sequences load correctly.
- Keep CLI/MCP/Web behavior shared through `FileSystem.loadConfig()` and remove the MCP comma rejection that existed only to avoid delimiter corruption.
- Add regressions for issue #599 flow-style commas, block-style/blank-adjacent sequences, empty block-style defaults, task creation, and MCP round-tripping.

Fixes #599.

## Validation

- `bun test src/test/definition-of-done.test.ts src/test/mcp-definition-of-done-defaults.test.ts`
- `bunx biome check src/file-system/operations.ts src/mcp/tools/definition-of-done/handlers.ts src/test/definition-of-done.test.ts src/test/mcp-definition-of-done-defaults.test.ts`
- `bunx tsc --noEmit`
- `bun test`

## Known blocker

- `bun run check .` currently fails on pre-existing `package.json` formatting from `origin/main`; touched TypeScript files pass targeted Biome checks, and unrelated package formatting was intentionally left out of this PR.