### PR TITLE
BACK-412 - Add touched-files field to tasks and filename-based search

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ backlog board
 backlog browser
 ```
 
-You can switch between AI-assisted and manual workflows at any time — both operate on the same Markdown task files. It is recommended to modify tasks via Backlog.md commands (CLI/MCP/Web) rather than editing task files manually, so field types and metadata stay consistent.
+You can switch between AI-assisted and manual workflows at any time — both operate on the same Markdown task files. It is recommended to modify tasks via Backlog.md commands (CLI/MCP/Web) rather than editing task files manually, so field types and metadata stay consistent. Tasks can record project-root-relative modified files and later be found with `backlog search --modified-file src/path.ts --plain`.
 
 **Learn more:** [CLI reference](CLI-INSTRUCTIONS.md) | [Advanced configuration](ADVANCED-CONFIG.md)
 

--- a/backlog/tasks/back-412 - Add-touched-files-field-to-tasks-and-filename-based-search.md
+++ b/backlog/tasks/back-412 - Add-touched-files-field-to-tasks-and-filename-based-search.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-412
 title: Add touched-files field to tasks and filename-based search
-status: To Do
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-04-13 16:02'
+updated_date: '2026-04-25 15:42'
 labels: []
 dependencies: []
 ---
@@ -19,14 +20,31 @@ This should cover task data model updates, persistence and indexing updates, and
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tasks include a dedicated field for touched or modified files.
-- [ ] #2 Users can query by filename and get all matching tasks.
-- [ ] #3 Documentation or instructions describe how to set and use the touched-files field.
+- [x] #1 Tasks include a dedicated field for touched or modified files.
+- [x] #2 Users can query by filename and get all matching tasks.
+- [x] #3 Documentation or instructions describe how to set and use the touched-files field.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a dedicated `modifiedFiles` task domain field, persisted as `modified_files` frontmatter, following the existing `references`/`documentation` array handling pattern.
+2. Thread `modifiedFiles` through create/edit inputs for Core, CLI, server API, and MCP so tasks can store project-root-relative paths without direct markdown edits.
+3. Extend shared task search indexing (`core/search-service.ts` and `utils/task-search.ts`) so existing CLI, Web UI, and TUI free-text search can find tasks by modified file paths without search UI changes.
+4. Add a separate MCP `task_search.modifiedFiles` filter and a CLI `backlog search --modified-file` filter; matching is case-insensitive substring matching against stored paths.
+5. Update shipped agent/MCP guidance to explain setting `modifiedFiles` and searching by modified file path.
+6. Add focused tests for markdown persistence, shared search behavior, CLI search, MCP filtering, and server search endpoint behavior, then run scoped tests plus type/check commands as needed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented `modifiedFiles` storage and search across task parsing/serialization, Core create/edit, CLI/server/MCP inputs, shared search indexes, plain/TUI display, and shipped guidance. Verification: focused feature tests passed; full `bun test` passed; `bunx tsc --noEmit` passed; touched source/docs passed `bunx biome check ...`. Repo-wide `bun run check .` is still blocked by an untouched pre-existing `package.json` formatting issue, so DoD item #2 remains unchecked.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
 - [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/backlog/tasks/back-412 - Add-touched-files-field-to-tasks-and-filename-based-search.md
+++ b/backlog/tasks/back-412 - Add-touched-files-field-to-tasks-and-filename-based-search.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-412
 title: Add touched-files field to tasks and filename-based search
-status: In Progress
+status: Done
 assignee:
-  - '@codex'
+  - '@alex-agent'
 created_date: '2026-04-13 16:02'
-updated_date: '2026-04-25 15:42'
+updated_date: '2026-04-25 18:38'
 labels: []
 dependencies: []
 ---
@@ -39,12 +39,29 @@ This should cover task data model updates, persistence and indexing updates, and
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented `modifiedFiles` storage and search across task parsing/serialization, Core create/edit, CLI/server/MCP inputs, shared search indexes, plain/TUI display, and shipped guidance. Verification: focused feature tests passed; full `bun test` passed; `bunx tsc --noEmit` passed; touched source/docs passed `bunx biome check ...`. Repo-wide `bun run check .` is still blocked by an untouched pre-existing `package.json` formatting issue, so DoD item #2 remains unchecked.
+Implemented `modifiedFiles` storage and search across task parsing/serialization, Core create/edit, CLI/server/MCP inputs, shared search indexes, plain/TUI display, and shipped guidance. Addressed Codex review feedback by ensuring `backlog search --modified-file ...` seeds the interactive unified view with the already-filtered task results instead of opening an unfiltered all-task list; no-result modified-file searches now print the empty search result instead of selecting an unrelated task.
+
+Verification: focused modified-file/search tests passed, full bun test passed before the original PR checks, bunx tsc --noEmit passed, and bun run check . passes on the rebased current-main branch with existing optional-chain warnings only.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Summary:
+- Added `modifiedFiles` task metadata persisted as `modified_files` frontmatter and threaded it through Core, CLI, MCP, server, and web API surfaces.
+- Indexed modified file paths in shared search so tasks can be found by filename/path query and filtered through CLI/MCP/server search paths.
+- Updated task display and shipped guidance to document setting and searching modified files.
+- Fixed interactive CLI search so `--modified-file` opens only matching tasks instead of falling back to an unfiltered all-task list.
+
+Validation:
+- bun test src/test/cli-search-command.test.ts src/test/search-service.test.ts src/test/task-search-label-filter.test.ts src/test/mcp-tasks.test.ts src/test/server-search-endpoint.test.ts
+- bunx tsc --noEmit
+- bun run check .
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
 - [x] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
+- [x] #2 bun run check . passes when formatting/linting touched
 - [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -185,7 +185,8 @@ function hasCreateFieldFlags(options: Record<string, unknown>): boolean {
 			options.dependsOn !== undefined ||
 			options.dep !== undefined ||
 			options.ref !== undefined ||
-			options.doc !== undefined,
+			options.doc !== undefined ||
+			options.modifiedFile !== undefined,
 	);
 }
 
@@ -220,7 +221,8 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.dependsOn !== undefined ||
 			options.dep !== undefined ||
 			options.ref !== undefined ||
-			options.doc !== undefined,
+			options.doc !== undefined ||
+			options.modifiedFile !== undefined,
 	);
 }
 
@@ -1442,6 +1444,14 @@ taskCmd
 		return [...soFar, value];
 	})
 	.option(
+		"--modified-file <path>",
+		"add modified file path from project root (can be used multiple times)",
+		(value, previous) => {
+			const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
+			return [...soFar, value];
+		},
+	)
+	.option(
 		"--doc <documentation>",
 		"add documentation URL or file path (can be used multiple times)",
 		(value, previous) => {
@@ -1500,6 +1510,7 @@ taskCmd
 					options.dependsOn || options.dep ? normalizeDependencies(options.dependsOn || options.dep) : undefined,
 				references: parseDelimitedStringList(options.ref),
 				documentation: parseDelimitedStringList(options.doc),
+				modifiedFiles: parseDelimitedStringList(options.modifiedFile),
 				parentTaskId: options.parent ? String(options.parent) : undefined,
 				priority: options.priority ? (String(options.priority).toLowerCase() as "high" | "medium" | "low") : undefined,
 				implementationPlan: options.plan ? String(options.plan) : undefined,
@@ -1535,6 +1546,11 @@ program
 	.option("--type <type>", "limit results to type (task, document, decision)", createMultiValueAccumulator())
 	.option("--status <status>", "filter task results by status")
 	.option("--priority <priority>", "filter task results by priority (high, medium, low)")
+	.option(
+		"--modified-file <path>",
+		"filter task results by modified file path substring",
+		createMultiValueAccumulator(),
+	)
 	.option("--limit <number>", "limit total results returned")
 	.option("--plain", "print plain text output instead of interactive UI")
 	.action(async (query: string | undefined, options) => {
@@ -1547,6 +1563,7 @@ program
 			contentStore.dispose();
 		};
 
+		const modifiedFileFilters = parseDelimitedStringList(options.modifiedFile);
 		const rawTypes = options.type ? (Array.isArray(options.type) ? options.type : [options.type]) : undefined;
 		const allowedTypes: SearchResultType[] = ["task", "document", "decision"];
 		const types = rawTypes
@@ -1559,9 +1576,11 @@ program
 						}
 						return true;
 					})
-			: allowedTypes;
+			: modifiedFileFilters?.length
+				? ["task"]
+				: allowedTypes;
 
-		const filters: { status?: string; priority?: SearchPriorityFilter } = {};
+		const filters: { status?: string; priority?: SearchPriorityFilter; modifiedFiles?: string[] } = {};
 		if (options.status) {
 			filters.status = options.status;
 		}
@@ -1575,6 +1594,9 @@ program
 				return;
 			}
 			filters.priority = priorityLower as SearchPriorityFilter;
+		}
+		if (modifiedFileFilters?.length) {
+			filters.modifiedFiles = modifiedFileFilters;
 		}
 
 		let limit: number | undefined;
@@ -2096,6 +2118,14 @@ taskCmd
 		const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
 		return [...soFar, value];
 	})
+	.option(
+		"--modified-file <path>",
+		"set modified file paths from project root (can be used multiple times)",
+		(value, previous) => {
+			const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
+			return [...soFar, value];
+		},
+	)
 	.option("--doc <documentation>", "set documentation (can be used multiple times)", (value, previous) => {
 		const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
 		return [...soFar, value];
@@ -2251,6 +2281,7 @@ taskCmd
 
 		const normalizedReferences = parseDelimitedStringList(options.ref);
 		const normalizedDocumentation = parseDelimitedStringList(options.doc);
+		const normalizedModifiedFiles = parseDelimitedStringList(options.modifiedFile);
 
 		const notesAppendValues = toStringArray(options.appendNotes);
 		const finalSummaryAppendValues = toStringArray(options.appendFinalSummary);
@@ -2292,6 +2323,9 @@ taskCmd
 		}
 		if (normalizedDocumentation && normalizedDocumentation.length > 0) {
 			editArgs.documentation = normalizedDocumentation;
+		}
+		if (normalizedModifiedFiles && normalizedModifiedFiles.length > 0) {
+			editArgs.modifiedFiles = normalizedModifiedFiles;
 		}
 		if (typeof options.plan === "string") {
 			editArgs.planSet = String(options.plan);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1639,8 +1639,16 @@ program
 			return;
 		}
 
+		const hasModifiedFileFilter = Boolean(modifiedFileFilters?.length);
+		const interactiveTasks = hasModifiedFileFilter ? searchResultTasks : allTasks;
+		if (interactiveTasks.length === 0) {
+			printSearchResults(searchResults);
+			cleanup();
+			return;
+		}
+
 		// Use the first search result as the selected task, or first available task if no results
-		const firstTask = searchResultTasks[0] || allTasks[0];
+		const firstTask = searchResultTasks[0] || interactiveTasks[0];
 		const priorityFilter = filters.priority ? filters.priority : undefined;
 		const statusFilter = filters.status;
 		const { runUnifiedView } = await import("./ui/unified-view.ts");
@@ -1649,13 +1657,14 @@ program
 			core,
 			initialView: "task-list",
 			selectedTask: firstTask,
-			tasks: allTasks, // Pass ALL tasks, not just search results
+			tasks: interactiveTasks,
 			filter: {
 				title: query ? `Search: ${query}` : "Search",
 				filterDescription: buildSearchFilterDescription({
 					status: statusFilter,
 					priority: priorityFilter,
 					query: query ?? "",
+					modifiedFiles: modifiedFileFilters ?? [],
 				}),
 				status: statusFilter,
 				priority: priorityFilter,
@@ -1669,6 +1678,7 @@ function buildSearchFilterDescription(filters: {
 	status?: string;
 	priority?: SearchPriorityFilter;
 	query?: string;
+	modifiedFiles?: string[];
 }): string {
 	const parts: string[] = [];
 	if (filters.query) {
@@ -1679,6 +1689,9 @@ function buildSearchFilterDescription(filters: {
 	}
 	if (filters.priority) {
 		parts.push(`Priority: ${filters.priority}`);
+	}
+	if (filters.modifiedFiles?.length) {
+		parts.push(`Modified files: ${filters.modifiedFiles.join(", ")}`);
 	}
 	return parts.join(" • ");
 }

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -930,6 +930,7 @@ export class Core {
 		const normalizedDependencies = normalizeDependencies(input.dependencies);
 		const normalizedReferences = normalizeStringList(input.references) ?? [];
 		const normalizedDocumentation = normalizeStringList(input.documentation) ?? [];
+		const normalizedModifiedFiles = normalizeStringList(input.modifiedFiles) ?? [];
 
 		const { valid: validDependencies, invalid: invalidDependencies } = await validateDependencies(
 			normalizedDependencies,
@@ -987,6 +988,7 @@ export class Core {
 				dependencies: validDependencies,
 				references: normalizedReferences,
 				documentation: normalizedDocumentation,
+				modifiedFiles: normalizedModifiedFiles,
 				rawContent: input.rawContent ?? "",
 				createdDate,
 				...(input.parentTaskId && { parentTaskId: input.parentTaskId }),
@@ -1300,6 +1302,19 @@ export class Core {
 		};
 
 		resolveDocumentation();
+
+		const resolveModifiedFiles = (): void => {
+			if (input.modifiedFiles === undefined) {
+				return;
+			}
+			const sanitizedModifiedFiles = normalizeStringList(input.modifiedFiles) ?? [];
+			if (!stringArraysEqual(sanitizedModifiedFiles, task.modifiedFiles ?? [])) {
+				task.modifiedFiles = sanitizedModifiedFiles;
+				mutated = true;
+			}
+		};
+
+		resolveModifiedFiles();
 
 		const sanitizeAppendInput = (values: string[] | undefined): string[] => {
 			if (!values) return [];

--- a/src/core/search-service.ts
+++ b/src/core/search-service.ts
@@ -10,6 +10,7 @@ import type {
 	SearchResultType,
 	Task,
 } from "../types/index.ts";
+import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "../utils/modified-files.ts";
 import type { ContentStore, ContentStoreEvent } from "./content-store.ts";
 
 interface BaseSearchEntity {
@@ -27,6 +28,7 @@ interface TaskSearchEntity extends BaseSearchEntity {
 	readonly labelsLower: string[];
 	readonly idVariants: string[];
 	readonly dependencyIds: string[];
+	readonly modifiedFiles: string[];
 }
 
 interface DocumentSearchEntity extends BaseSearchEntity {
@@ -45,6 +47,7 @@ type NormalizedFilters = {
 	statuses?: string[];
 	priorities?: SearchPriorityFilter[];
 	labels?: string[];
+	modifiedFiles?: string[];
 };
 
 // Regex pattern to match any prefix (letters followed by dash)
@@ -225,6 +228,7 @@ export class SearchService {
 			labelsLower: (task.labels || []).map((label) => label.toLowerCase()),
 			idVariants: createTaskIdVariants(task.id),
 			dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdVariants(dependency)),
+			modifiedFiles: task.modifiedFiles ?? [],
 		}));
 
 		this.documents = documents.map((document) => ({
@@ -265,6 +269,7 @@ export class SearchService {
 				{ name: "id", weight: 0.2 },
 				{ name: "idVariants", weight: 0.1 },
 				{ name: "dependencyIds", weight: 0.05 },
+				{ name: "modifiedFiles", weight: 0.15 },
 			],
 		});
 	}
@@ -331,6 +336,9 @@ export class SearchService {
 				return task.labelsLower.some((label) => requiredLabels.has(label));
 			});
 		}
+		if (filters.modifiedFiles && filters.modifiedFiles.length > 0) {
+			filtered = filtered.filter((task) => matchesModifiedFileFilters(task.modifiedFiles, filters.modifiedFiles));
+		}
 		return filtered;
 	}
 
@@ -358,6 +366,10 @@ export class SearchService {
 			}
 		}
 
+		if (filters.modifiedFiles && !matchesModifiedFileFilters(task.modifiedFiles, filters.modifiedFiles)) {
+			return false;
+		}
+
 		return true;
 	}
 
@@ -369,11 +381,13 @@ export class SearchService {
 		const statuses = this.normalizeStringArray(filters.status);
 		const priorities = this.normalizePriorityArray(filters.priority);
 		const labels = this.normalizeLabelsArray(filters.labels);
+		const modifiedFiles = normalizeModifiedFileFilters(filters.modifiedFiles);
 
 		return {
 			statuses,
 			priorities,
 			labels,
+			modifiedFiles,
 		};
 	}
 
@@ -478,6 +492,10 @@ function buildTaskBodyText(task: Task): string {
 
 	if (task.implementationNotes) {
 		parts.push(task.implementationNotes);
+	}
+
+	if (task.modifiedFiles?.length) {
+		parts.push(task.modifiedFiles.join("\n"));
 	}
 
 	return parts.join("\n\n");

--- a/src/formatters/task-plain-text.ts
+++ b/src/formatters/task-plain-text.ts
@@ -132,6 +132,10 @@ export function formatTaskPlainText(task: Task, options: TaskPlainTextOptions = 
 		lines.push(`Documentation: ${task.documentation.join(", ")}`);
 	}
 
+	if (task.modifiedFiles?.length) {
+		lines.push(`Modified files: ${task.modifiedFiles.join(", ")}`);
+	}
+
 	lines.push("");
 	lines.push("Description:");
 	lines.push("-".repeat(50));

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -108,6 +108,9 @@ title: Add GraphQL resolver
 status: To Do
 assignee: [@sara]
 labels: [backend, api]
+modified_files:
+  - src/server/api.ts
+  - src/web/components/TaskList.tsx
 ---
 
 ## Description
@@ -451,11 +454,15 @@ backlog search "login" --type task --plain
 # Search with filters
 backlog search "api" --status "In Progress" --plain
 backlog search "bug" --priority high --plain
+
+# Find tasks that modified a project file path
+backlog search --modified-file src/server/api.ts --plain
 ```
 
 **Key points:**
 - Uses fuzzy matching - finds "authentication" when searching "auth"
 - Searches task titles, descriptions, and content
+- Also searches `modified_files`; `--modified-file` applies a case-insensitive path substring filter
 - Also searches documents and decisions unless filtered with `--type task`
 - Always use `--plain` flag for AI-readable output
 
@@ -496,7 +503,8 @@ backlog search "bug" --priority high --plain
 | With final summary | `backlog task create "Title" --final-summary "PR-style summary"`                 |
 | With references  | `backlog task create "Title" --ref src/api.ts --ref https://github.com/issue/123`   |
 | With documentation | `backlog task create "Title" --doc https://design-docs.example.com`               |
-| With all options | `backlog task create "Title" -d "Desc" -a @sara -s "To Do" -l auth --priority high --ref src/api.ts --doc docs/spec.md` |
+| With modified files | `backlog task create "Title" --modified-file src/api.ts --modified-file src/ui.ts` |
+| With all options | `backlog task create "Title" -d "Desc" -a @sara -s "To Do" -l auth --priority high --ref src/api.ts --doc docs/spec.md --modified-file src/api.ts` |
 | Create draft     | `backlog task create "Title" --draft`                                               |
 | Create subtask   | `backlog task create "Title" -p 42`                                                 |
 
@@ -535,6 +543,7 @@ backlog search "bug" --priority high --plain
 | Add dependencies | `backlog task edit 42 --dep task-1 --dep task-2`         |
 | Add references   | `backlog task edit 42 --ref src/api.ts --ref https://github.com/issue/123` |
 | Add documentation | `backlog task edit 42 --doc https://design-docs.example.com --doc docs/spec.md` |
+| Set modified files | `backlog task edit 42 --modified-file src/api.ts --modified-file src/ui.ts` |
 
 ### Multi‑line Input (Description/Plan/Notes/Final Summary)
 
@@ -597,6 +606,7 @@ Tests:
 | List tasks         | `backlog task list --plain`                  |
 | Search tasks       | `backlog search "topic" --plain`              |
 | Search with filter | `backlog search "api" --status "To Do" --plain` |
+| Search by modified file | `backlog search --modified-file src/api.ts --plain` |
 | Filter by status   | `backlog task list -s "In Progress" --plain` |
 | Filter by assignee | `backlog task list -a @sara --plain`         |
 | Archive task       | `backlog task archive 42`                    |

--- a/src/guidelines/mcp/overview-tools.md
+++ b/src/guidelines/mcp/overview-tools.md
@@ -46,6 +46,7 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 
 - `get_backlog_instructions`
 - `task_list`, `task_search`, `task_view`, `task_create`, `task_edit`, `task_complete`, `task_archive`
+- `task_search` accepts `modifiedFiles` for case-insensitive substring filtering against project-root-relative modified file paths
 - `document_list`, `document_view`, `document_create`, `document_update`, `document_search`
 - `definition_of_done_defaults_get`, `definition_of_done_defaults_upsert`
 

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -55,7 +55,7 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 **Note:** "Done" tasks stay in the Done column until periodic cleanup moves them to the completed folder. Don't use `task_complete` immediately after finishing—it's for batch cleanup, not per-task workflow.
 
 - `task_list` — list tasks with optional filtering by status, assignee, or labels
-- `task_search` — search tasks by title and description
+- `task_search` — search tasks by title and description, or use `modifiedFiles` to filter by project-root-relative modified file path substrings
 - `task_view` — read full task context (description, plan, notes, final summary, acceptance criteria, Definition of Done)
 - `definition_of_done_defaults_get` — read project-level Definition of Done defaults from config
 - `definition_of_done_defaults_upsert` — replace project-level Definition of Done defaults in config

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -179,6 +179,7 @@ export function parseTask(content: string): Task {
 		dependencies: Array.isArray(frontmatter.dependencies) ? frontmatter.dependencies.map(String) : [],
 		references: Array.isArray(frontmatter.references) ? frontmatter.references.map(String) : [],
 		documentation: Array.isArray(frontmatter.documentation) ? frontmatter.documentation.map(String) : [],
+		modifiedFiles: Array.isArray(frontmatter.modified_files) ? frontmatter.modified_files.map(String) : [],
 		rawContent,
 		acceptanceCriteriaItems: structuredCriteria,
 		definitionOfDoneItems: structuredDefinitionOfDone,

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -45,6 +45,7 @@ export function serializeTask(task: Task): string {
 		dependencies: task.dependencies,
 		...(task.references && task.references.length > 0 && { references: task.references }),
 		...(task.documentation && task.documentation.length > 0 && { documentation: task.documentation }),
+		...(task.modifiedFiles && task.modifiedFiles.length > 0 && { modified_files: task.modifiedFiles }),
 		...(task.parentTaskId && { parent_task_id: task.parentTaskId }),
 		...(task.subtasks && task.subtasks.length > 0 && { subtasks: task.subtasks }),
 		...(task.priority && { priority: task.priority }),

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -38,6 +38,7 @@ export type TaskCreateArgs = {
 	dependencies?: string[];
 	references?: string[];
 	documentation?: string[];
+	modifiedFiles?: string[];
 	finalSummary?: string;
 };
 
@@ -51,9 +52,10 @@ export type TaskListArgs = {
 };
 
 export type TaskSearchArgs = {
-	query: string;
+	query?: string;
 	status?: string;
 	priority?: SearchPriorityFilter;
+	modifiedFiles?: string[];
 	limit?: number;
 };
 
@@ -219,6 +221,7 @@ export class TaskHandlers {
 				dependencies: args.dependencies,
 				references: args.references,
 				documentation: args.documentation,
+				modifiedFiles: args.modifiedFiles,
 				parentTaskId: args.parentTaskId,
 				finalSummary: args.finalSummary,
 				acceptanceCriteria,
@@ -401,9 +404,10 @@ export class TaskHandlers {
 	}
 
 	async searchTasks(args: TaskSearchArgs): Promise<CallToolResult> {
-		const query = args.query.trim();
-		if (!query) {
-			throw new BacklogToolError("Search query cannot be empty", "VALIDATION_ERROR");
+		const query = args.query?.trim() ?? "";
+		const modifiedFiles = args.modifiedFiles?.map((file) => file.trim()).filter((file) => file.length > 0);
+		if (!query && (!modifiedFiles || modifiedFiles.length === 0)) {
+			throw new BacklogToolError("Search query or modifiedFiles filter is required", "VALIDATION_ERROR");
 		}
 
 		if (this.isDraftStatus(args.status)) {
@@ -413,6 +417,7 @@ export class TaskHandlers {
 				query,
 				status: "Draft",
 				priority: args.priority,
+				modifiedFiles,
 			});
 			if (typeof args.limit === "number" && args.limit >= 0) {
 				draftMatches = draftMatches.slice(0, args.limit);
@@ -423,7 +428,7 @@ export class TaskHandlers {
 					content: [
 						{
 							type: "text",
-							text: `No tasks found for "${query}".`,
+							text: `No tasks found for "${query || modifiedFiles?.join(", ")}".`,
 						},
 					],
 				};
@@ -450,6 +455,7 @@ export class TaskHandlers {
 			query,
 			status: args.status,
 			priority: args.priority,
+			modifiedFiles,
 		});
 		if (typeof args.limit === "number" && args.limit >= 0) {
 			taskMatches = taskMatches.slice(0, args.limit);
@@ -461,7 +467,7 @@ export class TaskHandlers {
 				content: [
 					{
 						type: "text",
-						text: `No tasks found for "${query}".`,
+						text: `No tasks found for "${query || modifiedFiles?.join(", ")}".`,
 					},
 				],
 			};

--- a/src/mcp/tools/tasks/index.ts
+++ b/src/mcp/tools/tasks/index.ts
@@ -38,7 +38,7 @@ export function registerTaskTools(server: McpServer, config: BacklogConfig): voi
 	const searchTaskTool: McpToolHandler = createSimpleValidatedTool(
 		{
 			name: "task_search",
-			description: "Search Backlog.md tasks by title and description",
+			description: "Search Backlog.md tasks by title, description, and modified file path filters",
 			inputSchema: taskSearchSchema,
 			annotations: { title: "Search Tasks", readOnlyHint: true, destructiveHint: false },
 		},

--- a/src/mcp/tools/tasks/schemas.ts
+++ b/src/mcp/tools/tasks/schemas.ts
@@ -38,7 +38,6 @@ export const taskSearchSchema: JsonSchema = {
 	properties: {
 		query: {
 			type: "string",
-			minLength: 1,
 			maxLength: 200,
 		},
 		status: {
@@ -49,13 +48,18 @@ export const taskSearchSchema: JsonSchema = {
 			type: "string",
 			enum: ["high", "medium", "low"],
 		},
+		modifiedFiles: {
+			type: "array",
+			items: { type: "string", maxLength: 500 },
+			description: "Filter tasks by case-insensitive substring match against modified file paths",
+		},
 		limit: {
 			type: "number",
 			minimum: 1,
 			maximum: 100,
 		},
 	},
-	required: ["query"],
+	required: [],
 	additionalProperties: false,
 };
 

--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -94,6 +94,14 @@ export function generateTaskCreateSchema(config: BacklogConfig): JsonSchema {
 				},
 				description: "Documentation URLs or file paths for understanding this task",
 			},
+			modifiedFiles: {
+				type: "array",
+				items: {
+					type: "string",
+					maxLength: 500,
+				},
+				description: "Project-root-relative file paths modified by this task",
+			},
 			finalSummary: {
 				type: "string",
 				maxLength: 20000,
@@ -235,6 +243,14 @@ export function generateTaskEditSchema(config: BacklogConfig): JsonSchema {
 					maxLength: 500,
 				},
 				description: "Remove documentation URLs or file paths",
+			},
+			modifiedFiles: {
+				type: "array",
+				items: {
+					type: "string",
+					maxLength: 500,
+				},
+				description: "Set project-root-relative modified file paths (replaces existing)",
 			},
 			implementationNotes: {
 				type: "string",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -692,9 +692,17 @@ export class BacklogServer {
 			const statusParams = url.searchParams.getAll("status");
 			const priorityParamsRaw = url.searchParams.getAll("priority");
 			const labelParamsRaw = [...url.searchParams.getAll("label"), ...url.searchParams.getAll("labels")];
+			const modifiedFileParamsRaw = [
+				...url.searchParams.getAll("modifiedFile"),
+				...url.searchParams.getAll("modifiedFiles"),
+			];
 			const labelsCsv = url.searchParams.get("labels");
 			if (labelsCsv) {
 				labelParamsRaw.push(...labelsCsv.split(","));
+			}
+			const modifiedFilesCsv = url.searchParams.get("modifiedFiles");
+			if (modifiedFilesCsv) {
+				modifiedFileParamsRaw.push(...modifiedFilesCsv.split(","));
 			}
 
 			let limit: number | undefined;
@@ -724,6 +732,7 @@ export class BacklogServer {
 				status?: string | string[];
 				priority?: SearchPriorityFilter | SearchPriorityFilter[];
 				labels?: string | string[];
+				modifiedFiles?: string | string[];
 			} = {};
 
 			if (statusParams.length === 1) {
@@ -752,6 +761,16 @@ export class BacklogServer {
 				const normalizedLabels = labelParamsRaw.map((value) => value.trim()).filter((value) => value.length > 0);
 				if (normalizedLabels.length > 0) {
 					filters.labels = normalizedLabels.length === 1 ? normalizedLabels[0] : normalizedLabels;
+				}
+			}
+
+			if (modifiedFileParamsRaw.length > 0) {
+				const normalizedModifiedFiles = modifiedFileParamsRaw
+					.map((value) => value.trim())
+					.filter((value) => value.length > 0);
+				if (normalizedModifiedFiles.length > 0) {
+					filters.modifiedFiles =
+						normalizedModifiedFiles.length === 1 ? normalizedModifiedFiles[0] : normalizedModifiedFiles;
 				}
 			}
 
@@ -799,6 +818,7 @@ export class BacklogServer {
 				assignee: payload.assignee,
 				dependencies: payload.dependencies,
 				references: payload.references,
+				modifiedFiles: payload.modifiedFiles,
 				parentTaskId: payload.parentTaskId,
 				implementationPlan: payload.implementationPlan,
 				implementationNotes: payload.implementationNotes,
@@ -881,6 +901,10 @@ export class BacklogServer {
 
 		if ("references" in updates && Array.isArray(updates.references)) {
 			updateInput.references = updates.references;
+		}
+
+		if ("modifiedFiles" in updates && Array.isArray(updates.modifiedFiles)) {
+			updateInput.modifiedFiles = updates.modifiedFiles;
 		}
 
 		if ("implementationPlan" in updates && typeof updates.implementationPlan === "string") {

--- a/src/test/cli-refs-docs.test.ts
+++ b/src/test/cli-refs-docs.test.ts
@@ -111,6 +111,19 @@ describe("CLI --ref and --doc flags", () => {
 		});
 	});
 
+	describe("task create with --modified-file flag", () => {
+		it("creates task with multiple modified files", async () => {
+			const result =
+				await $`bun ${cliPath} task create "Feature" --modified-file src/api.ts --modified-file src/ui.ts --plain`
+					.cwd(TEST_DIR)
+					.quiet();
+
+			expect(result.exitCode).toBe(0);
+			const out = result.stdout.toString();
+			expect(out).toContain("Modified files: src/api.ts, src/ui.ts");
+		});
+	});
+
 	describe("task edit with --ref flag", () => {
 		it("sets references on existing task", async () => {
 			await $`bun ${cliPath} task create "Feature"`.cwd(TEST_DIR).quiet();
@@ -159,6 +172,20 @@ describe("CLI --ref and --doc flags", () => {
 		});
 	});
 
+	describe("task edit with --modified-file flag", () => {
+		it("sets modified files on existing task", async () => {
+			await $`bun ${cliPath} task create "Feature"`.cwd(TEST_DIR).quiet();
+
+			const result = await $`bun ${cliPath} task edit 1 --modified-file src/api.ts --modified-file src/ui.ts --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			expect(result.exitCode).toBe(0);
+			const out = result.stdout.toString();
+			expect(out).toContain("Modified files: src/api.ts, src/ui.ts");
+		});
+	});
+
 	describe("persistence in markdown files", () => {
 		it("persists references in task markdown file", async () => {
 			await $`bun ${cliPath} task create "Feature" --ref https://example.com --ref src/index.ts`.cwd(TEST_DIR).quiet();
@@ -176,6 +203,17 @@ describe("CLI --ref and --doc flags", () => {
 			expect(taskFile).toContain("documentation:");
 			expect(taskFile).toContain("https://docs.example.com");
 			expect(taskFile).toContain("spec.md");
+		});
+
+		it("persists modified files in task markdown file", async () => {
+			await $`bun ${cliPath} task create "Feature" --modified-file src/index.ts --modified-file src/ui.ts`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			const taskFile = await Bun.file(join(TEST_DIR, "backlog/tasks/task-1 - Feature.md")).text();
+			expect(taskFile).toContain("modified_files:");
+			expect(taskFile).toContain("src/index.ts");
+			expect(taskFile).toContain("src/ui.ts");
 		});
 	});
 });

--- a/src/test/cli-search-command.test.ts
+++ b/src/test/cli-search-command.test.ts
@@ -32,6 +32,7 @@ describe("CLI search command", () => {
 				dependencies: [],
 				rawContent: "Implements central search module",
 				description: "Implements central search module",
+				modifiedFiles: ["src/web/App.tsx"],
 			},
 			false,
 		);
@@ -48,6 +49,7 @@ describe("CLI search command", () => {
 				rawContent: "Follow-up work",
 				description: "Follow-up work",
 				priority: "high",
+				modifiedFiles: ["src/core/search-service.ts"],
 			},
 			false,
 		);
@@ -112,5 +114,21 @@ describe("CLI search command", () => {
 		const stdout = result.stdout.toString();
 		const taskMatches = stdout.match(/TASK-\d+ -/g) || [];
 		expect(taskMatches.length).toBeLessThanOrEqual(1);
+	});
+
+	it("finds tasks by modified file path", async () => {
+		const queryResult = await $`bun ${cliPath} search "src/web/App.tsx" --type task --plain`.cwd(TEST_DIR).quiet();
+		expect(queryResult.exitCode).toBe(0);
+		const queryStdout = queryResult.stdout.toString();
+		expect(queryStdout).toContain("TASK-1 - Central search integration");
+
+		const filterResult = await $`bun ${cliPath} search --modified-file core/search-service --plain`
+			.cwd(TEST_DIR)
+			.quiet();
+		expect(filterResult.exitCode).toBe(0);
+		const filterStdout = filterResult.stdout.toString();
+		expect(filterStdout).toContain("TASK-2 - High priority follow-up");
+		expect(filterStdout).not.toContain("TASK-1 - Central search integration");
+		expect(filterStdout).not.toContain("Documents:");
 	});
 });

--- a/src/test/markdown.test.ts
+++ b/src/test/markdown.test.ts
@@ -61,6 +61,7 @@ created_date: "2025-06-03"
 labels: ["bug", "frontend"]
 milestone: "v1.0"
 dependencies: ["task-0"]
+modified_files: ["src/auth/login.ts", "src/web/LoginForm.tsx"]
 parent_task_id: "task-parent"
 subtasks: ["task-1.1", "task-1.2"]
 ---
@@ -85,6 +86,7 @@ Fix the login bug that prevents users from signing in.
 			expect(task.labels).toEqual(["bug", "frontend"]);
 			expect(task.milestone).toBe("v1.0");
 			expect(task.dependencies).toEqual(["task-0"]);
+			expect(task.modifiedFiles).toEqual(["src/auth/login.ts", "src/web/LoginForm.tsx"]);
 			expect(task.parentTaskId).toBe("task-parent");
 			expect(task.subtasks).toEqual(["task-1.1", "task-1.2"]);
 			expect(task.acceptanceCriteriaItems?.map((item) => item.text)).toEqual([
@@ -381,6 +383,7 @@ describe("Markdown Serializer", () => {
 				labels: ["bug", "frontend"],
 				milestone: "v1.0",
 				dependencies: ["task-0"],
+				modifiedFiles: ["src/auth/login.ts", "src/web/LoginForm.tsx"],
 				description: "This is a test task description.",
 			};
 
@@ -393,6 +396,9 @@ describe("Markdown Serializer", () => {
 			expect(result).toContain("labels:");
 			expect(result).toContain("- bug");
 			expect(result).toContain("- frontend");
+			expect(result).toContain("modified_files:");
+			expect(result).toContain("- src/auth/login.ts");
+			expect(result).toContain("- src/web/LoginForm.tsx");
 			expect(result).toContain("## Description");
 			expect(result).toContain("This is a test task description.");
 		});

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -85,6 +85,35 @@ describe("MCP task tools (MVP)", () => {
 		expect(searchText).not.toContain("Implementation Plan:");
 	});
 
+	it("searches tasks with a separate modifiedFiles filter", async () => {
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Button search",
+					modifiedFiles: ["src/web/components/Button.tsx"],
+				},
+			},
+		});
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Server search",
+					modifiedFiles: ["src/server/index.ts"],
+				},
+			},
+		});
+
+		const searchResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_search", arguments: { modifiedFiles: ["components/Button"] } },
+		});
+
+		const searchText = getText(searchResult.content);
+		expect(searchText).toContain("TASK-1 - Button search");
+		expect(searchText).not.toContain("TASK-2 - Server search");
+	});
+
 	it("filters task_list by milestone using closest matching and combines with status", async () => {
 		await mcpServer.testInterface.callTool({
 			params: {

--- a/src/test/search-service.test.ts
+++ b/src/test/search-service.test.ts
@@ -32,6 +32,7 @@ describe("SearchService", () => {
 		dependencies: [],
 		rawContent: "## Description\nImplements Fuse based service",
 		priority: "high",
+		modifiedFiles: ["src/core/search-service.ts", "src/utils/task-search.ts"],
 	};
 
 	const baseDoc: Document = {
@@ -182,6 +183,34 @@ describe("SearchService", () => {
 			})
 			.filter(isTaskResult);
 		expect(anyFiltered.map((result) => result.task.id)).toStrictEqual(["TASK-2"]);
+	});
+
+	it("searches and filters tasks by modified file paths", async () => {
+		const uiTask: Task = {
+			...baseTask,
+			id: "task-2",
+			title: "UI search",
+			status: "To Do",
+			priority: "medium",
+			modifiedFiles: ["src/web/components/SearchBox.tsx"],
+			rawContent: "## Description\nUI work",
+		};
+
+		await filesystem.saveTask(baseTask);
+		await filesystem.saveTask(uiTask);
+
+		await search.ensureInitialized();
+
+		const queryMatches = search.search({ query: "components/SearchBox.tsx", types: ["task"] }).filter(isTaskResult);
+		expect(queryMatches.map((result) => result.task.id)).toStrictEqual(["TASK-2"]);
+
+		const filtered = search
+			.search({
+				types: ["task"],
+				filters: { modifiedFiles: ["core/search"] },
+			})
+			.filter(isTaskResult);
+		expect(filtered.map((result) => result.task.id)).toStrictEqual(["TASK-1"]);
 	});
 
 	it("refreshes the index when content changes", async () => {

--- a/src/test/server-search-endpoint.test.ts
+++ b/src/test/server-search-endpoint.test.ts
@@ -22,6 +22,7 @@ const baseTask: Task = {
 	dependencies: [],
 	description: "Alpha token appears here",
 	priority: "high",
+	modifiedFiles: ["src/server/index.ts", "src/core/search-service.ts"],
 };
 
 const baseDoc: Document = {
@@ -56,6 +57,7 @@ const dependentTask: Task = {
 	dependencies: [baseTask.id],
 	description: "Depends on task-0007 for completion",
 	priority: "medium",
+	modifiedFiles: ["src/ui/task-viewer-with-search.ts"],
 };
 
 describe("BacklogServer search endpoint", () => {
@@ -160,6 +162,20 @@ describe("BacklogServer search endpoint", () => {
 			.map((result) => result.task?.id)
 			.filter((id): id is string => Boolean(id));
 		expect(dependencyIds).toEqual(expect.arrayContaining([baseTask.id, dependentTask.id]));
+	});
+
+	it("searches and filters tasks by modified file path", async () => {
+		const queryMatches = await fetchJson<Array<{ type: string; task?: Task }>>(
+			"/api/search?type=task&query=src/server/index.ts",
+		);
+		const queryIds = queryMatches.filter((result) => result.type === "task").map((result) => result.task?.id);
+		expect(queryIds).toContain(baseTask.id);
+
+		const filterMatches = await fetchJson<Array<{ type: string; task?: Task }>>(
+			"/api/search?type=task&modifiedFile=task-viewer",
+		);
+		const filterIds = filterMatches.filter((result) => result.type === "task").map((result) => result.task?.id);
+		expect(filterIds).toEqual([dependentTask.id]);
 	});
 
 	it("returns newly created tasks immediately after POST", async () => {

--- a/src/test/task-search-label-filter.test.ts
+++ b/src/test/task-search-label-filter.test.ts
@@ -11,6 +11,7 @@ const tasks: Task[] = [
 		assignee: [],
 		createdDate: "2025-01-01",
 		dependencies: [],
+		modifiedFiles: ["src/server/auth.ts"],
 	},
 	{
 		id: "task-2",
@@ -20,6 +21,7 @@ const tasks: Task[] = [
 		assignee: [],
 		createdDate: "2025-01-01",
 		dependencies: [],
+		modifiedFiles: ["src/web/components/Button.tsx"],
 	},
 	{
 		id: "task-3",
@@ -29,6 +31,7 @@ const tasks: Task[] = [
 		assignee: [],
 		createdDate: "2025-01-01",
 		dependencies: [],
+		modifiedFiles: ["docs/search.md"],
 	},
 ];
 
@@ -43,5 +46,17 @@ describe("createTaskSearchIndex label filtering", () => {
 		const index = createTaskSearchIndex(tasks);
 		const results = index.search({ labels: ["ui", "docs"] });
 		expect(results.map((t) => t.id)).toEqual(["task-2", "task-3"]);
+	});
+
+	test("finds tasks by modified file query", () => {
+		const index = createTaskSearchIndex(tasks);
+		const results = index.search({ query: "components/Button.tsx" });
+		expect(results.map((t) => t.id)).toEqual(["task-2"]);
+	});
+
+	test("filters tasks by modified file substring", () => {
+		const index = createTaskSearchIndex(tasks);
+		const results = index.search({ modifiedFiles: ["button"] });
+		expect(results.map((t) => t.id)).toEqual(["task-2"]);
 	});
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export interface Task {
 	dependencies: string[];
 	references?: string[];
 	documentation?: string[];
+	modifiedFiles?: string[];
 	readonly rawContent?: string; // Raw markdown content without frontmatter (read-only: do not modify directly)
 	description?: string;
 	implementationPlan?: string;
@@ -97,6 +98,7 @@ export interface TaskCreateInput {
 	dependencies?: string[];
 	references?: string[];
 	documentation?: string[];
+	modifiedFiles?: string[];
 	parentTaskId?: string;
 	implementationPlan?: string;
 	implementationNotes?: string;
@@ -127,6 +129,7 @@ export interface TaskUpdateInput {
 	documentation?: string[];
 	addDocumentation?: string[];
 	removeDocumentation?: string[];
+	modifiedFiles?: string[];
 	implementationPlan?: string;
 	appendImplementationPlan?: string[];
 	clearImplementationPlan?: boolean;
@@ -205,6 +208,7 @@ export interface SearchFilters {
 	priority?: SearchPriorityFilter | SearchPriorityFilter[];
 	assignee?: string | string[];
 	labels?: string | string[];
+	modifiedFiles?: string | string[];
 }
 
 export interface SearchOptions {

--- a/src/types/task-edit-args.ts
+++ b/src/types/task-edit-args.ts
@@ -16,6 +16,7 @@ export interface TaskEditArgs {
 	documentation?: string[];
 	addDocumentation?: string[];
 	removeDocumentation?: string[];
+	modifiedFiles?: string[];
 	implementationPlan?: string;
 	planSet?: string;
 	planAppend?: string[];

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -1233,6 +1233,9 @@ function generateDetailContent(
 	if (task.dependencies?.length) {
 		metadata.push(`{bold}Dependencies:{/bold} ${task.dependencies.join(", ")}`);
 	}
+	if (task.modifiedFiles?.length) {
+		metadata.push(`{bold}Modified files:{/bold} ${task.modifiedFiles.join(", ")}`);
+	}
 
 	bodyContent.push(metadata.join("\n"));
 	bodyContent.push("");

--- a/src/utils/modified-files.ts
+++ b/src/utils/modified-files.ts
@@ -1,0 +1,25 @@
+export function normalizeModifiedFileFilters(value?: string | string[]): string[] | undefined {
+	if (!value) {
+		return undefined;
+	}
+
+	const values = Array.isArray(value) ? value : [value];
+	const normalized = values.map((item) => item.trim().toLowerCase()).filter((item) => item.length > 0);
+
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+export function matchesModifiedFileFilters(
+	modifiedFiles: readonly string[] | undefined,
+	filters: readonly string[] | undefined,
+): boolean {
+	if (!filters || filters.length === 0) {
+		return true;
+	}
+	if (!modifiedFiles || modifiedFiles.length === 0) {
+		return false;
+	}
+
+	const filePaths = modifiedFiles.map((file) => file.trim().toLowerCase()).filter((file) => file.length > 0);
+	return filters.some((filter) => filePaths.some((file) => file.includes(filter)));
+}

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -110,6 +110,11 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		updateInput.removeDocumentation = removeDocumentation;
 	}
 
+	const modifiedFiles = sanitizeStringArray(args.modifiedFiles);
+	if (modifiedFiles) {
+		updateInput.modifiedFiles = modifiedFiles;
+	}
+
 	const planSet = args.planSet ?? args.implementationPlan;
 	if (typeof planSet === "string") {
 		updateInput.implementationPlan = planSet;

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -5,18 +5,21 @@
 
 import Fuse from "fuse.js";
 import type { Task } from "../types/index.ts";
+import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "./modified-files.ts";
 
 export interface TaskSearchOptions {
 	query?: string;
 	status?: string;
 	priority?: "high" | "medium" | "low";
 	labels?: string[];
+	modifiedFiles?: string[];
 }
 
 export interface SharedTaskFilterOptions {
 	query?: string;
 	priority?: "high" | "medium" | "low";
 	labels?: string[];
+	modifiedFiles?: string[];
 	milestone?: string;
 	resolveMilestoneLabel?: (milestone: string) => string;
 }
@@ -92,6 +95,7 @@ interface SearchableTask {
 	statusLower: string;
 	priorityLower?: string;
 	labelsLower: string[];
+	modifiedFiles: string[];
 }
 
 function buildSearchableTask(task: Task): SearchableTask {
@@ -107,6 +111,7 @@ function buildSearchableTask(task: Task): SearchableTask {
 	if (task.implementationNotes) bodyParts.push(task.implementationNotes);
 	if (task.labels?.length) bodyParts.push(task.labels.join(" "));
 	if (task.assignee?.length) bodyParts.push(task.assignee.join(" "));
+	if (task.modifiedFiles?.length) bodyParts.push(task.modifiedFiles.join(" "));
 
 	return {
 		task,
@@ -118,6 +123,7 @@ function buildSearchableTask(task: Task): SearchableTask {
 		statusLower: (task.status || "").toLowerCase(),
 		priorityLower: task.priority?.toLowerCase(),
 		labelsLower: (task.labels || []).map((label) => label.toLowerCase()),
+		modifiedFiles: task.modifiedFiles ?? [],
 	};
 }
 
@@ -138,6 +144,7 @@ export function createTaskSearchIndex(tasks: Task[]): TaskSearchIndex {
 			{ name: "id", weight: 0.2 },
 			{ name: "idVariants", weight: 0.1 },
 			{ name: "dependencyIds", weight: 0.05 },
+			{ name: "modifiedFiles", weight: 0.15 },
 		],
 	});
 
@@ -178,6 +185,11 @@ export function createTaskSearchIndex(tasks: Task[]): TaskSearchIndex {
 				});
 			}
 
+			const modifiedFiles = normalizeModifiedFileFilters(options.modifiedFiles);
+			if (modifiedFiles) {
+				results = results.filter((task) => matchesModifiedFileFilters(task.modifiedFiles, modifiedFiles));
+			}
+
 			return results.map((r) => r.task);
 		},
 	};
@@ -205,7 +217,11 @@ function applyMilestoneFilter(
 export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, index?: TaskSearchIndex): Task[] {
 	const query = options.query?.trim() ?? "";
 	const hasBaseFilters = Boolean(
-		query || options.status || options.priority || (options.labels && options.labels.length > 0),
+		query ||
+			options.status ||
+			options.priority ||
+			(options.labels && options.labels.length > 0) ||
+			(options.modifiedFiles && options.modifiedFiles.length > 0),
 	);
 
 	let results = hasBaseFilters
@@ -214,6 +230,7 @@ export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, inde
 				status: options.status,
 				priority: options.priority,
 				labels: options.labels,
+				modifiedFiles: options.modifiedFiles,
 			})
 		: [...tasks];
 
@@ -235,6 +252,7 @@ export function applySharedTaskFilters(
 			query: options.query,
 			priority: options.priority,
 			labels: options.labels,
+			modifiedFiles: options.modifiedFiles,
 			milestone: options.milestone,
 			resolveMilestoneLabel: options.resolveMilestoneLabel,
 		},

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -169,6 +169,7 @@ export class ApiClient {
 			status?: string | string[];
 			priority?: SearchPriorityFilter | SearchPriorityFilter[];
 			labels?: string[];
+			modifiedFiles?: string[];
 			limit?: number;
 		} = {},
 	): Promise<SearchResult[]> {
@@ -197,6 +198,13 @@ export class ApiClient {
 			for (const label of options.labels) {
 				if (label && label.trim().length > 0) {
 					params.append("label", label.trim());
+				}
+			}
+		}
+		if (options.modifiedFiles) {
+			for (const file of options.modifiedFiles) {
+				if (file && file.trim().length > 0) {
+					params.append("modifiedFile", file.trim());
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Adds a dedicated `modifiedFiles` task field, persisted as `modified_files` frontmatter, so tasks can record project-root-relative file paths they touched.

Wires the field through task parsing/serialization, Core create/edit flows, CLI create/edit/search, server search, MCP create/edit/search schemas, shared search indexes, plain text output, and TUI detail display. MCP `task_search` now supports a separate `modifiedFiles` filter so file-path filtering does not have to share the generic query string.

Updates shipped agent/MCP guidance and README notes for setting and searching modified files.

## Validation

- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check README.md src/cli.ts src/core/backlog.ts src/core/search-service.ts src/formatters/task-plain-text.ts src/guidelines/agent-guidelines.md src/guidelines/mcp/overview-tools.md src/guidelines/mcp/overview.md src/markdown/parser.ts src/markdown/serializer.ts src/mcp/tools/tasks/handlers.ts src/mcp/tools/tasks/index.ts src/mcp/tools/tasks/schemas.ts src/mcp/utils/schema-generators.ts src/server/index.ts src/test/cli-refs-docs.test.ts src/test/cli-search-command.test.ts src/test/markdown.test.ts src/test/mcp-tasks.test.ts src/test/search-service.test.ts src/test/server-search-endpoint.test.ts src/test/task-search-label-filter.test.ts src/types/index.ts src/types/task-edit-args.ts src/ui/task-viewer-with-search.ts src/utils/modified-files.ts src/utils/task-edit-builder.ts src/utils/task-search.ts src/web/lib/api.ts`

## Notes

`bun run check .` is still blocked by an unrelated pre-existing `package.json` formatting issue; the staged source/docs files pass Biome.