### PR TITLE
BACK-462 - Use terminal status for cleanup instead of hardcoded Done

### DIFF
--- a/backlog/tasks/back-462 - Use-terminal-status-for-cleanup-instead-of-hardcoded-Done.md
+++ b/backlog/tasks/back-462 - Use-terminal-status-for-cleanup-instead-of-hardcoded-Done.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-03 18:18'
-updated_date: '2026-05-03 18:41'
+updated_date: '2026-05-03 18:52'
 labels:
   - bug
   - web
@@ -58,13 +58,17 @@ Cleanup must apply to the terminal Kanban status defined by the configured statu
 <!-- SECTION:NOTES:BEGIN -->
 Verification completed: targeted cleanup/web tests passed (20 tests), `bunx tsc --noEmit` passed, and `bun run check .` passed.
 
-Addressed Codex review feedback: terminal-status comparisons now normalize case/spacing so bookmarked URLs such as `?status=closed` still show the cleanup affordance for configured `Closed`. Added focused helper coverage for that behavior.
+Addressed first Codex review feedback: terminal-status comparisons now normalize case and surrounding whitespace so bookmarked URLs such as `?status=closed` still show the cleanup affordance for configured `Closed`. Added focused helper coverage for that behavior.
+
+Addressed follow-up Codex review feedback: terminal-status normalization preserves internal whitespace, so `In Progress` and `InProgress` remain distinct for cleanup selection.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Implemented cleanup around the configured terminal status, defined as the last entry in the `statuses` array. The core cleanup selector, web/server endpoints, CLI cleanup preflight, board cleanup affordance, task column rendering, and task-list cleanup affordance now use the same terminal-status rule. Added regression coverage for `Closed` as the final status across core cleanup, server cleanup endpoints, Board, TaskColumn, and TaskList.
+
+Follow-up review fixes: bookmarked/shared URL status filters now match the terminal status case-insensitively while preserving internal whitespace, with helper/core cleanup regression coverage for similarly named statuses such as `In Progress` versus `InProgress`.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-462 - Use-terminal-status-for-cleanup-instead-of-hardcoded-Done.md
+++ b/backlog/tasks/back-462 - Use-terminal-status-for-cleanup-instead-of-hardcoded-Done.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-462
 title: Use terminal status for cleanup instead of hardcoded Done
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-03 18:18'
-updated_date: '2026-05-03 18:23'
+updated_date: '2026-05-03 18:25'
 labels:
   - bug
   - web
@@ -35,11 +35,11 @@ Cleanup must apply to the terminal Kanban status defined by the configured statu
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 When the final configured status is renamed, the board cleanup affordance appears on that final column and not on earlier columns.
-- [ ] #2 The cleanup preview and execute endpoints select tasks in the final configured status rather than requiring `Done`.
-- [ ] #3 The task list cleanup affordance follows the same terminal-status rule when filtering by status.
-- [ ] #4 Existing default `To Do`, `In Progress`, `Done` projects keep the current cleanup behavior.
-- [ ] #5 Targeted tests cover a non-`Done` terminal status.
+- [x] #1 When the final configured status is renamed, the board cleanup affordance appears on that final column and not on earlier columns.
+- [x] #2 The cleanup preview and execute endpoints select tasks in the final configured status rather than requiring `Done`.
+- [x] #3 The task list cleanup affordance follows the same terminal-status rule when filtering by status.
+- [x] #4 Existing default `To Do`, `In Progress`, `Done` projects keep the current cleanup behavior.
+- [x] #5 Targeted tests cover a non-`Done` terminal status.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -52,9 +52,21 @@ Cleanup must apply to the terminal Kanban status defined by the configured statu
 5. Run targeted tests, typecheck, and Biome.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification completed: targeted cleanup/web tests passed (20 tests), `bunx tsc --noEmit` passed, and `bun run check .` passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented cleanup around the configured terminal status, defined as the last entry in the `statuses` array. The core cleanup selector, web/server endpoints, CLI cleanup preflight, board cleanup affordance, task column rendering, and task-list cleanup affordance now use the same terminal-status rule. Added regression coverage for `Closed` as the final status across core cleanup, server cleanup endpoints, Board, TaskColumn, and TaskList.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/backlog/tasks/back-462 - Use-terminal-status-for-cleanup-instead-of-hardcoded-Done.md
+++ b/backlog/tasks/back-462 - Use-terminal-status-for-cleanup-instead-of-hardcoded-Done.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-03 18:18'
-updated_date: '2026-05-03 18:25'
+updated_date: '2026-05-03 18:41'
 labels:
   - bug
   - web
@@ -24,6 +24,7 @@ modified_files:
   - src/test/web-board-filters.test.tsx
   - src/test/web-task-column-sort.test.tsx
   - src/test/web-task-list-labels-menu.test.tsx
+  - src/test/terminal-status.test.ts
 priority: high
 ---
 
@@ -56,6 +57,8 @@ Cleanup must apply to the terminal Kanban status defined by the configured statu
 
 <!-- SECTION:NOTES:BEGIN -->
 Verification completed: targeted cleanup/web tests passed (20 tests), `bunx tsc --noEmit` passed, and `bun run check .` passed.
+
+Addressed Codex review feedback: terminal-status comparisons now normalize case/spacing so bookmarked URLs such as `?status=closed` still show the cleanup affordance for configured `Closed`. Added focused helper coverage for that behavior.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ import { type CompletionInstallResult, installCompletion, registerCompletionComm
 import { configureAdvancedSettings } from "./commands/configure-advanced-settings.ts";
 import { registerMcpCommand } from "./commands/mcp.ts";
 import { pickTaskForEditWizard, runTaskCreateWizard, runTaskEditWizard } from "./commands/task-wizard.ts";
-import { DEFAULT_DIRECTORIES, DEFAULT_FILES } from "./constants/index.ts";
+import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES } from "./constants/index.ts";
 import { initializeProject } from "./core/init.ts";
 import { buildMilestoneBuckets, collectArchivedMilestoneKeys, milestoneKey } from "./core/milestones.ts";
 import { computeSequences } from "./core/sequences.ts";
@@ -67,6 +67,7 @@ import {
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
 import { normalizeTaskId, taskIdsEqual } from "./utils/task-path.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
+import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
 import { getVersion } from "./utils/version.ts";
 
 type IntegrationMode = "mcp" | "cli" | "none";
@@ -3713,16 +3714,22 @@ program
 			}
 			core.gitOps.setConfig(config);
 
-			// Get all Done tasks
-			const tasks = await core.queryTasks();
-			const doneTasks = tasks.filter((task) => task.status === "Done");
-
-			if (doneTasks.length === 0) {
-				console.log("No completed tasks found to clean up.");
+			const statuses = config.statuses ?? [...DEFAULT_STATUSES];
+			const terminalStatus = getTerminalStatus(statuses);
+			if (!terminalStatus) {
+				console.log("No terminal status configured for cleanup.");
 				return;
 			}
 
-			console.log(`Found ${doneTasks.length} tasks marked as Done.`);
+			const tasks = await core.queryTasks();
+			const terminalStatusTasks = tasks.filter((task) => isTerminalStatus(task.status, statuses));
+
+			if (terminalStatusTasks.length === 0) {
+				console.log(`No ${terminalStatus} tasks found to clean up.`);
+				return;
+			}
+
+			console.log(`Found ${terminalStatusTasks.length} tasks marked as ${terminalStatus}.`);
 
 			const ageOptions = [
 				{ title: "1 day", value: 1 },
@@ -3746,7 +3753,7 @@ program
 			}
 
 			// Get tasks older than selected period
-			const tasksToMove = await core.getDoneTasksByAge(selectedAge);
+			const tasksToMove = await core.getTerminalStatusTasksByAge(selectedAge);
 
 			if (tasksToMove.length === 0) {
 				console.log(`No tasks found that are older than ${ageOptions.find((o) => o.value === selectedAge)?.title}.`);

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -51,6 +51,7 @@ import {
 import { getTaskFilename, getTaskPath, normalizeTaskId, taskIdsEqual } from "../utils/task-path.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
+import { isTerminalStatus } from "../utils/terminal-status.ts";
 import { migrateConfig, needsMigration } from "./config-migration.ts";
 import { ContentStore } from "./content-store.ts";
 import { migrateDraftPrefixes, needsDraftPrefixMigration } from "./prefix-migration.ts";
@@ -2121,13 +2122,15 @@ export class Core {
 		return success;
 	}
 
-	async getDoneTasksByAge(olderThanDays: number): Promise<Task[]> {
+	async getTerminalStatusTasksByAge(olderThanDays: number): Promise<Task[]> {
 		const tasks = await this.fs.listTasks();
+		const config = await this.fs.loadConfig();
+		const statuses = config?.statuses ?? [...DEFAULT_STATUSES];
 		const cutoffDate = new Date();
 		cutoffDate.setDate(cutoffDate.getDate() - olderThanDays);
 
 		return tasks.filter((task) => {
-			if (task.status !== "Done") return false;
+			if (!isTerminalStatus(task.status, statuses)) return false;
 
 			// Check updatedDate first, then createdDate as fallback
 			const taskDate = task.updatedDate || task.createdDate;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1547,8 +1547,7 @@ export class BacklogServer {
 				return Response.json({ error: "Invalid age parameter" }, { status: 400 });
 			}
 
-			// Get Done tasks older than specified days
-			const tasksToCleanup = await this.core.getDoneTasksByAge(age);
+			const tasksToCleanup = await this.core.getTerminalStatusTasksByAge(age);
 
 			// Return preview of tasks to be cleaned up
 			const preview = tasksToCleanup.map((task) => ({
@@ -1581,8 +1580,7 @@ export class BacklogServer {
 				return Response.json({ error: "Invalid age parameter" }, { status: 400 });
 			}
 
-			// Get Done tasks older than specified days
-			const tasksToCleanup = await this.core.getDoneTasksByAge(ageInDays);
+			const tasksToCleanup = await this.core.getTerminalStatusTasksByAge(ageInDays);
 
 			if (tasksToCleanup.length === 0) {
 				return Response.json({

--- a/src/test/cleanup.test.ts
+++ b/src/test/cleanup.test.ts
@@ -81,7 +81,7 @@ describe("Cleanup functionality", () => {
 		});
 	});
 
-	describe("getDoneTasksByAge", () => {
+	describe("getTerminalStatusTasksByAge", () => {
 		it("should filter Done tasks by age", async () => {
 			// Create old Done task (7 days ago)
 			const oldDate = new Date();
@@ -120,13 +120,83 @@ describe("Cleanup functionality", () => {
 			await core.createTask(activeTask, false);
 
 			// Get tasks older than 3 days
-			const oldTasks = await core.getDoneTasksByAge(3);
+			const oldTasks = await core.getTerminalStatusTasksByAge(3);
 			expect(oldTasks).toHaveLength(1);
 			expect(oldTasks[0]?.id).toBe("TASK-1");
 
 			// Get tasks older than 0 days (should include recent task too)
-			const allDoneTasks = await core.getDoneTasksByAge(0);
+			const allDoneTasks = await core.getTerminalStatusTasksByAge(0);
 			expect(allDoneTasks).toHaveLength(2);
+		});
+
+		it("uses the final configured status as the cleanup status", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected test project config to exist");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				statuses: ["To Do", "Review", "Closed"],
+				defaultStatus: "To Do",
+			});
+
+			const oldDate = new Date();
+			oldDate.setDate(oldDate.getDate() - 7);
+			const recentDate = new Date();
+			recentDate.setDate(recentDate.getDate() - 1);
+			const oldDateValue = oldDate.toISOString().split("T")[0] as string;
+			const recentDateValue = recentDate.toISOString().split("T")[0] as string;
+
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-1",
+					title: "Old Closed Task",
+					status: "Closed",
+					createdDate: oldDateValue,
+					updatedDate: oldDateValue,
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-2",
+					title: "Recent Closed Task",
+					status: "Closed",
+					createdDate: recentDateValue,
+					updatedDate: recentDateValue,
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-3",
+					title: "Old Review Task",
+					status: "Review",
+					createdDate: oldDateValue,
+					updatedDate: oldDateValue,
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-4",
+					title: "Old Literal Done Task",
+					status: "Done",
+					createdDate: oldDateValue,
+					updatedDate: oldDateValue,
+				},
+				false,
+			);
+
+			const oldTasks = await core.getTerminalStatusTasksByAge(3);
+			expect(oldTasks.map((task) => task.id)).toEqual(["TASK-1"]);
+
+			const allTerminalTasks = await core.getTerminalStatusTasksByAge(0);
+			expect(allTerminalTasks.map((task) => task.id).sort()).toEqual(["TASK-1", "TASK-2"]);
 		});
 
 		it("should handle tasks without dates", async () => {
@@ -138,7 +208,7 @@ describe("Cleanup functionality", () => {
 			};
 			await core.createTask(task, false);
 
-			const oldTasks = await core.getDoneTasksByAge(1);
+			const oldTasks = await core.getTerminalStatusTasksByAge(1);
 			expect(oldTasks).toHaveLength(0); // Should not include tasks without valid dates
 		});
 
@@ -162,10 +232,10 @@ describe("Cleanup functionality", () => {
 			await core.createTask(task, false);
 
 			// Should use updatedDate (recent) not createdDate (old)
-			const oldTasks = await core.getDoneTasksByAge(5);
+			const oldTasks = await core.getTerminalStatusTasksByAge(5);
 			expect(oldTasks).toHaveLength(0); // updatedDate is recent, so not old enough
 
-			const recentTasks = await core.getDoneTasksByAge(0);
+			const recentTasks = await core.getTerminalStatusTasksByAge(0);
 			expect(recentTasks).toHaveLength(1); // updatedDate makes it recent
 		});
 	});

--- a/src/test/cleanup.test.ts
+++ b/src/test/cleanup.test.ts
@@ -199,6 +199,48 @@ describe("Cleanup functionality", () => {
 			expect(allTerminalTasks.map((task) => task.id).sort()).toEqual(["TASK-1", "TASK-2"]);
 		});
 
+		it("does not collapse internal spaces when matching the cleanup status", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected test project config to exist");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				statuses: ["To Do", "In Progress", "InProgress"],
+				defaultStatus: "To Do",
+			});
+
+			const oldDate = new Date();
+			oldDate.setDate(oldDate.getDate() - 7);
+			const oldDateValue = oldDate.toISOString().split("T")[0] as string;
+
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-1",
+					title: "Old Terminal Task",
+					status: "InProgress",
+					createdDate: oldDateValue,
+					updatedDate: oldDateValue,
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-2",
+					title: "Old Non-Terminal Task",
+					status: "In Progress",
+					createdDate: oldDateValue,
+					updatedDate: oldDateValue,
+				},
+				false,
+			);
+
+			const oldTasks = await core.getTerminalStatusTasksByAge(3);
+			expect(oldTasks.map((task) => task.id)).toEqual(["TASK-1"]);
+		});
+
 		it("should handle tasks without dates", async () => {
 			const task: Task = {
 				...sampleTask,

--- a/src/test/server-cleanup-endpoint.test.ts
+++ b/src/test/server-cleanup-endpoint.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { Core } from "../core/backlog.ts";
+import { BacklogServer } from "../server/index.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, retry, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let server: BacklogServer | null = null;
+let serverPort = 0;
+let core: Core;
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+	const response = await fetch(`http://127.0.0.1:${serverPort}${path}`, init);
+	if (!response.ok) {
+		throw new Error(`${response.status}: ${await response.text()}`);
+	}
+	return response.json();
+}
+
+function makeTask(overrides: Partial<Task>): Task {
+	return {
+		id: "task-1",
+		title: "Task",
+		status: "To Do",
+		assignee: [],
+		labels: [],
+		dependencies: [],
+		createdDate: "2026-01-01",
+		rawContent: "Task body",
+		...overrides,
+	};
+}
+
+describe("BacklogServer cleanup endpoints", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("server-cleanup");
+		await mkdir(TEST_DIR, { recursive: true });
+		core = new Core(TEST_DIR);
+		await core.filesystem.ensureBacklogStructure();
+		await core.filesystem.saveConfig({
+			projectName: "Server Cleanup",
+			statuses: ["To Do", "Review", "Closed"],
+			labels: [],
+			milestones: [],
+			dateFormat: "YYYY-MM-DD",
+			remoteOperations: false,
+		});
+
+		const oldDate = new Date();
+		oldDate.setDate(oldDate.getDate() - 7);
+		const oldDateValue = oldDate.toISOString().split("T")[0] as string;
+		await core.createTask(
+			makeTask({
+				id: "task-1",
+				title: "Old Closed Task",
+				status: "Closed",
+				createdDate: oldDateValue,
+				updatedDate: oldDateValue,
+			}),
+			false,
+		);
+		await core.createTask(
+			makeTask({
+				id: "task-2",
+				title: "Old Literal Done Task",
+				status: "Done",
+				createdDate: oldDateValue,
+				updatedDate: oldDateValue,
+			}),
+			false,
+		);
+
+		server = new BacklogServer(TEST_DIR);
+		await server.start(0, false);
+		const port = server.getPort();
+		expect(port).not.toBeNull();
+		serverPort = port ?? 0;
+
+		await retry(async () => {
+			await fetchJson<unknown>("/api/tasks/cleanup?age=3");
+		});
+	});
+
+	afterEach(async () => {
+		if (server) {
+			await server.stop();
+			server = null;
+		}
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("previews and executes cleanup for the final configured status", async () => {
+		const preview = await fetchJson<{ count: number; tasks: Array<{ id: string; title: string }> }>(
+			"/api/tasks/cleanup?age=3",
+		);
+		expect(preview.count).toBe(1);
+		expect(preview.tasks.map((task) => task.id)).toEqual(["TASK-1"]);
+		expect(preview.tasks[0]?.title).toBe("Old Closed Task");
+
+		const result = await fetchJson<{ success: boolean; movedCount: number; totalCount: number }>(
+			"/api/tasks/cleanup/execute",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ age: 3 }),
+			},
+		);
+		expect(result.success).toBe(true);
+		expect(result.movedCount).toBe(1);
+		expect(result.totalCount).toBe(1);
+
+		const activeTasks = await core.filesystem.listTasks();
+		expect(activeTasks.map((task) => task.id)).toEqual(["TASK-2"]);
+
+		const completedTasks = await core.filesystem.listCompletedTasks();
+		expect(completedTasks.map((task) => task.id)).toEqual(["TASK-1"]);
+	});
+});

--- a/src/test/terminal-status.test.ts
+++ b/src/test/terminal-status.test.ts
@@ -11,4 +11,9 @@ describe("terminal status helpers", () => {
 		expect(isTerminalStatus("CLOSED", ["To Do", "Review", "Closed"])).toBe(true);
 		expect(isTerminalStatus("review", ["To Do", "Review", "Closed"])).toBe(false);
 	});
+
+	it("preserves internal spaces when comparing status names", () => {
+		expect(isTerminalStatus("InProgress", ["To Do", "In Progress", "InProgress"])).toBe(true);
+		expect(isTerminalStatus("In Progress", ["To Do", "In Progress", "InProgress"])).toBe(false);
+	});
 });

--- a/src/test/terminal-status.test.ts
+++ b/src/test/terminal-status.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { getTerminalStatus, isTerminalStatus } from "../utils/terminal-status.ts";
+
+describe("terminal status helpers", () => {
+	it("uses the final configured status as terminal", () => {
+		expect(getTerminalStatus(["To Do", "Review", "Closed"])).toBe("Closed");
+	});
+
+	it("compares terminal statuses case-insensitively for URL and user input values", () => {
+		expect(isTerminalStatus("closed", ["To Do", "Review", "Closed"])).toBe(true);
+		expect(isTerminalStatus("CLOSED", ["To Do", "Review", "Closed"])).toBe(true);
+		expect(isTerminalStatus("review", ["To Do", "Review", "Closed"])).toBe(false);
+	});
+});

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -87,17 +87,22 @@ const setupDom = (url = "http://localhost/board") => {
 	}
 };
 
-const renderBoardPage = (url?: string): HTMLElement => {
+const renderBoardPage = (
+	url?: string,
+	options: { tasks?: Task[]; statuses?: string[] } = {},
+): HTMLElement => {
 	setupDom(url);
 	const container = document.getElementById("root");
 	expect(container).toBeTruthy();
+	const renderedTasks = options.tasks ?? tasks;
+	const renderedStatuses = options.statuses ?? ["To Do", "In Progress", "Done"];
 	activeRoot = createRoot(container as HTMLElement);
 	act(() => {
 		activeRoot?.render(
 			<BrowserRouter>
 				<BoardPage
-					tasks={tasks}
-					statuses={["To Do", "In Progress", "Done"]}
+					tasks={renderedTasks}
+					statuses={renderedStatuses}
 					milestones={[]}
 					milestoneEntities={[]}
 					archivedMilestones={[]}
@@ -209,5 +214,17 @@ describe("Web board filters", () => {
 		expect(text).toContain("Improve board");
 		expect(text).not.toContain("m-2");
 		expect(text).not.toContain("Write docs");
+	});
+
+	it("shows cleanup on the final configured status column when it is not named Done", () => {
+		const container = renderBoardPage(undefined, {
+			statuses: ["To Do", "Review", "Closed"],
+			tasks: [createTask({ id: "task-200", title: "Closed task", status: "Closed" })],
+		});
+
+		const cleanupButtons = Array.from(container.querySelectorAll("button")).filter((button) =>
+			button.textContent?.includes("Clean Up Old Tasks"),
+		);
+		expect(cleanupButtons).toHaveLength(1);
 	});
 });

--- a/src/test/web-task-column-sort.test.tsx
+++ b/src/test/web-task-column-sort.test.tsx
@@ -27,7 +27,11 @@ const setupDom = () => {
 	globalThis.navigator = dom.window.navigator as unknown as Navigator;
 };
 
-const renderTaskColumn = (tasks: Task[], onTaskReorder: (payload: ReorderTaskPayload) => void): HTMLElement => {
+const renderTaskColumn = (
+	tasks: Task[],
+	onTaskReorder: (payload: ReorderTaskPayload) => void,
+	options: { title?: string; onCleanup?: () => void } = {},
+): HTMLElement => {
 	setupDom();
 	const container = document.getElementById("root");
 	expect(container).toBeTruthy();
@@ -35,11 +39,12 @@ const renderTaskColumn = (tasks: Task[], onTaskReorder: (payload: ReorderTaskPay
 	act(() => {
 		activeRoot?.render(
 			<TaskColumn
-				title="To Do"
+				title={options.title ?? "To Do"}
 				tasks={tasks}
 				onTaskUpdate={() => {}}
 				onEditTask={() => {}}
 				onTaskReorder={onTaskReorder}
+				onCleanup={options.onCleanup}
 			/>,
 		);
 	});
@@ -117,5 +122,25 @@ describe("TaskColumn priority sorting", () => {
 		await clickElement(sortButton as Element);
 
 		expect(payloads).toEqual([]);
+	});
+});
+
+describe("TaskColumn cleanup affordance", () => {
+	it("renders cleanup when supplied for a non-Done terminal column", async () => {
+		let cleanupCalls = 0;
+		const container = renderTaskColumn([createTask({ status: "Closed" })], () => {}, {
+			title: "Closed",
+			onCleanup: () => {
+				cleanupCalls += 1;
+			},
+		});
+
+		const cleanupButton = Array.from(container.querySelectorAll("button")).find((button) =>
+			button.textContent?.includes("Clean Up Old Tasks"),
+		);
+		expect(cleanupButton).toBeTruthy();
+
+		await clickElement(cleanupButton as Element);
+		expect(cleanupCalls).toBe(1);
 	});
 });

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -59,17 +59,22 @@ const setupDom = () => {
 	}
 };
 
-const renderTaskList = (initialEntries?: string[]): HTMLElement => {
+const renderTaskList = (
+	initialEntries?: string[],
+	options: { tasks?: Task[]; availableStatuses?: string[] } = {},
+): HTMLElement => {
 	setupDom();
 	const container = document.getElementById("root");
 	expect(container).toBeTruthy();
+	const renderedTasks = options.tasks ?? tasks;
+	const renderedStatuses = options.availableStatuses ?? ["To Do", "In Progress", "Done"];
 	activeRoot = createRoot(container as HTMLElement);
 	act(() => {
 		activeRoot?.render(
 			<MemoryRouter initialEntries={initialEntries}>
 				<TaskList
-					tasks={tasks}
-					availableStatuses={["To Do", "In Progress", "Done"]}
+					tasks={renderedTasks}
+					availableStatuses={renderedStatuses}
 					availableLabels={["bug", "docs"]}
 					availableMilestones={[]}
 					milestoneEntities={[]}
@@ -86,6 +91,23 @@ const renderTaskList = (initialEntries?: string[]): HTMLElement => {
 const clickElement = async (element: Element) => {
 	await act(async () => {
 		element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+		await Promise.resolve();
+	});
+};
+
+const getSelectByFirstOption = (container: HTMLElement, firstOptionText: string): HTMLSelectElement => {
+	const select = Array.from(container.querySelectorAll("select")).find(
+		(element) => element.options[0]?.textContent === firstOptionText,
+	);
+	expect(select).toBeTruthy();
+	return select as HTMLSelectElement;
+};
+
+const setSelectValue = async (select: HTMLSelectElement, value: string) => {
+	await act(async () => {
+		const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value")?.set;
+		valueSetter?.call(select, value);
+		select.dispatchEvent(new window.Event("change", { bubbles: true }));
 		await Promise.resolve();
 	});
 };
@@ -173,5 +195,57 @@ describe("TaskList labels filter menu", () => {
 
 		expect(labelsButton.textContent).toContain("All");
 		expect(container.querySelector("#task-list-labels-menu")).toBeNull();
+	});
+
+	it("shows cleanup when filtering by the final configured status", async () => {
+		const closedTask = createTask({ id: "task-201", title: "Closed task", status: "Closed" });
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			expect(url).toContain("/api/search");
+			expect(url).toContain("status=Closed");
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () => [{ type: "task", score: 0, task: closedTask }],
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(undefined, {
+			tasks: [closedTask],
+			availableStatuses: ["To Do", "Review", "Closed"],
+		});
+		await setSelectValue(getSelectByFirstOption(container, "All statuses"), "Closed");
+		await waitFor(() => fetchCalls.length === 1 && (container.textContent ?? "").includes("Clean Up"));
+
+		expect(container.textContent).toContain("Clean Up");
+	});
+
+	it("does not show cleanup when filtering by a non-terminal status", async () => {
+		const reviewTask = createTask({ id: "task-202", title: "Review task", status: "Review" });
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			expect(url).toContain("/api/search");
+			expect(url).toContain("status=Review");
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () => [{ type: "task", score: 0, task: reviewTask }],
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(undefined, {
+			tasks: [reviewTask],
+			availableStatuses: ["To Do", "Review", "Closed"],
+		});
+		await setSelectValue(getSelectByFirstOption(container, "All statuses"), "Review");
+		await waitFor(() => fetchCalls.length === 1 && (container.textContent ?? "").includes("Review task"));
+
+		expect(container.textContent).not.toContain("Clean Up");
 	});
 });

--- a/src/utils/terminal-status.ts
+++ b/src/utils/terminal-status.ts
@@ -1,0 +1,10 @@
+export function getTerminalStatus(statuses: readonly string[]): string | null {
+	if (statuses.length === 0) return null;
+	const terminalStatus = statuses[statuses.length - 1];
+	return terminalStatus && terminalStatus.trim().length > 0 ? terminalStatus : null;
+}
+
+export function isTerminalStatus(status: string | null | undefined, statuses: readonly string[]): boolean {
+	const terminalStatus = getTerminalStatus(statuses);
+	return terminalStatus !== null && status === terminalStatus;
+}

--- a/src/utils/terminal-status.ts
+++ b/src/utils/terminal-status.ts
@@ -5,7 +5,7 @@ export function getTerminalStatus(statuses: readonly string[]): string | null {
 }
 
 function normalizeStatusForComparison(status: string | null | undefined): string {
-	return (status ?? "").trim().toLowerCase().replace(/\s+/g, "");
+	return (status ?? "").trim().toLowerCase();
 }
 
 export function isTerminalStatus(status: string | null | undefined, statuses: readonly string[]): boolean {

--- a/src/utils/terminal-status.ts
+++ b/src/utils/terminal-status.ts
@@ -4,7 +4,13 @@ export function getTerminalStatus(statuses: readonly string[]): string | null {
 	return terminalStatus && terminalStatus.trim().length > 0 ? terminalStatus : null;
 }
 
+function normalizeStatusForComparison(status: string | null | undefined): string {
+	return (status ?? "").trim().toLowerCase().replace(/\s+/g, "");
+}
+
 export function isTerminalStatus(status: string | null | undefined, statuses: readonly string[]): boolean {
 	const terminalStatus = getTerminalStatus(statuses);
-	return terminalStatus !== null && status === terminalStatus;
+	return (
+		terminalStatus !== null && normalizeStatusForComparison(status) === normalizeStatusForComparison(terminalStatus)
+	);
 }

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -3,6 +3,7 @@ import { type Milestone, type Task } from '../../types';
 import { apiClient, type ReorderTaskPayload } from '../lib/api';
 import { buildLanes, DEFAULT_LANE_KEY, groupTasksByLaneAndStatus, type LaneMode } from '../lib/lanes';
 import { collectArchivedMilestoneKeys, milestoneKey } from '../utils/milestones';
+import { getTerminalStatus } from '../../utils/terminal-status';
 import TaskColumn from './TaskColumn';
 import CleanupModal from './CleanupModal';
 import { SuccessToast } from './SuccessToast';
@@ -58,6 +59,7 @@ const Board: React.FC<BoardProps> = ({
   const [showCleanupModal, setShowCleanupModal] = useState(false);
   const [cleanupSuccessMessage, setCleanupSuccessMessage] = useState<string | null>(null);
   const [collapsedLanes, setCollapsedLanes] = useState<Record<string, boolean>>({});
+  const terminalStatus = getTerminalStatus(statuses);
   const archivedMilestoneIds = useMemo(
     () => collectArchivedMilestoneKeys(archivedMilestones, milestoneEntities),
     [archivedMilestones, milestoneEntities]
@@ -592,7 +594,7 @@ const Board: React.FC<BoardProps> = ({
                               setDragSourceStatus(null);
                               setDragSourceLane(null);
                             }}
-                            onCleanup={status.toLowerCase() === 'done' ? () => setShowCleanupModal(true) : undefined}
+                            onCleanup={status === terminalStatus ? () => setShowCleanupModal(true) : undefined}
                           />
                         </div>
                       ))}
@@ -625,7 +627,7 @@ const Board: React.FC<BoardProps> = ({
                     setDragSourceStatus(null);
                     setDragSourceLane(null);
                   }}
-                  onCleanup={status.toLowerCase() === 'done' ? () => setShowCleanupModal(true) : undefined}
+                  onCleanup={status === terminalStatus ? () => setShowCleanupModal(true) : undefined}
                 />
               </div>
             ))}

--- a/src/web/components/TaskColumn.tsx
+++ b/src/web/components/TaskColumn.tsx
@@ -299,8 +299,8 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
           </div>
         )}
 
-        {/* Cleanup button for Done column */}
-        {onCleanup && title.toLowerCase() === 'done' && tasks.length > 0 && (
+        {/* Cleanup button for the configured terminal column */}
+        {onCleanup && tasks.length > 0 && (
           <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
 	            <button
 	              onClick={onCleanup}

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -8,6 +8,7 @@ import type {
 	TaskSearchResult,
 } from "../../types";
 import { collectAvailableLabels } from "../../utils/label-filter.ts";
+import { isTerminalStatus } from "../../utils/terminal-status.ts";
 import { collectArchivedMilestoneKeys, getMilestoneLabel, milestoneKey } from "../utils/milestones";
 import { formatStoredUtcDateForCompactDisplay, parseStoredUtcDate } from "../utils/date-display";
 import CleanupModal from "./CleanupModal";
@@ -114,6 +115,7 @@ const TaskList: React.FC<TaskListProps> = ({
 	const tableHeaderScrollRef = useRef<HTMLDivElement | null>(null);
 	const tableBodyScrollRef = useRef<HTMLDivElement | null>(null);
 	const isSyncingTableScrollRef = useRef(false);
+	const isFilteringTerminalStatus = isTerminalStatus(statusFilter, availableStatuses);
 	const milestoneAliasToCanonical = useMemo(() => {
 		const aliasMap = new Map<string, string>();
 		const collectIdAliasKeys = (value: string): string[] => {
@@ -782,7 +784,7 @@ const TaskList: React.FC<TaskListProps> = ({
 					</div>
 
 					<div className="flex items-center gap-3 flex-shrink-0">
-						{statusFilter.toLowerCase() === "done" && currentCount > 0 && (
+						{isFilteringTerminalStatus && currentCount > 0 && (
 								<button
 									type="button"
 									onClick={() => setShowCleanupModal(true)}


### PR DESCRIPTION
## Summary
- Define cleanup terminal status as the last configured status value.
- Use that rule in core cleanup selection, server preview/execute, CLI cleanup, Board, TaskColumn, and TaskList.
- Add regression coverage for a non-Done terminal status (Closed).

## Tests
- bun test src/test/cleanup.test.ts src/test/server-cleanup-endpoint.test.ts src/test/web-board-filters.test.tsx src/test/web-task-column-sort.test.tsx src/test/web-task-list-labels-menu.test.tsx
- bunx tsc --noEmit
- bun run check .