### PR TITLE
BACK-455 - Support task milestone assignment in CLI task CRUD

### DIFF
--- a/backlog/tasks/back-455 - Support-task-milestone-assignment-in-CLI-task-CRUD.md
+++ b/backlog/tasks/back-455 - Support-task-milestone-assignment-in-CLI-task-CRUD.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-455
 title: Support task milestone assignment in CLI task CRUD
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-01 13:28'
+updated_date: '2026-05-02 01:01'
 labels:
   - cli
   - milestones
@@ -12,6 +13,12 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/618'
+modified_files:
+  - src/cli.ts
+  - src/mcp/tools/tasks/handlers.ts
+  - src/server/index.ts
+  - src/test/cli-task-milestone.test.ts
+  - src/utils/milestone-storage.ts
 priority: medium
 ---
 
@@ -23,15 +30,30 @@ GitHub issue #618 requests milestone support on CLI task create/edit so users do
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `backlog task create` supports setting a task milestone using the existing task milestone field
-- [ ] #2 `backlog task edit` supports setting and clearing a task milestone without direct file edits
-- [ ] #3 CLI help and validation make the milestone behavior discoverable and safe
-- [ ] #4 Focused tests cover create, update, and clear milestone flows
+- [x] #1 `backlog task create` supports setting a task milestone using the existing task milestone field
+- [x] #2 `backlog task edit` supports setting and clearing a task milestone without direct file edits
+- [x] #3 CLI help and validation make the milestone behavior discoverable and safe
+- [x] #4 Focused tests cover create, update, and clear milestone flows
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add shared milestone storage-input resolver used by CLI plus existing API/MCP paths.
+2. Add CLI task create/edit milestone flags, including explicit clearing on edit.
+3. Add focused CLI tests for create, edit, title/ID normalization, and clear.
+4. Validate with scoped tests, typecheck, and Biome.
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added CLI task milestone assignment for `task create` and `task edit`, including title/ID alias normalization shared with API/MCP and explicit clearing through `task edit --clear-milestone`. Added focused CLI coverage for create, edit, clear, conflicting flags, and help output, then validated with scoped tests, full test suite, typecheck, and Biome.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,7 @@ import { type AgentSelectionValue, processAgentSelection } from "./utils/agent-s
 import { normalizeProjectBacklogDirectory } from "./utils/backlog-directory.ts";
 import { findBacklogRoot } from "./utils/find-backlog-root.ts";
 import { createMilestoneFilterValueResolver, resolveClosestMilestoneFilterValue } from "./utils/milestone-filter.ts";
+import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
 import { hasAnyPrefix } from "./utils/prefix-config.ts";
 import { type RuntimeCwdResolution, resolveRuntimeCwd } from "./utils/runtime-cwd.ts";
 import { formatValidStatuses, getCanonicalStatus, getValidStatuses } from "./utils/status.ts";
@@ -174,6 +175,7 @@ function hasCreateFieldFlags(options: Record<string, unknown>): boolean {
 			options.labels !== undefined ||
 			options.priority !== undefined ||
 			options.ordinal !== undefined ||
+			options.milestone !== undefined ||
 			options.plain ||
 			options.ac !== undefined ||
 			options.acceptanceCriteria !== undefined ||
@@ -202,6 +204,8 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.label !== undefined ||
 			options.priority !== undefined ||
 			options.ordinal !== undefined ||
+			options.milestone !== undefined ||
+			options.clearMilestone ||
 			options.plain ||
 			options.addLabel !== undefined ||
 			options.removeLabel !== undefined ||
@@ -226,6 +230,14 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.doc !== undefined ||
 			options.modifiedFile !== undefined,
 	);
+}
+
+async function resolveCliMilestoneInput(core: Core, milestone: string): Promise<string> {
+	const [activeMilestones, archivedMilestones] = await Promise.all([
+		core.filesystem.listMilestones(),
+		core.filesystem.listArchivedMilestones(),
+	]);
+	return resolveMilestoneInputForStorage(milestone, activeMilestones, archivedMilestones);
 }
 
 // Helper function to process multiple AC operations
@@ -1457,6 +1469,7 @@ taskCmd
 	.option("--notes <text>", "add implementation notes")
 	.option("--final-summary <text>", "add final summary")
 	.option("--ordinal <number>", "set task ordinal for custom ordering")
+	.option("-m, --milestone <milestone>", "assign task to milestone by ID or title")
 	.option("--draft")
 	.option("-p, --parent <taskId>", "specify parent task ID")
 	.option(
@@ -1538,6 +1551,8 @@ taskCmd
 
 		try {
 			const criteria = processAcceptanceCriteriaOptions(options);
+			const milestone =
+				typeof options.milestone === "string" ? await resolveCliMilestoneInput(core, options.milestone) : undefined;
 			const { task, filePath } = await core.createTaskFromInput({
 				title: title ?? "",
 				description: options.description || options.desc ? String(options.description || options.desc) : undefined,
@@ -1557,6 +1572,7 @@ taskCmd
 				parentTaskId: options.parent ? String(options.parent) : undefined,
 				priority: options.priority ? (String(options.priority).toLowerCase() as "high" | "medium" | "low") : undefined,
 				...(ordinalValue !== undefined ? { ordinal: ordinalValue } : {}),
+				milestone,
 				implementationPlan: options.plan ? String(options.plan) : undefined,
 				implementationNotes: options.notes ? String(options.notes) : undefined,
 				finalSummary: options.finalSummary ? String(options.finalSummary) : undefined,
@@ -2109,6 +2125,8 @@ taskCmd
 	.option("-l, --label <labels>")
 	.option("--priority <priority>", "set task priority (high, medium, low)")
 	.option("--ordinal <number>", "set task ordinal for custom ordering")
+	.option("-m, --milestone <milestone>", "assign task to milestone by ID or title")
+	.option("--clear-milestone", "clear task milestone assignment")
 	.option("--plain", "use plain text output after editing")
 	.option("--add-label <label>")
 	.option("--remove-label <label>")
@@ -2286,6 +2304,19 @@ taskCmd
 			ordinalValue = parsed;
 		}
 
+		if (options.milestone !== undefined && options.clearMilestone) {
+			console.error("Cannot use --milestone and --clear-milestone together.");
+			process.exitCode = 1;
+			return;
+		}
+
+		let milestoneValue: string | null | undefined;
+		if (typeof options.milestone === "string") {
+			milestoneValue = await resolveCliMilestoneInput(core, options.milestone);
+		} else if (options.clearMilestone) {
+			milestoneValue = null;
+		}
+
 		let removeCriteria: number[] | undefined;
 		let checkCriteria: number[] | undefined;
 		let uncheckCriteria: number[] | undefined;
@@ -2359,6 +2390,9 @@ taskCmd
 		}
 		if (ordinalValue !== undefined) {
 			editArgs.ordinal = ordinalValue;
+		}
+		if (milestoneValue !== undefined) {
+			editArgs.milestone = milestoneValue;
 		}
 		if (labelValues.length > 0) {
 			editArgs.labels = labelValues;

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -2,7 +2,6 @@ import { basename, join } from "node:path";
 import { isCreateLockError } from "../../../file-system/operations.ts";
 import {
 	isLocalEditableTask,
-	type Milestone,
 	type SearchPriorityFilter,
 	type Task,
 	type TaskListFilter,
@@ -13,13 +12,13 @@ import {
 	normalizeMilestoneFilterValue,
 	resolveClosestMilestoneFilterValue,
 } from "../../../utils/milestone-filter.ts";
+import { resolveMilestoneInputForStorage } from "../../../utils/milestone-storage.ts";
 import { buildTaskUpdateInput } from "../../../utils/task-edit-builder.ts";
 import { createTaskSearchIndex } from "../../../utils/task-search.ts";
 import { sortByOrdinalAndPriority } from "../../../utils/task-sorting.ts";
 import { BacklogToolError } from "../../errors/mcp-errors.ts";
 import type { McpServer } from "../../server.ts";
 import type { CallToolResult } from "../../types.ts";
-import { milestoneKey } from "../../utils/milestone-resolution.ts";
 import { formatTaskCallResult } from "../../utils/task-response.ts";
 
 export type TaskCreateArgs = {
@@ -67,106 +66,7 @@ export class TaskHandlers {
 			this.core.filesystem.listMilestones(),
 			this.core.filesystem.listArchivedMilestones(),
 		]);
-		const normalized = milestone.trim();
-		const inputKey = milestoneKey(normalized);
-		const aliasKeys = new Set<string>([inputKey]);
-		const looksLikeMilestoneId = /^\d+$/.test(normalized) || /^m-\d+$/i.test(normalized);
-		const canonicalInputId =
-			/^\d+$/.test(normalized) || /^m-\d+$/i.test(normalized)
-				? `m-${String(Number.parseInt(normalized.replace(/^m-/i, ""), 10))}`
-				: null;
-		if (/^\d+$/.test(normalized)) {
-			const numericAlias = String(Number.parseInt(normalized, 10));
-			aliasKeys.add(numericAlias);
-			aliasKeys.add(`m-${numericAlias}`);
-		} else {
-			const idMatch = normalized.match(/^m-(\d+)$/i);
-			if (idMatch?.[1]) {
-				const numericAlias = String(Number.parseInt(idMatch[1], 10));
-				aliasKeys.add(numericAlias);
-				aliasKeys.add(`m-${numericAlias}`);
-			}
-		}
-		const idMatchesAlias = (milestoneId: string): boolean => {
-			const idKey = milestoneKey(milestoneId);
-			if (aliasKeys.has(idKey)) {
-				return true;
-			}
-			if (/^\d+$/.test(milestoneId.trim())) {
-				const numericAlias = String(Number.parseInt(milestoneId.trim(), 10));
-				return aliasKeys.has(numericAlias) || aliasKeys.has(`m-${numericAlias}`);
-			}
-			const idMatch = milestoneId.trim().match(/^m-(\d+)$/i);
-			if (!idMatch?.[1]) {
-				return false;
-			}
-			const numericAlias = String(Number.parseInt(idMatch[1], 10));
-			return aliasKeys.has(numericAlias) || aliasKeys.has(`m-${numericAlias}`);
-		};
-		const findIdMatch = (milestones: Milestone[]): Milestone | undefined => {
-			const rawExactMatch = milestones.find((item) => milestoneKey(item.id) === inputKey);
-			if (rawExactMatch) {
-				return rawExactMatch;
-			}
-			if (canonicalInputId) {
-				const canonicalRawMatch = milestones.find((item) => milestoneKey(item.id) === canonicalInputId);
-				if (canonicalRawMatch) {
-					return canonicalRawMatch;
-				}
-			}
-			return milestones.find((item) => idMatchesAlias(item.id));
-		};
-		const findUniqueTitleMatch = (milestones: Milestone[]): Milestone | null => {
-			const titleMatches = milestones.filter((item) => milestoneKey(item.title) === inputKey);
-			if (titleMatches.length === 1) {
-				return titleMatches[0] ?? null;
-			}
-			return null;
-		};
-		const resolveByAlias = (milestones: Milestone[]): string | null => {
-			const idMatch = findIdMatch(milestones);
-			const titleMatch = findUniqueTitleMatch(milestones);
-			if (looksLikeMilestoneId) {
-				return idMatch?.id ?? null;
-			}
-			if (titleMatch) {
-				return titleMatch.id;
-			}
-			if (idMatch) {
-				return idMatch.id;
-			}
-			return null;
-		};
-
-		const activeTitleMatches = activeMilestones.filter((item) => milestoneKey(item.title) === inputKey);
-		const hasAmbiguousActiveTitle = activeTitleMatches.length > 1;
-		if (looksLikeMilestoneId) {
-			const activeIdMatch = findIdMatch(activeMilestones);
-			if (activeIdMatch) {
-				return activeIdMatch.id;
-			}
-			const archivedIdMatch = findIdMatch(archivedMilestones);
-			if (archivedIdMatch) {
-				return archivedIdMatch.id;
-			}
-			if (activeTitleMatches.length === 1) {
-				return activeTitleMatches[0]?.id ?? normalized;
-			}
-			if (hasAmbiguousActiveTitle) {
-				return normalized;
-			}
-			const archivedTitleMatch = findUniqueTitleMatch(archivedMilestones);
-			return archivedTitleMatch?.id ?? normalized;
-		}
-
-		const activeMatch = resolveByAlias(activeMilestones);
-		if (activeMatch) {
-			return activeMatch;
-		}
-		if (hasAmbiguousActiveTitle) {
-			return normalized;
-		}
-		return resolveByAlias(archivedMilestones) ?? normalized;
+		return resolveMilestoneInputForStorage(milestone, activeMilestones, archivedMilestones);
 	}
 
 	private isDoneStatus(status?: string | null): boolean {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,6 +18,7 @@ import {
 	type TaskUpdateInput,
 } from "../types/index.ts";
 import { watchConfig } from "../utils/config-watcher.ts";
+import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
 import { getVersion } from "../utils/version.ts";
 
 // Regex pattern to match any prefix (letters followed by dash)
@@ -202,125 +203,11 @@ export class BacklogServer {
 	}
 
 	private async resolveMilestoneInput(milestone: string): Promise<string> {
-		const normalized = milestone.trim();
-		if (!normalized) {
-			return normalized;
-		}
-
-		const key = normalized.toLowerCase();
-		const aliasKeys = new Set<string>([key]);
-		const looksLikeMilestoneId = /^\d+$/.test(normalized) || /^m-\d+$/i.test(normalized);
-		const canonicalInputId =
-			/^\d+$/.test(normalized) || /^m-\d+$/i.test(normalized)
-				? `m-${String(Number.parseInt(normalized.replace(/^m-/i, ""), 10))}`
-				: null;
-		if (/^\d+$/.test(normalized)) {
-			const numeric = String(Number.parseInt(normalized, 10));
-			aliasKeys.add(numeric);
-			aliasKeys.add(`m-${numeric}`);
-		} else {
-			const match = normalized.match(/^m-(\d+)$/i);
-			if (match?.[1]) {
-				const numeric = String(Number.parseInt(match[1], 10));
-				aliasKeys.add(numeric);
-				aliasKeys.add(`m-${numeric}`);
-			}
-		}
 		const [activeMilestones, archivedMilestones] = await Promise.all([
 			this.core.filesystem.listMilestones(),
 			this.core.filesystem.listArchivedMilestones(),
 		]);
-		const idMatchesAlias = (milestoneId: string): boolean => {
-			const idKey = milestoneId.trim().toLowerCase();
-			if (aliasKeys.has(idKey)) {
-				return true;
-			}
-			if (/^\d+$/.test(milestoneId.trim())) {
-				const numeric = String(Number.parseInt(milestoneId.trim(), 10));
-				return aliasKeys.has(numeric) || aliasKeys.has(`m-${numeric}`);
-			}
-			const idMatch = milestoneId.trim().match(/^m-(\d+)$/i);
-			if (!idMatch?.[1]) {
-				return false;
-			}
-			const numeric = String(Number.parseInt(idMatch[1], 10));
-			return aliasKeys.has(numeric) || aliasKeys.has(`m-${numeric}`);
-		};
-		const findIdMatch = (
-			milestones: Array<{ id: string; title: string }>,
-		): { id: string; title: string } | undefined => {
-			const rawExactMatch = milestones.find((item) => item.id.trim().toLowerCase() === key);
-			if (rawExactMatch) {
-				return rawExactMatch;
-			}
-			if (canonicalInputId) {
-				const canonicalRawMatch = milestones.find((item) => item.id.trim().toLowerCase() === canonicalInputId);
-				if (canonicalRawMatch) {
-					return canonicalRawMatch;
-				}
-			}
-			return milestones.find((item) => idMatchesAlias(item.id));
-		};
-		const findUniqueTitleMatch = (
-			milestones: Array<{ id: string; title: string }>,
-		): { id: string; title: string } | null => {
-			const titleMatches = milestones.filter((item) => item.title.trim().toLowerCase() === key);
-			if (titleMatches.length === 1) {
-				return titleMatches[0] ?? null;
-			}
-			return null;
-		};
-
-		const matchByAlias = (milestones: Array<{ id: string; title: string }>): string | null => {
-			const idMatch = findIdMatch(milestones);
-			const titleMatch = findUniqueTitleMatch(milestones);
-			if (looksLikeMilestoneId) {
-				return idMatch?.id ?? null;
-			}
-			if (titleMatch) {
-				return titleMatch.id;
-			}
-			if (idMatch) {
-				return idMatch.id;
-			}
-			return null;
-		};
-
-		const activeTitleMatches = activeMilestones.filter((item) => item.title.trim().toLowerCase() === key);
-		const hasAmbiguousActiveTitle = activeTitleMatches.length > 1;
-		if (looksLikeMilestoneId) {
-			const activeIdMatch = findIdMatch(activeMilestones);
-			if (activeIdMatch) {
-				return activeIdMatch.id;
-			}
-			const archivedIdMatch = findIdMatch(archivedMilestones);
-			if (archivedIdMatch) {
-				return archivedIdMatch.id;
-			}
-			if (activeTitleMatches.length === 1) {
-				return activeTitleMatches[0]?.id ?? normalized;
-			}
-			if (hasAmbiguousActiveTitle) {
-				return normalized;
-			}
-			const archivedTitleMatch = findUniqueTitleMatch(archivedMilestones);
-			return archivedTitleMatch?.id ?? normalized;
-		}
-
-		const activeMatch = matchByAlias(activeMilestones);
-		if (activeMatch) {
-			return activeMatch;
-		}
-		if (hasAmbiguousActiveTitle) {
-			return normalized;
-		}
-
-		const archivedMatch = matchByAlias(archivedMilestones);
-		if (archivedMatch) {
-			return archivedMatch;
-		}
-
-		return normalized;
+		return resolveMilestoneInputForStorage(milestone, activeMilestones, archivedMilestones);
 	}
 
 	private async ensureServicesReady(): Promise<void> {

--- a/src/test/cli-task-milestone.test.ts
+++ b/src/test/cli-task-milestone.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+describe("CLI task milestone assignment", () => {
+	const cliPath = join(process.cwd(), "src", "cli.ts");
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-cli-task-milestone");
+		try {
+			await rm(TEST_DIR, { recursive: true, force: true });
+		} catch {
+			// Ignore cleanup errors
+		}
+		await mkdir(TEST_DIR, { recursive: true });
+
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await initializeTestProject(core, "CLI Milestone Assignment Project");
+	});
+
+	afterEach(async () => {
+		try {
+			await safeCleanup(TEST_DIR);
+		} catch {
+			// Ignore cleanup errors - unique directory names prevent conflicts
+		}
+	});
+
+	it("creates tasks with milestone titles resolved to canonical milestone IDs", async () => {
+		const core = new Core(TEST_DIR);
+		const milestone = await core.filesystem.createMilestone("Release CLI");
+
+		const result = await $`bun ${cliPath} task create "Milestone create task" --milestone "Release CLI" --plain`
+			.cwd(TEST_DIR)
+			.quiet();
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain(`Milestone: ${milestone.id}`);
+
+		const task = await core.filesystem.loadTask("task-1");
+		expect(task?.milestone).toBe(milestone.id);
+	});
+
+	it("edits and clears task milestones from the CLI", async () => {
+		const core = new Core(TEST_DIR);
+		const first = await core.filesystem.createMilestone("Release Alpha");
+		const second = await core.filesystem.createMilestone("Release Beta");
+
+		const create = await $`bun ${cliPath} task create "Milestone edit task" --milestone ${first.id}`
+			.cwd(TEST_DIR)
+			.quiet();
+		expect(create.exitCode).toBe(0);
+
+		const edit = await $`bun ${cliPath} task edit 1 --milestone "Release Beta" --plain`.cwd(TEST_DIR).quiet();
+		expect(edit.exitCode).toBe(0);
+		expect(edit.stdout.toString()).toContain(`Milestone: ${second.id}`);
+
+		const updated = await core.filesystem.loadTask("task-1");
+		expect(updated?.milestone).toBe(second.id);
+
+		const clear = await $`bun ${cliPath} task edit 1 --clear-milestone --plain`.cwd(TEST_DIR).quiet();
+		expect(clear.exitCode).toBe(0);
+		expect(clear.stdout.toString()).not.toContain("Milestone:");
+
+		const cleared = await core.filesystem.loadTask("task-1");
+		expect(cleared?.milestone).toBeUndefined();
+	});
+
+	it("rejects conflicting milestone edit flags", async () => {
+		const core = new Core(TEST_DIR);
+		await core.filesystem.createMilestone("Release CLI");
+		await $`bun ${cliPath} task create "Conflicting milestone flags"`.cwd(TEST_DIR).quiet();
+
+		const result = await $`bun ${cliPath} task edit 1 --milestone "Release CLI" --clear-milestone`
+			.cwd(TEST_DIR)
+			.quiet()
+			.nothrow();
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("Cannot use --milestone and --clear-milestone together.");
+	});
+
+	it("shows milestone create and edit flags in help output", async () => {
+		const createHelp = await $`bun ${cliPath} task create --help`.cwd(TEST_DIR).quiet();
+		const editHelp = await $`bun ${cliPath} task edit --help`.cwd(TEST_DIR).quiet();
+
+		expect(createHelp.stdout.toString()).toContain("-m, --milestone <milestone>");
+		expect(editHelp.stdout.toString()).toContain("-m, --milestone <milestone>");
+		expect(editHelp.stdout.toString()).toContain("--clear-milestone");
+	});
+});

--- a/src/utils/milestone-storage.ts
+++ b/src/utils/milestone-storage.ts
@@ -1,0 +1,129 @@
+import type { Milestone } from "../types/index.ts";
+
+type MilestoneRef = Pick<Milestone, "id" | "title">;
+
+function milestoneStorageKey(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function collectMilestoneAliasKeys(value: string): Set<string> {
+	const normalized = value.trim();
+	const keys = new Set<string>();
+	const baseKey = milestoneStorageKey(normalized);
+	if (!baseKey) {
+		return keys;
+	}
+
+	keys.add(baseKey);
+
+	if (/^\d+$/.test(normalized)) {
+		const numeric = String(Number.parseInt(normalized, 10));
+		keys.add(numeric);
+		keys.add(`m-${numeric}`);
+		return keys;
+	}
+
+	const idMatch = normalized.match(/^m-(\d+)$/i);
+	if (idMatch?.[1]) {
+		const numeric = String(Number.parseInt(idMatch[1], 10));
+		keys.add(numeric);
+		keys.add(`m-${numeric}`);
+	}
+
+	return keys;
+}
+
+function canonicalMilestoneIdAlias(value: string): string | null {
+	const normalized = value.trim();
+	if (/^\d+$/.test(normalized) || /^m-\d+$/i.test(normalized)) {
+		return `m-${String(Number.parseInt(normalized.replace(/^m-/i, ""), 10))}`;
+	}
+	return null;
+}
+
+function milestoneIdMatchesAlias(milestoneId: string, aliasKeys: Set<string>): boolean {
+	for (const key of collectMilestoneAliasKeys(milestoneId)) {
+		if (aliasKeys.has(key)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function findIdMatch(input: string, milestones: MilestoneRef[], aliasKeys: Set<string>): MilestoneRef | undefined {
+	const inputKey = milestoneStorageKey(input);
+	const rawExactMatch = milestones.find((item) => milestoneStorageKey(item.id) === inputKey);
+	if (rawExactMatch) {
+		return rawExactMatch;
+	}
+
+	const canonicalInputId = canonicalMilestoneIdAlias(input);
+	if (canonicalInputId) {
+		const canonicalRawMatch = milestones.find((item) => milestoneStorageKey(item.id) === canonicalInputId);
+		if (canonicalRawMatch) {
+			return canonicalRawMatch;
+		}
+	}
+
+	return milestones.find((item) => milestoneIdMatchesAlias(item.id, aliasKeys));
+}
+
+function findUniqueTitleMatch(input: string, milestones: MilestoneRef[]): MilestoneRef | null {
+	const inputKey = milestoneStorageKey(input);
+	const titleMatches = milestones.filter((item) => milestoneStorageKey(item.title) === inputKey);
+	return titleMatches.length === 1 ? (titleMatches[0] ?? null) : null;
+}
+
+export function resolveMilestoneInputForStorage(
+	milestone: string,
+	activeMilestones: MilestoneRef[],
+	archivedMilestones: MilestoneRef[] = [],
+): string {
+	const normalized = milestone.trim();
+	if (!normalized) {
+		return normalized;
+	}
+
+	const aliasKeys = collectMilestoneAliasKeys(normalized);
+	const looksLikeMilestoneId = /^\d+$/.test(normalized) || /^m-\d+$/i.test(normalized);
+	const resolveByAlias = (milestones: MilestoneRef[]): string | null => {
+		const idMatch = findIdMatch(normalized, milestones, aliasKeys);
+		const titleMatch = findUniqueTitleMatch(normalized, milestones);
+		if (looksLikeMilestoneId) {
+			return idMatch?.id ?? null;
+		}
+		return titleMatch?.id ?? idMatch?.id ?? null;
+	};
+
+	const inputKey = milestoneStorageKey(normalized);
+	const activeTitleMatches = activeMilestones.filter((item) => milestoneStorageKey(item.title) === inputKey);
+	const hasAmbiguousActiveTitle = activeTitleMatches.length > 1;
+	if (looksLikeMilestoneId) {
+		const activeIdMatch = findIdMatch(normalized, activeMilestones, aliasKeys);
+		if (activeIdMatch) {
+			return activeIdMatch.id;
+		}
+		const archivedIdMatch = findIdMatch(normalized, archivedMilestones, aliasKeys);
+		if (archivedIdMatch) {
+			return archivedIdMatch.id;
+		}
+		if (activeTitleMatches.length === 1) {
+			return activeTitleMatches[0]?.id ?? normalized;
+		}
+		if (hasAmbiguousActiveTitle) {
+			return normalized;
+		}
+		const archivedTitleMatch = findUniqueTitleMatch(normalized, archivedMilestones);
+		return archivedTitleMatch?.id ?? normalized;
+	}
+
+	const activeMatch = resolveByAlias(activeMilestones);
+	if (activeMatch) {
+		return activeMatch;
+	}
+	if (hasAmbiguousActiveTitle) {
+		return normalized;
+	}
+
+	return resolveByAlias(archivedMilestones) ?? normalized;
+}


### PR DESCRIPTION
## Summary
- Add `--milestone` support to `backlog task create` and `backlog task edit`
- Add `--clear-milestone` for CLI task edits and reject conflicting milestone flags
- Share milestone title/ID alias normalization between CLI, API, and MCP task paths
- Add focused CLI milestone assignment tests

Closes #618

## Verification
- `bun test src/test/cli-task-milestone.test.ts src/test/mcp-milestones.test.ts src/test/server-search-endpoint.test.ts`
- `bun test src/test/mcp-tasks.test.ts src/test/cli-plain-create-edit.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test --timeout=30000 --max-concurrency=4`