### PR TITLE
BACK-458 - Fix promoted draft default status

### DIFF
--- a/backlog/tasks/back-458 - Fix-promoted-draft-default-status.md
+++ b/backlog/tasks/back-458 - Fix-promoted-draft-default-status.md
@@ -1,0 +1,71 @@
+---
+id: BACK-458
+title: Fix promoted draft default status
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-02 15:28'
+updated_date: '2026-05-02 15:30'
+labels:
+  - bug
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/624'
+  - 'https://github.com/MrLesk/Backlog.md/pull/625'
+modified_files:
+  - src/file-system/operations.ts
+  - src/test/filesystem.test.ts
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Promoting a draft currently leaves the promoted task with status `Draft`, which can make the task invisible on boards whose configured statuses do not include `Draft`. Fix draft promotion so promoted tasks enter the configured default workflow status instead of remaining draft-only.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Promoting a draft writes the promoted task with the configured `default_status` when one is set.
+- [x] #2 Promoting a draft falls back to the built-in task status when no `default_status` is configured, instead of preserving `Draft`.
+- [x] #3 Regression coverage verifies promoted drafts are visible as regular tasks and do not keep the draft-only status.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update `FileSystem.promoteDraft` so promoted tasks replace draft-only `Draft` status with `config.defaultStatus` or the built-in fallback status.
+2. Add focused regression tests in `src/test/filesystem.test.ts` for configured default status and no-config fallback.
+3. Run the scoped filesystem test, then typecheck/check if the change touches formatting or TypeScript behavior broadly.
+4. Mark acceptance criteria and summarize issue/PR readiness, including PR 625, PR 623, and PR 626 state.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented draft promotion status normalization in `FileSystem.promoteDraft` using configured `defaultStatus` with `FALLBACK_STATUS` fallback. Added filesystem regression coverage for both the no-config fallback (`To Do`) and an explicit configured default (`Ready`).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Summary
+- Promoted drafts now leave the draft-only `Draft` status and become regular workflow tasks using `defaultStatus` or the built-in fallback status.
+- Added regression tests for both fallback behavior and configured default status behavior in draft promotion.
+
+## Validation
+- `bun test src/test/filesystem.test.ts`
+- `bunx tsc --noEmit`
+- `bun run check .`
+- `git diff --check`
+
+## Related GitHub
+- Fixes the behavior reported in issue #624.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-458 - Fix-promoted-draft-default-status.md
+++ b/backlog/tasks/back-458 - Fix-promoted-draft-default-status.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-02 15:28'
-updated_date: '2026-05-02 15:30'
+updated_date: '2026-05-02 19:17'
 labels:
   - bug
 dependencies: []
@@ -44,23 +44,14 @@ Promoting a draft currently leaves the promoted task with status `Draft`, which 
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented draft promotion status normalization in `FileSystem.promoteDraft` using configured `defaultStatus` with `FALLBACK_STATUS` fallback. Added filesystem regression coverage for both the no-config fallback (`To Do`) and an explicit configured default (`Ready`).
+
+Addressed Codex P1 review feedback by preserving non-draft statuses during demote/promote round trips while still defaulting draft-only statuses.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-## Summary
-- Promoted drafts now leave the draft-only `Draft` status and become regular workflow tasks using `defaultStatus` or the built-in fallback status.
-- Added regression tests for both fallback behavior and configured default status behavior in draft promotion.
-
-## Validation
-- `bun test src/test/filesystem.test.ts`
-- `bunx tsc --noEmit`
-- `bun run check .`
-- `git diff --check`
-
-## Related GitHub
-- Fixes the behavior reported in issue #624.
+Promoted draft-only tasks now enter the default workflow status, while demoted tasks with an existing non-draft status keep that status when promoted again. Added regression coverage for both paths.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -2,7 +2,7 @@ import { mkdir, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import matter from "gray-matter";
 import lockfile from "proper-lockfile";
-import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES } from "../constants/index.ts";
+import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
 import { parseDecision, parseDocument, parseMilestone, parseTask } from "../markdown/parser.ts";
 import { serializeDecision, serializeDocument, serializeTask } from "../markdown/serializer.ts";
 import type { BacklogConfig, Decision, Document, Milestone, Task, TaskListFilter } from "../types/index.ts";
@@ -578,10 +578,13 @@ export class FileSystem {
 				// Generate new task ID
 				const newTaskId = generateNextId(existingIds, taskPrefix, config?.zeroPaddedIds);
 
-				// Update draft with new task ID and save as task
+				// Update draft with new task ID and save as task. The status is "Draft"
+				// while in the drafts dir; on promotion fall back to defaultStatus so the
+				// task lands in a column visible on the kanban board (#624).
 				const promotedTask: Task = {
 					...draft,
 					id: newTaskId,
+					status: config?.defaultStatus || FALLBACK_STATUS,
 					filePath: undefined, // Will be set by saveTask
 				};
 

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -578,9 +578,7 @@ export class FileSystem {
 				// Generate new task ID
 				const newTaskId = generateNextId(existingIds, taskPrefix, config?.zeroPaddedIds);
 
-				// Update draft with new task ID and save as task. The status is "Draft"
-				// while in the drafts dir; on promotion fall back to defaultStatus so the
-				// task lands in a column visible on the kanban board (#624).
+				// Promoted drafts should enter the normal task workflow.
 				const promotedTask: Task = {
 					...draft,
 					id: newTaskId,

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -578,11 +578,16 @@ export class FileSystem {
 				// Generate new task ID
 				const newTaskId = generateNextId(existingIds, taskPrefix, config?.zeroPaddedIds);
 
-				// Promoted drafts should enter the normal task workflow.
+				const promotedStatus =
+					!draft.status || draft.status.trim().toLowerCase() === "draft"
+						? config?.defaultStatus || FALLBACK_STATUS
+						: draft.status;
+
+				// Draft-only statuses should enter the normal task workflow.
 				const promotedTask: Task = {
 					...draft,
 					id: newTaskId,
-					status: config?.defaultStatus || FALLBACK_STATUS,
+					status: promotedStatus,
 					filePath: undefined, // Will be set by saveTask
 				};
 

--- a/src/test/filesystem.test.ts
+++ b/src/test/filesystem.test.ts
@@ -279,6 +279,28 @@ Invalid content`,
 			expect(promotedTask?.status).toBe("Ready");
 		});
 
+		it("should preserve a non-draft status when promoting a demoted task", async () => {
+			await filesystem.saveTask({
+				...sampleDraft,
+				id: "task-1",
+				title: "Demoted Task",
+				status: "In Progress",
+			});
+
+			const demoted = await filesystem.demoteTask("task-1");
+			expect(demoted).toBe(true);
+
+			const draft = await filesystem.loadDraft("draft-1");
+			expect(draft?.status).toBe("In Progress");
+
+			const promoted = await filesystem.promoteDraft("draft-1");
+			expect(promoted).toBe(true);
+
+			const promotedTask = await filesystem.loadTask("task-1");
+			expect(promotedTask?.id).toBe("TASK-1");
+			expect(promotedTask?.status).toBe("In Progress");
+		});
+
 		it("should promote draft with custom task prefix", async () => {
 			// Configure custom task prefix
 			const customConfig: BacklogConfig = {

--- a/src/test/filesystem.test.ts
+++ b/src/test/filesystem.test.ts
@@ -256,6 +256,27 @@ Invalid content`,
 			const promotedTask = await filesystem.loadTask("task-1");
 			expect(promotedTask?.id).toBe("TASK-1");
 			expect(promotedTask?.title).toBe(sampleDraft.title);
+			expect(promotedTask?.status).toBe("To Do");
+		});
+
+		it("should promote a draft to the configured default status", async () => {
+			const customConfig: BacklogConfig = {
+				projectName: "Custom Default Status Project",
+				defaultStatus: "Ready",
+				statuses: ["Ready", "In Progress", "Done"],
+				labels: [],
+				milestones: [],
+				dateFormat: "yyyy-MM-dd",
+			};
+			await filesystem.saveConfig(customConfig);
+			await filesystem.saveDraft(sampleDraft);
+
+			const promoted = await filesystem.promoteDraft("draft-1");
+			expect(promoted).toBe(true);
+
+			const promotedTask = await filesystem.loadTask("task-1");
+			expect(promotedTask?.id).toBe("TASK-1");
+			expect(promotedTask?.status).toBe("Ready");
 		});
 
 		it("should promote draft with custom task prefix", async () => {


### PR DESCRIPTION
Closes #624.

Promoting a draft now resets the draft-only `Draft` status to the configured `defaultStatus`, falling back to the built-in `To Do` status when no default is configured. This keeps promoted drafts visible as regular tasks on the kanban board.

The PR now includes the Backlog task metadata for `BACK-458` and focused regression coverage for both fallback and configured-default behavior.

### Validation
- `bun test src/test/filesystem.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `git diff --check`
