### PR TITLE
BACK-456 - Lock milestone ID allocation during creation

### DIFF
--- a/backlog/tasks/back-456 - Lock-milestone-ID-allocation-during-creation.md
+++ b/backlog/tasks/back-456 - Lock-milestone-ID-allocation-during-creation.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-456
 title: Lock milestone ID allocation during creation
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-01 20:59'
+updated_date: '2026-05-01 21:02'
 labels:
   - bug
   - milestones
@@ -26,14 +27,20 @@ Issue #619 reports that concurrent MCP milestone creation can allocate the same 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Concurrent milestone creation from two Core/FileSystem instances produces unique milestone IDs.
-- [ ] #2 Milestone ID allocation includes active and archived milestone files while holding the create lock.
-- [ ] #3 The existing task create lock timeout behavior remains unchanged and covered by tests.
+- [x] #1 Concurrent milestone creation from two Core/FileSystem instances produces unique milestone IDs.
+- [x] #2 Milestone ID allocation includes active and archived milestone files while holding the create lock.
+- [x] #3 The existing task create lock timeout behavior remains unchanged and covered by tests.
 <!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wrapped milestone ID scan-and-write in the existing proper-lockfile create lock so MCP, web, and core milestone creation share the same concurrency protection as task creation. Added a deterministic race regression covering concurrent milestone creation and verified atomic create plus MCP milestone suites, typecheck, and Biome.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1084,67 +1084,69 @@ ${rawContent.trim()}
 	}
 
 	async createMilestone(title: string, description?: string): Promise<Milestone> {
-		const milestonesDir = await this.getMilestonesDir();
+		return await this.withCreateLock(async () => {
+			const milestonesDir = await this.getMilestonesDir();
 
-		// Ensure milestones directory exists
-		await mkdir(milestonesDir, { recursive: true });
+			// Ensure milestones directory exists
+			await mkdir(milestonesDir, { recursive: true });
 
-		// Find next available milestone ID
-		const archiveMilestonesDir = await this.getArchiveMilestonesDir();
-		await mkdir(archiveMilestonesDir, { recursive: true });
-		const [existingFiles, archivedFiles] = await Promise.all([
-			Array.fromAsync(new Bun.Glob("m-*.md").scan({ cwd: milestonesDir, followSymlinks: true })),
-			Array.fromAsync(new Bun.Glob("m-*.md").scan({ cwd: archiveMilestonesDir, followSymlinks: true })),
-		]);
-		const parseMilestoneId = async (dir: string, file: string): Promise<number | null> => {
-			if (file.toLowerCase() === "readme.md") {
-				return null;
-			}
-			const filepath = join(dir, file);
-			try {
-				const content = await Bun.file(filepath).text();
-				const parsed = parseMilestone(content);
-				const parsedIdMatch = parsed.id.match(/^m-(\d+)$/i);
-				if (parsedIdMatch?.[1]) {
-					return Number.parseInt(parsedIdMatch[1], 10);
+			// Find next available milestone ID
+			const archiveMilestonesDir = await this.getArchiveMilestonesDir();
+			await mkdir(archiveMilestonesDir, { recursive: true });
+			const [existingFiles, archivedFiles] = await Promise.all([
+				Array.fromAsync(new Bun.Glob("m-*.md").scan({ cwd: milestonesDir, followSymlinks: true })),
+				Array.fromAsync(new Bun.Glob("m-*.md").scan({ cwd: archiveMilestonesDir, followSymlinks: true })),
+			]);
+			const parseMilestoneId = async (dir: string, file: string): Promise<number | null> => {
+				if (file.toLowerCase() === "readme.md") {
+					return null;
 				}
-			} catch {
-				// Fall through to filename-based fallback.
-			}
-			const filenameIdMatch = file.match(/^m-(\d+)/i);
-			if (filenameIdMatch?.[1]) {
-				return Number.parseInt(filenameIdMatch[1], 10);
-			}
-			return null;
-		};
-		const existingIds = (
-			await Promise.all([
-				...existingFiles.map((file) => parseMilestoneId(milestonesDir, file)),
-				...archivedFiles.map((file) => parseMilestoneId(archiveMilestonesDir, file)),
-			])
-		).filter((id): id is number => typeof id === "number" && id >= 0);
+				const filepath = join(dir, file);
+				try {
+					const content = await Bun.file(filepath).text();
+					const parsed = parseMilestone(content);
+					const parsedIdMatch = parsed.id.match(/^m-(\d+)$/i);
+					if (parsedIdMatch?.[1]) {
+						return Number.parseInt(parsedIdMatch[1], 10);
+					}
+				} catch {
+					// Fall through to filename-based fallback.
+				}
+				const filenameIdMatch = file.match(/^m-(\d+)/i);
+				if (filenameIdMatch?.[1]) {
+					return Number.parseInt(filenameIdMatch[1], 10);
+				}
+				return null;
+			};
+			const existingIds = (
+				await Promise.all([
+					...existingFiles.map((file) => parseMilestoneId(milestonesDir, file)),
+					...archivedFiles.map((file) => parseMilestoneId(archiveMilestonesDir, file)),
+				])
+			).filter((id): id is number => typeof id === "number" && id >= 0);
 
-		const nextId = existingIds.length > 0 ? Math.max(...existingIds) + 1 : 0;
-		const id = `m-${nextId}`;
+			const nextId = existingIds.length > 0 ? Math.max(...existingIds) + 1 : 0;
+			const id = `m-${nextId}`;
 
-		const filename = this.buildMilestoneFilename(id, title);
-		const content = this.serializeMilestoneContent(
-			id,
-			title,
-			`## Description
+			const filename = this.buildMilestoneFilename(id, title);
+			const content = this.serializeMilestoneContent(
+				id,
+				title,
+				`## Description
 
 ${description || `Milestone: ${title}`}`,
-		);
+			);
 
-		const filepath = join(milestonesDir, filename);
-		await Bun.write(filepath, content);
+			const filepath = join(milestonesDir, filename);
+			await Bun.write(filepath, content);
 
-		return {
-			id,
-			title,
-			description: description || `Milestone: ${title}`,
-			rawContent: parseMilestone(content).rawContent,
-		};
+			return {
+				id,
+				title,
+				description: description || `Milestone: ${title}`,
+				rawContent: parseMilestone(content).rawContent,
+			};
+		});
 	}
 
 	async renameMilestone(

--- a/src/test/atomic-task-create.test.ts
+++ b/src/test/atomic-task-create.test.ts
@@ -218,6 +218,46 @@ describe("atomic task creation", () => {
 		expect(drafts.map((draft) => draft.title)).toEqual(["Task A", "Task B"]);
 	});
 
+	it("assigns unique ids when two milestone creations race", async () => {
+		const first = new Core(testDir);
+		const second = new Core(testDir);
+		const firstEnteredWrite = createDeferred<void>();
+		const releaseFirstWrite = createDeferred<void>();
+		let writeEntries = 0;
+		const originalWrite = Bun.write;
+		const milestonePathPrefix = `${testDir}/backlog/milestones/`.replace(/\\/g, "/");
+
+		Bun.write = (async (...args: Parameters<typeof Bun.write>) => {
+			const targetPath = String(args[0]).replace(/\\/g, "/");
+			if (targetPath.includes(milestonePathPrefix)) {
+				writeEntries += 1;
+				if (targetPath.includes("alpha-milestone")) {
+					firstEnteredWrite.resolve();
+					await releaseFirstWrite.promise;
+				}
+			}
+			return await originalWrite(...args);
+		}) as typeof Bun.write;
+
+		try {
+			const firstCreate = first.fs.createMilestone("Alpha Milestone");
+			await expectResolvesWithin(firstEnteredWrite.promise, 250, "first milestone create should reach Bun.write");
+
+			const secondCreate = second.fs.createMilestone("Beta Milestone");
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(writeEntries).toBe(1);
+
+			releaseFirstWrite.resolve();
+			const [createdA, createdB] = await Promise.all([firstCreate, secondCreate]);
+
+			expect(new Set([createdA.id, createdB.id]).size).toBe(2);
+			expect([createdA.id, createdB.id].sort()).toEqual(["m-0", "m-1"]);
+		} finally {
+			Bun.write = originalWrite;
+		}
+	});
+
 	it("returns a user-facing error when the create lock times out", async () => {
 		const core = new Core(testDir);
 		const lockEntered = createDeferred<void>();


### PR DESCRIPTION
## Summary
- wrap milestone ID scan-and-write in the existing create lock
- keep the fix in `FileSystem.createMilestone()` so MCP, web/API, and core callers all benefit
- add a deterministic regression for concurrent milestone creation

## Related Tasks
- BACK-456 - Lock milestone ID allocation during creation

## Fixes
- Fixes #619

## Testing
- `bun test src/test/atomic-task-create.test.ts src/test/mcp-milestones.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`