### PR TITLE
BACK-452 - Add TUI keyboard shortcuts: Yank, Complete, Archive, and Help Menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,3 @@ tmp/
 test-benchmark-report.json
 
 .conductor
-
-# Local helper scripts
-scripts/switch-to-local.sh
-scripts/revert-to-brew.sh

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ tmp/
 test-benchmark-report.json
 
 .conductor
+
+# Local helper scripts
+scripts/switch-to-local.sh
+scripts/revert-to-brew.sh

--- a/backlog/tasks/back-452 - Add-TUI-keyboard-shortcuts-Yank-Archive-and-Help-Menu.md
+++ b/backlog/tasks/back-452 - Add-TUI-keyboard-shortcuts-Yank-Archive-and-Help-Menu.md
@@ -1,0 +1,45 @@
+---
+id: BACK-452
+title: 'Add TUI keyboard shortcuts: Yank, Complete, Archive, and Help Menu'
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-04-28 12:53'
+updated_date: '2026-05-03 11:06'
+labels: []
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement 'y' to yank task ID, 'c' to complete task, 'a' to archive task with confirmation, and '?' to show a help popup in the TUI board.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Yank (y/Y) copies task ID to clipboard with footer notification.
+- [x] #2 Complete (c/C) shows confirmation popup and moves task to completed.
+- [x] #3 Archive (a/A) shows confirmation popup and archives task on success.
+- [x] #4 Help (?) shows popup with all keyboard shortcuts.
+- [x] #5 Footer is updated to include [?] Help.
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented 'y' to yank task ID, 'c' to complete task, 'a' to archive task with confirmation, and '?' to show a help popup in the TUI board.
+- Created `src/utils/clipboard.ts` for cross-platform clipboard support.
+- Created `src/ui/components/confirm-popup.ts` for reusable confirmation dialogs.
+- Created `src/ui/components/help-popup.ts` for displaying keyboard shortcuts.
+- Updated `src/ui/board.ts` and `src/ui/task-viewer-with-search.ts` to include new shortcuts and Help menu.
+- Refactored `src/ui/components/filter-popup.ts` to export `createPopupChrome` for reuse.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/test/help-popup.test.ts
+++ b/src/test/help-popup.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { getHelpShortcuts } from "../ui/components/help-popup.ts";
+
+const keysFor = (context: "board" | "task-list") => getHelpShortcuts(context).map((shortcut) => shortcut.key);
+
+describe("help popup shortcuts", () => {
+	it("keeps board-specific shortcuts in the board help menu", () => {
+		const keys = keysFor("board");
+
+		expect(keys).toContain("F");
+		expect(keys).toContain("M");
+		expect(keys).toContain("←→");
+	});
+
+	it("uses task-list shortcuts in the task viewer help menu", () => {
+		const keys = keysFor("task-list");
+
+		expect(keys).toContain("s");
+		expect(keys).toContain("l");
+		expect(keys).not.toContain("F");
+		expect(keys).not.toContain("M");
+	});
+});

--- a/src/test/task-viewer-boundary-navigation.test.ts
+++ b/src/test/task-viewer-boundary-navigation.test.ts
@@ -3,6 +3,7 @@ import {
 	type PendingSearchWrap,
 	resolveFilterExitPane,
 	resolveSearchExitTargetIndex,
+	resolveTaskListSelection,
 	shouldMoveFromDetailBoundaryToSearch,
 	shouldMoveFromListBoundaryToSearch,
 } from "../ui/task-viewer-with-search.ts";
@@ -53,5 +54,18 @@ describe("task viewer boundary navigation", () => {
 		expect(resolveFilterExitPane("detail", true, false)).toBe("list");
 		expect(resolveFilterExitPane("list", false, true)).toBe("detail");
 		expect(resolveFilterExitPane("list", false, false)).toBeNull();
+	});
+
+	it("resolves the selected task from a list index", () => {
+		const tasks = [{ id: "TASK-1" }, { id: "TASK-2" }];
+		expect(resolveTaskListSelection(tasks, 1)?.id).toBe("TASK-2");
+		expect(resolveTaskListSelection(tasks, [0])?.id).toBe("TASK-1");
+	});
+
+	it("falls back when the selected list index is unavailable", () => {
+		const fallback = { id: "TASK-1" };
+		expect(resolveTaskListSelection([], undefined, fallback)).toBe(fallback);
+		expect(resolveTaskListSelection([], 0, fallback)).toBe(fallback);
+		expect(resolveTaskListSelection([{ id: "TASK-2" }], -1, fallback)).toBe(fallback);
 	});
 });

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -8,12 +8,15 @@ import {
 } from "../board.ts";
 import { Core } from "../core/backlog.ts";
 import type { Milestone, Task } from "../types/index.ts";
+import { copyToClipboard } from "../utils/clipboard.ts";
 import { collectAvailableLabels } from "../utils/label-filter.ts";
 import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
 import { applySharedTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { compareTaskIds } from "../utils/task-sorting.ts";
+import { openConfirmPopup } from "./components/confirm-popup.ts";
 import { createFilterHeader, type FilterHeader, type FilterState } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
+import { openHelpPopup } from "./components/help-popup.ts";
 import { formatFooterContent } from "./footer-content.ts";
 import { getStatusIcon } from "./status-icon.ts";
 import {
@@ -141,7 +144,7 @@ function formatColumnLabel(status: string, count: number): string {
 }
 
 const DEFAULT_FOOTER_CONTENT =
-	" {cyan-fg}[Tab]{/} Switch View | {cyan-fg}[/]{/} Search | {cyan-fg}[P]{/} Priority | {cyan-fg}[F]{/} Labels | {cyan-fg}[I]{/} Milestone | {cyan-fg}[←→]{/} Columns | {cyan-fg}[↑↓]{/} Tasks | {cyan-fg}[Enter]{/} View | {cyan-fg}[E]{/} Edit | {cyan-fg}[M]{/} Move | {cyan-fg}[q/Esc]{/} Quit";
+	" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[P/F/I]{/} Filter | {cyan-fg}[←→/↑↓]{/} Nav | {cyan-fg}[Enter]{/} Details | {cyan-fg}[E/M/C/A]{/} Edit/Move/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 
 export function shouldRebuildColumns(current: ColumnData[], next: ColumnData[]): boolean {
 	if (current.length !== next.length) {
@@ -239,6 +242,7 @@ export async function renderBoardTui(
 		let popupOpen = false;
 		let currentFocus: "board" | "filters" = "board";
 		let filterPopupOpen = false;
+		let modalOpen = false;
 		let pendingSearchWrap: "to-first" | "to-last" | null = null;
 		let programmaticColumnSelection = false;
 		const sharedFilters = {
@@ -246,6 +250,14 @@ export async function renderBoardTui(
 			priorityFilter: options?.filters?.priorityFilter ?? "",
 			labelFilter: [...(options?.filters?.labelFilter ?? [])],
 			milestoneFilter: options?.filters?.milestoneFilter ?? "",
+		};
+		const runWithModalGuard = async <T>(operation: () => Promise<T>): Promise<T> => {
+			modalOpen = true;
+			try {
+				return await operation();
+			} finally {
+				modalOpen = false;
+			}
 		};
 		let configuredLabels = collectAvailableLabels(initialTasks, options?.availableLabels ?? []);
 		let availableMilestones = [...(options?.availableMilestones ?? [])];
@@ -443,7 +455,7 @@ export async function renderBoardTui(
 				});
 
 				taskList.on("select item", (_item: unknown, selected: unknown) => {
-					if (programmaticColumnSelection || popupOpen || filterPopupOpen) return;
+					if (programmaticColumnSelection || popupOpen || filterPopupOpen || modalOpen) return;
 					const column = columns[idx];
 					if (!column) return;
 					if (currentCol !== idx) {
@@ -459,7 +471,7 @@ export async function renderBoardTui(
 				});
 
 				taskList.on("focus", () => {
-					if (popupOpen || filterPopupOpen) return;
+					if (popupOpen || filterPopupOpen || modalOpen) return;
 					if (currentCol !== idx) {
 						setColumnActiveState(columns[currentCol], false);
 						currentCol = idx;
@@ -491,7 +503,7 @@ export async function renderBoardTui(
 		};
 
 		const focusColumn = (idx: number, preferredRow?: number, activate = true) => {
-			if (popupOpen) return;
+			if (popupOpen || modalOpen) return;
 			if (idx < 0 || idx >= columns.length) return;
 			const previous = columns[currentCol];
 			setColumnActiveState(previous, false);
@@ -609,7 +621,7 @@ export async function renderBoardTui(
 		};
 
 		const openFilterPicker = async (filterId: "priority" | "milestone" | "labels") => {
-			if (filterPopupOpen || moveOp || !filterHeader) {
+			if (filterPopupOpen || modalOpen || moveOp || !filterHeader) {
 				return;
 			}
 			filterPopupOpen = true;
@@ -841,29 +853,29 @@ export async function renderBoardTui(
 		};
 
 		screen.key(["/", "C-f"], () => {
-			if (popupOpen || filterPopupOpen || moveOp) return;
+			if (popupOpen || filterPopupOpen || modalOpen || moveOp) return;
 			pendingSearchWrap = null;
 			focusFilterControl("search");
 			updateFooter();
 		});
 
 		screen.key(["p", "P"], () => {
-			if (popupOpen || filterPopupOpen || moveOp) return;
+			if (popupOpen || filterPopupOpen || modalOpen || moveOp) return;
 			void openFilterPicker("priority");
 		});
 
 		screen.key(["f", "F"], () => {
-			if (popupOpen || filterPopupOpen || moveOp) return;
+			if (popupOpen || filterPopupOpen || modalOpen || moveOp) return;
 			void openFilterPicker("labels");
 		});
 
 		screen.key(["i", "I"], () => {
-			if (popupOpen || filterPopupOpen || moveOp) return;
+			if (popupOpen || filterPopupOpen || modalOpen || moveOp) return;
 			void openFilterPicker("milestone");
 		});
 
 		screen.key(["left", "h"], () => {
-			if (popupOpen || filterPopupOpen || currentFocus === "filters") return;
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			if (moveOp) {
 				const currentStatusIndex = currentStatuses.indexOf(moveOp.targetStatus);
 				if (currentStatusIndex > 0) {
@@ -882,7 +894,7 @@ export async function renderBoardTui(
 		});
 
 		screen.key(["right", "l"], () => {
-			if (popupOpen || filterPopupOpen || currentFocus === "filters") return;
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			if (moveOp) {
 				const currentStatusIndex = currentStatuses.indexOf(moveOp.targetStatus);
 				if (currentStatusIndex < currentStatuses.length - 1) {
@@ -901,7 +913,7 @@ export async function renderBoardTui(
 		});
 
 		screen.key(["up", "k"], () => {
-			if (popupOpen || filterPopupOpen || currentFocus === "filters") return;
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 
 			if (moveOp) {
 				if (moveOp.targetIndex > 0) {
@@ -935,7 +947,7 @@ export async function renderBoardTui(
 		});
 
 		screen.key(["down", "j"], () => {
-			if (popupOpen || filterPopupOpen || currentFocus === "filters") return;
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 
 			if (moveOp) {
 				const column = columns[currentCol];
@@ -1009,7 +1021,7 @@ export async function renderBoardTui(
 		};
 
 		screen.key(["enter"], async () => {
-			if (popupOpen || filterPopupOpen || currentFocus === "filters") return;
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 
 			// In move mode, Enter confirms the move
 			if (moveOp) {
@@ -1042,11 +1054,94 @@ export async function renderBoardTui(
 				await openTaskEditor(task);
 			});
 
+			contentArea.key(["y", "Y"], async () => {
+				const success = await copyToClipboard(task.id);
+				if (success) {
+					showTransientFooter(` {green-fg}Copied ${task.id} to clipboard{/}`);
+				} else {
+					showTransientFooter(" {red-fg}Failed to copy to clipboard{/}");
+				}
+			});
+
+			contentArea.key(["c", "C"], async () => {
+				if (task.branch) {
+					showTransientFooter(` {red-fg}Cannot complete task from branch "${task.branch}".{/}`);
+					return;
+				}
+
+				const confirmed = await runWithModalGuard(() =>
+					openConfirmPopup({
+						screen,
+						title: "Complete Task",
+						message: `Mark task {bold}${task.id}{/bold} as completed?\n{gray-fg}${task.title}{/}`,
+					}),
+				);
+
+				if (confirmed) {
+					try {
+						const core = new Core(process.cwd(), { enableWatchers: true });
+						const config = await core.fs.loadConfig();
+						const success = await core.completeTask(task.id, config?.autoCommit ?? false);
+
+						if (success) {
+							currentTasks = currentTasks.filter((t) => t.id !== task.id);
+							showTransientFooter(` {green-fg}Completed ${task.id}{/}`);
+							close();
+							popupOpen = false;
+							renderView();
+						} else {
+							showTransientFooter(` {red-fg}Failed to complete ${task.id}{/}`);
+						}
+					} catch (error) {
+						showTransientFooter(
+							` {red-fg}Error completing task: ${error instanceof Error ? error.message : "Unknown error"}{/}`,
+						);
+					}
+				}
+			});
+
+			contentArea.key(["a", "A"], async () => {
+				if (task.branch) {
+					showTransientFooter(` {red-fg}Cannot archive task from branch "${task.branch}".{/}`);
+					return;
+				}
+
+				const confirmed = await runWithModalGuard(() =>
+					openConfirmPopup({
+						screen,
+						title: "Archive Task",
+						message: `Archive task {bold}${task.id}{/bold}?\n{gray-fg}${task.title}{/}`,
+					}),
+				);
+
+				if (confirmed) {
+					try {
+						const core = new Core(process.cwd(), { enableWatchers: true });
+						const config = await core.fs.loadConfig();
+						const success = await core.archiveTask(task.id, config?.autoCommit ?? false);
+
+						if (success) {
+							currentTasks = currentTasks.filter((t) => t.id !== task.id);
+							showTransientFooter(` {green-fg}Archived ${task.id}{/}`);
+							close();
+							popupOpen = false;
+							renderView();
+						} else {
+							showTransientFooter(` {red-fg}Failed to archive ${task.id}{/}`);
+						}
+					} catch (error) {
+						showTransientFooter(
+							` {red-fg}Error archiving task: ${error instanceof Error ? error.message : "Unknown error"}{/}`,
+						);
+					}
+				}
+			});
+
 			screen.render();
 		});
 
 		screen.key(["e", "E", "S-e"], async () => {
-			if (popupOpen || filterPopupOpen || currentFocus === "filters") return;
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			const column = columns[currentCol];
 			if (!column) return;
 			const idx = column.list.selected ?? 0;
@@ -1122,7 +1217,7 @@ export async function renderBoardTui(
 		};
 
 		screen.key(["m", "M", "S-m"], async () => {
-			if (popupOpen || filterPopupOpen || currentFocus === "filters") return;
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			if (hasActiveSharedFilters()) {
 				showTransientFooter(" {yellow-fg}Clear filters before moving tasks.{/}");
 				return;
@@ -1158,7 +1253,7 @@ export async function renderBoardTui(
 		});
 
 		screen.key(["tab"], async () => {
-			if (popupOpen || filterPopupOpen || currentFocus === "filters") return;
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			const column = columns[currentCol];
 			if (column) {
 				const idx = column.list.selected ?? 0;
@@ -1184,15 +1279,120 @@ export async function renderBoardTui(
 			}
 		});
 
+		screen.key(["?"], async () => {
+			if (popupOpen || filterPopupOpen || modalOpen || moveOp) return;
+			await runWithModalGuard(() => openHelpPopup(screen));
+		});
+
+		screen.key(["y", "Y"], async () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
+			const column = columns[currentCol];
+			if (!column) return;
+			const idx = column.list.selected ?? 0;
+			const task = column.tasks[idx];
+			if (!task) return;
+
+			const success = await copyToClipboard(task.id);
+			if (success) {
+				showTransientFooter(` {green-fg}Copied ${task.id} to clipboard{/}`);
+			} else {
+				showTransientFooter(" {red-fg}Failed to copy to clipboard{/}");
+			}
+		});
+
+		screen.key(["c", "C"], async () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters" || moveOp) return;
+			const column = columns[currentCol];
+			if (!column) return;
+			const idx = column.list.selected ?? 0;
+			const task = column.tasks[idx];
+			if (!task) return;
+
+			if (task.branch) {
+				showTransientFooter(` {red-fg}Cannot complete task from branch "${task.branch}".{/}`);
+				return;
+			}
+
+			const confirmed = await runWithModalGuard(() =>
+				openConfirmPopup({
+					screen,
+					title: "Complete Task",
+					message: `Mark task {bold}${task.id}{/bold} as completed?\n{gray-fg}${task.title}{/}`,
+				}),
+			);
+
+			if (confirmed) {
+				try {
+					const core = new Core(process.cwd(), { enableWatchers: true });
+					const config = await core.fs.loadConfig();
+					const success = await core.completeTask(task.id, config?.autoCommit ?? false);
+
+					if (success) {
+						currentTasks = currentTasks.filter((t) => t.id !== task.id);
+						showTransientFooter(` {green-fg}Completed ${task.id}{/}`);
+						renderView();
+					} else {
+						showTransientFooter(` {red-fg}Failed to complete ${task.id}{/}`);
+					}
+				} catch (error) {
+					showTransientFooter(
+						` {red-fg}Error completing task: ${error instanceof Error ? error.message : "Unknown error"}{/}`,
+					);
+				}
+			}
+		});
+
+		screen.key(["a", "A"], async () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters" || moveOp) return;
+			const column = columns[currentCol];
+			if (!column) return;
+			const idx = column.list.selected ?? 0;
+			const task = column.tasks[idx];
+			if (!task) return;
+
+			if (task.branch) {
+				showTransientFooter(` {red-fg}Cannot archive task from branch "${task.branch}".{/}`);
+				return;
+			}
+
+			const confirmed = await runWithModalGuard(() =>
+				openConfirmPopup({
+					screen,
+					title: "Archive Task",
+					message: `Archive task {bold}${task.id}{/bold}?\n{gray-fg}${task.title}{/}`,
+				}),
+			);
+
+			if (confirmed) {
+				try {
+					const core = new Core(process.cwd(), { enableWatchers: true });
+					const config = await core.fs.loadConfig();
+					const success = await core.archiveTask(task.id, config?.autoCommit ?? false);
+
+					if (success) {
+						currentTasks = currentTasks.filter((t) => t.id !== task.id);
+						showTransientFooter(` {green-fg}Archived ${task.id}{/}`);
+						renderView();
+					} else {
+						showTransientFooter(` {red-fg}Failed to archive ${task.id}{/}`);
+					}
+				} catch (error) {
+					showTransientFooter(
+						` {red-fg}Error archiving task: ${error instanceof Error ? error.message : "Unknown error"}{/}`,
+					);
+				}
+			}
+		});
+
 		screen.key(["q", "C-c"], () => {
-			if (popupOpen || filterPopupOpen) return;
+			if (popupOpen || filterPopupOpen || modalOpen) return;
 			clearFooterTimer();
 			screen.destroy();
 			resolve();
 		});
 
 		screen.key(["escape"], () => {
-			if (popupOpen || filterPopupOpen) return;
+			if (popupOpen || filterPopupOpen || modalOpen) return;
 			if (currentFocus === "filters") {
 				focusColumn(currentCol);
 				updateFooter();

--- a/src/ui/components/confirm-popup.ts
+++ b/src/ui/components/confirm-popup.ts
@@ -1,0 +1,57 @@
+import type { ScreenInterface } from "neo-neo-bblessed";
+import { box } from "neo-neo-bblessed";
+import { createPopupChrome } from "./filter-popup.ts";
+
+export async function openConfirmPopup(options: {
+	screen: ScreenInterface;
+	title: string;
+	message: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+}): Promise<boolean> {
+	return new Promise<boolean>((resolve) => {
+		let settled = false;
+		const { popup, close } = createPopupChrome({
+			screen: options.screen,
+			title: options.title,
+			helpText: " {cyan-fg}[Enter/y]{/} Yes | {cyan-fg}[Esc/n]{/} No",
+			width: 40,
+			height: 10,
+		});
+
+		const content = box({
+			parent: popup,
+			top: "center",
+			left: 1,
+			right: 1,
+			height: 3,
+			align: "center",
+			content: options.message,
+			tags: true,
+		});
+
+		const finish = (value: boolean) => {
+			if (settled) return;
+			settled = true;
+			content.destroy();
+			close();
+			options.screen.render();
+			resolve(value);
+		};
+
+		popup.key(["escape", "n", "N"], () => {
+			finish(false);
+			return false;
+		});
+
+		popup.key(["enter", "y", "Y"], () => {
+			finish(true);
+			return false;
+		});
+
+		setImmediate(() => {
+			popup.focus();
+			options.screen.render();
+		});
+	});
+}

--- a/src/ui/components/filter-popup.ts
+++ b/src/ui/components/filter-popup.ts
@@ -7,7 +7,7 @@ export interface FilterPopupChoice {
 	value: string;
 }
 
-interface PopupChromeOptions {
+export interface PopupChromeOptions {
 	screen: ScreenInterface;
 	title: string;
 	helpText: string;
@@ -46,7 +46,7 @@ function resolvePosition(value: string | number, total: number, size: number): n
 	return Number.isNaN(parsed) ? 0 : parsed;
 }
 
-function createPopupChrome(options: PopupChromeOptions): {
+export function createPopupChrome(options: PopupChromeOptions): {
 	popup: BoxInterface;
 	close: () => void;
 } {

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -1,0 +1,64 @@
+import type { ScreenInterface } from "neo-neo-bblessed";
+import { box } from "neo-neo-bblessed";
+import { createPopupChrome } from "./filter-popup.ts";
+
+export async function openHelpPopup(screen: ScreenInterface): Promise<void> {
+	return new Promise<void>((resolve) => {
+		let settled = false;
+		const { popup, close } = createPopupChrome({
+			screen,
+			title: "Keyboard Shortcuts",
+			helpText: " {cyan-fg}[Esc/q]{/} Close Help",
+			width: 60,
+			height: 20,
+		});
+
+		const shortcuts = [
+			{ key: "Tab", desc: "Switch View (Kanban/List)" },
+			{ key: "/", desc: "Search tasks" },
+			{ key: "P", desc: "Filter by Priority" },
+			{ key: "F", desc: "Filter by Labels" },
+			{ key: "I", desc: "Filter by Milestone" },
+			{ key: "←→", desc: "Navigate columns" },
+			{ key: "↑↓", desc: "Navigate tasks" },
+			{ key: "Enter", desc: "View task details" },
+			{ key: "E", desc: "Edit task" },
+			{ key: "M", desc: "Move task (Status/Order)" },
+			{ key: "C", desc: "Complete task" },
+			{ key: "A", desc: "Archive task" },
+			{ key: "Y", desc: "Yank (Copy) task ID" },
+			{ key: "?", desc: "Show this help menu" },
+			{ key: "q/Esc", desc: "Quit / Close" },
+		];
+
+		const content = shortcuts.map((s) => `{cyan-fg}[${s.key.padStart(5)}]{/} ${s.desc}`).join("\n");
+
+		box({
+			parent: popup,
+			top: 1,
+			left: 2,
+			right: 2,
+			bottom: 1,
+			content,
+			tags: true,
+		});
+
+		const finish = () => {
+			if (settled) return;
+			settled = true;
+			close();
+			screen.render();
+			resolve();
+		};
+
+		popup.key(["escape", "q", "Q", "?"], () => {
+			finish();
+			return false;
+		});
+
+		setImmediate(() => {
+			popup.focus();
+			screen.render();
+		});
+	});
+}

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -2,7 +2,54 @@ import type { ScreenInterface } from "neo-neo-bblessed";
 import { box } from "neo-neo-bblessed";
 import { createPopupChrome } from "./filter-popup.ts";
 
-export async function openHelpPopup(screen: ScreenInterface): Promise<void> {
+export type HelpPopupContext = "board" | "task-list";
+
+type Shortcut = {
+	key: string;
+	desc: string;
+};
+
+const BOARD_SHORTCUTS: Shortcut[] = [
+	{ key: "Tab", desc: "Switch View (Kanban/List)" },
+	{ key: "/", desc: "Search tasks" },
+	{ key: "P", desc: "Filter by Priority" },
+	{ key: "F", desc: "Filter by Labels" },
+	{ key: "I", desc: "Filter by Milestone" },
+	{ key: "←→", desc: "Navigate columns" },
+	{ key: "↑↓", desc: "Navigate tasks" },
+	{ key: "Enter", desc: "View task details" },
+	{ key: "E", desc: "Edit task" },
+	{ key: "M", desc: "Move task (Status/Order)" },
+	{ key: "C", desc: "Complete task" },
+	{ key: "A", desc: "Archive task" },
+	{ key: "Y", desc: "Yank (Copy) task ID" },
+	{ key: "?", desc: "Show this help menu" },
+	{ key: "q/Esc", desc: "Quit / Close" },
+];
+
+const TASK_LIST_SHORTCUTS: Shortcut[] = [
+	{ key: "Tab", desc: "Switch View (Kanban/List)" },
+	{ key: "/", desc: "Search tasks" },
+	{ key: "s", desc: "Filter by Status" },
+	{ key: "p", desc: "Filter by Priority" },
+	{ key: "l", desc: "Filter by Labels" },
+	{ key: "i", desc: "Filter by Milestone" },
+	{ key: "↑↓", desc: "Navigate tasks" },
+	{ key: "←→", desc: "Switch between list and details" },
+	{ key: "Enter", desc: "Focus task details" },
+	{ key: "E", desc: "Edit task" },
+	{ key: "C", desc: "Complete task" },
+	{ key: "A", desc: "Archive task" },
+	{ key: "Y", desc: "Yank (Copy) task ID" },
+	{ key: "?", desc: "Show this help menu" },
+	{ key: "q/Esc", desc: "Quit / Close" },
+];
+
+export function getHelpShortcuts(context: HelpPopupContext = "board"): Shortcut[] {
+	return context === "task-list" ? TASK_LIST_SHORTCUTS : BOARD_SHORTCUTS;
+}
+
+export async function openHelpPopup(screen: ScreenInterface, context: HelpPopupContext = "board"): Promise<void> {
 	return new Promise<void>((resolve) => {
 		let settled = false;
 		const { popup, close } = createPopupChrome({
@@ -13,23 +60,7 @@ export async function openHelpPopup(screen: ScreenInterface): Promise<void> {
 			height: 20,
 		});
 
-		const shortcuts = [
-			{ key: "Tab", desc: "Switch View (Kanban/List)" },
-			{ key: "/", desc: "Search tasks" },
-			{ key: "P", desc: "Filter by Priority" },
-			{ key: "F", desc: "Filter by Labels" },
-			{ key: "I", desc: "Filter by Milestone" },
-			{ key: "←→", desc: "Navigate columns" },
-			{ key: "↑↓", desc: "Navigate tasks" },
-			{ key: "Enter", desc: "View task details" },
-			{ key: "E", desc: "Edit task" },
-			{ key: "M", desc: "Move task (Status/Order)" },
-			{ key: "C", desc: "Complete task" },
-			{ key: "A", desc: "Archive task" },
-			{ key: "Y", desc: "Yank (Copy) task ID" },
-			{ key: "?", desc: "Show this help menu" },
-			{ key: "q/Esc", desc: "Quit / Close" },
-		];
+		const shortcuts = getHelpShortcuts(context);
 
 		const content = shortcuts.map((s) => `{cyan-fg}[${s.key.padStart(5)}]{/} ${s.desc}`).join("\n");
 

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -1221,7 +1221,7 @@ export async function viewTaskEnhanced(
 
 	screen.key(["?"], async () => {
 		if (modalOpen || filterPopupOpen) return;
-		await runWithModalGuard(() => openHelpPopup(screen));
+		await runWithModalGuard(() => openHelpPopup(screen, "task-list"));
 	});
 
 	screen.key(["escape"], () => {

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -11,6 +11,7 @@ import {
 	formatTaskPlainText,
 } from "../formatters/task-plain-text.ts";
 import type { Milestone, Task, TaskSearchResult } from "../types/index.ts";
+import { copyToClipboard } from "../utils/clipboard.ts";
 import { collectAvailableLabels } from "../utils/label-filter.ts";
 import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
@@ -18,6 +19,7 @@ import { applyTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { formatChecklistItem } from "./checklist.ts";
 import { transformCodePaths } from "./code-path.ts";
+import { openConfirmPopup } from "./components/confirm-popup.ts";
 import {
 	createFilterHeader,
 	type FilterControlId,
@@ -26,6 +28,7 @@ import {
 } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
 import { createGenericList, type GenericList } from "./components/generic-list.ts";
+import { openHelpPopup } from "./components/help-popup.ts";
 import { formatFooterContent } from "./footer-content.ts";
 import { formatHeading } from "./heading.ts";
 import { createLoadingScreen } from "./loading.ts";
@@ -139,6 +142,18 @@ export function resolveFilterExitPane(
 		return "detail";
 	}
 	return null;
+}
+
+export function resolveTaskListSelection<T>(
+	items: readonly T[],
+	selectedIndex: number | number[] | undefined,
+	fallback: T | null = null,
+): T | null {
+	const index = Array.isArray(selectedIndex) ? selectedIndex[0] : selectedIndex;
+	if (typeof index !== "number") {
+		return fallback;
+	}
+	return items[index] ?? fallback;
 }
 
 /**
@@ -271,6 +286,7 @@ export async function viewTaskEnhanced(
 	// State for tracking focus
 	let currentFocus: "filters" | "list" | "detail" = "list";
 	let filterPopupOpen = false;
+	let modalOpen = false;
 	let pendingSearchWrap: PendingSearchWrap = null;
 	let filterExitPane: PaneFocus = "list";
 
@@ -664,6 +680,11 @@ export async function viewTaskEnhanced(
 			if (forceFirst || desiredIndex < 0) {
 				desiredIndex = 0;
 			}
+			const desiredTask = filteredTasks[desiredIndex];
+			if (desiredTask && desiredTask.id !== currentSelectedTask.id) {
+				currentSelectedTask = enrichTask(desiredTask) ?? desiredTask;
+				options.onTaskChange?.(currentSelectedTask);
+			}
 			const currentIndexRaw = listController.getSelectedIndex();
 			const currentIndex = Array.isArray(currentIndexRaw) ? (currentIndexRaw[0] ?? 0) : currentIndexRaw;
 			if (forceFirst || currentIndex !== desiredIndex) {
@@ -995,11 +1016,11 @@ export async function viewTaskEnhanced(
 			}
 		} else if (currentFocus === "detail") {
 			content =
-				" {cyan-fg}[Tab]{/} Switch View | {cyan-fg}[←]{/} Task List | {cyan-fg}[↑↓]{/} Scroll | {cyan-fg}[E]{/} Edit | {cyan-fg}[q/Esc]{/} Quit";
+				" {cyan-fg}[Tab]{/} View | {cyan-fg}[←]{/} List | {cyan-fg}[↑↓]{/} Scroll | {cyan-fg}[E]{/} Edit | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 		} else {
 			// Task list help
 			content =
-				" {cyan-fg}[Tab]{/} Switch View | {cyan-fg}[/]{/} Search | {cyan-fg}[s]{/} Status | {cyan-fg}[p]{/} Priority | {cyan-fg}[i]{/} Milestone | {cyan-fg}[l]{/} Labels | {cyan-fg}[↑↓]{/} Navigate | {cyan-fg}[E]{/} Edit | {cyan-fg}[q/Esc]{/} Quit";
+				" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[s/p/i/l]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 		}
 
 		setHelpBarContent(content);
@@ -1052,6 +1073,82 @@ export async function viewTaskEnhanced(
 		}
 	};
 
+	const getCurrentShortcutTask = (): Task | null => {
+		if (noResultsMessage) {
+			return null;
+		}
+		return resolveTaskListSelection(filteredTasks, taskList?.getSelectedIndex(), currentSelectedTask);
+	};
+
+	const removeTaskFromCurrentView = (taskId: string) => {
+		const currentIndex = filteredTasks.findIndex((taskItem) => taskItem.id === taskId);
+		const remainingFilteredTasks = filteredTasks.filter((taskItem) => taskItem.id !== taskId);
+		const nextIndex = Math.min(Math.max(currentIndex, 0), remainingFilteredTasks.length - 1);
+		const nextTask = remainingFilteredTasks[nextIndex] ?? null;
+
+		allTasks = allTasks.filter((taskItem) => taskItem.id !== taskId);
+		if (taskSearchIndex) {
+			taskSearchIndex = createTaskSearchIndex(allTasks);
+		}
+		if (nextTask) {
+			currentSelectedTask = enrichTask(nextTask) ?? nextTask;
+			options.onTaskChange?.(currentSelectedTask);
+		}
+		applyFilters();
+	};
+
+	const runWithModalGuard = async <T>(operation: () => Promise<T>): Promise<T> => {
+		modalOpen = true;
+		try {
+			return await operation();
+		} finally {
+			modalOpen = false;
+		}
+	};
+
+	const applyTaskLifecycleShortcut = async (task: Task, action: "complete" | "archive") => {
+		if (task.branch) {
+			const verb = action === "complete" ? "complete" : "archive";
+			showTransientHelp(` {red-fg}Cannot ${verb} task from branch "${task.branch}".{/}`);
+			return;
+		}
+
+		const confirmed = await runWithModalGuard(() =>
+			openConfirmPopup({
+				screen,
+				title: action === "complete" ? "Complete Task" : "Archive Task",
+				message:
+					action === "complete"
+						? `Mark task {bold}${task.id}{/bold} as completed?\n{gray-fg}${task.title}{/}`
+						: `Archive task {bold}${task.id}{/bold}?\n{gray-fg}${task.title}{/}`,
+			}),
+		);
+
+		if (!confirmed) {
+			return;
+		}
+
+		try {
+			const config = await core.fs.loadConfig();
+			const success =
+				action === "complete"
+					? await core.completeTask(task.id, config?.autoCommit ?? false)
+					: await core.archiveTask(task.id, config?.autoCommit ?? false);
+
+			if (success) {
+				removeTaskFromCurrentView(task.id);
+				const label = action === "complete" ? "Completed" : "Archived";
+				showTransientHelp(` {green-fg}${label} ${task.id}{/}`);
+			} else {
+				const verb = action === "complete" ? "complete" : "archive";
+				showTransientHelp(` {red-fg}Failed to ${verb} ${task.id}{/}`);
+			}
+		} catch (error) {
+			const verb = action === "complete" ? "completing" : "archiving";
+			showTransientHelp(` {red-fg}Error ${verb} task: ${error instanceof Error ? error.message : "Unknown error"}{/}`);
+		}
+	};
+
 	// Handle resize
 	screen.on("resize", () => {
 		filterHeader.rebuild();
@@ -1060,37 +1157,75 @@ export async function viewTaskEnhanced(
 
 	// Keyboard shortcuts
 	screen.key(["/"], () => {
+		if (modalOpen) return;
 		pendingSearchWrap = null;
 		filterHeader.focusSearch();
 	});
 
 	screen.key(["C-f"], () => {
+		if (modalOpen) return;
 		pendingSearchWrap = null;
 		filterHeader.focusSearch();
 	});
 
 	screen.key(["s", "S"], () => {
+		if (modalOpen) return;
 		void openFilterPicker("status");
 	});
 
 	screen.key(["p", "P"], () => {
+		if (modalOpen) return;
 		void openFilterPicker("priority");
 	});
 
 	screen.key(["l", "L"], () => {
+		if (modalOpen) return;
 		void openFilterPicker("labels");
 	});
 
 	screen.key(["i", "I"], () => {
+		if (modalOpen) return;
 		void openFilterPicker("milestone");
 	});
 
 	screen.key(["e", "E", "S-e"], () => {
+		if (modalOpen) return;
 		void openCurrentTaskInEditor();
 	});
 
+	screen.key(["y", "Y"], async () => {
+		if (modalOpen || filterPopupOpen || currentFocus === "filters") return;
+		const task = getCurrentShortcutTask();
+		if (!task) return;
+		const success = await copyToClipboard(task.id);
+		if (success) {
+			showTransientHelp(` {green-fg}Copied ${task.id} to clipboard{/}`);
+		} else {
+			showTransientHelp(" {red-fg}Failed to copy to clipboard{/}");
+		}
+	});
+
+	screen.key(["c", "C"], async () => {
+		if (modalOpen || filterPopupOpen || currentFocus === "filters") return;
+		const task = getCurrentShortcutTask();
+		if (!task) return;
+		await applyTaskLifecycleShortcut(task, "complete");
+	});
+
+	screen.key(["a", "A"], async () => {
+		if (modalOpen || filterPopupOpen || currentFocus === "filters") return;
+		const task = getCurrentShortcutTask();
+		if (!task) return;
+		await applyTaskLifecycleShortcut(task, "archive");
+	});
+
+	screen.key(["?"], async () => {
+		if (modalOpen || filterPopupOpen) return;
+		await runWithModalGuard(() => openHelpPopup(screen));
+	});
+
 	screen.key(["escape"], () => {
-		if (filterPopupOpen) {
+		if (modalOpen || filterPopupOpen) {
 			return;
 		}
 		if (currentFocus === "filters") {
@@ -1119,7 +1254,7 @@ export async function viewTaskEnhanced(
 	if (options.onTabPress) {
 		screen.key(["tab"], async () => {
 			// Keep tab as filter-navigation while filters are focused.
-			if (filterPopupOpen || currentFocus === "filters") {
+			if (modalOpen || filterPopupOpen || currentFocus === "filters") {
 				return;
 			}
 			if (currentFocus === "list" || currentFocus === "detail") {
@@ -1135,7 +1270,7 @@ export async function viewTaskEnhanced(
 
 	// Quit handlers
 	screen.key(["q", "C-c"], () => {
-		if (filterPopupOpen) {
+		if (modalOpen || filterPopupOpen) {
 			return;
 		}
 		searchService?.dispose();

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,50 @@
+/**
+ * Lightweight clipboard utility for copying text to the system clipboard.
+ * Supports macOS (pbcopy), Windows (clip.exe), and Linux (xclip/wl-copy/xsel).
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+	try {
+		const platform = process.platform;
+
+		if (platform === "darwin") {
+			const proc = Bun.spawn(["pbcopy"], {
+				stdin: "pipe",
+			});
+			proc.stdin.write(text);
+			await proc.stdin.end();
+			return (await proc.exited) === 0;
+		}
+
+		if (platform === "win32") {
+			const proc = Bun.spawn(["clip.exe"], {
+				stdin: "pipe",
+			});
+			proc.stdin.write(text);
+			await proc.stdin.end();
+			return (await proc.exited) === 0;
+		}
+
+		if (platform === "linux") {
+			// Try wl-copy first, then xclip, then xsel
+			const commands = ["wl-copy", "xclip -selection clipboard", "xsel --clipboard --input"];
+			for (const cmdStr of commands) {
+				const cmd = cmdStr.split(" ");
+				try {
+					const proc = Bun.spawn(cmd, {
+						stdin: "pipe",
+					});
+					proc.stdin.write(text);
+					await proc.stdin.end();
+					if ((await proc.exited) === 0) return true;
+				} catch {}
+			}
+		}
+
+		return false;
+	} catch (error) {
+		if (process.env.DEBUG) {
+			console.error("Clipboard copy failed:", error);
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
## Overview
Implement keyboard shortcuts in the TUI board for common task operations: 'y' to yank task ID, 'c' to complete task, 'a' to archive task with confirmation, and '?' to show a help popup.

## Changes
- Created `src/utils/clipboard.ts` for cross-platform clipboard support (macOS/Linux/Windows)
- Created `src/ui/components/confirm-popup.ts` for reusable confirmation dialogs
- Created `src/ui/components/help-popup.ts` for displaying keyboard shortcuts
- Updated `src/ui/board.ts` and `src/ui/task-viewer-with-search.ts` to include new shortcuts
- Refactored `src/ui/components/filter-popup.ts` to export `createPopupChrome` for reuse

## Acceptance Criteria
- [x] Yank (y/Y) copies task ID to clipboard with footer notification
- [x] Complete (c/C) shows confirmation popup and moves task to completed
- [x] Archive (a/A) shows confirmation popup and archives task on success
- [x] Help (?) shows popup with all keyboard shortcuts
- [x] Footer is updated to include [?] Help

## Testing
- All tests passing (`bun test`)
- Code formatting and linting pass (`bun run check .`)