### PR TITLE
BACK-454 - Default ordinals for created tasks

### DIFF
--- a/backlog/tasks/back-454 - Default-ordinals-for-created-tasks.md
+++ b/backlog/tasks/back-454 - Default-ordinals-for-created-tasks.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-454
 title: Default ordinals for created tasks
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-01 13:28'
+updated_date: '2026-05-01 13:33'
 labels: []
 dependencies: []
 references:
@@ -26,14 +27,20 @@ PR #617 adds default ordinal assignment for newly created tasks and preserves ex
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 New tasks created without an explicit ordinal receive a tail ordinal based on existing tasks
-- [ ] #2 Explicit ordinal values remain preserved through CLI/core/MCP create paths
-- [ ] #3 PR #617 title follows the BACK task title format and includes this task
+- [x] #1 New tasks created without an explicit ordinal receive a tail ordinal based on existing tasks
+- [x] #2 Explicit ordinal values remain preserved through CLI/core/MCP create paths
+- [x] #3 PR #617 title follows the BACK task title format and includes this task
 <!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Linked PR #617 to BACK-454, tightened ordinal validation to reject non-finite values, and verified CLI/core/MCP ordinal coverage plus typecheck and lint.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -173,6 +173,7 @@ function hasCreateFieldFlags(options: Record<string, unknown>): boolean {
 			options.status !== undefined ||
 			options.labels !== undefined ||
 			options.priority !== undefined ||
+			options.ordinal !== undefined ||
 			options.plain ||
 			options.ac !== undefined ||
 			options.acceptanceCriteria !== undefined ||
@@ -1455,6 +1456,7 @@ taskCmd
 	.option("--plan <text>", "add implementation plan")
 	.option("--notes <text>", "add implementation notes")
 	.option("--final-summary <text>", "add final summary")
+	.option("--ordinal <number>", "set task ordinal for custom ordering")
 	.option("--draft")
 	.option("-p, --parent <taskId>", "specify parent task ID")
 	.option(
@@ -1522,6 +1524,17 @@ taskCmd
 
 		const createAsDraft = Boolean(options.draft);
 		const usePlainOutput = isPlainRequested(options);
+		let ordinalValue: number | undefined;
+
+		if (options.ordinal !== undefined) {
+			const parsed = Number(options.ordinal);
+			if (!Number.isFinite(parsed) || parsed < 0) {
+				console.error(`Invalid ordinal: ${options.ordinal}. Must be a non-negative number.`);
+				process.exitCode = 1;
+				return;
+			}
+			ordinalValue = parsed;
+		}
 
 		try {
 			const criteria = processAcceptanceCriteriaOptions(options);
@@ -1543,6 +1556,7 @@ taskCmd
 				modifiedFiles: parseDelimitedStringList(options.modifiedFile),
 				parentTaskId: options.parent ? String(options.parent) : undefined,
 				priority: options.priority ? (String(options.priority).toLowerCase() as "high" | "medium" | "low") : undefined,
+				...(ordinalValue !== undefined ? { ordinal: ordinalValue } : {}),
 				implementationPlan: options.plan ? String(options.plan) : undefined,
 				implementationNotes: options.notes ? String(options.notes) : undefined,
 				finalSummary: options.finalSummary ? String(options.finalSummary) : undefined,

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -189,6 +189,26 @@ export class Core {
 		return await this.fs.withCreateLock(fn);
 	}
 
+	private async resolveCreateOrdinal(inputOrdinal: number | undefined, isDraft: boolean): Promise<number | undefined> {
+		if (typeof inputOrdinal === "number") {
+			return inputOrdinal;
+		}
+		if (isDraft) {
+			return undefined;
+		}
+
+		const tasks = await this.fs.listTasks();
+		const ordinals = tasks
+			.map((task) => task.ordinal)
+			.filter((ordinal): ordinal is number => typeof ordinal === "number" && Number.isFinite(ordinal));
+
+		if (ordinals.length === 0) {
+			return tasks.length === 0 ? DEFAULT_ORDINAL_STEP : undefined;
+		}
+
+		return Math.max(...ordinals) + DEFAULT_ORDINAL_STEP;
+	}
+
 	async getContentStore(): Promise<ContentStore> {
 		if (!this.contentStore) {
 			// Use loadTasks as the task loader to include cross-branch tasks
@@ -981,7 +1001,7 @@ export class Core {
 		const createdDate = new Date().toISOString().slice(0, 16).replace("T", " ");
 		if (
 			input.ordinal !== undefined &&
-			(typeof input.ordinal !== "number" || Number.isNaN(input.ordinal) || input.ordinal < 0)
+			(typeof input.ordinal !== "number" || !Number.isFinite(input.ordinal) || input.ordinal < 0)
 		) {
 			throw new Error("Ordinal must be a non-negative number.");
 		}
@@ -1005,6 +1025,7 @@ export class Core {
 
 		const { task, filePath } = await this.withCreateLock(async () => {
 			const id = await this.generateNextId(entityType, isDraft ? undefined : input.parentTaskId);
+			const ordinal = await this.resolveCreateOrdinal(input.ordinal, isDraft);
 			const task: Task = {
 				id,
 				title: input.title.trim(),
@@ -1019,7 +1040,7 @@ export class Core {
 				createdDate,
 				...(input.parentTaskId && { parentTaskId: input.parentTaskId }),
 				...(priority && { priority }),
-				...(typeof input.ordinal === "number" && { ordinal: input.ordinal }),
+				...(typeof ordinal === "number" && { ordinal }),
 				...(typeof input.milestone === "string" &&
 					input.milestone.trim().length > 0 && {
 						milestone: input.milestone.trim(),
@@ -1152,7 +1173,7 @@ export class Core {
 		}
 
 		if (input.ordinal !== undefined) {
-			if (Number.isNaN(input.ordinal) || input.ordinal < 0) {
+			if (typeof input.ordinal !== "number" || !Number.isFinite(input.ordinal) || input.ordinal < 0) {
 				throw new Error("Ordinal must be a non-negative number.");
 			}
 			if (task.ordinal !== input.ordinal) {

--- a/src/test/cli-plain-create-edit.test.ts
+++ b/src/test/cli-plain-create-edit.test.ts
@@ -57,6 +57,32 @@ describe("CLI --plain for task create/edit", () => {
 		expect(out).not.toContain("\x1b");
 	});
 
+	it("assigns default tail ordinals and preserves explicit ordinals on CLI create", async () => {
+		const first = await $`bun ${cliPath} task create "First ordinal CLI task" --plain`.cwd(TEST_DIR).quiet();
+		expect(first.exitCode).toBe(0);
+		expect(first.stdout.toString()).toContain("Ordinal: 1000");
+
+		const second = await $`bun ${cliPath} task create "Second ordinal CLI task" --plain`.cwd(TEST_DIR).quiet();
+		expect(second.exitCode).toBe(0);
+		expect(second.stdout.toString()).toContain("Ordinal: 2000");
+
+		const explicit = await $`bun ${cliPath} task create "Explicit ordinal CLI task" --ordinal 7500 --plain`
+			.cwd(TEST_DIR)
+			.quiet();
+		expect(explicit.exitCode).toBe(0);
+		expect(explicit.stdout.toString()).toContain("Ordinal: 7500");
+	});
+
+	it("rejects non-finite ordinals on CLI create", async () => {
+		const result = await $`bun ${cliPath} task create "Invalid ordinal CLI task" --ordinal Infinity`
+			.cwd(TEST_DIR)
+			.quiet()
+			.nothrow();
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("Invalid ordinal: Infinity. Must be a non-negative number.");
+	});
+
 	it("prints plain details after task edit --plain", async () => {
 		// Create base task first (without plain)
 		await $`bun ${cliPath} task create "Edit Me" --desc "First"`.cwd(TEST_DIR).quiet();

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -190,6 +190,88 @@ describe("Core", () => {
 			expect(byLowercase?.id).toBe("BACK-358");
 		});
 
+		it("assigns ordinal 1000 to the first created task when none exist", async () => {
+			const { task } = await core.createTaskFromInput({ title: "First ordinal task" });
+			expect(task.ordinal).toBe(1000);
+
+			const loadedTask = await core.filesystem.loadTask(task.id);
+			expect(loadedTask?.ordinal).toBe(1000);
+		});
+
+		it("assigns the next tail ordinal when existing tasks already have ordinals", async () => {
+			await core.createTask({
+				...sampleTask,
+				id: "task-10",
+				title: "Seed 1000",
+				ordinal: 1000,
+			});
+			await core.createTask({
+				...sampleTask,
+				id: "task-11",
+				title: "Seed 4000",
+				ordinal: 4000,
+			});
+
+			const { task } = await core.createTaskFromInput({ title: "Appended ordinal task" });
+			expect(task.ordinal).toBe(5000);
+		});
+
+		it("preserves explicit ordinals on create input", async () => {
+			const { task } = await core.createTaskFromInput({
+				title: "Explicit ordinal task",
+				ordinal: 2750,
+			});
+			expect(task.ordinal).toBe(2750);
+		});
+
+		it("rejects non-finite ordinals on create input", async () => {
+			await expect(
+				core.createTaskFromInput({
+					title: "Invalid ordinal task",
+					ordinal: Number.POSITIVE_INFINITY,
+				}),
+			).rejects.toThrow("Ordinal must be a non-negative number.");
+		});
+
+		it("ignores tasks without ordinals when computing the next tail ordinal", async () => {
+			await core.createTask({
+				...sampleTask,
+				id: "task-20",
+				title: "No ordinal seed",
+			});
+			await core.createTask({
+				...sampleTask,
+				id: "task-21",
+				title: "Ordinal seed",
+				ordinal: 3000,
+			});
+
+			const { task } = await core.createTaskFromInput({ title: "Mixed ordinal task" });
+			expect(task.ordinal).toBe(4000);
+		});
+
+		it("preserves legacy no-ordinal ordering when no existing tasks have ordinals", async () => {
+			await core.createTask({
+				...sampleTask,
+				id: "task-20",
+				title: "Legacy no ordinal seed",
+			});
+
+			const { task } = await core.createTaskFromInput({ title: "Legacy appended task" });
+			expect(task.ordinal).toBeUndefined();
+
+			const loadedTask = await core.filesystem.loadTask(task.id);
+			expect(loadedTask?.ordinal).toBeUndefined();
+		});
+
+		it("rejects non-finite ordinals on update input", async () => {
+			const { task } = await core.createTaskFromInput({ title: "Ordinal update target" });
+
+			await expect(core.updateTaskFromInput(task.id, { ordinal: Number.POSITIVE_INFINITY })).rejects.toThrow(
+				"Ordinal must be a non-negative number.",
+			);
+		});
+
 		it("should NOT match numeric ID with typos when using custom prefix (BACK-364)", async () => {
 			// Configure custom prefix
 			const config = await core.filesystem.loadConfig();

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -85,6 +85,39 @@ describe("MCP task tools (MVP)", () => {
 		expect(searchText).not.toContain("Implementation Plan:");
 	});
 
+	it("assigns default tail ordinals for task_create and preserves explicit ordinals", async () => {
+		const first = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "First MCP ordinal task",
+				},
+			},
+		});
+		expect(getText(first.content)).toContain("Ordinal: 1000");
+
+		const second = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Second MCP ordinal task",
+				},
+			},
+		});
+		expect(getText(second.content)).toContain("Ordinal: 2000");
+
+		const explicit = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Explicit MCP ordinal task",
+					ordinal: 9000,
+				},
+			},
+		});
+		expect(getText(explicit.content)).toContain("Ordinal: 9000");
+	});
+
 	it("searches tasks with a separate modifiedFiles filter", async () => {
 		await mcpServer.testInterface.callTool({
 			params: {
@@ -522,6 +555,7 @@ describe("MCP task tools (MVP)", () => {
 				arguments: {
 					title: "Limited ordinal later id",
 					status: "To Do",
+					ordinal: 2000,
 				},
 			},
 		});


### PR DESCRIPTION
## Summary
This pull request adds default ordinal assignment when creating tasks without an explicit ordinal, and preserves explicit ordinals across the shared create path.

Changes included:
- assign `1000` to the first created task when no ordinals exist yet
- assign `max(existing ordinals) + 1000` for subsequent creates when ordinal is omitted
- expose `--ordinal` on `backlog task create` so explicit CLI create ordinals are preserved
- reject non-finite ordinal values before they can be persisted
- add regression coverage for CLI, core, MCP, and create-time sorting behavior

## Related Tasks
- BACK-454 - Default ordinals for created tasks

## Task Checklist
- [x] BACK-454 task included in the PR
- [x] Acceptance criteria completed
- [x] Definition of Done completed

## Testing
- `bun test src/test/core.test.ts src/test/cli-plain-create-edit.test.ts src/test/mcp-tasks.test.ts src/test/atomic-task-create.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`