### PR TITLE
BACK-450 - Add CLI document update command

### DIFF
--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -26,6 +26,7 @@ You can rerun the wizard anytime with `backlog config`. All existing CLI flags (
 
 - Document IDs are global across all subdirectories under `backlog/docs`. You can organize files in nested folders (e.g., `backlog/docs/guides/`), and `backlog doc list` and `backlog doc view <id>` work across the entire tree.
 - Use `backlog doc create "New Guide" -p guides` to create a document in a docs subdirectory. The created output includes the persisted docs-relative file path, such as `backlog/docs/guides/doc-1 - New-Guide.md`.
+- Use `backlog doc update doc-1 --content "Updated markdown"` to update document content. Add `--title`, `-t/--type`, `--tags`, or `-p/--path` to update metadata or move the document while preserving omitted fields.
 - Document paths are always relative to the docs directory. Absolute paths and traversal segments such as `..` are rejected.
 
 ## Task Management
@@ -190,6 +191,8 @@ To keep the Web UI running in the background with auto-start on boot, see [Runni
 | Create doc | `backlog doc create "API Guidelines"` |
 | Create with path | `backlog doc create "Setup Guide" -p guides/setup` |
 | Create with type | `backlog doc create "Architecture" -t guide` |
+| Update content | `backlog doc update doc-1 --content "Updated markdown"` |
+| Update metadata/path | `backlog doc update doc-1 --title "Setup Handbook" -t guide --tags setup,runbook -p guides` |
 | List docs | `backlog doc list` |
 | View doc | `backlog doc view doc-1` |
 

--- a/backlog/tasks/back-450 - Add-CLI-document-update-command.md
+++ b/backlog/tasks/back-450 - Add-CLI-document-update-command.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-450
 title: Add CLI document update command
-status: In Progress
+status: Done
 assignee:
-  - '@codex'
+  - '@alex-agent'
 created_date: '2026-04-26 13:21'
-updated_date: '2026-04-26 13:22'
+updated_date: '2026-05-03 16:01'
 labels:
   - feature
   - cli
@@ -18,6 +18,7 @@ modified_files:
   - src/cli.ts
   - src/test/cli.test.ts
   - src/guidelines/agent-guidelines.md
+  - CLI-INSTRUCTIONS.md
 priority: medium
 ---
 
@@ -29,11 +30,11 @@ BACK-436 aligned document create/update behavior in core, Web/server APIs, and M
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `backlog doc update <docId>` updates an existing document through the core document update contract and preserves existing metadata when options are omitted.
-- [ ] #2 The command exposes user-facing options for updating title, content, type, tags, and docs-relative path, with help text matching supported document types and path rules.
-- [ ] #3 The command rejects missing documents, invalid document types, and unsafe absolute/traversal paths with clear CLI failures rather than corrupting files.
-- [ ] #4 CLI regression tests cover content/metadata updates, path moves, metadata preservation, and at least one invalid input case.
-- [ ] #5 Agent/CLI guidance is updated so document management instructions include the new CLI update path.
+- [x] #1 `backlog doc update <docId>` updates an existing document through the core document update contract and preserves existing metadata when options are omitted.
+- [x] #2 The command exposes user-facing options for updating title, content, type, tags, and docs-relative path, with help text matching supported document types and path rules.
+- [x] #3 The command rejects missing documents, invalid document types, and unsafe absolute/traversal paths with clear CLI failures rather than corrupting files.
+- [x] #4 CLI regression tests cover content/metadata updates, path moves, metadata preservation, and at least one invalid input case.
+- [x] #5 Agent/CLI guidance is updated so document management instructions include the new CLI update path.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -52,9 +53,15 @@ BACK-436 aligned document create/update behavior in core, Web/server APIs, and M
 Context check before implementation: BACK-436 added `Core.updateDocumentFromInput` and Web/MCP document updates, but `src/cli.ts` still registers only `doc create`, `doc list`, and `doc view`. Existing CLI document tests live in `src/test/cli.test.ts` under `doc and decision commands`; document types are constrained by `DOCUMENT_TYPE_VALUES`. Chosen implementation keeps CLI as a thin adapter over core rather than duplicating document path or type validation.
 <!-- SECTION:NOTES:END -->
 
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the public backlog doc update command, including content/title/type/tags/path updates through Core.updateDocumentFromInput, regression coverage for preservation and invalid inputs, and updated CLI/agent guidance.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3076,6 +3076,37 @@ docCmd
 	});
 
 docCmd
+	.command("update <docId>")
+	.description("update a document")
+	.option("--title <title>", "update document title")
+	.option("--content <content>", "replace document markdown content")
+	.option("-p, --path <path>", "move document under a docs-relative path (absolute paths and .. are rejected)")
+	.option("-t, --type <type>", `document type (${DOCUMENT_TYPE_VALUES.join(", ")})`)
+	.option("--tags <tags>", "set tags (comma-separated or use multiple times)", createMultiValueAccumulator())
+	.action(async (docId: string, options) => {
+		const cwd = await requireProjectRoot();
+		const core = new Core(cwd);
+		const existingDocument = await core.getDocument(docId);
+		if (!existingDocument) {
+			throw new Error(`Document not found: ${docId}`);
+		}
+
+		const document = await core.updateDocumentFromInput({
+			id: docId,
+			title: options.title,
+			content: options.content ?? existingDocument.rawContent,
+			type: options.type,
+			path: options.path,
+			...(options.tags !== undefined && { tags: parseDelimitedStringList(options.tags) ?? [] }),
+		});
+
+		console.log(`Updated document ${document.id}`);
+		if (document.path) {
+			console.log(`Path: ${core.filesystem.backlogDirName}/docs/${document.path}`);
+		}
+	});
+
+docCmd
 	.command("list")
 	.option("--plain", "use plain text output instead of interactive UI")
 	.action(async (options) => {

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -66,7 +66,7 @@ remains fully synchronized and up-to-date.
 - **All task operations MUST use the Backlog.md CLI tool**
 - This ensures metadata is correctly updated and the project stays in sync
 - **Always use `--plain` flag** when listing or viewing tasks for AI-friendly text output
-- Create project docs through Backlog.md APIs so frontmatter and paths stay valid. For CLI users, run `backlog doc create "Title" -p guides/setup`; MCP users should use `document_create` with `path: "guides/setup"`.
+- Create and update project docs through Backlog.md APIs so frontmatter and paths stay valid. For CLI users, run `backlog doc create "Title" -p guides/setup` or `backlog doc update doc-1 --content "Updated markdown"`; MCP users should use `document_create` / `document_update`.
 - Document paths are relative to `backlog/docs/`; absolute paths and `..` traversal are rejected.
 
 ---
@@ -669,7 +669,7 @@ Use Backlog.md public interfaces for document creation and updates so IDs, front
 
 #### CLI Usage
 
-The CLI currently supports creating, listing, and viewing documents. Use MCP or the Web UI for document updates.
+The CLI supports creating, updating, listing, and viewing documents.
 
 ```bash
 # Create a new doc (saved under backlog/docs/ by default)
@@ -680,6 +680,12 @@ backlog doc create "Setup Guide" -p guides/setup
 
 # Specify type at creation time
 backlog doc create "Architecture" -t guide
+
+# Update content while preserving omitted metadata
+backlog doc update doc-1 --content "Updated markdown"
+
+# Update metadata or move a doc within backlog/docs/
+backlog doc update doc-1 --title "Setup Handbook" -t guide --tags setup,runbook -p guides
 
 # List all docs (searched globally across subdirectories)
 backlog doc list

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1371,6 +1371,99 @@ describe("CLI Integration", () => {
 			expect(result.stderr.toString()).toContain("Document path cannot include traversal segments.");
 		});
 
+		it("should update document content and metadata", async () => {
+			const core = new Core(TEST_DIR);
+			await core.createDocument(
+				{
+					id: "doc-1",
+					title: "Setup Guide",
+					type: "guide",
+					createdDate: "2025-06-08",
+					rawContent: "Old content",
+					tags: ["setup"],
+				},
+				false,
+				"guides/setup",
+			);
+
+			const updatedContent = "# Updated\n\nRun install steps.";
+			const result =
+				await $`bun ${CLI_PATH} doc update doc-1 --title "Install Runbook" --content ${updatedContent} -t specification --tags ops,runbook -p runbooks`
+					.cwd(TEST_DIR)
+					.quiet();
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toContain("Updated document doc-1");
+			expect(result.stdout.toString()).toContain("Path: backlog/docs/runbooks/doc-1 - Install-Runbook.md");
+
+			const docs = await core.filesystem.listDocuments();
+			const updated = docs.find((doc) => doc.id === "doc-1");
+			expect(updated?.title).toBe("Install Runbook");
+			expect(updated?.type).toBe("specification");
+			expect(updated?.tags).toEqual(["ops", "runbook"]);
+			expect(updated?.path).toBe("runbooks/doc-1 - Install-Runbook.md");
+			expect(updated?.rawContent).toBe(updatedContent);
+		});
+
+		it("should preserve omitted document fields when updating", async () => {
+			const core = new Core(TEST_DIR);
+			await core.createDocument(
+				{
+					id: "doc-1",
+					title: "Setup Guide",
+					type: "guide",
+					createdDate: "2025-06-08",
+					rawContent: "Keep this content",
+					tags: ["setup", "guide"],
+				},
+				false,
+				"guides",
+			);
+
+			await $`bun ${CLI_PATH} doc update doc-1 --title "Setup Handbook"`.cwd(TEST_DIR).quiet();
+
+			const docs = await core.filesystem.listDocuments();
+			const updated = docs.find((doc) => doc.id === "doc-1");
+			expect(updated?.title).toBe("Setup Handbook");
+			expect(updated?.type).toBe("guide");
+			expect(updated?.tags).toEqual(["setup", "guide"]);
+			expect(updated?.path).toBe("guides/doc-1 - Setup-Handbook.md");
+			expect(updated?.rawContent).toBe("Keep this content");
+		});
+
+		it("should reject invalid document update inputs", async () => {
+			const core = new Core(TEST_DIR);
+			await core.createDocument(
+				{
+					id: "doc-1",
+					title: "Setup Guide",
+					type: "guide",
+					createdDate: "2025-06-08",
+					rawContent: "Content",
+				},
+				false,
+			);
+
+			const missing = await $`bun ${CLI_PATH} doc update doc-404 --content "Nope"`.cwd(TEST_DIR).quiet().nothrow();
+			expect(missing.exitCode).not.toBe(0);
+			expect(missing.stderr.toString()).toContain("Document not found: doc-404");
+
+			const invalidType = await $`bun ${CLI_PATH} doc update doc-1 --content "Nope" -t invalid`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(invalidType.exitCode).not.toBe(0);
+			expect(invalidType.stderr.toString()).toContain(
+				"Document type must be one of: readme, guide, specification, other.",
+			);
+
+			const unsafePath = await $`bun ${CLI_PATH} doc update doc-1 --content "Nope" -p ../outside`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(unsafePath.exitCode).not.toBe(0);
+			expect(unsafePath.stderr.toString()).toContain("Document path cannot include traversal segments.");
+		});
+
 		it("should create and list decisions", async () => {
 			const core = new Core(TEST_DIR);
 			const decision: Decision = {


### PR DESCRIPTION
## Summary
- add `backlog doc update <docId>` for content/title/type/tags/path updates
- preserve existing document body and metadata when options are omitted
- update CLI and agent guidance for the new document update path

## Task
- BACK-450 - Add CLI document update command

## Validation
- bun test src/test/cli.test.ts
- bunx tsc --noEmit
- bun run check .
