### PR TITLE
BACK-457 - Avoid stale task reads after milestone mutations

### DIFF
--- a/backlog/tasks/back-457 - Avoid-stale-task-reads-after-milestone-mutations.md
+++ b/backlog/tasks/back-457 - Avoid-stale-task-reads-after-milestone-mutations.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-457
 title: Avoid stale task reads after milestone mutations
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-01 21:49'
+updated_date: '2026-05-01 21:55'
 labels:
   - bug
   - web
@@ -14,27 +15,34 @@ references:
   - 'https://github.com/MrLesk/Backlog.md/actions/runs/25233629990'
   - 'https://github.com/MrLesk/Backlog.md/pull/620'
 modified_files:
+  - src/mcp/tools/milestones/handlers.ts
   - src/server/index.ts
-  - src/test/server-search-endpoint.test.ts
 priority: high
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-The post-merge CI run for BACK-456 failed because an immediate `GET /api/task/:id` after Web API milestone removal sometimes read stale milestone data from the server ContentStore. Direct task reads should prefer the local task file so read-after-write behavior is deterministic, while still falling back to the store for non-local/cross-branch tasks.
+The post-merge CI run for BACK-456 failed because Web API milestone removal could read or return stale milestone data from the server ContentStore immediately after task writes. Milestone mutations should load editable local tasks directly from disk, and direct task reads should prefer the local task file while still falling back to the store for non-local/cross-branch tasks.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `GET /api/task/:id` returns the freshly persisted local task when the file exists, even if ContentStore has stale data.
-- [ ] #2 Cross-branch/store-backed task lookup still works when no local task file exists.
-- [ ] #3 The failing milestone removal Web API test passes reliably.
+- [x] #1 `GET /api/task/:id` returns the freshly persisted local task when the file exists, even if ContentStore has stale data.
+- [x] #2 Cross-branch/store-backed task lookup still works when no local task file exists.
+- [x] #3 Milestone removal uses fresh local task files when clearing or reassigning tasks.
+- [x] #4 The failing milestone removal Web API test passes reliably.
 <!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the stale milestone mutation CI failure by loading editable local tasks directly from disk during milestone rename/remove operations and by making direct task GETs prefer a fresh local file before falling back to the ContentStore. Verified with the failing two-file test combination, full bun test with CI concurrency, typecheck, and Biome check.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/mcp/tools/milestones/handlers.ts
+++ b/src/mcp/tools/milestones/handlers.ts
@@ -215,7 +215,7 @@ export class MilestoneHandlers {
 	constructor(private readonly core: Core) {}
 
 	private async listLocalTasks(): Promise<Task[]> {
-		return await this.core.queryTasks({ includeCrossBranch: false });
+		return await this.core.filesystem.listTasks();
 	}
 
 	private async rollbackTaskMilestones(previousMilestones: Map<string, string | undefined>): Promise<string[]> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -968,18 +968,19 @@ export class BacklogServer {
 
 	private async handleGetTask(taskId: string): Promise<Response> {
 		const store = await this.getContentStoreInstance();
-		const tasks = store.getTasks();
-		const task = findTaskByLooseId(tasks, taskId);
-		if (!task) {
-			const fallbackId = ensurePrefix(taskId);
-			const fallback = await this.core.filesystem.loadTask(fallbackId);
-			if (fallback) {
-				store.upsertTask(fallback);
-				return Response.json(fallback);
-			}
-			return Response.json({ error: "Task not found" }, { status: 404 });
+
+		const localTask = await this.core.filesystem.loadTask(taskId);
+		if (localTask) {
+			store.upsertTask(localTask);
+			return Response.json(localTask);
 		}
-		return Response.json(task);
+
+		const task = findTaskByLooseId(store.getTasks(), taskId);
+		if (task) {
+			return Response.json(task);
+		}
+
+		return Response.json({ error: "Task not found" }, { status: 404 });
 	}
 
 	private async handleUpdateTask(req: Request, taskId: string): Promise<Response> {


### PR DESCRIPTION
## Summary
- Load editable local tasks directly from disk for milestone rename/remove task rewrites.
- Make direct task GETs prefer the freshly persisted local task file before falling back to ContentStore/cross-branch results.
- Mark BACK-457 complete with verification details.

## Verification
- bun test src/test/server-search-endpoint.test.ts src/test/mcp-milestones.test.ts
- bunx tsc --noEmit
- bun run check .
- bun test --timeout=30000 --max-concurrency=4

Fixes CI run: https://github.com/MrLesk/Backlog.md/actions/runs/25233629990