### PR TITLE
BACK-436 - Align document management across CLI, Web UI, and MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ permissions:
   checks: write
   pull-requests: write
 
+env:
+  BUN_VERSION: 1.3.11
+
 jobs:
   test:
     name: lint-and-unit-test
@@ -22,14 +25,14 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           # Bun >=1.3 includes stdin pause/subprocess handoff fixes used by TUI editor launch.
-          bun-version: 1.3.9
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v4
         id: cache
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ matrix.os }}-bun-1.3.9-${{ hashFiles('**/bun.lock') }}
+          key: ${{ runner.os }}-${{ matrix.os }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.os }}-bun-1.3.9-
+            ${{ runner.os }}-${{ matrix.os }}-bun-${{ env.BUN_VERSION }}-
       - run: bun install --frozen-lockfile --linker=isolated
       - run: bun run lint
       - name: Run tests
@@ -70,14 +73,14 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           # Bun >=1.3 includes stdin pause/subprocess handoff fixes used by TUI editor launch.
-          bun-version: 1.3.9
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v4
         id: cache
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ matrix.os }}-bun-1.3.9-${{ hashFiles('**/bun.lock') }}
+          key: ${{ runner.os }}-${{ matrix.os }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.os }}-bun-1.3.9-
+            ${{ runner.os }}-${{ matrix.os }}-bun-${{ env.BUN_VERSION }}-
       - run: bun install --frozen-lockfile --linker=isolated
       - name: Prime Bun cache for baseline target (Windows workaround)
         if: ${{ contains(matrix.target, 'baseline') && matrix.os == 'windows-latest' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  BUN_VERSION: 1.3.11
+
 jobs:
   build:
     name: build-${{ matrix.target }}
@@ -32,14 +35,14 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           # Bun >=1.3 includes stdin pause/subprocess handoff fixes used by TUI editor launch.
-          bun-version: 1.3.9
+          bun-version: ${{ env.BUN_VERSION }}
       - uses: actions/cache@v4
         id: cache
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-${{ matrix.target }}-bun-1.3.9-${{ hashFiles('**/bun.lock') }}
+          key: ${{ runner.os }}-${{ matrix.target }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.target }}-bun-1.3.9-
+            ${{ runner.os }}-${{ matrix.target }}-bun-${{ env.BUN_VERSION }}-
       - run: bun install --frozen-lockfile
       - name: Sync version to tag
         shell: bash

--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -24,7 +24,9 @@ You can rerun the wizard anytime with `backlog config`. All existing CLI flags (
 
 ## Documentation
 
-- Document IDs are global across all subdirectories under `backlog/docs`. You can organize files in nested folders (e.g., `backlog/docs/guides/`), and `backlog doc list` and `backlog doc view <id>` work across the entire tree. Example: `backlog doc create -p guides "New Guide"`.
+- Document IDs are global across all subdirectories under `backlog/docs`. You can organize files in nested folders (e.g., `backlog/docs/guides/`), and `backlog doc list` and `backlog doc view <id>` work across the entire tree.
+- Use `backlog doc create "New Guide" -p guides` to create a document in a docs subdirectory. The created output includes the persisted docs-relative file path, such as `backlog/docs/guides/doc-1 - New-Guide.md`.
+- Document paths are always relative to the docs directory. Absolute paths and traversal segments such as `..` are rejected.
 
 ## Task Management
 
@@ -160,7 +162,7 @@ Manage task dependencies to create execution sequences and prevent circular rela
 |-------------|------------------------------------------------------|
 | Create doc | `backlog doc create "API Guidelines"` |
 | Create with path | `backlog doc create "Setup Guide" -p guides/setup` |
-| Create with type | `backlog doc create "Architecture" -t technical` |
+| Create with type | `backlog doc create "Architecture" -t guide` |
 | List docs | `backlog doc list` |
 | View doc | `backlog doc view doc-1` |
 

--- a/backlog/docs/readme.md
+++ b/backlog/docs/readme.md
@@ -2,8 +2,9 @@
 
 This directory contains the project's documentation files, including guides, specifications, and other relevant information.
 
-Use `backlog doc create <title>` to add a new document. By default, files are saved here, but you can specify a subfolder with `-p <path>`.
+Use `backlog doc create <title>` to add a new document. By default, files are saved here, but you can specify a docs-relative subfolder with `-p <path>`.
 List all documents with `backlog doc list`.
+Document paths are always relative to this directory; absolute paths and `..` traversal segments are rejected.
 
 ## Configuration Options
 

--- a/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
+++ b/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-25 21:01'
-updated_date: '2026-04-25 22:22'
+updated_date: '2026-04-25 22:32'
 labels:
   - docs
   - core
@@ -78,6 +78,8 @@ Keep the public surface explicit: external agents may rely on CLI help, MCP tool
 CI follow-up: after the watcher fix, macOS and Ubuntu passed; Windows still failed in the full unit suite with a Bun 1.3.9 segmentation fault near `src/test/mcp-milestones.test.ts` and no test assertion failure. Bumped the GitHub workflow Bun pin to 1.3.11 and centralized the workflow cache version so CI uses the same patch level validated locally.
 
 CI follow-up: Bun 1.3.11 removed the Windows segfault and exposed Windows portability failures in the full suite. Fixed docs path assertions/cleanup to normalize recursive glob separators, preserved document path metadata when ContentStore handles document watcher events directly, normalized MCP roots fixture paths with `join`, and quoted POSIX-style callback output paths while disabling unrelated branch scanning in status-callback fixtures.
+
+CI follow-up: Ubuntu full-suite failure on PR #610 was isolated to `src/test/server-assets.test.ts` beforeEach/afterEach hook timeouts. The asset server readiness probe now uses bounded `/api/status` requests, and asset fetches are timeout-wrapped so failures stay within the CI hook timeout. Local validation now passes with `bun test --timeout=10000` using the same timeout as Ubuntu CI.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -101,6 +103,8 @@ CI follow-up: Updated content-store watcher deletion handling so missing watched
 CI follow-up: fixed the remaining Windows CI runtime crash by moving GitHub workflows from Bun 1.3.9 to 1.3.11 and keeping cache keys tied to the workflow Bun version.
 
 CI follow-up: addressed the Windows-only portability failures revealed after the Bun bump. Targeted core/server docs, MCP roots, status-callback, content-store, filesystem, and MCP document tests pass locally with typecheck and Biome.
+
+Stabilized the server asset tests by switching readiness checks from `/` to bounded `/api/status` probes and timeout-wrapping asset fetches; verified the full suite with `bun test --timeout=10000` passes locally.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
+++ b/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
@@ -1,0 +1,99 @@
+---
+id: BACK-436
+title: 'Align document management across CLI, Web UI, and MCP'
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-04-25 21:01'
+updated_date: '2026-04-25 21:36'
+labels:
+  - docs
+  - core
+  - cli
+  - web
+  - mcp
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/pull/598'
+  - src/cli.ts
+  - src/server/index.ts
+  - src/web/lib/api.ts
+  - src/web/components/DocumentationDetail.tsx
+  - src/mcp/tools/documents
+  - src/core/backlog.ts
+  - src/file-system/operations.ts
+  - src/guidelines/mcp/overview.md
+  - src/guidelines/agent-guidelines.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Document management is currently inconsistent across public interfaces. CLI supports creating docs in a subpath with `backlog doc create -p`, but Web UI/server and MCP create/update flows do not expose the same path capability, and MCP responses do not expose persisted document paths. This blocks merging guidance like PR #598 because agents need a stable public way to create, locate, update, and reference docs without relying on source-only implementation details or direct file writes.
+
+Align the document domain contract so core owns document ID generation, path normalization, safe subdirectory handling, metadata/frontmatter persistence, rename/move/update behavior, and returned document metadata. Then make CLI, Web UI/server APIs, and MCP document tools expose the same supported document-management behavior as thin adapters over that core contract.
+
+Keep the public surface explicit: external agents may rely on CLI help, MCP tool schemas/descriptions, MCP workflow resources/instruction files, Web/server API behavior used by the Web UI, and shipped docs. Do not require agents to inspect `/src` internals to know how docs paths work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A single core document-management path handles create, list, view, update/rename, search metadata, path/subdirectory normalization, safe path validation, ID generation, and persisted metadata for docs.
+- [x] #2 CLI, Web UI/server API, and MCP expose equivalent document-management functionality for supported operations, including creating docs in a docs subdirectory/path and returning the persisted document path or file location.
+- [x] #3 Document update/rename behavior is consistent across interfaces, preserves or intentionally changes the document path according to an explicit public contract, and rejects unsafe paths such as traversal or absolute paths.
+- [x] #4 MCP document tool schemas, descriptions, and formatted responses include the same document metadata needed by agents: id, title, type, path, created/updated dates, tags, and content where appropriate.
+- [x] #5 CLI help/output, Web API behavior, and MCP resource/instruction guidance document the same docs path rules and do not instruct agents to depend on direct file writes as the primary workflow.
+- [x] #6 Regression tests cover core document path handling plus interface parity for CLI, Web/server API, and MCP document tools, including nested paths and unsafe-path rejection.
+- [x] #7 PR #598's proposed agent guidance can be revised to reference the aligned public APIs instead of documenting incomplete or interface-specific behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a single core document-management contract for create/update operations: typed input objects, shared ID generation, type/content/title normalization, persisted `path` metadata, and safe docs subpath normalization.
+2. Make filesystem document persistence reject unsafe paths such as absolute paths and traversal instead of silently dropping path segments.
+3. Update CLI document commands to call the core contract and print generated document path metadata so agents can locate created docs without inspecting internals.
+4. Update Web/server document APIs and Web UI document creation/editing to expose the same path capability for create, preserve path on edit by default, and return full document metadata.
+5. Update MCP document schemas, handlers, descriptions, and formatted responses to accept/return the same metadata and path behavior as CLI/Web.
+6. Update shipped guidance/resources so docs path rules are public and consistent, and PR #598 can be revised against stable public APIs.
+7. Add focused regression coverage for core/filesystem path validation, CLI output, server API create/update behavior, and MCP document path metadata; run scoped tests plus typecheck/check as appropriate.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+2026-04-25: Took over task in new worktree `/Users/alex/projects/Backlog.md-back-436` on branch `tasks/back-436-align-document-management`, based on `origin/main` at `3901c4b`. Pending implementation plan approval before code changes.
+
+2026-04-25: Implementation plan approved by user. Discovery classified this as L2 because it touches core data semantics, filesystem persistence, CLI, Web/server, MCP schemas/responses, shipped guidance, and tests. Closest pattern is task create/update parity: adapters should map public payloads into typed core inputs while persistence stays in FileSystem.
+
+2026-04-25: Implemented shared document path normalization and core document create/update input methods. CLI, Web/server API, Web UI, and MCP document tools now route create/update behavior through core, expose docs-relative path metadata, preserve paths by default on update, support explicit moves, and reject unsafe absolute/traversal paths.
+
+2026-04-25: Updated public guidance/resources for CLI, MCP, agent instructions, and docs readme so agents can rely on shipped CLI/MCP/Web behavior instead of direct file writes or source-only conventions.
+
+2026-04-25: Validation: `bunx tsc --noEmit` passed; `bun run check .` passed; scoped docs/interface tests passed with 150 pass / 0 fail; `src/test/remote-id-conflict.test.ts` passes after aligning its stale lowercase expectation with normalized uppercase task output; `src/test/server-search-endpoint.test.ts` passes in isolation. A full `bun test` rerun hit order/load-sensitive server-search hook timeouts/socket failures after the remote-id expectation was fixed, while the same server-search file passed separately.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Summary:
+- Added shared document path normalization and core document create/update inputs so document ID generation, persisted path metadata, path preservation/moves, and unsafe-path rejection live in core/filesystem behavior.
+- Routed CLI document creation, Web/server document APIs/UI, and MCP document tools through the aligned core contract, including path metadata in list/view/search/update responses where agents need it.
+- Updated shipped CLI/MCP/agent guidance and regression tests for nested docs paths, path metadata, and unsafe-path rejection.
+
+Validation:
+- `bunx tsc --noEmit` passed.
+- `bun run check .` passed.
+- `bun test src/test/filesystem.test.ts src/test/core.test.ts src/test/cli.test.ts src/test/mcp-documents.test.ts src/test/server-documents-endpoint.test.ts` passed: 150 pass / 0 fail.
+- `bun test src/test/remote-id-conflict.test.ts` passed after correcting the stale task-ID casing expectation.
+- `bun test src/test/server-search-endpoint.test.ts` passed in isolation.
+- Full `bun test` was attempted after the casing fix; it no longer fails at `remote-id-conflict`, but one long-run attempt hit server-search hook timeouts/socket failures that passed when isolated.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
+++ b/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-25 21:01'
-updated_date: '2026-04-25 21:36'
+updated_date: '2026-04-25 22:02'
 labels:
   - docs
   - core
@@ -72,6 +72,8 @@ Keep the public surface explicit: external agents may rely on CLI help, MCP tool
 2026-04-25: Updated public guidance/resources for CLI, MCP, agent instructions, and docs readme so agents can rely on shipped CLI/MCP/Web behavior instead of direct file writes or source-only conventions.
 
 2026-04-25: Validation: `bunx tsc --noEmit` passed; `bun run check .` passed; scoped docs/interface tests passed with 150 pass / 0 fail; `src/test/remote-id-conflict.test.ts` passes after aligning its stale lowercase expectation with normalized uppercase task output; `src/test/server-search-endpoint.test.ts` passes in isolation. A full `bun test` rerun hit order/load-sensitive server-search hook timeouts/socket failures after the remote-id expectation was fixed, while the same server-search file passed separately.
+
+2026-04-25: CI follow-up for PR #610: macOS `lint-and-unit-test` failed in `ContentStore > removes decisions when files are deleted` because the file watcher deletion path only treated missing files as removals for `rename` events. The fix broadens cached removal handling to any watcher event where the watched path no longer exists, keeping task/document/decision watcher behavior consistent.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -89,6 +91,8 @@ Validation:
 - `bun test src/test/remote-id-conflict.test.ts` passed after correcting the stale task-ID casing expectation.
 - `bun test src/test/server-search-endpoint.test.ts` passed in isolation.
 - Full `bun test` was attempted after the casing fix; it no longer fails at `remote-id-conflict`, but one long-run attempt hit server-search hook timeouts/socket failures that passed when isolated.
+
+CI follow-up: Updated content-store watcher deletion handling so missing watched task/document/decision files remove cached entries regardless of whether the platform reports the event as `rename` or `change`. Verified with `bun test src/test/content-store.test.ts`, `bun test src/test/server-search-endpoint.test.ts`, `bunx tsc --noEmit`, and `bun run check .`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
+++ b/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-25 21:01'
-updated_date: '2026-04-25 22:14'
+updated_date: '2026-04-25 22:22'
 labels:
   - docs
   - core
@@ -76,6 +76,8 @@ Keep the public surface explicit: external agents may rely on CLI help, MCP tool
 2026-04-25: CI follow-up for PR #610: macOS `lint-and-unit-test` failed in `ContentStore > removes decisions when files are deleted` because the file watcher deletion path only treated missing files as removals for `rename` events. The fix broadens cached removal handling to any watcher event where the watched path no longer exists, keeping task/document/decision watcher behavior consistent.
 
 CI follow-up: after the watcher fix, macOS and Ubuntu passed; Windows still failed in the full unit suite with a Bun 1.3.9 segmentation fault near `src/test/mcp-milestones.test.ts` and no test assertion failure. Bumped the GitHub workflow Bun pin to 1.3.11 and centralized the workflow cache version so CI uses the same patch level validated locally.
+
+CI follow-up: Bun 1.3.11 removed the Windows segfault and exposed Windows portability failures in the full suite. Fixed docs path assertions/cleanup to normalize recursive glob separators, preserved document path metadata when ContentStore handles document watcher events directly, normalized MCP roots fixture paths with `join`, and quoted POSIX-style callback output paths while disabling unrelated branch scanning in status-callback fixtures.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -97,6 +99,8 @@ Validation:
 CI follow-up: Updated content-store watcher deletion handling so missing watched task/document/decision files remove cached entries regardless of whether the platform reports the event as `rename` or `change`. Verified with `bun test src/test/content-store.test.ts`, `bun test src/test/server-search-endpoint.test.ts`, `bunx tsc --noEmit`, and `bun run check .`.
 
 CI follow-up: fixed the remaining Windows CI runtime crash by moving GitHub workflows from Bun 1.3.9 to 1.3.11 and keeping cache keys tied to the workflow Bun version.
+
+CI follow-up: addressed the Windows-only portability failures revealed after the Bun bump. Targeted core/server docs, MCP roots, status-callback, content-store, filesystem, and MCP document tests pass locally with typecheck and Biome.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
+++ b/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-25 21:01'
-updated_date: '2026-04-25 22:32'
+updated_date: '2026-04-25 22:47'
 labels:
   - docs
   - core
@@ -58,6 +58,8 @@ Keep the public surface explicit: external agents may rely on CLI help, MCP tool
 5. Update MCP document schemas, handlers, descriptions, and formatted responses to accept/return the same metadata and path behavior as CLI/Web.
 6. Update shipped guidance/resources so docs path rules are public and consistent, and PR #598 can be revised against stable public APIs.
 7. Add focused regression coverage for core/filesystem path validation, CLI output, server API create/update behavior, and MCP document path metadata; run scoped tests plus typecheck/check as appropriate.
+
+Review follow-up plan for unresolved Codex comments on PR #610: fix docs subpath normalization to trim individual path segments, add Web/server document metadata validation for create/update payloads, preserve HTTP 500 for unexpected create/update failures while keeping explicit validation errors as 400, and add regression coverage in the focused document tests before pushing.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -80,6 +82,12 @@ CI follow-up: after the watcher fix, macOS and Ubuntu passed; Windows still fail
 CI follow-up: Bun 1.3.11 removed the Windows segfault and exposed Windows portability failures in the full suite. Fixed docs path assertions/cleanup to normalize recursive glob separators, preserved document path metadata when ContentStore handles document watcher events directly, normalized MCP roots fixture paths with `join`, and quoted POSIX-style callback output paths while disabling unrelated branch scanning in status-callback fixtures.
 
 CI follow-up: Ubuntu full-suite failure on PR #610 was isolated to `src/test/server-assets.test.ts` beforeEach/afterEach hook timeouts. The asset server readiness probe now uses bounded `/api/status` requests, and asset fetches are timeout-wrapped so failures stay within the CI hook timeout. Local validation now passes with `bun test --timeout=10000` using the same timeout as Ubuntu CI.
+
+Review follow-up: PR #610 has five unresolved Codex review threads covering document subpath segment trimming, document metadata validation on server create/update, and preserving 500 responses for unexpected document create/update failures. Reopened the task while addressing these PR comments.
+
+Review follow-up complete: addressed all five unresolved Codex review threads on PR #610. Document subpath normalization now trims each path segment before traversal checks; server document create/update handlers reject invalid type/tags/path metadata instead of coercing malformed values; unexpected operational failures from core document create/update now remain HTTP 500 while explicit validation errors stay 400 and missing documents stay 404. Validation passed with focused document interface tests, typecheck, Biome, and the full local suite using the CI timeout.
+
+Validation correction for review follow-up: after the last server metadata test addition, focused server document tests, typecheck, Biome, the document interface suite, and `src/test/server-search-endpoint.test.ts` in isolation pass. A full-suite rerun hit two pre-existing/order-sensitive `server-search-endpoint` hook timeouts; the same file passed in isolation immediately afterward.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -105,6 +113,10 @@ CI follow-up: fixed the remaining Windows CI runtime crash by moving GitHub work
 CI follow-up: addressed the Windows-only portability failures revealed after the Bun bump. Targeted core/server docs, MCP roots, status-callback, content-store, filesystem, and MCP document tests pass locally with typecheck and Biome.
 
 Stabilized the server asset tests by switching readiness checks from `/` to bounded `/api/status` probes and timeout-wrapping asset fetches; verified the full suite with `bun test --timeout=10000` passes locally.
+
+Review follow-up: resolved Codex feedback by trimming document path segments, validating server document metadata payloads, and preserving HTTP 500 for unexpected document create/update failures. Verified with `bun test src/test/filesystem.test.ts src/test/core.test.ts src/test/cli.test.ts src/test/mcp-documents.test.ts src/test/server-documents-endpoint.test.ts --timeout=15000`, `bunx tsc --noEmit`, `bun run check .`, and full `bun test --timeout=10000` (1159 pass, 2 skip, 0 fail).
+
+Validation note: after the final metadata test addition, focused document tests, typecheck, Biome, and the document interface suite passed. A full-suite rerun hit the known `server-search-endpoint` hook timeout flake; `bun test src/test/server-search-endpoint.test.ts --timeout=15000` passed in isolation immediately afterward.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
+++ b/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-25 21:01'
-updated_date: '2026-04-25 22:02'
+updated_date: '2026-04-25 22:14'
 labels:
   - docs
   - core
@@ -74,6 +74,8 @@ Keep the public surface explicit: external agents may rely on CLI help, MCP tool
 2026-04-25: Validation: `bunx tsc --noEmit` passed; `bun run check .` passed; scoped docs/interface tests passed with 150 pass / 0 fail; `src/test/remote-id-conflict.test.ts` passes after aligning its stale lowercase expectation with normalized uppercase task output; `src/test/server-search-endpoint.test.ts` passes in isolation. A full `bun test` rerun hit order/load-sensitive server-search hook timeouts/socket failures after the remote-id expectation was fixed, while the same server-search file passed separately.
 
 2026-04-25: CI follow-up for PR #610: macOS `lint-and-unit-test` failed in `ContentStore > removes decisions when files are deleted` because the file watcher deletion path only treated missing files as removals for `rename` events. The fix broadens cached removal handling to any watcher event where the watched path no longer exists, keeping task/document/decision watcher behavior consistent.
+
+CI follow-up: after the watcher fix, macOS and Ubuntu passed; Windows still failed in the full unit suite with a Bun 1.3.9 segmentation fault near `src/test/mcp-milestones.test.ts` and no test assertion failure. Bumped the GitHub workflow Bun pin to 1.3.11 and centralized the workflow cache version so CI uses the same patch level validated locally.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -93,6 +95,8 @@ Validation:
 - Full `bun test` was attempted after the casing fix; it no longer fails at `remote-id-conflict`, but one long-run attempt hit server-search hook timeouts/socket failures that passed when isolated.
 
 CI follow-up: Updated content-store watcher deletion handling so missing watched task/document/decision files remove cached entries regardless of whether the platform reports the event as `rename` or `change`. Verified with `bun test src/test/content-store.test.ts`, `bun test src/test/server-search-endpoint.test.ts`, `bunx tsc --noEmit`, and `bun run check .`.
+
+CI follow-up: fixed the remaining Windows CI runtime crash by moving GitHub workflows from Bun 1.3.9 to 1.3.11 and keeping cache keys tied to the workflow Bun version.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
+++ b/backlog/tasks/back-436 - Align-document-management-across-CLI-Web-UI-and-MCP.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-25 21:01'
-updated_date: '2026-04-25 22:47'
+updated_date: '2026-04-25 22:53'
 labels:
   - docs
   - core
@@ -88,6 +88,10 @@ Review follow-up: PR #610 has five unresolved Codex review threads covering docu
 Review follow-up complete: addressed all five unresolved Codex review threads on PR #610. Document subpath normalization now trims each path segment before traversal checks; server document create/update handlers reject invalid type/tags/path metadata instead of coercing malformed values; unexpected operational failures from core document create/update now remain HTTP 500 while explicit validation errors stay 400 and missing documents stay 404. Validation passed with focused document interface tests, typecheck, Biome, and the full local suite using the CI timeout.
 
 Validation correction for review follow-up: after the last server metadata test addition, focused server document tests, typecheck, Biome, the document interface suite, and `src/test/server-search-endpoint.test.ts` in isolation pass. A full-suite rerun hit two pre-existing/order-sensitive `server-search-endpoint` hook timeouts; the same file passed in isolation immediately afterward.
+
+Additional review follow-up: after pushing the first review-fix commit, GitHub reported a newer unresolved Codex thread on `src/mcp/tools/documents/schemas.ts` asking to constrain MCP document `type` values to the supported enum. Reopened the task to address that remaining MCP schema parity issue.
+
+Addressed the remaining active Codex review thread by sharing the document type enum across types/core/server/MCP schema, constraining MCP `document_create`/`document_update` type inputs, and adding MCP/core regression tests. Verified with focused MCP/core tests, TypeScript, Biome, and the broader document suite.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -117,6 +121,8 @@ Stabilized the server asset tests by switching readiness checks from `/` to boun
 Review follow-up: resolved Codex feedback by trimming document path segments, validating server document metadata payloads, and preserving HTTP 500 for unexpected document create/update failures. Verified with `bun test src/test/filesystem.test.ts src/test/core.test.ts src/test/cli.test.ts src/test/mcp-documents.test.ts src/test/server-documents-endpoint.test.ts --timeout=15000`, `bunx tsc --noEmit`, `bun run check .`, and full `bun test --timeout=10000` (1159 pass, 2 skip, 0 fail).
 
 Validation note: after the final metadata test addition, focused document tests, typecheck, Biome, and the document interface suite passed. A full-suite rerun hit the known `server-search-endpoint` hook timeout flake; `bun test src/test/server-search-endpoint.test.ts --timeout=15000` passed in isolation immediately afterward.
+
+Additional review follow-up: constrained `document_create` and `document_update` MCP schemas to the shared supported document type enum, exposed the same enum in CLI help, and added core/runtime validation so invalid document types are not persisted through domain methods. Validation passed with `bun test src/test/mcp-documents.test.ts src/test/core.test.ts --timeout=15000`, `bunx tsc --noEmit`, `bun run check .`, and `bun test src/test/filesystem.test.ts src/test/core.test.ts src/test/cli.test.ts src/test/mcp-documents.test.ts src/test/server-documents-endpoint.test.ts --timeout=15000`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
 	type BacklogConfig,
 	type Decision,
 	type DecisionSearchResult,
+	DOCUMENT_TYPE_VALUES,
 	type Document as DocType,
 	type DocumentSearchResult,
 	isLocalEditableTask,
@@ -2990,7 +2991,7 @@ const docCmd = program.command("doc");
 docCmd
 	.command("create <title>")
 	.option("-p, --path <path>")
-	.option("-t, --type <type>")
+	.option("-t, --type <type>", `document type (${DOCUMENT_TYPE_VALUES.join(", ")})`)
 	.action(async (title: string, options) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2994,16 +2994,16 @@ docCmd
 	.action(async (title: string, options) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
-		const id = await generateNextDocId(core);
-		const document: DocType = {
-			id,
+		const document = await core.createDocumentFromInput({
 			title: title as string,
 			type: (options.type || "other") as DocType["type"],
-			createdDate: new Date().toISOString().slice(0, 16).replace("T", " "),
-			rawContent: "",
-		};
-		await core.createDocument(document, undefined, options.path || "");
-		console.log(`Created document ${id}`);
+			path: options.path,
+			content: "",
+		});
+		console.log(`Created document ${document.id}`);
+		if (document.path) {
+			console.log(`Path: ${core.filesystem.backlogDirName}/docs/${document.path}`);
+		}
 	});
 
 docCmd

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -7,6 +7,8 @@ import {
 	type AcceptanceCriterion,
 	type Decision,
 	type Document,
+	type DocumentCreateInput,
+	type DocumentUpdateInput,
 	EntityType,
 	isLocalEditableTask,
 	type Milestone,
@@ -18,8 +20,14 @@ import {
 	type TaskUpdateInput,
 } from "../types/index.ts";
 import { normalizeAssignee } from "../utils/assignee.ts";
-import { documentIdsEqual } from "../utils/document-id.ts";
+import { documentIdsEqual, normalizeDocumentId } from "../utils/document-id.ts";
+import {
+	getDocumentSubPathFromRelativePath,
+	normalizeDocumentRelativePath,
+	normalizeDocumentSubPath,
+} from "../utils/document-path.ts";
 import { openInEditor } from "../utils/editor.ts";
+import { generateNextDocId } from "../utils/id-generators.ts";
 import {
 	createMilestoneFilterValueResolver,
 	normalizeMilestoneFilterValue,
@@ -444,8 +452,8 @@ export class Core {
 		const document = await this.getDocument(documentId);
 		if (!document) return null;
 
-		const relativePath = document.path ?? `${document.id}.md`;
-		const filePath = join(this.fs.docsDir, relativePath);
+		const relativePath = normalizeDocumentRelativePath(document.path ?? `${document.id}.md`);
+		const filePath = join(this.fs.docsDir, ...relativePath.split("/"));
 		try {
 			return await Bun.file(filePath).text();
 		} catch {
@@ -2305,7 +2313,7 @@ export class Core {
 	}
 
 	async createDocument(doc: Document, autoCommit?: boolean, subPath = ""): Promise<void> {
-		const relativePath = await this.fs.saveDocument(doc, subPath);
+		const relativePath = await this.fs.saveDocument(doc, normalizeDocumentSubPath(subPath));
 		doc.path = relativePath;
 
 		if (await this.shouldAutoCommit(autoCommit)) {
@@ -2316,38 +2324,77 @@ export class Core {
 	}
 
 	async updateDocument(existingDoc: Document, content: string, autoCommit?: boolean): Promise<void> {
-		const updatedDoc = {
-			...existingDoc,
-			rawContent: content,
-			updatedDate: new Date().toISOString().slice(0, 16).replace("T", " "),
-		};
-
-		let normalizedSubPath = "";
-		if (existingDoc.path) {
-			const segments = existingDoc.path.split(/[\\/]/).slice(0, -1);
-			if (segments.length > 0) {
-				normalizedSubPath = segments.join("/");
-			}
-		}
-
-		await this.createDocument(updatedDoc, autoCommit, normalizedSubPath);
+		await this.updateDocumentFromInput(
+			{
+				id: existingDoc.id,
+				title: existingDoc.title,
+				type: existingDoc.type,
+				tags: existingDoc.tags,
+				content,
+				...(existingDoc.path !== undefined && { path: getDocumentSubPathFromRelativePath(existingDoc.path) }),
+			},
+			autoCommit,
+		);
 	}
 
 	async createDocumentWithId(title: string, content: string, autoCommit?: boolean): Promise<Document> {
-		// Import the generateNextDocId function from CLI
-		const { generateNextDocId } = await import("../cli.js");
-		const id = await generateNextDocId(this);
+		return await this.createDocumentFromInput({ title, content }, autoCommit);
+	}
 
-		const document: Document = {
-			id,
-			title,
-			type: "other" as const,
-			createdDate: new Date().toISOString().slice(0, 16).replace("T", " "),
-			rawContent: content,
+	async createDocumentFromInput(input: DocumentCreateInput, autoCommit?: boolean): Promise<Document> {
+		const title = input.title.trim();
+		if (!title) {
+			throw new Error("Title is required to create a document.");
+		}
+
+		const subPath = normalizeDocumentSubPath(input.path);
+		const tags = normalizeStringList(input.tags);
+		const document = await this.withCreateLock(async () => {
+			const id = normalizeDocumentId(await generateNextDocId(this));
+			const document: Document = {
+				id,
+				title,
+				type: input.type ?? "other",
+				createdDate: new Date().toISOString().slice(0, 16).replace("T", " "),
+				rawContent: input.content ?? "",
+				...(tags && tags.length > 0 && { tags }),
+			};
+
+			await this.createDocument(document, autoCommit, subPath);
+			return document;
+		});
+
+		return (await this.getDocument(document.id)) ?? document;
+	}
+
+	async updateDocumentFromInput(input: DocumentUpdateInput, autoCommit?: boolean): Promise<Document> {
+		const existingDoc = await this.getDocument(input.id);
+		if (!existingDoc) {
+			throw new Error(`Document not found: ${input.id}`);
+		}
+
+		const normalizedTitle = input.title?.trim();
+		if (input.title !== undefined && !normalizedTitle) {
+			throw new Error("Document title cannot be empty.");
+		}
+
+		const tags = input.tags !== undefined ? normalizeStringList(input.tags) : existingDoc.tags;
+		const subPath =
+			input.path === undefined
+				? getDocumentSubPathFromRelativePath(existingDoc.path)
+				: normalizeDocumentSubPath(input.path);
+		const updatedDoc: Document = {
+			...existingDoc,
+			id: normalizeDocumentId(existingDoc.id),
+			title: normalizedTitle ?? existingDoc.title,
+			type: input.type ?? existingDoc.type,
+			rawContent: input.content,
+			updatedDate: new Date().toISOString().slice(0, 16).replace("T", " "),
+			tags: tags && tags.length > 0 ? tags : undefined,
 		};
 
-		await this.createDocument(document, autoCommit);
-		return document;
+		await this.createDocument(updatedDoc, autoCommit, subPath);
+		return (await this.getDocument(existingDoc.id)) ?? updatedDoc;
 	}
 
 	async listTasksWithMetadata(

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -6,8 +6,10 @@ import { GitOperations } from "../git/operations.ts";
 import {
 	type AcceptanceCriterion,
 	type Decision,
+	DOCUMENT_TYPE_VALUES,
 	type Document,
 	type DocumentCreateInput,
+	type DocumentType,
 	type DocumentUpdateInput,
 	EntityType,
 	isLocalEditableTask,
@@ -141,6 +143,16 @@ function filterTasksByStateSnapshots(tasks: Task[], latestState: Map<string, Bra
 		if (!latest) return true;
 		return latest.type === "task";
 	});
+}
+
+function normalizeDocumentTypeInput(type: unknown): DocumentType | undefined {
+	if (type === undefined) {
+		return undefined;
+	}
+	if (typeof type === "string" && (DOCUMENT_TYPE_VALUES as readonly string[]).includes(type)) {
+		return type as DocumentType;
+	}
+	throw new Error(`Document type must be one of: ${DOCUMENT_TYPE_VALUES.join(", ")}.`);
 }
 
 /**
@@ -2349,12 +2361,13 @@ export class Core {
 
 		const subPath = normalizeDocumentSubPath(input.path);
 		const tags = normalizeStringList(input.tags);
+		const type = normalizeDocumentTypeInput(input.type) ?? "other";
 		const document = await this.withCreateLock(async () => {
 			const id = normalizeDocumentId(await generateNextDocId(this));
 			const document: Document = {
 				id,
 				title,
-				type: input.type ?? "other",
+				type,
 				createdDate: new Date().toISOString().slice(0, 16).replace("T", " "),
 				rawContent: input.content ?? "",
 				...(tags && tags.length > 0 && { tags }),
@@ -2379,6 +2392,7 @@ export class Core {
 		}
 
 		const tags = input.tags !== undefined ? normalizeStringList(input.tags) : existingDoc.tags;
+		const type = normalizeDocumentTypeInput(input.type) ?? existingDoc.type;
 		const subPath =
 			input.path === undefined
 				? getDocumentSubPathFromRelativePath(existingDoc.path)
@@ -2387,7 +2401,7 @@ export class Core {
 			...existingDoc,
 			id: normalizeDocumentId(existingDoc.id),
 			title: normalizedTitle ?? existingDoc.title,
-			type: input.type ?? existingDoc.type,
+			type,
 			rawContent: input.content,
 			updatedDate: new Date().toISOString().slice(0, 16).replace("T", " "),
 			tags: tags && tags.length > 0 ? tags : undefined,

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -326,7 +326,7 @@ export class ContentStore {
 				const fullPath = join(tasksDir, file);
 				const exists = await Bun.file(fullPath).exists();
 
-				if (!exists && eventType === "rename") {
+				if (!exists) {
 					if (this.tasks.delete(normalizedTaskId)) {
 						this.cachedTasks = sortByTaskId(Array.from(this.tasks.values()));
 						this.notify("tasks");
@@ -399,7 +399,7 @@ export class ContentStore {
 				const fullPath = join(decisionsDir, file);
 				const exists = await Bun.file(fullPath).exists();
 
-				if (!exists && eventType === "rename") {
+				if (!exists) {
 					if (this.decisions.delete(idPart)) {
 						this.cachedDecisions = sortByTaskId(Array.from(this.decisions.values()));
 						this.notify("decisions");
@@ -477,7 +477,7 @@ export class ContentStore {
 
 			const exists = await Bun.file(absolutePath).exists();
 
-			if (!exists && eventType === "rename") {
+			if (!exists) {
 				if (this.documents.delete(idPart)) {
 					this.cachedDocuments = [...this.documents.values()].sort((a, b) => a.title.localeCompare(b.title));
 					this.notify("documents");

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -4,6 +4,7 @@ import { basename, join, relative, sep } from "node:path";
 import type { FileSystem } from "../file-system/operations.ts";
 import { parseDecision, parseDocument, parseTask } from "../markdown/parser.ts";
 import type { Decision, Document, Task, TaskListFilter } from "../types/index.ts";
+import { normalizeDocumentRelativePath } from "../utils/document-path.ts";
 import { normalizeTaskId, normalizeTaskIdentity, taskIdsEqual } from "../utils/task-path.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
 
@@ -495,7 +496,8 @@ export class ContentStore {
 				async () => {
 					try {
 						const content = await Bun.file(absolutePath).text();
-						return parseDocument(content);
+						const documentPath = normalizeDocumentRelativePath(relativePath ?? relative(docsDir, absolutePath));
+						return { ...parseDocument(content), path: documentPath };
 					} catch {
 						return null;
 					}

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -772,7 +772,9 @@ export class FileSystem {
 		await this.ensureDirectoryExists(dirname(filepath));
 
 		const glob = new Bun.Glob("**/doc-*.md");
-		const existingMatches = await Array.fromAsync(glob.scan({ cwd: docsDir, followSymlinks: true }));
+		const existingMatches = (await Array.fromAsync(glob.scan({ cwd: docsDir, followSymlinks: true }))).map((relative) =>
+			normalizeDocumentRelativePath(relative),
+		);
 		const matchesForId = existingMatches.filter((relative) => {
 			const base = relative.split("/").pop() || relative;
 			const [candidateId] = base.split(" - ");

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -9,6 +9,7 @@ import type { BacklogConfig, Decision, Document, Milestone, Task, TaskListFilter
 import type { BacklogConfigSource } from "../utils/backlog-directory.ts";
 import { normalizeProjectBacklogDirectory, resolveBacklogDirectory } from "../utils/backlog-directory.ts";
 import { documentIdsEqual, normalizeDocumentId } from "../utils/document-id.ts";
+import { normalizeDocumentRelativePath, normalizeDocumentSubPath } from "../utils/document-path.ts";
 import {
 	buildGlobPattern,
 	extractAnyPrefix,
@@ -763,12 +764,9 @@ export class FileSystem {
 		const canonicalId = normalizeDocumentId(document.id);
 		document.id = canonicalId;
 		const filename = `${canonicalId} - ${this.sanitizeFilename(document.title)}.md`;
-		const subPathSegments = subPath
-			.split(/[\\/]+/)
-			.map((segment) => segment.trim())
-			.filter((segment) => segment.length > 0 && segment !== "." && segment !== "..");
-		const relativePath = subPathSegments.length > 0 ? join(...subPathSegments, filename) : filename;
-		const filepath = join(docsDir, relativePath);
+		const normalizedSubPath = normalizeDocumentSubPath(subPath);
+		const relativePath = normalizedSubPath ? `${normalizedSubPath}/${filename}` : filename;
+		const filepath = join(docsDir, ...relativePath.split("/"));
 		const content = serializeDocument(document);
 
 		await this.ensureDirectoryExists(dirname(filepath));
@@ -782,13 +780,13 @@ export class FileSystem {
 			return documentIdsEqual(canonicalId, candidateId);
 		});
 
-		let sourceRelativePath = document.path;
+		let sourceRelativePath = document.path ? normalizeDocumentRelativePath(document.path) : undefined;
 		if (!sourceRelativePath && matchesForId.length > 0) {
-			sourceRelativePath = matchesForId[0];
+			sourceRelativePath = normalizeDocumentRelativePath(matchesForId[0] ?? "");
 		}
 
 		if (sourceRelativePath && sourceRelativePath !== relativePath) {
-			const sourcePath = join(docsDir, sourceRelativePath);
+			const sourcePath = join(docsDir, ...sourceRelativePath.split("/"));
 			try {
 				await this.ensureDirectoryExists(dirname(filepath));
 				await rename(sourcePath, filepath);
@@ -801,7 +799,7 @@ export class FileSystem {
 		}
 
 		for (const match of matchesForId) {
-			const matchPath = join(docsDir, match);
+			const matchPath = join(docsDir, ...normalizeDocumentRelativePath(match).split("/"));
 			if (matchPath === filepath) {
 				continue;
 			}
@@ -848,14 +846,15 @@ export class FileSystem {
 			const docFiles = await Array.fromAsync(glob.scan({ cwd: docsDir, followSymlinks: true }));
 			const docs: Document[] = [];
 			for (const file of docFiles) {
-				const base = file.split("/").pop() || file;
+				const relativePath = normalizeDocumentRelativePath(file);
+				const base = relativePath.split("/").pop() || relativePath;
 				if (base.toLowerCase() === "readme.md") continue;
-				const filepath = join(docsDir, file);
+				const filepath = join(docsDir, ...relativePath.split("/"));
 				const content = await Bun.file(filepath).text();
 				const parsed = parseDocument(content);
 				docs.push({
 					...parsed,
-					path: file,
+					path: relativePath,
 				});
 			}
 

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -66,6 +66,8 @@ remains fully synchronized and up-to-date.
 - **All task operations MUST use the Backlog.md CLI tool**
 - This ensures metadata is correctly updated and the project stays in sync
 - **Always use `--plain` flag** when listing or viewing tasks for AI-friendly text output
+- Create project docs through Backlog.md APIs so frontmatter and paths stay valid. For CLI users, run `backlog doc create "Title" -p guides/setup`; MCP users should use `document_create` with `path: "guides/setup"`.
+- Document paths are relative to `backlog/docs/`; absolute paths and `..` traversal are rejected.
 
 ---
 

--- a/src/guidelines/mcp/overview-tools.md
+++ b/src/guidelines/mcp/overview-tools.md
@@ -48,6 +48,7 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 - `task_list`, `task_search`, `task_view`, `task_create`, `task_edit`, `task_complete`, `task_archive`
 - `task_search` accepts `modifiedFiles` for case-insensitive substring filtering against project-root-relative modified file paths
 - `document_list`, `document_view`, `document_create`, `document_update`, `document_search`
+- `document_create` and `document_update` support docs-directory-relative `path` values such as `guides/setup`; absolute paths and `..` traversal are rejected
 - `definition_of_done_defaults_get`, `definition_of_done_defaults_upsert`
 
 **Definition of Done support**

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -59,10 +59,17 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 - `task_view` — read full task context (description, plan, notes, final summary, acceptance criteria, Definition of Done)
 - `definition_of_done_defaults_get` — read project-level Definition of Done defaults from config
 - `definition_of_done_defaults_upsert` — replace project-level Definition of Done defaults in config
+- `document_list` — list documents, including type, path, timestamps, and tags
+- `document_view` — view document metadata and markdown content
+- `document_create` — create a document with title, content, optional type/tags, and optional docs-directory-relative path
+- `document_update` — update document content, optional title/type/tags, and optional docs-directory-relative path
+- `document_search` — search documents using the shared fuzzy index
 - `task_create` — create new tasks with description and acceptance criteria; DoD fields are for **exceptional** task-level overrides only (`definitionOfDoneAdd`, `disableDefinitionOfDoneDefaults`)
 - `task_edit` — update task metadata, status, plan, notes, final summary, acceptance criteria, task-level Definition of Done (`definitionOfDoneAdd/Remove/Check/Uncheck`) for **exceptional** per-task updates, and dependencies
 - DoD is not acceptance criteria: acceptance criteria define scope/behavior, while DoD tracks completion hygiene
 - `task_complete` — move a Done task to the completed folder (periodic cleanup, not immediate)
 - `task_archive` — archive a task that should not be completed (duplicate, canceled, invalid). Note: archived task IDs can be reused by new tasks (soft delete behavior).
+
+**Document path rules:** document paths are relative to the docs directory. Use `path` values like `guides/setup`; absolute paths and `..` traversal are rejected.
 
 **Always operate through MCP tools. Never edit markdown files directly so relationships, metadata, and history stay consistent.**

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -7,12 +7,16 @@ logic.
 
 - `server.ts` / `createMcpServer()` – bootstraps a stdio-only server that extends `Core` and registers task, milestone, Definition of Done defaults, and document tools (`task_*`, `milestone_*`, `definition_of_done_defaults_*`, `document_*`) for MCP clients.
 - `tasks/` – consolidated task tooling that delegates to shared Core helpers (including plan/notes/AC editing).
-- `documents/` – document tooling layered on `Core`’s document helpers for list/view/create/update/search flows.
+- `documents/` – document tooling layered on `Core`’s document helpers for list/view/create/update/search flows, including docs-directory-relative path metadata.
 - `tools/dependency-tools.ts` – dependency helpers reusing shared builders.
 - `resources/` – lightweight resource adapters for agents.
 - `guidelines/mcp/` – task workflow content surfaced via MCP.
 
 Everything routes through existing Core APIs so the MCP layer stays a protocol wrapper.
+
+Document tool `path` inputs are subdirectories under the configured docs directory, for example `guides/setup`.
+Created and updated document responses include the persisted docs-relative file path. Absolute paths and traversal
+segments such as `..` are rejected by the shared core/filesystem path handling.
 
 ## Development workflow
 

--- a/src/mcp/tools/documents/handlers.ts
+++ b/src/mcp/tools/documents/handlers.ts
@@ -15,12 +15,18 @@ export type DocumentViewArgs = {
 export type DocumentCreateArgs = {
 	title: string;
 	content: string;
+	type?: Document["type"];
+	path?: string;
+	tags?: string[];
 };
 
 export type DocumentUpdateArgs = {
 	id: string;
 	title?: string;
 	content: string;
+	type?: Document["type"];
+	path?: string;
+	tags?: string[];
 };
 
 export type DocumentSearchArgs = {
@@ -32,7 +38,11 @@ export class DocumentHandlers {
 	constructor(private readonly core: McpServer) {}
 
 	private formatDocumentSummaryLine(document: Document): string {
-		const metadata: string[] = [`type: ${document.type}`, `created: ${document.createdDate}`];
+		const metadata: string[] = [
+			`type: ${document.type}`,
+			`path: ${document.path ?? "(unknown)"}`,
+			`created: ${document.createdDate}`,
+		];
 		if (document.updatedDate) {
 			metadata.push(`updated: ${document.updatedDate}`);
 		}
@@ -105,7 +115,13 @@ export class DocumentHandlers {
 
 	async createDocument(args: DocumentCreateArgs): Promise<CallToolResult> {
 		try {
-			const document = await this.core.createDocumentWithId(args.title, args.content);
+			const document = await this.core.createDocumentFromInput({
+				title: args.title,
+				content: args.content,
+				type: args.type,
+				path: args.path,
+				tags: args.tags,
+			});
 			return await formatDocumentCallResult(document, {
 				summaryLines: ["Document created successfully."],
 			});
@@ -118,16 +134,18 @@ export class DocumentHandlers {
 	}
 
 	async updateDocument(args: DocumentUpdateArgs): Promise<CallToolResult> {
-		const existing = await this.loadDocumentOrThrow(args.id);
-		const nextDocument = args.title ? { ...existing, title: args.title } : existing;
+		await this.loadDocumentOrThrow(args.id);
 
 		try {
-			await this.core.updateDocument(nextDocument, args.content);
-			const refreshed = await this.core.getDocument(existing.id);
-			if (!refreshed) {
-				throw new BacklogToolError(`Document not found: ${args.id}`, "DOCUMENT_NOT_FOUND");
-			}
-			return await formatDocumentCallResult(refreshed, {
+			const document = await this.core.updateDocumentFromInput({
+				id: args.id,
+				content: args.content,
+				title: args.title,
+				type: args.type,
+				path: args.path,
+				tags: args.tags,
+			});
+			return await formatDocumentCallResult(document, {
 				summaryLines: ["Document updated successfully."],
 			});
 		} catch (error) {
@@ -162,7 +180,7 @@ export class DocumentHandlers {
 		for (const result of documents) {
 			const { document } = result;
 			const scoreText = this.formatScore(result.score);
-			lines.push(`  ${document.id} - ${document.title}${scoreText}`);
+			lines.push(`  ${document.id} - ${document.title} (${document.path ?? "(unknown)"})${scoreText}`);
 		}
 
 		return {

--- a/src/mcp/tools/documents/index.ts
+++ b/src/mcp/tools/documents/index.ts
@@ -46,7 +46,8 @@ export function registerDocumentTools(server: McpServer, _config: BacklogConfig)
 	const createDocumentTool: McpToolHandler = createSimpleValidatedTool(
 		{
 			name: "document_create",
-			description: "Create a Backlog.md document using the shared ID generator",
+			description:
+				"Create a Backlog.md document using the shared core document pipeline, with optional docs subdirectory path",
 			inputSchema: documentCreateSchema,
 			annotations: { title: "Create Document", destructiveHint: false },
 		},
@@ -57,7 +58,8 @@ export function registerDocumentTools(server: McpServer, _config: BacklogConfig)
 	const updateDocumentTool: McpToolHandler = createSimpleValidatedTool(
 		{
 			name: "document_update",
-			description: "Update an existing Backlog.md document's content and optional title",
+			description:
+				"Update an existing Backlog.md document's content, optional title, metadata, and optional docs subdirectory path",
 			inputSchema: documentUpdateSchema,
 			annotations: { title: "Update Document", destructiveHint: false },
 		},

--- a/src/mcp/tools/documents/schemas.ts
+++ b/src/mcp/tools/documents/schemas.ts
@@ -1,4 +1,7 @@
+import { DOCUMENT_TYPE_VALUES } from "../../../types/index.ts";
 import type { JsonSchema } from "../../validation/validators.ts";
+
+const DOCUMENT_TYPE_ENUM = [...DOCUMENT_TYPE_VALUES];
 
 export const documentListSchema: JsonSchema = {
 	type: "object",
@@ -39,6 +42,7 @@ export const documentCreateSchema: JsonSchema = {
 		type: {
 			type: "string",
 			maxLength: 50,
+			enum: DOCUMENT_TYPE_ENUM,
 		},
 		path: {
 			type: "string",
@@ -73,6 +77,7 @@ export const documentUpdateSchema: JsonSchema = {
 		type: {
 			type: "string",
 			maxLength: 50,
+			enum: DOCUMENT_TYPE_ENUM,
 		},
 		path: {
 			type: "string",

--- a/src/mcp/tools/documents/schemas.ts
+++ b/src/mcp/tools/documents/schemas.ts
@@ -36,6 +36,19 @@ export const documentCreateSchema: JsonSchema = {
 		content: {
 			type: "string",
 		},
+		type: {
+			type: "string",
+			maxLength: 50,
+		},
+		path: {
+			type: "string",
+			maxLength: 300,
+		},
+		tags: {
+			type: "array",
+			items: { type: "string", maxLength: 100 },
+			maxItems: 50,
+		},
 	},
 	required: ["title", "content"],
 	additionalProperties: false,
@@ -56,6 +69,19 @@ export const documentUpdateSchema: JsonSchema = {
 		},
 		content: {
 			type: "string",
+		},
+		type: {
+			type: "string",
+			maxLength: 50,
+		},
+		path: {
+			type: "string",
+			maxLength: 300,
+		},
+		tags: {
+			type: "array",
+			items: { type: "string", maxLength: 100 },
+			maxItems: 50,
 		},
 	},
 	required: ["id", "content"],

--- a/src/mcp/utils/document-response.ts
+++ b/src/mcp/utils/document-response.ts
@@ -12,6 +12,7 @@ function buildDocumentText(document: Document, options?: { includeContent?: bool
 	const lines: string[] = [
 		`Document ${document.id} - ${document.title}`,
 		`Type: ${document.type}`,
+		`Path: ${document.path ?? "(unknown)"}`,
 		`Created: ${document.createdDate}`,
 	];
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1009,10 +1009,11 @@ export class BacklogServer {
 			const store = await this.getContentStoreInstance();
 			const docs = store.getDocuments();
 			const docFiles = docs.map((doc) => ({
-				name: `${doc.title}.md`,
+				name: doc.path?.split(/[\\/]+/).pop() ?? `${doc.title}.md`,
 				id: doc.id,
 				title: doc.title,
 				type: doc.type,
+				path: doc.path,
 				createdDate: doc.createdDate,
 				updatedDate: doc.updatedDate,
 				lastModified: doc.updatedDate || doc.createdDate,
@@ -1039,13 +1040,29 @@ export class BacklogServer {
 	}
 
 	private async handleCreateDoc(req: Request): Promise<Response> {
-		const { filename, content } = await req.json();
-
 		try {
-			const title = filename.replace(".md", "");
-			const document = await this.core.createDocumentWithId(title, content);
-			return Response.json({ success: true, id: document.id }, { status: 201 });
+			const body = await req.json();
+			const filename = typeof body?.filename === "string" ? body.filename : undefined;
+			const title = typeof body?.title === "string" ? body.title : filename?.replace(/\.md$/i, "");
+			if (!title || title.trim().length === 0) {
+				return Response.json({ error: "Document title is required" }, { status: 400 });
+			}
+
+			const document = await this.core.createDocumentFromInput({
+				title,
+				content: typeof body?.content === "string" ? body.content : "",
+				type: body?.type,
+				path: typeof body?.path === "string" ? body.path : undefined,
+				tags: Array.isArray(body?.tags) ? body.tags.map(String) : undefined,
+			});
+			return Response.json({ success: true, ...document }, { status: 201 });
 		} catch (error) {
+			if (error instanceof SyntaxError) {
+				return Response.json({ error: "Invalid request payload" }, { status: 400 });
+			}
+			if (error instanceof Error) {
+				return Response.json({ error: error.message }, { status: 400 });
+			}
 			console.error("Error creating document:", error);
 			return Response.json({ error: "Failed to create document" }, { status: 500 });
 		}
@@ -1056,6 +1073,7 @@ export class BacklogServer {
 			const body = await req.json();
 			const content = typeof body?.content === "string" ? body.content : undefined;
 			const title = typeof body?.title === "string" ? body.title : undefined;
+			const path = typeof body?.path === "string" || body?.path === null ? body.path : undefined;
 
 			if (typeof content !== "string") {
 				return Response.json({ error: "Document content is required" }, { status: 400 });
@@ -1070,20 +1088,24 @@ export class BacklogServer {
 				}
 			}
 
-			const existingDoc = await this.core.getDocument(docId);
-			if (!existingDoc) {
-				return Response.json({ error: "Document not found" }, { status: 404 });
-			}
-
-			const nextDoc = normalizedTitle ? { ...existingDoc, title: normalizedTitle } : { ...existingDoc };
-
-			await this.core.updateDocument(nextDoc, content);
-			return Response.json({ success: true });
+			const document = await this.core.updateDocumentFromInput({
+				id: docId,
+				content,
+				...(normalizedTitle && { title: normalizedTitle }),
+				...(path !== undefined && { path }),
+				...(typeof body?.type === "string" && { type: body.type }),
+				...(Array.isArray(body?.tags) && { tags: body.tags.map(String) }),
+			});
+			return Response.json({ success: true, ...document });
 		} catch (error) {
-			console.error("Error updating document:", error);
 			if (error instanceof SyntaxError) {
 				return Response.json({ error: "Invalid request payload" }, { status: 400 });
 			}
+			if (error instanceof Error) {
+				const status = error.message.startsWith("Document not found") ? 404 : 400;
+				return Response.json({ error: error.message }, { status });
+			}
+			console.error("Error updating document:", error);
 			return Response.json({ error: "Failed to update document" }, { status: 500 });
 		}
 	}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,13 +9,76 @@ import { getTaskStatistics } from "../core/statistics.ts";
 import { isCreateLockError } from "../file-system/operations.ts";
 import { BacklogToolError } from "../mcp/errors/mcp-errors.ts";
 import { MilestoneHandlers } from "../mcp/tools/milestones/handlers.ts";
-import type { SearchPriorityFilter, SearchResultType, Task, TaskUpdateInput } from "../types/index.ts";
+import type { Document, SearchPriorityFilter, SearchResultType, Task, TaskUpdateInput } from "../types/index.ts";
 import { watchConfig } from "../utils/config-watcher.ts";
 import { getVersion } from "../utils/version.ts";
 
 // Regex pattern to match any prefix (letters followed by dash)
 const PREFIX_PATTERN = /^[a-zA-Z]+-/i;
 const DEFAULT_PREFIX = "task-";
+const DOCUMENT_TYPES = new Set<Document["type"]>(["readme", "guide", "specification", "other"]);
+
+class DocumentPayloadValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "DocumentPayloadValidationError";
+	}
+}
+
+function parseDocumentType(value: unknown): Document["type"] | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new DocumentPayloadValidationError("Document type must be a string.");
+	}
+	if (!DOCUMENT_TYPES.has(value as Document["type"])) {
+		throw new DocumentPayloadValidationError("Document type must be one of: readme, guide, specification, other.");
+	}
+	return value as Document["type"];
+}
+
+function parseDocumentTags(value: unknown): string[] | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (!Array.isArray(value)) {
+		throw new DocumentPayloadValidationError("Document tags must be an array of strings.");
+	}
+	if (value.some((tag) => typeof tag !== "string")) {
+		throw new DocumentPayloadValidationError("Document tags must be an array of strings.");
+	}
+	return Array.from(new Set(value.map((tag) => tag.trim()).filter((tag) => tag.length > 0)));
+}
+
+function parseCreateDocumentPath(value: unknown): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "string") {
+		throw new DocumentPayloadValidationError("Document path must be a string.");
+	}
+	return value;
+}
+
+function parseUpdateDocumentPath(value: unknown): string | null | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (value === null || typeof value === "string") {
+		return value;
+	}
+	throw new DocumentPayloadValidationError("Document path must be a string or null.");
+}
+
+function isDocumentValidationError(error: Error): boolean {
+	return (
+		error instanceof DocumentPayloadValidationError ||
+		error.message.startsWith("Document path ") ||
+		error.message === "Title is required to create a document." ||
+		error.message === "Document title cannot be empty."
+	);
+}
 
 /**
  * Strip any prefix from an ID (e.g., "task-123" -> "123", "JIRA-456" -> "456")
@@ -1047,20 +1110,23 @@ export class BacklogServer {
 			if (!title || title.trim().length === 0) {
 				return Response.json({ error: "Document title is required" }, { status: 400 });
 			}
+			const type = parseDocumentType(body?.type);
+			const path = parseCreateDocumentPath(body?.path);
+			const tags = parseDocumentTags(body?.tags);
 
 			const document = await this.core.createDocumentFromInput({
 				title,
 				content: typeof body?.content === "string" ? body.content : "",
-				type: body?.type,
-				path: typeof body?.path === "string" ? body.path : undefined,
-				tags: Array.isArray(body?.tags) ? body.tags.map(String) : undefined,
+				type,
+				path,
+				tags,
 			});
 			return Response.json({ success: true, ...document }, { status: 201 });
 		} catch (error) {
 			if (error instanceof SyntaxError) {
 				return Response.json({ error: "Invalid request payload" }, { status: 400 });
 			}
-			if (error instanceof Error) {
+			if (error instanceof Error && isDocumentValidationError(error)) {
 				return Response.json({ error: error.message }, { status: 400 });
 			}
 			console.error("Error creating document:", error);
@@ -1073,7 +1139,9 @@ export class BacklogServer {
 			const body = await req.json();
 			const content = typeof body?.content === "string" ? body.content : undefined;
 			const title = typeof body?.title === "string" ? body.title : undefined;
-			const path = typeof body?.path === "string" || body?.path === null ? body.path : undefined;
+			const path = parseUpdateDocumentPath(body?.path);
+			const type = parseDocumentType(body?.type);
+			const tags = parseDocumentTags(body?.tags);
 
 			if (typeof content !== "string") {
 				return Response.json({ error: "Document content is required" }, { status: 400 });
@@ -1093,8 +1161,8 @@ export class BacklogServer {
 				content,
 				...(normalizedTitle && { title: normalizedTitle }),
 				...(path !== undefined && { path }),
-				...(typeof body?.type === "string" && { type: body.type }),
-				...(Array.isArray(body?.tags) && { tags: body.tags.map(String) }),
+				...(type !== undefined && { type }),
+				...(tags !== undefined && { tags }),
 			});
 			return Response.json({ success: true, ...document });
 		} catch (error) {
@@ -1102,8 +1170,12 @@ export class BacklogServer {
 				return Response.json({ error: "Invalid request payload" }, { status: 400 });
 			}
 			if (error instanceof Error) {
-				const status = error.message.startsWith("Document not found") ? 404 : 400;
-				return Response.json({ error: error.message }, { status });
+				if (error.message.startsWith("Document not found")) {
+					return Response.json({ error: error.message }, { status: 404 });
+				}
+				if (isDocumentValidationError(error)) {
+					return Response.json({ error: error.message }, { status: 400 });
+				}
 			}
 			console.error("Error updating document:", error);
 			return Response.json({ error: "Failed to update document" }, { status: 500 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,14 +9,21 @@ import { getTaskStatistics } from "../core/statistics.ts";
 import { isCreateLockError } from "../file-system/operations.ts";
 import { BacklogToolError } from "../mcp/errors/mcp-errors.ts";
 import { MilestoneHandlers } from "../mcp/tools/milestones/handlers.ts";
-import type { Document, SearchPriorityFilter, SearchResultType, Task, TaskUpdateInput } from "../types/index.ts";
+import {
+	DOCUMENT_TYPE_VALUES,
+	type Document,
+	type SearchPriorityFilter,
+	type SearchResultType,
+	type Task,
+	type TaskUpdateInput,
+} from "../types/index.ts";
 import { watchConfig } from "../utils/config-watcher.ts";
 import { getVersion } from "../utils/version.ts";
 
 // Regex pattern to match any prefix (letters followed by dash)
 const PREFIX_PATTERN = /^[a-zA-Z]+-/i;
 const DEFAULT_PREFIX = "task-";
-const DOCUMENT_TYPES = new Set<Document["type"]>(["readme", "guide", "specification", "other"]);
+const DOCUMENT_TYPES = new Set<Document["type"]>(DOCUMENT_TYPE_VALUES);
 
 class DocumentPayloadValidationError extends Error {
 	constructor(message: string) {
@@ -33,7 +40,7 @@ function parseDocumentType(value: unknown): Document["type"] | undefined {
 		throw new DocumentPayloadValidationError("Document type must be a string.");
 	}
 	if (!DOCUMENT_TYPES.has(value as Document["type"])) {
-		throw new DocumentPayloadValidationError("Document type must be one of: readme, guide, specification, other.");
+		throw new DocumentPayloadValidationError(`Document type must be one of: ${DOCUMENT_TYPE_VALUES.join(", ")}.`);
 	}
 	return value as Document["type"];
 }
@@ -74,6 +81,7 @@ function parseUpdateDocumentPath(value: unknown): string | null | undefined {
 function isDocumentValidationError(error: Error): boolean {
 	return (
 		error instanceof DocumentPayloadValidationError ||
+		error.message.startsWith("Document type ") ||
 		error.message.startsWith("Document path ") ||
 		error.message === "Title is required to create a document." ||
 		error.message === "Document title cannot be empty."

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1353,6 +1353,24 @@ describe("CLI Integration", () => {
 			expect(docs[0]?.title).toBe("Guide");
 		});
 
+		it("should create documents in a subpath and print the persisted path", async () => {
+			const result = await $`bun ${CLI_PATH} doc create "Setup Guide" -p guides/setup`.cwd(TEST_DIR).quiet();
+			expect(result.exitCode).toBe(0);
+			const stdout = result.stdout.toString();
+			expect(stdout).toContain("Created document doc-1");
+			expect(stdout).toContain("Path: backlog/docs/guides/setup/doc-1 - Setup-Guide.md");
+
+			const core = new Core(TEST_DIR);
+			const docs = await core.filesystem.listDocuments();
+			expect(docs[0]?.path).toBe("guides/setup/doc-1 - Setup-Guide.md");
+		});
+
+		it("should reject unsafe document paths", async () => {
+			const result = await $`bun ${CLI_PATH} doc create "Unsafe" -p ../outside`.cwd(TEST_DIR).quiet().nothrow();
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stderr.toString()).toContain("Document path cannot include traversal segments.");
+		});
+
 		it("should create and list decisions", async () => {
 			const core = new Core(TEST_DIR);
 			const decision: Decision = {

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -391,6 +391,51 @@ describe("Core", () => {
 			expect(updatedDocs[0]?.title).toBe("Operations Guide Updated");
 		});
 
+		it("creates and moves documents through core input methods", async () => {
+			const created = await core.createDocumentFromInput({
+				title: "Setup Guide",
+				content: "# Setup",
+				type: "guide",
+				path: "guides/setup",
+				tags: ["setup", "guide"],
+			});
+
+			expect(created.id).toBe("doc-1");
+			expect(created.path).toBe("guides/setup/doc-1 - Setup-Guide.md");
+
+			const updated = await core.updateDocumentFromInput({
+				id: created.id,
+				title: "Install Guide",
+				content: "# Install",
+				path: "runbooks",
+			});
+
+			expect(updated.title).toBe("Install Guide");
+			expect(updated.path).toBe("runbooks/doc-1 - Install-Guide.md");
+			expect(updated.rawContent).toBe("# Install");
+
+			const docFiles = await Array.fromAsync(
+				new Bun.Glob("**/doc-*.md").scan({ cwd: core.filesystem.docsDir, followSymlinks: true }),
+			);
+			expect(docFiles).toEqual(["runbooks/doc-1 - Install-Guide.md"]);
+		});
+
+		it("preserves document path when updating without an explicit path", async () => {
+			const created = await core.createDocumentFromInput({
+				title: "Nested",
+				content: "Initial",
+				path: "guides",
+			});
+
+			const updated = await core.updateDocumentFromInput({
+				id: created.id,
+				content: "Updated",
+				title: "Nested Updated",
+			});
+
+			expect(updated.path).toBe("guides/doc-1 - Nested-Updated.md");
+		});
+
 		it("shows a git rename when the document title changes", async () => {
 			await core.createDocument(baseDocument, true);
 

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -7,6 +7,8 @@ import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-
 
 let TEST_DIR: string;
 
+const toPosixPath = (path: string): string => path.replace(/\\/g, "/");
+
 describe("Core", () => {
 	let core: Core;
 
@@ -417,7 +419,7 @@ describe("Core", () => {
 			const docFiles = await Array.fromAsync(
 				new Bun.Glob("**/doc-*.md").scan({ cwd: core.filesystem.docsDir, followSymlinks: true }),
 			);
-			expect(docFiles).toEqual(["runbooks/doc-1 - Install-Guide.md"]);
+			expect(docFiles.map(toPosixPath)).toEqual(["runbooks/doc-1 - Install-Guide.md"]);
 		});
 
 		it("preserves document path when updating without an explicit path", async () => {

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -398,7 +398,7 @@ describe("Core", () => {
 				title: "Setup Guide",
 				content: "# Setup",
 				type: "guide",
-				path: "guides/setup",
+				path: "guides / setup",
 				tags: ["setup", "guide"],
 			});
 

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -438,6 +438,30 @@ describe("Core", () => {
 			expect(updated.path).toBe("guides/doc-1 - Nested-Updated.md");
 		});
 
+		it("rejects unsupported document types in core input methods", async () => {
+			await expect(
+				core.createDocumentFromInput({
+					title: "Invalid",
+					content: "Content",
+					type: "unexpected",
+				} as unknown as Parameters<typeof core.createDocumentFromInput>[0]),
+			).rejects.toThrow("Document type must be one of");
+
+			const created = await core.createDocumentFromInput({
+				title: "Valid",
+				content: "Content",
+				type: "guide",
+			});
+
+			await expect(
+				core.updateDocumentFromInput({
+					id: created.id,
+					content: "Updated",
+					type: "unexpected",
+				} as unknown as Parameters<typeof core.updateDocumentFromInput>[0]),
+			).rejects.toThrow("Document type must be one of");
+		});
+
 		it("shows a git rename when the document title changes", async () => {
 			await core.createDocument(baseDocument, true);
 

--- a/src/test/filesystem.test.ts
+++ b/src/test/filesystem.test.ts
@@ -558,7 +558,29 @@ Invalid content`,
 
 			const docs = await filesystem.listDocuments();
 			const nested = docs.find((doc) => doc.id === "doc-3");
-			expect(nested?.path).toBe(join("guides", "doc-3 - Nested-Guide.md"));
+			expect(nested?.path).toBe("guides/doc-3 - Nested-Guide.md");
+		});
+
+		it("rejects unsafe document paths", async () => {
+			await expect(
+				filesystem.saveDocument(
+					{
+						...sampleDocument,
+						id: "doc-4",
+					},
+					"../outside",
+				),
+			).rejects.toThrow("Document path cannot include traversal segments.");
+
+			await expect(
+				filesystem.saveDocument(
+					{
+						...sampleDocument,
+						id: "doc-5",
+					},
+					"/tmp/docs",
+				),
+			).rejects.toThrow("Document path must be relative");
 		});
 
 		it("should load documents using flexible ID formats", async () => {

--- a/src/test/mcp-documents.test.ts
+++ b/src/test/mcp-documents.test.ts
@@ -52,6 +52,8 @@ describe("MCP document tools", () => {
 				arguments: {
 					title: "Engineering Guidelines",
 					content: "# Overview\n\nFollow the documented practices.",
+					path: "guides",
+					tags: ["engineering"],
 				},
 			},
 		});
@@ -59,6 +61,8 @@ describe("MCP document tools", () => {
 		const createText = getText(createResult.content);
 		expect(createText).toContain("Document created successfully.");
 		expect(createText).toContain("Document doc-1 - Engineering Guidelines");
+		expect(createText).toContain("Path: guides/doc-1 - Engineering-Guidelines.md");
+		expect(createText).toContain("Tags: engineering");
 		expect(createText).toContain("# Overview");
 
 		const listResult = await mcpServer.testInterface.callTool({
@@ -68,7 +72,8 @@ describe("MCP document tools", () => {
 		const listText = getText(listResult.content);
 		expect(listText).toContain("Documents:");
 		expect(listText).toContain("doc-1 - Engineering Guidelines");
-		expect(listText).toContain("tags: (none)");
+		expect(listText).toContain("path: guides/doc-1 - Engineering-Guidelines.md");
+		expect(listText).toContain("tags: engineering");
 	});
 
 	it("filters documents using substring search", async () => {
@@ -155,6 +160,7 @@ describe("MCP document tools", () => {
 					id: "DOC-0001",
 					title: "Incident Response Handbook",
 					content: "Updated procedures",
+					path: "runbooks",
 				},
 			},
 		});
@@ -162,6 +168,7 @@ describe("MCP document tools", () => {
 		const updateText = getText(updateResult.content);
 		expect(updateText).toContain("Document updated successfully.");
 		expect(updateText).toContain("Document doc-1 - Incident Response Handbook");
+		expect(updateText).toContain("Path: runbooks/doc-1 - Incident-Response-Handbook.md");
 		expect(updateText).toContain("Updated procedures");
 
 		const viewResult = await mcpServer.testInterface.callTool({
@@ -169,7 +176,24 @@ describe("MCP document tools", () => {
 		});
 		const viewText = getText(viewResult.content);
 		expect(viewText).toContain("Incident Response Handbook");
+		expect(viewText).toContain("Path: runbooks/doc-1 - Incident-Response-Handbook.md");
 		expect(viewText).toContain("Updated procedures");
+	});
+
+	it("rejects unsafe document paths", async () => {
+		const result = await mcpServer.testInterface.callTool({
+			params: {
+				name: "document_create",
+				arguments: {
+					title: "Unsafe",
+					content: "Content",
+					path: "../outside",
+				},
+			},
+		});
+
+		expect(result.isError).toBe(true);
+		expect(getText(result.content)).toContain("Document path cannot include traversal segments.");
 	});
 
 	it("searches documents and includes formatted scores", async () => {
@@ -195,6 +219,7 @@ describe("MCP document tools", () => {
 		const searchText = getText(searchResult.content);
 		expect(searchText).toContain("Documents:");
 		expect(searchText).toMatch(/Architecture Overview/);
+		expect(searchText).toContain("doc-1 - Architecture Overview (doc-1 - Architecture-Overview.md)");
 		expect(searchText).toMatch(/\[score [0-1]\.\d{3}]/);
 	});
 });

--- a/src/test/mcp-documents.test.ts
+++ b/src/test/mcp-documents.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { $ } from "bun";
 import { McpServer } from "../mcp/server.ts";
 import { registerDocumentTools } from "../mcp/tools/documents/index.ts";
+import type { JsonSchema } from "../mcp/validation/validators.ts";
+import { DOCUMENT_TYPE_VALUES } from "../types/index.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
 
 // Helper to extract text from MCP content (handles union types)
@@ -74,6 +76,62 @@ describe("MCP document tools", () => {
 		expect(listText).toContain("doc-1 - Engineering Guidelines");
 		expect(listText).toContain("path: guides/doc-1 - Engineering-Guidelines.md");
 		expect(listText).toContain("tags: engineering");
+	});
+
+	it("exposes supported document type enums", async () => {
+		const tools = await mcpServer.testInterface.listTools();
+		const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+
+		const createSchema = toolByName.get("document_create")?.inputSchema as JsonSchema | undefined;
+		const updateSchema = toolByName.get("document_update")?.inputSchema as JsonSchema | undefined;
+
+		expect(createSchema?.properties?.type?.enum).toEqual([...DOCUMENT_TYPE_VALUES]);
+		expect(updateSchema?.properties?.type?.enum).toEqual([...DOCUMENT_TYPE_VALUES]);
+	});
+
+	it("rejects unsupported document types", async () => {
+		const invalidCreate = await mcpServer.testInterface.callTool({
+			params: {
+				name: "document_create",
+				arguments: {
+					title: "Invalid Type",
+					content: "Content",
+					type: "unexpected",
+				},
+			},
+		});
+
+		expect(invalidCreate.isError).toBe(true);
+		expect(getText(invalidCreate.content)).toContain(
+			"Field 'type' must be one of: readme, guide, specification, other",
+		);
+
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "document_create",
+				arguments: {
+					title: "Valid Type",
+					content: "Content",
+					type: "guide",
+				},
+			},
+		});
+
+		const invalidUpdate = await mcpServer.testInterface.callTool({
+			params: {
+				name: "document_update",
+				arguments: {
+					id: "doc-1",
+					content: "Updated",
+					type: "unexpected",
+				},
+			},
+		});
+
+		expect(invalidUpdate.isError).toBe(true);
+		expect(getText(invalidUpdate.content)).toContain(
+			"Field 'type' must be one of: readme, guide, specification, other",
+		);
 	});
 
 	it("filters documents using substring search", async () => {

--- a/src/test/mcp-roots-discovery.test.ts
+++ b/src/test/mcp-roots-discovery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -39,9 +40,9 @@ async function setupDirs(): Promise<{
 }> {
 	TEST_DIR = createUniqueTestDir("mcp-roots");
 
-	const uninitializedDir = `${TEST_DIR}/no-backlog`;
-	const projectRoot = `${TEST_DIR}/real-project`;
-	const secondProjectRoot = `${TEST_DIR}/second-project`;
+	const uninitializedDir = join(TEST_DIR, "no-backlog");
+	const projectRoot = join(TEST_DIR, "real-project");
+	const secondProjectRoot = join(TEST_DIR, "second-project");
 
 	await $`mkdir -p ${uninitializedDir}`.quiet();
 	await createProject(projectRoot, "Roots Test Project");
@@ -168,7 +169,7 @@ describe("MCP roots discovery", () => {
 
 	it("normalizes file roots to their parent directory", async () => {
 		const { uninitializedDir, projectRoot } = await setupDirs();
-		const readmePath = `${projectRoot}/README.md`;
+		const readmePath = join(projectRoot, "README.md");
 		await $`touch ${readmePath}`.quiet();
 
 		const server = await createMcpServer(uninitializedDir);
@@ -193,7 +194,7 @@ describe("MCP roots discovery", () => {
 		const rootsRef = {
 			current: [
 				"file://not-a-local-host/path",
-				pathToFileURL(`${TEST_DIR}/missing-root`).toString(),
+				pathToFileURL(join(TEST_DIR, "missing-root")).toString(),
 				pathToFileURL(projectRoot).toString(),
 			],
 		};

--- a/src/test/remote-id-conflict.test.ts
+++ b/src/test/remote-id-conflict.test.ts
@@ -61,7 +61,7 @@ describe("next id across remote branches", () => {
 
 	it("uses id after highest remote task", async () => {
 		const result = await $`bun run ${CLI_PATH} task create "Local Task"`.cwd(LOCAL_DIR).quiet();
-		expect(result.stdout.toString()).toContain("Created task task-2");
+		expect(result.stdout.toString()).toContain("Created task TASK-2");
 		const core = new Core(LOCAL_DIR);
 		const task = await core.filesystem.loadTask("task-2");
 		expect(task).not.toBeNull();

--- a/src/test/server-assets.test.ts
+++ b/src/test/server-assets.test.ts
@@ -10,6 +10,16 @@ let filesystem: FileSystem;
 let server: BacklogServer | null = null;
 let serverPort = 0;
 
+async function fetchWithTimeout(path: string, timeoutMs = 1000): Promise<Response> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		return await fetch(`http://127.0.0.1:${serverPort}${path}`, { signal: controller.signal });
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
 describe("BacklogServer asset serving", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("server-assets");
@@ -45,7 +55,7 @@ describe("BacklogServer asset serving", () => {
 		// wait for server to be reachable
 		await retry(
 			async () => {
-				const res = await fetch(`http://127.0.0.1:${serverPort}/`);
+				const res = await fetchWithTimeout("/api/status", 500);
 				if (!res.ok) throw new Error("server not ready");
 				return true;
 			},
@@ -63,7 +73,7 @@ describe("BacklogServer asset serving", () => {
 	});
 
 	it("serves existing image assets with appropriate Content-Type and body", async () => {
-		const res = await fetch(`http://127.0.0.1:${serverPort}/assets/images/test.png`);
+		const res = await fetchWithTimeout("/assets/images/test.png");
 		expect(res.status).toBe(200);
 		expect(res.headers.get("content-type")).toBe("image/png");
 		const body = await res.text();
@@ -71,7 +81,7 @@ describe("BacklogServer asset serving", () => {
 	});
 
 	it("serves text files with text/plain Content-Type", async () => {
-		const res = await fetch(`http://127.0.0.1:${serverPort}/assets/docs/readme.txt`);
+		const res = await fetchWithTimeout("/assets/docs/readme.txt");
 		expect(res.status).toBe(200);
 		expect(res.headers.get("content-type")).toBe("text/plain");
 		const body = await res.text();
@@ -79,17 +89,17 @@ describe("BacklogServer asset serving", () => {
 	});
 
 	it("returns 404 for missing files", async () => {
-		const res = await fetch(`http://127.0.0.1:${serverPort}/assets/images/missing.png`);
+		const res = await fetchWithTimeout("/assets/images/missing.png");
 		expect(res.status).toBe(404);
 	});
 
 	it("rejects path traversal attempts with 404", async () => {
 		// attempt to escape assets via ..
-		const res = await fetch(`http://127.0.0.1:${serverPort}/assets/../config.yml`);
+		const res = await fetchWithTimeout("/assets/../config.yml");
 		expect(res.status).toBe(404);
 
 		// encoded traversal
-		const res2 = await fetch(`http://127.0.0.1:${serverPort}/assets/%2e%2e/config.yml`);
+		const res2 = await fetchWithTimeout("/assets/%2e%2e/config.yml");
 		expect(res2.status).toBe(404);
 	});
 });

--- a/src/test/server-documents-endpoint.test.ts
+++ b/src/test/server-documents-endpoint.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { FileSystem } from "../file-system/operations.ts";
+import { BacklogServer } from "../server/index.ts";
+import type { Document } from "../types/index.ts";
+import { createUniqueTestDir, retry, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let server: BacklogServer | null = null;
+let serverPort = 0;
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+	const response = await fetch(`http://127.0.0.1:${serverPort}${path}`, init);
+	if (!response.ok) {
+		throw new Error(`${response.status}: ${await response.text()}`);
+	}
+	return response.json();
+}
+
+describe("BacklogServer document endpoints", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("server-documents");
+		const filesystem = new FileSystem(TEST_DIR);
+		await filesystem.ensureBacklogStructure();
+		await filesystem.saveConfig({
+			projectName: "Server Documents",
+			statuses: ["To Do", "In Progress", "Done"],
+			labels: [],
+			milestones: [],
+			dateFormat: "YYYY-MM-DD",
+			remoteOperations: false,
+		});
+
+		server = new BacklogServer(TEST_DIR);
+		await server.start(0, false);
+		const port = server.getPort();
+		expect(port).not.toBeNull();
+		serverPort = port ?? 0;
+
+		await retry(async () => {
+			await fetchJson<Document[]>("/api/docs");
+		});
+	});
+
+	afterEach(async () => {
+		if (server) {
+			await server.stop();
+			server = null;
+		}
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("creates, lists, views, and moves documents with path metadata", async () => {
+		const created = await fetchJson<Document & { success: boolean }>("/api/docs", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Setup Guide",
+				content: "# Setup",
+				type: "guide",
+				path: "guides/setup",
+				tags: ["setup"],
+			}),
+		});
+
+		expect(created.success).toBe(true);
+		expect(created.id).toBe("doc-1");
+		expect(created.path).toBe("guides/setup/doc-1 - Setup-Guide.md");
+		expect(created.tags).toEqual(["setup"]);
+
+		const list = await fetchJson<Document[]>("/api/docs");
+		expect(list[0]?.path).toBe("guides/setup/doc-1 - Setup-Guide.md");
+
+		const viewed = await fetchJson<Document>("/api/docs/doc-1");
+		expect(viewed.rawContent).toBe("# Setup");
+		expect(viewed.path).toBe("guides/setup/doc-1 - Setup-Guide.md");
+
+		const updated = await fetchJson<Document & { success: boolean }>("/api/docs/doc-1", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Install Guide",
+				content: "# Install",
+				path: "runbooks",
+			}),
+		});
+
+		expect(updated.success).toBe(true);
+		expect(updated.title).toBe("Install Guide");
+		expect(updated.path).toBe("runbooks/doc-1 - Install-Guide.md");
+	});
+
+	it("rejects unsafe document paths", async () => {
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/docs`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Unsafe",
+				content: "Content",
+				path: "../outside",
+			}),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain("Document path cannot include traversal segments.");
+	});
+});

--- a/src/test/server-documents-endpoint.test.ts
+++ b/src/test/server-documents-endpoint.test.ts
@@ -57,7 +57,7 @@ describe("BacklogServer document endpoints", () => {
 				title: "Setup Guide",
 				content: "# Setup",
 				type: "guide",
-				path: "guides/setup",
+				path: "guides / setup",
 				tags: ["setup"],
 			}),
 		});
@@ -102,5 +102,120 @@ describe("BacklogServer document endpoints", () => {
 
 		expect(response.status).toBe(400);
 		expect(await response.text()).toContain("Document path cannot include traversal segments.");
+	});
+
+	it("rejects invalid document metadata", async () => {
+		const invalidCreateTypeShape = await fetch(`http://127.0.0.1:${serverPort}/api/docs`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Invalid Type",
+				content: "Content",
+				type: { name: "guide" },
+			}),
+		});
+		expect(invalidCreateTypeShape.status).toBe(400);
+		expect(await invalidCreateTypeShape.text()).toContain("Document type must be a string.");
+
+		const invalidCreateType = await fetch(`http://127.0.0.1:${serverPort}/api/docs`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Unsupported Type",
+				content: "Content",
+				type: "unexpected",
+			}),
+		});
+		expect(invalidCreateType.status).toBe(400);
+		expect(await invalidCreateType.text()).toContain("Document type must be one of");
+
+		const invalidCreateTags = await fetch(`http://127.0.0.1:${serverPort}/api/docs`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Invalid Tags",
+				content: "Content",
+				type: "guide",
+				tags: [{ label: "setup" }],
+			}),
+		});
+		expect(invalidCreateTags.status).toBe(400);
+		expect(await invalidCreateTags.text()).toContain("Document tags must be an array of strings.");
+
+		const created = await fetchJson<Document & { success: boolean }>("/api/docs", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Valid Metadata",
+				content: "Content",
+				type: "guide",
+				tags: ["setup"],
+			}),
+		});
+
+		const invalidUpdateType = await fetch(`http://127.0.0.1:${serverPort}/api/docs/${created.id}`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Updated",
+				type: "unexpected",
+			}),
+		});
+		expect(invalidUpdateType.status).toBe(400);
+		expect(await invalidUpdateType.text()).toContain("Document type must be one of");
+
+		const invalidUpdateTags = await fetch(`http://127.0.0.1:${serverPort}/api/docs/${created.id}`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Updated",
+				tags: [{ label: "setup" }],
+			}),
+		});
+		expect(invalidUpdateTags.status).toBe(400);
+		expect(await invalidUpdateTags.text()).toContain("Document tags must be an array of strings.");
+	});
+
+	it("preserves 500 status for unexpected document create and update failures", async () => {
+		if (!server) {
+			throw new Error("Expected server to be started");
+		}
+		const core = (
+			server as unknown as {
+				core: {
+					createDocumentFromInput: (...args: unknown[]) => Promise<Document>;
+					updateDocumentFromInput: (...args: unknown[]) => Promise<Document>;
+				};
+			}
+		).core;
+
+		core.createDocumentFromInput = async () => {
+			throw new Error("disk full");
+		};
+		const createResponse = await fetch(`http://127.0.0.1:${serverPort}/api/docs`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Create Failure",
+				content: "Content",
+				type: "guide",
+			}),
+		});
+		expect(createResponse.status).toBe(500);
+		expect(await createResponse.text()).toContain("Failed to create document");
+
+		core.updateDocumentFromInput = async () => {
+			throw new Error("rename failed");
+		};
+		const updateResponse = await fetch(`http://127.0.0.1:${serverPort}/api/docs/doc-1`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				content: "Updated",
+				type: "guide",
+			}),
+		});
+		expect(updateResponse.status).toBe(500);
+		expect(await updateResponse.text()).toContain("Failed to update document");
 	});
 });

--- a/src/test/status-callback.test.ts
+++ b/src/test/status-callback.test.ts
@@ -87,6 +87,7 @@ describe("Status Change Callbacks", () => {
 		let testDir: string;
 		let core: Core;
 		let callbackOutputFile: string;
+		let callbackOutputPath: string;
 
 		beforeEach(async () => {
 			testDir = join(tmpdir(), `backlog-callback-test-${Date.now()}`);
@@ -94,6 +95,7 @@ describe("Status Change Callbacks", () => {
 			await mkdir(join(testDir, "backlog", "tasks"), { recursive: true });
 
 			callbackOutputFile = join(testDir, "callback-output.txt");
+			callbackOutputPath = callbackOutputFile.replace(/\\/g, "/");
 
 			core = new Core(testDir);
 		});
@@ -116,7 +118,8 @@ statuses:
 labels: []
 milestones: []
 dateFormat: yyyy-mm-dd
-onStatusChange: 'echo "$TASK_ID:$OLD_STATUS->$NEW_STATUS" > ${callbackOutputFile}'
+checkActiveBranches: false
+onStatusChange: 'echo "$TASK_ID:$OLD_STATUS->$NEW_STATUS" > "${callbackOutputPath}"'
 `;
 			await writeFile(join(testDir, "backlog", "config.yml"), configContent);
 
@@ -154,7 +157,8 @@ statuses:
 labels: []
 milestones: []
 dateFormat: yyyy-mm-dd
-onStatusChange: 'echo "global" > ${callbackOutputFile}'
+checkActiveBranches: false
+onStatusChange: 'echo "global" > "${callbackOutputPath}"'
 `;
 			await writeFile(join(testDir, "backlog", "config.yml"), configContent);
 
@@ -167,7 +171,7 @@ assignee: []
 created_date: 2025-01-01
 labels: []
 dependencies: []
-onStatusChange: 'echo "per-task:$NEW_STATUS" > ${callbackOutputFile}'
+onStatusChange: 'echo "per-task:$NEW_STATUS" > "${callbackOutputPath}"'
 ---
 `;
 			await writeFile(join(testDir, "backlog", "tasks", "task-1 - Task with custom callback.md"), taskContent);
@@ -193,7 +197,8 @@ statuses:
 labels: []
 milestones: []
 dateFormat: yyyy-mm-dd
-onStatusChange: 'echo "callback-ran" > ${callbackOutputFile}'
+checkActiveBranches: false
+onStatusChange: 'echo "callback-ran" > "${callbackOutputPath}"'
 `;
 			await writeFile(join(testDir, "backlog", "config.yml"), configContent);
 
@@ -224,6 +229,7 @@ statuses:
 labels: []
 milestones: []
 dateFormat: yyyy-mm-dd
+checkActiveBranches: false
 `;
 			await writeFile(join(testDir, "backlog", "config.yml"), configContent);
 
@@ -248,6 +254,7 @@ statuses:
 labels: []
 milestones: []
 dateFormat: yyyy-mm-dd
+checkActiveBranches: false
 onStatusChange: 'exit 1'
 `;
 			await writeFile(join(testDir, "backlog", "config.yml"), configContent);
@@ -273,7 +280,8 @@ statuses:
 labels: []
 milestones: []
 dateFormat: yyyy-mm-dd
-onStatusChange: 'echo "$TASK_ID:$OLD_STATUS->$NEW_STATUS" >> ${callbackOutputFile}'
+checkActiveBranches: false
+onStatusChange: 'echo "$TASK_ID:$OLD_STATUS->$NEW_STATUS" >> "${callbackOutputPath}"'
 `;
 			await writeFile(join(testDir, "backlog", "config.yml"), configContent);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -179,10 +179,13 @@ export interface Milestone {
 	readonly rawContent: string; // Raw markdown content without frontmatter
 }
 
+export const DOCUMENT_TYPE_VALUES = ["readme", "guide", "specification", "other"] as const;
+export type DocumentType = (typeof DOCUMENT_TYPE_VALUES)[number];
+
 export interface Document {
 	id: string;
 	title: string;
-	type: "readme" | "guide" | "specification" | "other";
+	type: DocumentType;
 	createdDate: string;
 	updatedDate?: string;
 	rawContent: string; // Raw markdown content without frontmatter

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -193,6 +193,23 @@ export interface Document {
 	lastModified?: string;
 }
 
+export interface DocumentCreateInput {
+	title: string;
+	content?: string;
+	type?: Document["type"];
+	path?: string;
+	tags?: string[];
+}
+
+export interface DocumentUpdateInput {
+	id: string;
+	content: string;
+	title?: string;
+	type?: Document["type"];
+	path?: string | null;
+	tags?: string[];
+}
+
 export type SearchResultType = "task" | "document" | "decision";
 
 export type SearchPriorityFilter = "high" | "medium" | "low";

--- a/src/utils/document-path.ts
+++ b/src/utils/document-path.ts
@@ -14,7 +14,10 @@ export function normalizeDocumentSubPath(path?: string | null): string {
 		throw new Error("Document path must be relative to the docs directory.");
 	}
 
-	const segments = trimmed.split(/[\\/]+/).filter((segment) => segment.length > 0 && segment !== ".");
+	const segments = trimmed
+		.split(/[\\/]+/)
+		.map((segment) => segment.trim())
+		.filter((segment) => segment.length > 0 && segment !== ".");
 	if (segments.some((segment) => segment === "..")) {
 		throw new Error("Document path cannot include traversal segments.");
 	}

--- a/src/utils/document-path.ts
+++ b/src/utils/document-path.ts
@@ -1,0 +1,43 @@
+const WINDOWS_ABSOLUTE_PATH = /^[a-zA-Z]:[\\/]/;
+
+function hasAbsolutePrefix(value: string): boolean {
+	return value.startsWith("/") || value.startsWith("\\") || WINDOWS_ABSOLUTE_PATH.test(value);
+}
+
+export function normalizeDocumentSubPath(path?: string | null): string {
+	const trimmed = path?.trim();
+	if (!trimmed || trimmed === ".") {
+		return "";
+	}
+
+	if (hasAbsolutePrefix(trimmed)) {
+		throw new Error("Document path must be relative to the docs directory.");
+	}
+
+	const segments = trimmed.split(/[\\/]+/).filter((segment) => segment.length > 0 && segment !== ".");
+	if (segments.some((segment) => segment === "..")) {
+		throw new Error("Document path cannot include traversal segments.");
+	}
+
+	return segments.join("/");
+}
+
+export function normalizeDocumentRelativePath(path: string): string {
+	const normalized = normalizeDocumentSubPath(path);
+	if (!normalized) {
+		throw new Error("Document path cannot be empty.");
+	}
+	return normalized;
+}
+
+export function getDocumentSubPathFromRelativePath(path?: string): string {
+	if (!path) {
+		return "";
+	}
+	return normalizeDocumentSubPath(
+		path
+			.split(/[\\/]+/)
+			.slice(0, -1)
+			.join("/"),
+	);
+}

--- a/src/web/components/DocumentationDetail.tsx
+++ b/src/web/components/DocumentationDetail.tsx
@@ -61,6 +61,11 @@ const addDocPrefix = (id: string): string => {
     return id.startsWith('doc-') ? id : `doc-${id}`;
 };
 
+const getDocumentDirectory = (path?: string): string => {
+    if (!path) return '';
+    return path.split(/[\\/]+/).slice(0, -1).join('/');
+};
+
 interface DocumentationDetailProps {
     docs: Document[];
     onRefreshData: () => Promise<void>;
@@ -75,6 +80,8 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
     const [originalContent, setOriginalContent] = useState<string>('');
     const [docTitle, setDocTitle] = useState<string>('');
     const [originalDocTitle, setOriginalDocTitle] = useState<string>('');
+    const [docPath, setDocPath] = useState<string>('');
+    const [originalDocPath, setOriginalDocPath] = useState<string>('');
     const [isLoading, setIsLoading] = useState(true);
     const [isSaving, setIsSaving] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
@@ -91,6 +98,8 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
             setIsLoading(false);
             setDocTitle('');
             setOriginalDocTitle('');
+            setDocPath('');
+            setOriginalDocPath('');
             setContent('');
             setOriginalContent('');
         } else if (id) {
@@ -130,6 +139,8 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
                 setOriginalContent(fullDoc.rawContent || '');
                 setDocTitle(fullDoc.title || '');
                 setOriginalDocTitle(fullDoc.title || '');
+                setDocPath(getDocumentDirectory(fullDoc.path));
+                setOriginalDocPath(getDocumentDirectory(fullDoc.path));
                 // Update document state with full data
                 setDocument(fullDoc);
             } catch (fetchError) {
@@ -142,6 +153,8 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
                     setDocument(doc);
                     setDocTitle(doc.title || '');
                     setOriginalDocTitle(doc.title || '');
+                    setDocPath(getDocumentDirectory(doc.path));
+                    setOriginalDocPath(getDocumentDirectory(doc.path));
                 }
             }
         } catch (err) {
@@ -163,10 +176,11 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
             setIsSaving(true);
             setSaveError(null);
             const normalizedTitle = docTitle.trim();
+            const normalizedPath = docPath.trim();
 
             if (isNewDocument) {
                 // Create new document
-                const result = await apiClient.createDoc(normalizedTitle, content);
+                const result = await apiClient.createDoc(normalizedTitle, content, normalizedPath);
                 // Refresh data and navigate to the new document
                 await onRefreshData();
                 // Show success toast
@@ -177,6 +191,8 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
                 setIsNewDocument(false);
                 setDocTitle(normalizedTitle);
                 setOriginalDocTitle(normalizedTitle);
+                setDocPath(getDocumentDirectory(result.path) || normalizedPath);
+                setOriginalDocPath(getDocumentDirectory(result.path) || normalizedPath);
                 // Use the returned document ID for navigation
                 const documentId = result.id.replace('doc-', ''); // Remove prefix for URL
                 navigate(`/documentation/${documentId}/${sanitizeUrlTitle(normalizedTitle)}`);
@@ -186,18 +202,25 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
 
                 // Check if title has changed
                 const titleChanged = normalizedTitle !== originalDocTitle;
+                const pathChanged = normalizedPath !== originalDocPath;
 
                 // Pass title only if it has changed
-                await apiClient.updateDoc(
+                const updatedDocument = await apiClient.updateDoc(
                     addDocPrefix(id),
                     content,
-                    titleChanged ? normalizedTitle : undefined
+                    titleChanged ? normalizedTitle : undefined,
+                    pathChanged ? normalizedPath : undefined
                 );
 
                 // Update original title to the new value
                 if (titleChanged) {
                     setDocTitle(normalizedTitle);
                     setOriginalDocTitle(normalizedTitle);
+                }
+                if (pathChanged) {
+                    const updatedPath = getDocumentDirectory(updatedDocument.path) || normalizedPath;
+                    setDocPath(updatedPath);
+                    setOriginalDocPath(updatedPath);
                 }
 
                 // Refresh data from parent
@@ -216,7 +239,7 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
         } finally {
             setIsSaving(false);
         }
-    }, [id, docTitle, content, isNewDocument, onRefreshData, navigate, loadDocContent]);
+    }, [id, docTitle, docPath, originalDocPath, content, isNewDocument, onRefreshData, navigate, loadDocContent]);
 
     const handleEdit = () => {
         setIsEditing(true);
@@ -230,11 +253,12 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
             // Revert changes for existing documents
             setContent(originalContent);
             setDocTitle(originalDocTitle);
+            setDocPath(originalDocPath);
             setIsEditing(false);
         }
     };
 
-    const hasChanges = content !== originalContent || docTitle !== originalDocTitle;
+    const hasChanges = content !== originalContent || docTitle !== originalDocTitle || docPath !== originalDocPath;
 
     if (!id) {
         return (
@@ -270,13 +294,22 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
                         <div className="flex items-start justify-between mb-6">
                             <div className="flex-1">
                                 {isEditing ? (
-                                    <input
-                                        type="text"
-                                        value={docTitle}
-                                        onChange={(e) => setDocTitle(e.target.value)}
-                                        className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 w-full bg-transparent border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-transparent transition-colors duration-200"
-                                        placeholder="Document title"
-                                    />
+                                    <div className="space-y-3 mb-2">
+                                        <input
+                                            type="text"
+                                            value={docTitle}
+                                            onChange={(e) => setDocTitle(e.target.value)}
+                                            className="text-3xl font-bold text-gray-900 dark:text-gray-100 w-full bg-transparent border border-gray-300 dark:border-gray-600 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-transparent transition-colors duration-200"
+                                            placeholder="Document title"
+                                        />
+                                        <input
+                                            type="text"
+                                            value={docPath}
+                                            onChange={(e) => setDocPath(e.target.value)}
+                                            className="w-full max-w-md bg-transparent border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-transparent transition-colors duration-200"
+                                            placeholder="guides/setup"
+                                        />
+                                    </div>
                                 ) : (
                                     <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 transition-colors duration-200">
                                         {docTitle || document?.title || (title ? decodeURIComponent(title) : `Document ${id}`)}
@@ -297,6 +330,15 @@ export default function DocumentationDetail({docs, onRefreshData}: Documentation
                                         </svg>
                                         <span>Documentation</span>
                                     </div>
+                                    {document?.path && (
+                                        <div className="flex items-center space-x-2">
+                                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                                                      d="M3 7h5l2 2h11v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"/>
+                                            </svg>
+                                            <span>{document.path}</span>
+                                        </div>
+                                    )}
                                     {document?.createdDate && (
                                         <div className="flex items-center space-x-2">
                                             <svg className="w-4 h-4" fill="none" stroke="currentColor"

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -339,10 +339,13 @@ export class ApiClient {
 		return response.json();
 	}
 
-	async updateDoc(filename: string, content: string, title?: string): Promise<void> {
+	async updateDoc(filename: string, content: string, title?: string, path?: string | null): Promise<Document> {
 		const payload: Record<string, unknown> = { content };
 		if (typeof title === "string") {
 			payload.title = title;
+		}
+		if (path !== undefined) {
+			payload.path = path;
 		}
 
 		const response = await fetch(`${API_BASE}/docs/${encodeURIComponent(filename)}`, {
@@ -355,15 +358,16 @@ export class ApiClient {
 		if (!response.ok) {
 			throw new Error("Failed to update document");
 		}
+		return response.json();
 	}
 
-	async createDoc(filename: string, content: string): Promise<{ id: string }> {
+	async createDoc(filename: string, content: string, path?: string): Promise<Document & { success?: boolean }> {
 		const response = await fetch(`${API_BASE}/docs`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ filename, content }),
+			body: JSON.stringify({ filename, content, path }),
 		});
 		if (!response.ok) {
 			throw new Error("Failed to create document");


### PR DESCRIPTION
## Summary
- Move docs create/update path handling into core/filesystem with shared normalization and unsafe path validation.
- Align CLI, Web/server API/UI, and MCP document tools so they expose docs-relative path support and return persisted path metadata.
- Update shipped CLI/MCP/agent guidance and tests so PR #598 can reference public APIs instead of source internals or direct file writes.

## Validation
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test src/test/filesystem.test.ts src/test/core.test.ts src/test/cli.test.ts src/test/mcp-documents.test.ts src/test/server-documents-endpoint.test.ts` (150 pass / 0 fail)
- `bun test src/test/remote-id-conflict.test.ts`
- `bun test src/test/server-search-endpoint.test.ts`

## Notes
- Also updates a stale remote-id test expectation from lowercase `task-2` to normalized `TASK-2`, matching the rest of the CLI output tests.
- A full `bun test` run was attempted after that fix; it no longer failed at `remote-id-conflict`, but one long run hit order/load-sensitive `server-search-endpoint` hook/socket timeouts. That file passes in isolation.
