### PR TITLE
BACK-433 - Make task edit preserve unrelated file details

### DIFF
--- a/backlog/tasks/back-433 - Make-task-edit-preserve-unrelated-file-details.md
+++ b/backlog/tasks/back-433 - Make-task-edit-preserve-unrelated-file-details.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-433
 title: Make task edit preserve unrelated file details
-status: To Do
+status: In Progress
 assignee:
-  - '@alex-agent'
+  - '@codex'
 created_date: '2026-04-25 12:15'
+updated_date: '2026-04-25 12:24'
 labels:
   - cli
   - core
@@ -23,14 +24,29 @@ Track GitHub issue #603: editing one field should not rename, recase, or otherwi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Editing a single task field preserves the task ID casing, filename identity, and unrelated metadata/content.
-- [ ] #2 A label-only edit does not inject or remove unrelated markers or sections.
-- [ ] #3 Regression tests cover the issue's task create/edit script or an equivalent fixture.
+- [x] #1 Editing a single task field preserves the task ID casing, filename identity, and unrelated metadata/content.
+- [x] #2 A label-only edit does not inject or remove unrelated markers or sections.
+- [x] #3 Regression tests cover the issue's task create/edit script or an equivalent fixture.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Preserve existing task file paths during task updates while keeping create-time filename generation unchanged.
+2. Preserve existing on-disk task ID casing during existing-file writes while keeping normalized IDs for loaded API results.
+3. Update serialization so parsed body sections and checklists are rewritten only when their values actually change.
+4. Cover issue #603 with a label-only regression fixture that preserves filename, id casing, legacy description, and unrelated sections.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented preservation in saveTask and serializeTask, then added a regression fixture matching GitHub issue #603. Targeted tests, TypeScript, changed-file Biome, affected suites, and full bun test pass. Full bun run check . is blocked by existing package.json formatting on origin/main, so the formatting DoD remains unchecked.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
 - [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -15,7 +15,7 @@ import {
 	idForFilename,
 	normalizeId,
 } from "../utils/prefix-config.ts";
-import { getTaskFilename, getTaskPath, normalizeTaskIdentity } from "../utils/task-path.ts";
+import { getTaskFilename, getTaskPath, normalizeTaskIdentity, taskIdsEqual } from "../utils/task-path.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
 
 // Interface for task path resolution context
@@ -294,26 +294,46 @@ export class FileSystem {
 		const taskId = normalizeId(task.id, prefix);
 		const filename = `${idForFilename(taskId)} - ${this.sanitizeFilename(task.title)}.md`;
 		const tasksDir = await this.getTasksDir();
-		const filepath = join(tasksDir, filename);
-		// Normalize task ID and parentTaskId to uppercase before serialization
+		const shouldPreservePath = typeof task.filePath === "string" && task.filePath.trim().length > 0;
+		const filepath = shouldPreservePath ? (task.filePath as string) : join(tasksDir, filename);
+		let existingTask: Task | null = null;
+
+		if (shouldPreservePath) {
+			try {
+				existingTask = parseTask(await Bun.file(filepath).text());
+			} catch {
+				existingTask = null;
+			}
+		}
+
+		const persistedTaskId = existingTask?.id && taskIdsEqual(existingTask.id, task.id) ? existingTask.id : taskId;
+		const normalizedParentTaskId = task.parentTaskId
+			? normalizeId(task.parentTaskId, extractAnyPrefix(task.parentTaskId) ?? prefix)
+			: undefined;
+		const persistedParentTaskId =
+			existingTask?.parentTaskId && task.parentTaskId && taskIdsEqual(existingTask.parentTaskId, task.parentTaskId)
+				? existingTask.parentTaskId
+				: normalizedParentTaskId;
+
+		// Normalize new task IDs before serialization, but preserve existing file identity on updates.
 		const normalizedTask = {
 			...task,
-			id: taskId,
-			parentTaskId: task.parentTaskId
-				? normalizeId(task.parentTaskId, extractAnyPrefix(task.parentTaskId) ?? prefix)
-				: undefined,
+			id: persistedTaskId,
+			parentTaskId: persistedParentTaskId,
 		};
 		const content = serializeTask(normalizedTask);
 
-		// Delete any existing task files with the same ID but different filenames
-		try {
-			const core = { filesystem: { tasksDir } };
-			const existingPath = await getTaskPath(taskId, core as TaskPathContext);
-			if (existingPath && !existingPath.endsWith(filename)) {
-				await unlink(existingPath);
+		if (!shouldPreservePath) {
+			// Delete any existing task files with the same ID but different filenames
+			try {
+				const core = { filesystem: { tasksDir } };
+				const existingPath = await getTaskPath(taskId, core as TaskPathContext);
+				if (existingPath && !existingPath.endsWith(filename)) {
+					await unlink(existingPath);
+				}
+			} catch {
+				// Ignore errors if no existing files found
 			}
-		} catch {
-			// Ignore errors if no existing files found
 		}
 
 		await this.ensureDirectoryExists(dirname(filepath));

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -1,5 +1,5 @@
 import matter from "gray-matter";
-import type { Decision, Document, Task } from "../types/index.ts";
+import type { AcceptanceCriterion, Decision, Document, Task } from "../types/index.ts";
 import { normalizeAssignee } from "../utils/assignee.ts";
 import {
 	AcceptanceCriteriaManager,
@@ -7,6 +7,28 @@ import {
 	getStructuredSections,
 	updateStructuredSections,
 } from "./structured-sections.ts";
+
+function normalizeOptionalText(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function sectionChanged(
+	rawContent: string,
+	key: keyof ReturnType<typeof getStructuredSections>,
+	nextValue: string,
+): boolean {
+	const existing = normalizeOptionalText(getStructuredSections(rawContent)[key]);
+	return existing !== normalizeOptionalText(nextValue);
+}
+
+function checklistItemsEqual(left: AcceptanceCriterion[], right: AcceptanceCriterion[]): boolean {
+	if (left.length !== right.length) return false;
+	return left.every((item, index) => {
+		const other = right[index];
+		return other?.index === item.index && other.checked === item.checked && other.text === item.text;
+	});
+}
 
 export function serializeTask(task: Task): string {
 	normalizeAssignee(task);
@@ -31,30 +53,47 @@ export function serializeTask(task: Task): string {
 	};
 
 	let contentBody = task.rawContent ?? "";
-	if (typeof task.description === "string" && task.description.trim() !== "") {
+	const rawContent = task.rawContent ?? "";
+	if (
+		typeof task.description === "string" &&
+		task.description.trim() !== "" &&
+		sectionChanged(rawContent, "description", task.description)
+	) {
 		contentBody = updateTaskDescription(contentBody, task.description);
 	}
 	if (Array.isArray(task.acceptanceCriteriaItems)) {
 		const existingCriteria = AcceptanceCriteriaManager.parseAllCriteria(task.rawContent ?? "");
 		const hasExistingStructuredCriteria = existingCriteria.length > 0;
-		if (task.acceptanceCriteriaItems.length > 0 || hasExistingStructuredCriteria) {
+		if (
+			(task.acceptanceCriteriaItems.length > 0 || hasExistingStructuredCriteria) &&
+			!checklistItemsEqual(existingCriteria, task.acceptanceCriteriaItems)
+		) {
 			contentBody = AcceptanceCriteriaManager.updateContent(contentBody, task.acceptanceCriteriaItems);
 		}
 	}
 	if (Array.isArray(task.definitionOfDoneItems)) {
 		const existingDefinitionOfDone = DefinitionOfDoneManager.parseAllCriteria(task.rawContent ?? "");
 		const hasExistingDefinitionOfDone = existingDefinitionOfDone.length > 0;
-		if (task.definitionOfDoneItems.length > 0 || hasExistingDefinitionOfDone) {
+		if (
+			(task.definitionOfDoneItems.length > 0 || hasExistingDefinitionOfDone) &&
+			!checklistItemsEqual(existingDefinitionOfDone, task.definitionOfDoneItems)
+		) {
 			contentBody = DefinitionOfDoneManager.updateContent(contentBody, task.definitionOfDoneItems);
 		}
 	}
-	if (typeof task.implementationPlan === "string") {
+	if (
+		typeof task.implementationPlan === "string" &&
+		sectionChanged(rawContent, "implementationPlan", task.implementationPlan)
+	) {
 		contentBody = updateTaskImplementationPlan(contentBody, task.implementationPlan);
 	}
-	if (typeof task.implementationNotes === "string") {
+	if (
+		typeof task.implementationNotes === "string" &&
+		sectionChanged(rawContent, "implementationNotes", task.implementationNotes)
+	) {
 		contentBody = updateTaskImplementationNotes(contentBody, task.implementationNotes);
 	}
-	if (typeof task.finalSummary === "string") {
+	if (typeof task.finalSummary === "string" && sectionChanged(rawContent, "finalSummary", task.finalSummary)) {
 		contentBody = updateTaskFinalSummary(contentBody, task.finalSummary);
 	}
 

--- a/src/test/task-edit-preservation.test.ts
+++ b/src/test/task-edit-preservation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -31,6 +31,53 @@ describe("Task edit section preservation", () => {
 		} catch {
 			// Ignore cleanup errors - the unique directory names prevent conflicts
 		}
+	});
+
+	it("preserves legacy task file identity and body when editing only labels", async () => {
+		const tasksDir = join(TEST_DIR, "backlog", "tasks");
+		const taskPath = join(tasksDir, "task-1 - hello world.md");
+		await Bun.write(
+			taskPath,
+			`---
+id: task-1
+title: hello world
+status: To Do
+assignee: []
+created_date: '2026-01-01'
+labels: []
+dependencies: []
+---
+
+## Description
+
+Test description.
+
+## Extra Notes
+
+Keep me exactly.
+`,
+		);
+
+		await $`bun ${cliPath} task edit 1 --label foo`.cwd(TEST_DIR).quiet();
+
+		const files = await readdir(tasksDir);
+		expect(files).toContain("task-1 - hello world.md");
+		expect(files).not.toContain("task-1 - hello-world.md");
+
+		const content = await Bun.file(taskPath).text();
+		expect(content).toContain("id: task-1");
+		expect(content).not.toContain("id: TASK-1");
+		expect(content).toContain("title: hello world");
+		expect(content).toContain("status: To Do");
+		expect(content).toContain("created_date:");
+		expect(content).toContain("2026-01-01");
+		expect(content).toContain("dependencies: []");
+		expect(content).toContain("labels:\n  - foo");
+		expect(content).toContain("## Description\n\nTest description.");
+		expect(content).toContain("## Extra Notes\n\nKeep me exactly.");
+		expect(content).not.toContain("<!-- SECTION:");
+		expect(content).not.toContain("<!-- AC:");
+		expect(content).not.toContain("## Acceptance Criteria");
 	});
 
 	it("should preserve all sections when updating description", async () => {


### PR DESCRIPTION
## Summary
- Preserve existing task file paths during task updates so metadata-only edits do not rename legacy filenames.
- Preserve existing on-disk task ID casing for existing-file writes while keeping normalized IDs for loaded API results.
- Avoid rewriting parsed body sections and checklists unless their values actually change.
- Add a regression fixture based on GitHub issue #603 for `backlog task edit 1 --label foo`.

Closes #603.

## Validation
- `bun test src/test/task-edit-preservation.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check src/file-system/operations.ts src/markdown/serializer.ts src/test/task-edit-preservation.test.ts`
- `bun test src/test/filesystem.test.ts src/test/cli.test.ts src/test/final-summary.test.ts src/test/definition-of-done.test.ts`
- `bun test`

## Notes
- `bun run check .` was attempted and is currently blocked by existing root `package.json` formatting on `origin/main`; this PR leaves that unrelated file untouched.