### PR TITLE
BACK-451 - Guard cross-branch loading behind checkActiveBranches flag

### DIFF
--- a/backlog/tasks/back-451 - Fix-Guard-cross-branch-loading-behind-checkActiveBranches-flag.md
+++ b/backlog/tasks/back-451 - Fix-Guard-cross-branch-loading-behind-checkActiveBranches-flag.md
@@ -1,0 +1,37 @@
+---
+id: BACK-451
+title: 'Fix: Guard cross-branch loading behind checkActiveBranches flag'
+status: Done
+assignee: []
+created_date: '2026-04-28 04:57'
+updated_date: '2026-04-28 04:59'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The current implementation of loadTasks and loadTasksForKanban calls loadRemoteTasks and loadLocalBranchTasks regardless of the checkActiveBranches flag. While it conditionally sets branchStateEntries to undefined, the loading itself still occurs and stamps tasks with a .branch property, which triggers read-only behavior in the UI. We need to guard these calls behind the checkActiveBranches flag.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Setting check_active_branches: false in config skips loadRemoteTasks and loadLocalBranchTasks.
+- [x] #2 Remote tasks do not appear as read-only when check_active_branches: false.
+- [x] #3 Existing cross-branch behavior is unchanged when check_active_branches: true.
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Guarded `loadRemoteTasks` and `loadLocalBranchTasks` calls behind `checkActiveBranches !== false` in both `loadTasks` and `loadTasksForKanban` methods in `src/core/backlog.ts`. This prevents tasks from other branches from being loaded (and stamped with a `.branch` property) when cross-branch scanning is disabled, ensuring they don't trigger read-only behavior in the UI. Added a verification test case in `src/test/board-loading.test.ts`.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2580,13 +2580,19 @@ export class Core {
 		]);
 
 		// Load remote tasks and local branch tasks in parallel
-		const branchStateEntries: BranchTaskStateEntry[] | undefined =
-			config?.checkActiveBranches === false ? undefined : [];
-		const backlogDir = await this.getBacklogDirectoryName();
-		const [remoteTasks, localBranchTasks] = await Promise.all([
-			loadRemoteTasks(this.git, config, progressCallback, localTasks, branchStateEntries, false, backlogDir),
-			loadLocalBranchTasks(this.git, config, progressCallback, localTasks, branchStateEntries, false, backlogDir),
-		]);
+		// Skip entirely when cross-branch scanning is disabled
+		let remoteTasks: Task[] = [];
+		let localBranchTasks: Task[] = [];
+		let branchStateEntries: BranchTaskStateEntry[] | undefined;
+
+		if (config?.checkActiveBranches !== false) {
+			const backlogDir = await this.getBacklogDirectoryName();
+			branchStateEntries = [];
+			[remoteTasks, localBranchTasks] = await Promise.all([
+				loadRemoteTasks(this.git, config, progressCallback, localTasks, branchStateEntries, false, backlogDir),
+				loadLocalBranchTasks(this.git, config, progressCallback, localTasks, branchStateEntries, false, backlogDir),
+			]);
+		}
 		progressCallback?.("Loaded tasks");
 
 		// Create map with local tasks
@@ -2671,23 +2677,36 @@ export class Core {
 		}
 
 		// Load tasks from remote branches and other local branches in parallel
-		progressCallback?.(getTaskLoadingMessage(config));
+		// Skip entirely when cross-branch scanning is disabled
+		let remoteTasks: Task[] = [];
+		let localBranchTasks: Task[] = [];
+		let branchStateEntries: BranchTaskStateEntry[] | undefined;
 
-		const branchStateEntries: BranchTaskStateEntry[] | undefined =
-			config?.checkActiveBranches === false ? undefined : [];
-		const backlogDir = await this.getBacklogDirectoryName();
-		const [remoteTasks, localBranchTasks] = await Promise.all([
-			loadRemoteTasks(this.git, config, progressCallback, localTasks, branchStateEntries, includeCompleted, backlogDir),
-			loadLocalBranchTasks(
-				this.git,
-				config,
-				progressCallback,
-				localTasks,
-				branchStateEntries,
-				includeCompleted,
-				backlogDir,
-			),
-		]);
+		if (config?.checkActiveBranches !== false) {
+			progressCallback?.(getTaskLoadingMessage(config));
+			branchStateEntries = [];
+			const backlogDir = await this.getBacklogDirectoryName();
+			[remoteTasks, localBranchTasks] = await Promise.all([
+				loadRemoteTasks(
+					this.git,
+					config,
+					progressCallback,
+					localTasks,
+					branchStateEntries,
+					includeCompleted,
+					backlogDir,
+				),
+				loadLocalBranchTasks(
+					this.git,
+					config,
+					progressCallback,
+					localTasks,
+					branchStateEntries,
+					includeCompleted,
+					backlogDir,
+				),
+			]);
+		}
 
 		// Check for cancellation after loading
 		if (abortSignal?.aborted) {

--- a/src/test/board-loading.test.ts
+++ b/src/test/board-loading.test.ts
@@ -31,18 +31,18 @@ describe("Board Loading with checkActiveBranches", () => {
 		}
 	});
 
-	describe("Core.loadTasks()", () => {
-		const createTestTask = (id: string, status = "To Do"): Task => ({
-			id,
-			title: `Test Task ${id}`,
-			status,
-			assignee: [],
-			createdDate: "2025-01-08",
-			labels: ["test"],
-			dependencies: [],
-			description: `This is test task ${id}`,
-		});
+	const createTestTask = (id: string, status = "To Do"): Task => ({
+		id,
+		title: `Test Task ${id}`,
+		status,
+		assignee: [],
+		createdDate: "2025-01-08",
+		labels: ["test"],
+		dependencies: [],
+		description: `This is test task ${id}`,
+	});
 
+	describe("Core.loadTasks()", () => {
 		beforeEach(async () => {
 			// Create some test tasks
 			await core.createTask(createTestTask("task-1", "To Do"), false);
@@ -258,6 +258,39 @@ describe("Board Loading with checkActiveBranches", () => {
 				msg.includes("Applying latest task states from branch scans..."),
 			);
 			expect(applySnapshotsMessage).toBeUndefined();
+		});
+
+		it("should not load tasks from other branches when checkActiveBranches is false", async () => {
+			// 0. Ensure main has at least one commit so it exists
+			await core.createTask(createTestTask("task-main"), false);
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Initial commit on main"`.cwd(TEST_DIR).quiet();
+
+			// 1. Create a task on a different branch
+			await $`git checkout -b other-branch`.cwd(TEST_DIR).quiet();
+			const otherTask = createTestTask("task-other", "To Do");
+			await core.createTask(otherTask, false);
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add task on other branch"`.cwd(TEST_DIR).quiet();
+
+			// 2. Go back to main
+			await $`git checkout main`.cwd(TEST_DIR).quiet();
+
+			// 3. Disable checkActiveBranches
+			const config = await core.filesystem.loadConfig();
+			if (!config) throw new Error("Config not loaded");
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: false,
+			});
+
+			// 4. Load tasks
+			const tasks = await core.loadTasks();
+
+			// 5. Verify task from other branch is NOT loaded
+			expect(tasks.find((t) => t.id === "TASK-OTHER")).toBeUndefined();
+			// Only the 1 task from main should be there
+			expect(tasks).toHaveLength(1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
This PR fixes issue #613 where tasks were incorrectly marked as read-only even when `check_active_branches` was set to `false`.

## Changes
- Guarded `loadRemoteTasks` and `loadLocalBranchTasks` calls behind the `checkActiveBranches` flag in `src/core/backlog.ts`.
- This ensures that if scanning is disabled, no tasks are loaded from other branches and stamped with a `.branch` property (which triggers the read-only UI).
- Added a regression test in `src/test/board-loading.test.ts`.

Fixes #613
