### PR TITLE
BACK-434 - Use request-scoped MCP roots discovery

### DIFF
--- a/backlog/tasks/back-434 - Use-request-scoped-MCP-roots-discovery.md
+++ b/backlog/tasks/back-434 - Use-request-scoped-MCP-roots-discovery.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-434
 title: Use request-scoped MCP roots discovery
-status: In Progress
+status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-04-25 16:49'
+updated_date: '2026-04-25 16:54'
 labels: []
 dependencies: []
 references:
@@ -31,12 +32,12 @@ This task turns that adaptation into a focused PR: preserve explicit cwd behavio
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Fallback/init-required MCP mode can recover a Backlog project from client-provided file roots.
-- [ ] #2 Explicit --cwd, BACKLOG_CWD, and valid process.cwd() resolution keep precedence and do not perform roots discovery on the normal path.
-- [ ] #3 Root list changes from the client are handled so later requests use updated roots.
-- [ ] #4 Unsupported, invalid, or inaccessible roots leave the server in safe fallback mode without crashing.
-- [ ] #5 Tests cover fallback recovery, cache reuse, root-change invalidation, file-root normalization, and normal-mode behavior.
-- [ ] #6 The SDK/package changes needed for the protocol support are included without unrelated dependency or web UI changes.
+- [x] #1 Fallback/init-required MCP mode can recover a Backlog project from client-provided file roots.
+- [x] #2 Explicit --cwd, BACKLOG_CWD, and valid process.cwd() resolution keep precedence and do not perform roots discovery on the normal path.
+- [x] #3 Root list changes from the client are handled so later requests use updated roots.
+- [x] #4 Unsupported, invalid, or inaccessible roots leave the server in safe fallback mode without crashing.
+- [x] #5 Tests cover fallback recovery, cache reuse, root-change invalidation, file-root normalization, and normal-mode behavior.
+- [x] #6 The SDK/package changes needed for the protocol support are included without unrelated dependency or web UI changes.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -49,9 +50,36 @@ This task turns that adaptation into a focused PR: preserve explicit cwd behavio
 5. Run targeted tests plus typecheck/check as practical, then open a PR titled with the task ID.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Researched MCP roots against the 2025-11-25 spec, draft schema notes, and TypeScript SDK v1.x behavior. The implementation uses request-scoped roots/list via RequestHandlerExtra.sendRequest, treats roots/list_changed as cache invalidation, and keeps explicit cwd/env/process cwd resolution ahead of roots recovery. Non-file roots are rejected by the SDK result schema; malformed or inaccessible file roots are skipped by Backlog before later valid roots are considered.
+
+Validation: focused MCP roots/fallback tests passed, typecheck passed, Biome check passed. A full bun test run completed with one transient timeout in server-search-endpoint; rerunning that exact test and the whole server-search-endpoint file passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Summary:
+- Reworked fallback-mode MCP roots discovery to run from request-scoped handlers using RequestHandlerExtra.sendRequest({ method: "roots/list" }, ListRootsResultSchema), aligning Backlog with current roots protocol guidance.
+- Replaced initialization-time readiness gating with cached roots resolution that is invalidated by notifications/roots/list_changed and refreshed on the next request.
+- Normalized file roots, skipped malformed/inaccessible file roots, and preserved fallback mode when roots are unsupported or do not contain a Backlog project.
+- Bumped @modelcontextprotocol/sdk to 1.29.0 without pulling in the unrelated Mermaid/web UI dependency refresh.
+
+Validation:
+- bun test src/test/mcp-roots-discovery.test.ts src/test/mcp-fallback.test.ts
+- bunx tsc --noEmit
+- bun run check .
+- bun test src/test/server-search-endpoint.test.ts -t "returns newly created tasks immediately after POST"
+- bun test src/test/server-search-endpoint.test.ts
+
+Note: a full bun test pass was attempted and hit a transient timeout in one server-search-endpoint test; the exact test and file passed immediately when rerun.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@biomejs/biome": "2.3.11",
         "@clack/core": "1.0.1",
         "@clack/prompts": "1.0.1",
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "@tailwindcss/cli": "4.1.18",
         "@types/bun": "1.3.6",
         "@types/jsdom": "27.0.0",
@@ -189,7 +189,7 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@0.6.3", "", { "dependencies": { "langium": "3.3.1" } }, "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,99 +1,99 @@
 {
-  "name": "backlog.md",
-  "version": "1.44.0",
-  "type": "module",
-  "module": "src/cli.ts",
-  "files": [
-    "scripts/*.cjs",
-    "README.md",
-    "LICENSE"
-  ],
-  "bin": {
-    "backlog": "scripts/cli.cjs"
-  },
-  "optionalDependencies": {
-    "backlog.md-darwin-arm64": "*",
-    "backlog.md-darwin-x64": "*",
-    "backlog.md-linux-arm64": "*",
-    "backlog.md-linux-x64": "*",
-    "backlog.md-windows-x64": "*"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.11",
-    "@clack/core": "1.0.1",
-    "@clack/prompts": "1.0.1",
-    "@modelcontextprotocol/sdk": "1.27.1",
-    "@tailwindcss/cli": "4.1.18",
-    "@types/bun": "1.3.6",
-    "@types/jsdom": "27.0.0",
-    "@types/react": "19.2.8",
-    "@types/react-dom": "19.2.3",
-    "@types/react-router-dom": "5.3.3",
-    "@uiw/react-markdown-preview": "5.1.5",
-    "@uiw/react-md-editor": "4.0.11",
-    "commander": "14.0.2",
-    "fuse.js": "7.1.0",
-    "gray-matter": "4.0.3",
-    "husky": "9.1.7",
-    "install": "0.13.0",
-    "jsdom": "27.4.0",
-    "lint-staged": "16.2.7",
-    "mermaid": "11.12.2",
-    "neo-neo-bblessed": "1.0.9",
-    "picocolors": "1.1.1",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
-    "react-router-dom": "7.12.0",
-    "react-tooltip": "5.30.0",
-    "tailwindcss": "4.1.18",
-    "proper-lockfile": "4.1.2"
-  },
-  "scripts": {
-    "test": "bun test",
-    "format": "biome format --write .",
-    "lint": "biome lint --write .",
-    "check": "biome check .",
-    "check:types": "bunx tsc --noEmit",
-    "prepare": "husky",
-    "build:css": "bun ./node_modules/@tailwindcss/cli/dist/index.mjs -i src/web/styles/source.css -o src/web/styles/style.css --minify",
-    "build": "bun run build:css && VER=$(bun -e 'console.log(require(\"./package.json\").version)') && bun build --production --compile --minify --define __EMBEDDED_VERSION__=\"\\\"$VER\\\"\" --outfile=dist/backlog src/cli.ts",
-    "cli": "bun run build:css && bun src/cli.ts",
-    "mcp": "bun src/cli.ts mcp start",
-    "update-nix": "sh scripts/update-nix.sh",
-    "postinstall": "sh -c 'command -v bun2nix >/dev/null 2>&1 && bun2nix -o bun.nix || (command -v nix >/dev/null 2>&1 && nix --extra-experimental-features \"nix-command flakes\" run github:baileyluTCD/bun2nix/85d692d68a5345d868d3bb1158b953d2996d70f7 -- -o bun.nix || true)'"
-  },
-  "lint-staged": {
-    "package.json": [
-      "biome check --write --files-ignore-unknown=true"
-    ],
-    "*.json": [
-      "biome check --write --files-ignore-unknown=true"
-    ],
-    "src/**/*.{ts,js}": [
-      "biome check --write --files-ignore-unknown=true"
-    ]
-  },
-  "author": "Alex Gavrilescu (https://github.com/MrLesk)",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/MrLesk/Backlog.md.git"
-  },
-  "bugs": {
-    "url": "https://github.com/MrLesk/Backlog.md/issues"
-  },
-  "homepage": "https://backlog.md",
-  "keywords": [
-    "cli",
-    "markdown",
-    "kanban",
-    "task",
-    "project-management",
-    "backlog",
-    "agents"
-  ],
-  "license": "MIT",
-  "trustedDependencies": [
-    "@biomejs/biome",
-    "node-pty"
-  ]
+	"name": "backlog.md",
+	"version": "1.44.0",
+	"type": "module",
+	"module": "src/cli.ts",
+	"files": [
+		"scripts/*.cjs",
+		"README.md",
+		"LICENSE"
+	],
+	"bin": {
+		"backlog": "scripts/cli.cjs"
+	},
+	"optionalDependencies": {
+		"backlog.md-darwin-arm64": "*",
+		"backlog.md-darwin-x64": "*",
+		"backlog.md-linux-arm64": "*",
+		"backlog.md-linux-x64": "*",
+		"backlog.md-windows-x64": "*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.11",
+		"@clack/core": "1.0.1",
+		"@clack/prompts": "1.0.1",
+		"@modelcontextprotocol/sdk": "1.29.0",
+		"@tailwindcss/cli": "4.1.18",
+		"@types/bun": "1.3.6",
+		"@types/jsdom": "27.0.0",
+		"@types/react": "19.2.8",
+		"@types/react-dom": "19.2.3",
+		"@types/react-router-dom": "5.3.3",
+		"@uiw/react-markdown-preview": "5.1.5",
+		"@uiw/react-md-editor": "4.0.11",
+		"commander": "14.0.2",
+		"fuse.js": "7.1.0",
+		"gray-matter": "4.0.3",
+		"husky": "9.1.7",
+		"install": "0.13.0",
+		"jsdom": "27.4.0",
+		"lint-staged": "16.2.7",
+		"mermaid": "11.12.2",
+		"neo-neo-bblessed": "1.0.9",
+		"picocolors": "1.1.1",
+		"proper-lockfile": "4.1.2",
+		"react": "19.2.3",
+		"react-dom": "19.2.3",
+		"react-router-dom": "7.12.0",
+		"react-tooltip": "5.30.0",
+		"tailwindcss": "4.1.18"
+	},
+	"scripts": {
+		"test": "bun test",
+		"format": "biome format --write .",
+		"lint": "biome lint --write .",
+		"check": "biome check .",
+		"check:types": "bunx tsc --noEmit",
+		"prepare": "husky",
+		"build:css": "bun ./node_modules/@tailwindcss/cli/dist/index.mjs -i src/web/styles/source.css -o src/web/styles/style.css --minify",
+		"build": "bun run build:css && VER=$(bun -e 'console.log(require(\"./package.json\").version)') && bun build --production --compile --minify --define __EMBEDDED_VERSION__=\"\\\"$VER\\\"\" --outfile=dist/backlog src/cli.ts",
+		"cli": "bun run build:css && bun src/cli.ts",
+		"mcp": "bun src/cli.ts mcp start",
+		"update-nix": "sh scripts/update-nix.sh",
+		"postinstall": "sh -c 'command -v bun2nix >/dev/null 2>&1 && bun2nix -o bun.nix || (command -v nix >/dev/null 2>&1 && nix --extra-experimental-features \"nix-command flakes\" run github:baileyluTCD/bun2nix/85d692d68a5345d868d3bb1158b953d2996d70f7 -- -o bun.nix || true)'"
+	},
+	"lint-staged": {
+		"package.json": [
+			"biome check --write --files-ignore-unknown=true"
+		],
+		"*.json": [
+			"biome check --write --files-ignore-unknown=true"
+		],
+		"src/**/*.{ts,js}": [
+			"biome check --write --files-ignore-unknown=true"
+		]
+	},
+	"author": "Alex Gavrilescu (https://github.com/MrLesk)",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/MrLesk/Backlog.md.git"
+	},
+	"bugs": {
+		"url": "https://github.com/MrLesk/Backlog.md/issues"
+	},
+	"homepage": "https://backlog.md",
+	"keywords": [
+		"cli",
+		"markdown",
+		"kanban",
+		"task",
+		"project-management",
+		"backlog",
+		"agents"
+	],
+	"license": "MIT",
+	"trustedDependencies": [
+		"@biomejs/biome",
+		"node-pty"
+	]
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,6 +1,9 @@
+import { stat } from "node:fs/promises";
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import {
 	CallToolRequestSchema,
 	ErrorCode,
@@ -8,10 +11,13 @@ import {
 	ListPromptsRequestSchema,
 	ListResourcesRequestSchema,
 	ListResourceTemplatesRequestSchema,
+	ListRootsResultSchema,
 	ListToolsRequestSchema,
 	McpError,
 	ReadResourceRequestSchema,
 	RootsListChangedNotificationSchema,
+	type ServerNotification,
+	type ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Core } from "../core/backlog.ts";
 import { getPackageName } from "../utils/app-info.ts";
@@ -53,13 +59,12 @@ type ServerInitOptions = {
 	debug?: boolean;
 };
 
+type ServerRequestExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
 export class McpServer extends Core {
 	private readonly server: Server;
 	private transport?: StdioServerTransport;
 	private stopping = false;
-
-	/** Resolved once roots discovery completes (or immediately in normal mode). */
-	private _ready: Promise<void> = Promise.resolve();
 
 	/** Debug log lines collected during roots discovery (exposed to init-required resource). */
 	public readonly debugLog: string[] = [];
@@ -67,6 +72,8 @@ export class McpServer extends Core {
 	/** Whether roots discovery is enabled (and options for re-runs on roots change). */
 	private rootsDiscoveryEnabled = false;
 	private rootsDiscoveryOptions: { debug?: boolean } = {};
+	private rootsResolutionDirty = false;
+	private rootsResolutionInFlight?: Promise<void>;
 
 	/** The projectRoot passed to createMcpServer, used to revert on downgrade. */
 	private readonly initialProjectRoot: string;
@@ -104,25 +111,15 @@ export class McpServer extends Core {
 	/**
 	 * Enable roots-based project discovery for fallback mode.
 	 *
-	 * After the client completes initialization, the server queries MCP roots
-	 * and looks for a valid backlog project. If found, it reinitializes the
-	 * Core, registers the full toolset, and notifies the client.
-	 *
-	 * A readiness gate ensures all handlers wait until discovery completes
-	 * so clients see the correct tool/resource list from the first request.
+	 * The first request-scoped handler invocation can query MCP roots to look
+	 * for a valid backlog project. If found, the server reinitializes the Core,
+	 * registers the full toolset, and notifies the client. Subsequent requests
+	 * reuse the cached resolution until the client reports roots changes.
 	 */
 	enableRootsDiscovery(options?: { debug?: boolean }): void {
 		this.rootsDiscoveryEnabled = true;
 		this.rootsDiscoveryOptions = options ?? {};
-
-		let resolveReady!: () => void;
-		this._ready = new Promise<void>((r) => {
-			resolveReady = r;
-		});
-
-		this.server.oninitialized = () => {
-			this.resolveFromRoots(options).finally(resolveReady);
-		};
+		this.rootsResolutionDirty = true;
 	}
 
 	private log(message: string, options?: { debug?: boolean }): void {
@@ -134,7 +131,26 @@ export class McpServer extends Core {
 		this.server.sendLoggingMessage({ level: "info", logger: "backlog", data: message }).catch(() => {});
 	}
 
-	private async resolveFromRoots(options?: { debug?: boolean }): Promise<void> {
+	private async ensureRootsResolved(extra?: ServerRequestExtra): Promise<void> {
+		if (!this.rootsDiscoveryEnabled || !this.rootsResolutionDirty || !extra) {
+			return;
+		}
+
+		if (!this.rootsResolutionInFlight) {
+			const resolutionPromise = this.resolveFromRoots(extra, this.rootsDiscoveryOptions).finally(() => {
+				if (this.rootsResolutionInFlight === resolutionPromise) {
+					this.rootsResolutionInFlight = undefined;
+				}
+			});
+			this.rootsResolutionInFlight = resolutionPromise;
+		}
+
+		await this.rootsResolutionInFlight;
+	}
+
+	private async resolveFromRoots(extra: ServerRequestExtra, options?: { debug?: boolean }): Promise<void> {
+		this.rootsResolutionDirty = false;
+
 		const caps = this.server.getClientCapabilities();
 		if (!caps?.roots) {
 			this.log("Client does not support MCP roots capability, staying in fallback mode.", options);
@@ -142,15 +158,14 @@ export class McpServer extends Core {
 		}
 
 		try {
-			const { roots } = await this.server.listRoots();
+			const { roots } = await extra.sendRequest({ method: "roots/list" }, ListRootsResultSchema);
 			this.log(`Received ${roots.length} root(s) from client.`, options);
 
-			const checkedPaths: string[] = [];
+			const checkedPaths = new Set<string>();
 			for (const root of roots) {
-				if (!root.uri.startsWith("file://")) continue;
-
-				const rootPath = fileURLToPath(root.uri);
-				checkedPaths.push(rootPath);
+				const rootPath = await this.resolveRootSearchPath(root.uri);
+				if (!rootPath) continue;
+				checkedPaths.add(rootPath);
 
 				// Only check the root itself — don't walk up the tree, as that
 				// could match an unrelated ancestor project outside the workspace.
@@ -166,14 +181,38 @@ export class McpServer extends Core {
 				await this.downgradeToFallback(options);
 			}
 
-			this.log(
-				`No valid backlog project found in MCP roots: ${checkedPaths.map((p) => `\`${p}\``).join(", ")}`,
-				options,
-			);
+			const checkedRoots =
+				checkedPaths.size > 0
+					? Array.from(checkedPaths)
+							.map((path) => `\`${path}\``)
+							.join(", ")
+					: "no usable file roots";
+			this.log(`No valid backlog project found in MCP roots: ${checkedRoots}`, options);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			this.log(`Roots discovery failed: ${message}`, options);
 		}
+	}
+
+	private async resolveRootSearchPath(rootUri: string): Promise<string | null> {
+		if (!rootUri.startsWith("file://")) {
+			return null;
+		}
+
+		try {
+			const rootPath = fileURLToPath(rootUri);
+			const rootStat = await stat(rootPath);
+			if (rootStat.isDirectory()) {
+				return rootPath;
+			}
+			if (rootStat.isFile()) {
+				return dirname(rootPath);
+			}
+		} catch {
+			return null;
+		}
+
+		return null;
 	}
 
 	/**
@@ -181,11 +220,18 @@ export class McpServer extends Core {
 	 * toolset, replacing fallback-mode registrations.
 	 */
 	private async upgradeToProject(projectRoot: string, options?: { debug?: boolean }): Promise<boolean> {
+		if (this.upgraded && this.filesystem.rootDir === projectRoot) {
+			this.log(`MCP roots still resolve to current project: ${projectRoot}`, options);
+			return true;
+		}
+
+		const previousProjectRoot = this.filesystem.rootDir;
 		this.reinitializeProjectRoot(projectRoot);
 		await this.ensureConfigLoaded();
 		const config = await this.filesystem.loadConfig();
 
 		if (!config) {
+			this.reinitializeProjectRoot(previousProjectRoot);
 			this.log(`Skipping root ${projectRoot} (no valid config).`, options);
 			return false;
 		}
@@ -234,18 +280,22 @@ export class McpServer extends Core {
 	}
 
 	private setupHandlers(): void {
-		this.server.setRequestHandler(ListToolsRequestSchema, async () => this.listTools());
-		this.server.setRequestHandler(CallToolRequestSchema, async (request) => this.callTool(request));
-		this.server.setRequestHandler(ListResourcesRequestSchema, async () => this.listResources());
-		this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => this.listResourceTemplates());
-		this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => this.readResource(request));
-		this.server.setRequestHandler(ListPromptsRequestSchema, async () => this.listPrompts());
-		this.server.setRequestHandler(GetPromptRequestSchema, async (request) => this.getPrompt(request));
+		this.server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => this.listTools(extra));
+		this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => this.callTool(request, extra));
+		this.server.setRequestHandler(ListResourcesRequestSchema, async (_request, extra) => this.listResources(extra));
+		this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async (_request, extra) =>
+			this.listResourceTemplates(extra),
+		);
+		this.server.setRequestHandler(ReadResourceRequestSchema, async (request, extra) =>
+			this.readResource(request, extra),
+		);
+		this.server.setRequestHandler(ListPromptsRequestSchema, async (_request, extra) => this.listPrompts(extra));
+		this.server.setRequestHandler(GetPromptRequestSchema, async (request, extra) => this.getPrompt(request, extra));
 
-		// Re-run roots discovery when client workspace changes
-		this.server.setNotificationHandler(RootsListChangedNotificationSchema, async () => {
+		// Mark cached roots resolution dirty when client workspace changes.
+		this.server.setNotificationHandler(RootsListChangedNotificationSchema, () => {
 			if (this.rootsDiscoveryEnabled) {
-				await this.resolveFromRoots(this.rootsDiscoveryOptions);
+				this.rootsResolutionDirty = true;
 			}
 		});
 	}
@@ -317,8 +367,8 @@ export class McpServer extends Core {
 
 	// -- Internal handlers --------------------------------------------------
 
-	protected async listTools(): Promise<ListToolsResult> {
-		await this._ready;
+	protected async listTools(extra?: ServerRequestExtra): Promise<ListToolsResult> {
+		await this.ensureRootsResolved(extra);
 		return {
 			tools: Array.from(this.tools.values()).map((tool) => ({
 				name: tool.name,
@@ -332,10 +382,13 @@ export class McpServer extends Core {
 		};
 	}
 
-	protected async callTool(request: {
-		params: { name: string; arguments?: Record<string, unknown> };
-	}): Promise<CallToolResult> {
-		await this._ready;
+	protected async callTool(
+		request: {
+			params: { name: string; arguments?: Record<string, unknown> };
+		},
+		extra?: ServerRequestExtra,
+	): Promise<CallToolResult> {
+		await this.ensureRootsResolved(extra);
 		const { name, arguments: args = {} } = request.params;
 		const tool = this.tools.get(name);
 
@@ -346,8 +399,8 @@ export class McpServer extends Core {
 		return await tool.handler(args);
 	}
 
-	protected async listResources(): Promise<ListResourcesResult> {
-		await this._ready;
+	protected async listResources(extra?: ServerRequestExtra): Promise<ListResourcesResult> {
+		await this.ensureRootsResolved(extra);
 		return {
 			resources: Array.from(this.resources.values()).map((resource) => ({
 				uri: resource.uri,
@@ -358,15 +411,18 @@ export class McpServer extends Core {
 		};
 	}
 
-	protected async listResourceTemplates(): Promise<ListResourceTemplatesResult> {
-		await this._ready;
+	protected async listResourceTemplates(extra?: ServerRequestExtra): Promise<ListResourceTemplatesResult> {
+		await this.ensureRootsResolved(extra);
 		return {
 			resourceTemplates: [],
 		};
 	}
 
-	protected async readResource(request: { params: { uri: string } }): Promise<ReadResourceResult> {
-		await this._ready;
+	protected async readResource(
+		request: { params: { uri: string } },
+		extra?: ServerRequestExtra,
+	): Promise<ReadResourceResult> {
+		await this.ensureRootsResolved(extra);
 		const { uri } = request.params;
 
 		// Exact match first
@@ -385,8 +441,8 @@ export class McpServer extends Core {
 		return await resource.handler(uri);
 	}
 
-	protected async listPrompts(): Promise<ListPromptsResult> {
-		await this._ready;
+	protected async listPrompts(extra?: ServerRequestExtra): Promise<ListPromptsResult> {
+		await this.ensureRootsResolved(extra);
 		return {
 			prompts: Array.from(this.prompts.values()).map((prompt) => ({
 				name: prompt.name,
@@ -396,10 +452,13 @@ export class McpServer extends Core {
 		};
 	}
 
-	protected async getPrompt(request: {
-		params: { name: string; arguments?: Record<string, unknown> };
-	}): Promise<GetPromptResult> {
-		await this._ready;
+	protected async getPrompt(
+		request: {
+			params: { name: string; arguments?: Record<string, unknown> };
+		},
+		extra?: ServerRequestExtra,
+	): Promise<GetPromptResult> {
+		await this.ensureRootsResolved(extra);
 		const { name, arguments: args = {} } = request.params;
 		const prompt = this.prompts.get(name);
 
@@ -431,8 +490,8 @@ export class McpServer extends Core {
  * Factory that bootstraps a fully configured MCP server instance.
  *
  * If backlog is not initialized in the project directory, the server will start
- * in fallback mode with roots discovery enabled — after the client completes
- * initialization, the server queries MCP roots to find the correct project.
+ * in fallback mode with roots discovery enabled — the first request-scoped MCP
+ * handler can then query client roots to find the correct project.
  */
 export async function createMcpServer(projectRoot: string, options: ServerInitOptions = {}): Promise<McpServer> {
 	// We need to check config first to determine which instructions to use

--- a/src/test/mcp-fallback.test.ts
+++ b/src/test/mcp-fallback.test.ts
@@ -35,9 +35,6 @@ describe("MCP Server Fallback Mode", () => {
 	test("should provide backlog://init-required resource in fallback mode", async () => {
 		const server = await createMcpServer(tempDir, { debug: false });
 
-		// Simulate client init to unblock the readiness gate (roots discovery)
-		server.getServer().oninitialized?.();
-
 		const resources = await server.testInterface.listResources();
 
 		expect(resources.resources).toHaveLength(1);
@@ -47,9 +44,6 @@ describe("MCP Server Fallback Mode", () => {
 
 	test("should be able to read backlog://init-required resource", async () => {
 		const server = await createMcpServer(tempDir, { debug: false });
-
-		// Simulate client init to unblock the readiness gate
-		server.getServer().oninitialized?.();
 
 		const result = await server.testInterface.readResource({
 			params: { uri: "backlog://init-required" },
@@ -62,9 +56,6 @@ describe("MCP Server Fallback Mode", () => {
 
 	test("should not provide task tools in fallback mode", async () => {
 		const server = await createMcpServer(tempDir, { debug: false });
-
-		// Simulate client init to unblock the readiness gate
-		server.getServer().oninitialized?.();
 
 		const tools = await server.testInterface.listTools();
 

--- a/src/test/mcp-roots-discovery.test.ts
+++ b/src/test/mcp-roots-discovery.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { pathToFileURL } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ListRootsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { $ } from "bun";
 import { registerWorkflowResources } from "../mcp/resources/workflow/index.ts";
 import { createMcpServer, McpServer } from "../mcp/server.ts";
@@ -10,56 +14,91 @@ import { registerWorkflowTools } from "../mcp/tools/workflow/index.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
 
 let TEST_DIR: string;
-let PROJECT_DIR: string;
 
-/**
- * Set up two directories: one without backlog (simulates the cwd the
- * harness launches from), and one with a fully initialized project
- * (simulates the root that MCP roots would point to).
- */
-async function setupDirs(): Promise<{ uninitializedDir: string; projectRoot: string }> {
+type ConnectedRootsClient = {
+	client: Client;
+	getRootsRequestCount: () => number;
+};
+
+async function createProject(projectRoot: string, projectName: string): Promise<void> {
+	await $`mkdir -p ${projectRoot}`.quiet();
+
+	const bootstrap = new McpServer(projectRoot, "Bootstrap");
+	await bootstrap.filesystem.ensureBacklogStructure();
+	await $`git init -b main`.cwd(projectRoot).quiet();
+	await $`git config user.name "Test User"`.cwd(projectRoot).quiet();
+	await $`git config user.email test@example.com`.cwd(projectRoot).quiet();
+	await initializeTestProject(bootstrap, projectName);
+	await bootstrap.stop();
+}
+
+async function setupDirs(): Promise<{
+	uninitializedDir: string;
+	projectRoot: string;
+	secondProjectRoot: string;
+}> {
 	TEST_DIR = createUniqueTestDir("mcp-roots");
 
-	// Directory without a backlog project
 	const uninitializedDir = `${TEST_DIR}/no-backlog`;
+	const projectRoot = `${TEST_DIR}/real-project`;
+	const secondProjectRoot = `${TEST_DIR}/second-project`;
+
 	await $`mkdir -p ${uninitializedDir}`.quiet();
+	await createProject(projectRoot, "Roots Test Project");
+	await createProject(secondProjectRoot, "Roots Test Project 2");
 
-	// Directory with a valid backlog setup
-	PROJECT_DIR = `${TEST_DIR}/real-project`;
-	await $`mkdir -p ${PROJECT_DIR}`.quiet();
+	return { uninitializedDir, projectRoot, secondProjectRoot };
+}
 
-	const bootstrap = new McpServer(PROJECT_DIR, "Bootstrap");
-	await bootstrap.filesystem.ensureBacklogStructure();
-	await $`git init -b main`.cwd(PROJECT_DIR).quiet();
-	await $`git config user.name "Test User"`.cwd(PROJECT_DIR).quiet();
-	await $`git config user.email test@example.com`.cwd(PROJECT_DIR).quiet();
-	await initializeTestProject(bootstrap, "Roots Test Project");
-	await bootstrap.stop();
+async function connectRootsClient(server: McpServer, rootsRef: { current: string[] }): Promise<ConnectedRootsClient> {
+	let rootsRequestCount = 0;
 
-	return { uninitializedDir, projectRoot: PROJECT_DIR };
+	const client = new Client(
+		{ name: "Roots Test Client", version: "1.0.0" },
+		{
+			capabilities: {
+				roots: {
+					listChanged: true,
+				},
+			},
+		},
+	);
+
+	client.setRequestHandler(ListRootsRequestSchema, async () => {
+		rootsRequestCount += 1;
+		return {
+			roots: rootsRef.current.map((uri) => ({ uri })),
+		};
+	});
+
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+	await server.getServer().connect(serverTransport);
+	await client.connect(clientTransport);
+
+	return {
+		client,
+		getRootsRequestCount: () => rootsRequestCount,
+	};
 }
 
 afterEach(async () => {
-	if (TEST_DIR) await safeCleanup(TEST_DIR);
+	if (TEST_DIR) {
+		await safeCleanup(TEST_DIR);
+	}
 });
 
 describe("MCP roots discovery", () => {
-	it("createMcpServer enables roots discovery in fallback mode", async () => {
+	it("fallback mode stays init-required without an initialization callback", async () => {
 		const { uninitializedDir } = await setupDirs();
 
 		const server = await createMcpServer(uninitializedDir);
 
-		// Simulate client init completing (no real client, so roots check
-		// returns early — readiness gate resolves, fallback state preserved)
-		server.getServer().oninitialized?.();
+		expect(server.getServer().oninitialized).toBeUndefined();
 
-		// Should be in fallback mode with only init-required resource
 		const resources = await server.testInterface.listResources();
-		expect(resources.resources.map((r) => r.uri)).toEqual(["backlog://init-required"]);
-		// Resource name should include the directory path for debugging
+		expect(resources.resources.map((resource) => resource.uri)).toEqual(["backlog://init-required"]);
 		expect(resources.resources[0]?.name).toBe(`Backlog.md Not Initialized [${uninitializedDir}]`);
 
-		// Should have no task tools
 		const tools = await server.testInterface.listTools();
 		expect(tools.tools).toEqual([]);
 
@@ -69,14 +108,11 @@ describe("MCP roots discovery", () => {
 	it("reinitializeProjectRoot switches Core to a different project", async () => {
 		const { uninitializedDir, projectRoot } = await setupDirs();
 
-		// Start with uninitialized dir (use McpServer directly, no roots discovery)
 		const server = new McpServer(uninitializedDir, "Fallback instructions");
 
-		// Verify it starts pointing at a dir with no config
 		const configBefore = await server.filesystem.loadConfig();
 		expect(configBefore).toBeNull();
 
-		// Reinitialize to the real project
 		server.reinitializeProjectRoot(projectRoot);
 		await server.ensureConfigLoaded();
 		const configAfter = await server.filesystem.loadConfig();
@@ -86,7 +122,6 @@ describe("MCP roots discovery", () => {
 			throw new Error("Expected config after reinitializing to a valid project");
 		}
 
-		// Register full toolset on the reinitialized server
 		registerWorkflowResources(server);
 		registerWorkflowTools(server);
 		registerTaskTools(server, configAfter);
@@ -95,85 +130,135 @@ describe("MCP roots discovery", () => {
 		registerDocumentTools(server, configAfter);
 
 		const tools = await server.testInterface.listTools();
-		const toolNames = tools.tools.map((t) => t.name);
+		const toolNames = tools.tools.map((tool) => tool.name);
 		expect(toolNames).toContain("task_create");
 		expect(toolNames).toContain("task_list");
 		expect(toolNames).toContain("get_backlog_instructions");
 
 		const resources = await server.testInterface.listResources();
-		const uris = resources.resources.map((r) => r.uri);
+		const uris = resources.resources.map((resource) => resource.uri);
 		expect(uris).toContain("backlog://workflow/overview");
 
 		await server.stop();
 	});
 
-	it("readiness gate blocks handlers until resolved", async () => {
-		const { uninitializedDir } = await setupDirs();
+	it("first request upgrades fallback mode via request-scoped directory roots and caches the result", async () => {
+		const { uninitializedDir, projectRoot } = await setupDirs();
 
-		const server = new McpServer(uninitializedDir, "Fallback instructions");
+		const server = await createMcpServer(uninitializedDir);
+		const rootsRef = { current: [pathToFileURL(projectRoot).toString()] };
+		const { client, getRootsRequestCount } = await connectRootsClient(server, rootsRef);
 
-		// Set up a controlled readiness gate
-		let resolveReady!: () => void;
-		const readyPromise = new Promise<void>((r) => {
-			resolveReady = r;
-		});
-		(server as unknown as { _ready: Promise<void> })._ready = readyPromise;
+		try {
+			const tools = await client.listTools();
+			const toolNames = tools.tools.map((tool) => tool.name);
+			expect(toolNames).toContain("task_create");
+			expect(toolNames).toContain("get_backlog_instructions");
+			expect(server.filesystem.rootDir).toBe(projectRoot);
+			expect(getRootsRequestCount()).toBe(1);
 
-		// Start a listTools call — it should be blocked by _ready
-		let toolsResolved = false;
-		const toolsPromise = server.testInterface.listTools().then((result) => {
-			toolsResolved = true;
-			return result;
-		});
-
-		// Give the event loop a chance to process
-		await new Promise((r) => setTimeout(r, 10));
-		expect(toolsResolved).toBe(false);
-
-		// Resolve the readiness gate
-		resolveReady();
-		const tools = await toolsPromise;
-		expect(toolsResolved).toBe(true);
-		expect(tools.tools).toEqual([]); // No tools registered in this test
-
-		await server.stop();
+			const resources = await client.listResources();
+			expect(resources.resources.map((resource) => resource.uri)).toContain("backlog://workflow/overview");
+			expect(getRootsRequestCount()).toBe(1);
+		} finally {
+			await client.close();
+			await server.stop();
+		}
 	});
 
-	it("enableRootsDiscovery sets up oninitialized callback", async () => {
-		const { uninitializedDir } = await setupDirs();
+	it("normalizes file roots to their parent directory", async () => {
+		const { uninitializedDir, projectRoot } = await setupDirs();
+		const readmePath = `${projectRoot}/README.md`;
+		await $`touch ${readmePath}`.quiet();
 
-		const server = new McpServer(uninitializedDir, "Fallback instructions");
-		server.enableRootsDiscovery();
+		const server = await createMcpServer(uninitializedDir);
+		const rootsRef = { current: [pathToFileURL(readmePath).toString()] };
+		const { client, getRootsRequestCount } = await connectRootsClient(server, rootsRef);
 
-		// The oninitialized callback should be set on the underlying SDK server
-		expect(server.getServer().oninitialized).toBeDefined();
-
-		// Trigger oninitialized to unblock the readiness gate (no client = no roots)
-		server.getServer().oninitialized?.();
-		// Wait for async resolution
-		await new Promise((r) => setTimeout(r, 10));
-
-		// Handlers should now work without blocking
-		const tools = await server.testInterface.listTools();
-		expect(tools.tools).toEqual([]);
-
-		await server.stop();
+		try {
+			const resources = await client.listResources();
+			expect(resources.resources.map((resource) => resource.uri)).toContain("backlog://workflow/overview");
+			expect(server.filesystem.rootDir).toBe(projectRoot);
+			expect(getRootsRequestCount()).toBe(1);
+		} finally {
+			await client.close();
+			await server.stop();
+		}
 	});
 
-	it("normal mode has no roots discovery and no readiness delay", async () => {
+	it("skips invalid and inaccessible file roots before later valid roots", async () => {
+		const { uninitializedDir, projectRoot } = await setupDirs();
+
+		const server = await createMcpServer(uninitializedDir);
+		const rootsRef = {
+			current: [
+				"file://not-a-local-host/path",
+				pathToFileURL(`${TEST_DIR}/missing-root`).toString(),
+				pathToFileURL(projectRoot).toString(),
+			],
+		};
+		const { client, getRootsRequestCount } = await connectRootsClient(server, rootsRef);
+
+		try {
+			const tools = await client.listTools();
+			expect(tools.tools.map((tool) => tool.name)).toContain("task_create");
+			expect(server.filesystem.rootDir).toBe(projectRoot);
+			expect(getRootsRequestCount()).toBe(1);
+		} finally {
+			await client.close();
+			await server.stop();
+		}
+	});
+
+	it("invalidates cached roots on roots/list_changed and re-resolves on the next request", async () => {
+		const { uninitializedDir, projectRoot, secondProjectRoot } = await setupDirs();
+
+		const server = await createMcpServer(uninitializedDir);
+		const rootsRef = { current: [pathToFileURL(projectRoot).toString()] };
+		const { client, getRootsRequestCount } = await connectRootsClient(server, rootsRef);
+
+		try {
+			await client.listTools();
+			expect(server.filesystem.rootDir).toBe(projectRoot);
+			expect(getRootsRequestCount()).toBe(1);
+
+			rootsRef.current = [pathToFileURL(uninitializedDir).toString()];
+			await client.sendRootsListChanged();
+			expect(getRootsRequestCount()).toBe(1);
+
+			const fallbackResources = await client.listResources();
+			expect(fallbackResources.resources.map((resource) => resource.uri)).toEqual(["backlog://init-required"]);
+			expect(server.filesystem.rootDir).toBe(uninitializedDir);
+			expect(getRootsRequestCount()).toBe(2);
+
+			rootsRef.current = [pathToFileURL(secondProjectRoot).toString()];
+			await client.sendRootsListChanged();
+			expect(getRootsRequestCount()).toBe(2);
+
+			const recoveredTools = await client.listTools();
+			expect(recoveredTools.tools.map((tool) => tool.name)).toContain("task_create");
+			expect(server.filesystem.rootDir).toBe(secondProjectRoot);
+			expect(getRootsRequestCount()).toBe(3);
+		} finally {
+			await client.close();
+			await server.stop();
+		}
+	});
+
+	it("normal mode does not issue roots/list requests", async () => {
 		const { projectRoot } = await setupDirs();
 
 		const server = await createMcpServer(projectRoot);
+		const rootsRef = { current: [pathToFileURL(projectRoot).toString()] };
+		const { client, getRootsRequestCount } = await connectRootsClient(server, rootsRef);
 
-		// Should have full toolset immediately
-		const tools = await server.testInterface.listTools();
-		const toolNames = tools.tools.map((t) => t.name);
-		expect(toolNames).toContain("task_create");
-		expect(toolNames).toContain("get_backlog_instructions");
-
-		// oninitialized should NOT be set
-		expect(server.getServer().oninitialized).toBeUndefined();
-
-		await server.stop();
+		try {
+			const tools = await client.listTools();
+			expect(tools.tools.map((tool) => tool.name)).toContain("task_create");
+			expect(getRootsRequestCount()).toBe(0);
+		} finally {
+			await client.close();
+			await server.stop();
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Move MCP roots recovery from initialization-time `server.listRoots()` to request-scoped `extra.sendRequest({ method: "roots/list" }, ListRootsResultSchema)`.
- Cache roots resolution for fallback mode and invalidate it on `notifications/roots/list_changed` so the next request re-resolves client roots.
- Normalize directory/file roots, skip malformed or inaccessible file roots, and keep fallback mode safe when roots are unsupported or do not contain a Backlog project.
- Bump `@modelcontextprotocol/sdk` to `1.29.0` without the unrelated Mermaid/web UI dependency refresh.

## Validation
- `bun test src/test/mcp-roots-discovery.test.ts src/test/mcp-fallback.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test src/test/server-search-endpoint.test.ts -t "returns newly created tasks immediately after POST"`
- `bun test src/test/server-search-endpoint.test.ts`

Note: I also attempted a full `bun test`; it completed with one transient timeout in `server-search-endpoint`, and the exact test plus full file passed immediately when rerun.