### PR TITLE
BACK-463 - Fix BACK-441 web filter UI regressions

### DIFF
--- a/backlog/tasks/back-463 - Fix-BACK-441-web-filter-UI-regressions.md
+++ b/backlog/tasks/back-463 - Fix-BACK-441-web-filter-UI-regressions.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-463
 title: Fix BACK-441 web filter UI regressions
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-03 19:05'
+updated_date: '2026-05-03 19:09'
 labels:
   - bug
   - web
@@ -26,15 +27,36 @@ Follow-up to BACK-441 after manual release testing. The kanban board filter cont
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The kanban board clearly exposes board filter controls for assignee, label, and priority.
-- [ ] #2 Board filter state still reads/writes `assignee`, `label`, and `priority` URL query parameters and clear filters still removes them.
-- [ ] #3 The All Tasks page no longer renders a local `Search tasks` text input because global search already exists in the sidebar.
-- [ ] #4 All Tasks structured filters for status, priority, label, milestone, and cleanup behavior keep working.
+- [x] #1 The kanban board clearly exposes board filter controls for assignee, label, and priority.
+- [x] #2 Board filter state still reads/writes `assignee`, `label`, and `priority` URL query parameters and clear filters still removes them.
+- [x] #3 The All Tasks page no longer renders a local `Search tasks` text input because global search already exists in the sidebar.
+- [x] #4 All Tasks structured filters for status, priority, label, milestone, and cleanup behavior keep working.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Keep the existing BoardPage URL-backed assignee/label/priority filter state, but make the Board filter bar visibly labeled and accessible so the kanban filter affordance is obvious during manual testing.
+2. Remove the All Tasks local free-text `Search tasks` input and its `query` URL/search plumbing from TaskList, while preserving status, priority, label, milestone, cleanup, and clear-filter behavior.
+3. Update focused web tests to assert board filters are visibly exposed and All Tasks no longer renders the duplicate local search input.
+4. Run targeted web tests, typecheck, and Biome before opening a PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented follow-up fix: Board filter controls now have a visible `Filters` affordance and accessible labels while preserving BoardPage URL-backed assignee/label/priority params. Removed the duplicate All Tasks local free-text search input and `query` plumbing from TaskList; structured status, priority, label, and milestone filters remain intact.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made BACK-441's board filters visible in the kanban board UI by labeling the filter bar and adding accessible labels for the assignee, label, and priority controls. Removed the duplicate local `Search tasks` input from All Tasks and deleted its `query` URL/search plumbing, leaving global sidebar search as the only free-text search. Preserved All Tasks structured filters and board filter URL persistence.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -165,6 +165,10 @@ describe("Web board filters", () => {
 	it("filters board cards by assignee, label, and priority while updating URL params", async () => {
 		const container = renderBoardPage();
 
+		expect(container.textContent).toContain("Filters");
+		expect(container.querySelector("select[aria-label='Filter board by assignee']")).toBeTruthy();
+		expect(container.querySelector("select[aria-label='Filter board by label']")).toBeTruthy();
+		expect(container.querySelector("select[aria-label='Filter board by priority']")).toBeTruthy();
 		expectVisibleTasks(container, ["Fix login bug", "Write docs", "Improve board", "Triage unassigned issue"]);
 
 		await setSelectValue(getSelectByFirstOption(container, "All assignees"), "alice");

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -146,6 +146,12 @@ afterEach(() => {
 });
 
 describe("TaskList labels filter menu", () => {
+	it("does not render a duplicate local task search input", () => {
+		const container = renderTaskList();
+
+		expect(container.querySelector("input[placeholder='Search tasks']")).toBeNull();
+	});
+
 	it("renders the labels menu above the sticky table header", async () => {
 		const container = renderTaskList();
 		const labelsButton = getLabelsButton(container);

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -476,49 +476,60 @@ const Board: React.FC<BoardProps> = ({
 
       {/* Filter bar */}
       {onFiltersChange && (
-        <div className="flex items-center gap-3 mb-6 flex-wrap">
-          <select
-            value={filterAssignee}
-            onChange={e => onFiltersChange({ assignee: e.target.value, label: filterLabel, priority: filterPriority })}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
-          >
-            <option value="">All assignees</option>
-            <option value="__unassigned__">Unassigned</option>
-            {uniqueAssignees.map(a => (
-              <option key={a} value={a}>{a}</option>
-            ))}
-          </select>
-
-          <select
-            value={filterLabel}
-            onChange={e => onFiltersChange({ assignee: filterAssignee, label: e.target.value, priority: filterPriority })}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
-          >
-            <option value="">All labels</option>
-            {uniqueLabels.map(l => (
-              <option key={l} value={l}>{l}</option>
-            ))}
-          </select>
-
-          <select
-            value={filterPriority}
-            onChange={e => onFiltersChange({ assignee: filterAssignee, label: filterLabel, priority: e.target.value })}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
-          >
-            {PRIORITY_OPTIONS.map(opt => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
-            ))}
-          </select>
-
-          {hasActiveFilters && (
-            <button
-              type="button"
-              onClick={() => onFiltersChange({ assignee: '', label: '', priority: '' })}
-              className="px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 border border-gray-200 dark:border-gray-700 rounded-md hover:border-gray-300 dark:hover:border-gray-600 bg-white dark:bg-gray-800 transition-colors duration-200"
+        <div className="mb-6 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-3 transition-colors duration-200">
+          <div className="flex items-center gap-3 flex-wrap">
+            <div className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+              <svg className="h-4 w-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h18M6 12h12M10 19h4" />
+              </svg>
+              <span>Filters</span>
+            </div>
+            <select
+              aria-label="Filter board by assignee"
+              value={filterAssignee}
+              onChange={e => onFiltersChange({ assignee: e.target.value, label: filterLabel, priority: filterPriority })}
+              className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
             >
-              Clear filters
-            </button>
-          )}
+              <option value="">All assignees</option>
+              <option value="__unassigned__">Unassigned</option>
+              {uniqueAssignees.map(a => (
+                <option key={a} value={a}>{a}</option>
+              ))}
+            </select>
+
+            <select
+              aria-label="Filter board by label"
+              value={filterLabel}
+              onChange={e => onFiltersChange({ assignee: filterAssignee, label: e.target.value, priority: filterPriority })}
+              className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
+            >
+              <option value="">All labels</option>
+              {uniqueLabels.map(l => (
+                <option key={l} value={l}>{l}</option>
+              ))}
+            </select>
+
+            <select
+              aria-label="Filter board by priority"
+              value={filterPriority}
+              onChange={e => onFiltersChange({ assignee: filterAssignee, label: filterLabel, priority: e.target.value })}
+              className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
+            >
+              {PRIORITY_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+
+            {hasActiveFilters && (
+              <button
+                type="button"
+                onClick={() => onFiltersChange({ assignee: '', label: '', priority: '' })}
+                className="px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 border border-gray-200 dark:border-gray-700 rounded-md hover:border-gray-300 dark:hover:border-gray-600 bg-white dark:bg-gray-800 transition-colors duration-200"
+              >
+                Clear filters
+              </button>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -90,7 +90,6 @@ const TaskList: React.FC<TaskListProps> = ({
 	onRefreshData,
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
-	const [searchValue, setSearchValue] = useState(() => searchParams.get("query") ?? "");
 	const [statusFilter, setStatusFilter] = useState(() => searchParams.get("status") ?? "");
 	const [priorityFilter, setPriorityFilter] = useState<"" | SearchPriorityFilter>(
 		() => (searchParams.get("priority") as SearchPriorityFilter | null) ?? "",
@@ -258,14 +257,12 @@ const TaskList: React.FC<TaskListProps> = ({
 		const uniqueMilestones = Array.from(new Set([...availableMilestones.map((m) => m.trim()).filter(Boolean)]));
 		return uniqueMilestones;
 	}, [availableMilestones]);
-	const normalizedSearch = searchValue.trim();
 	const hasActiveFilters = Boolean(
-		normalizedSearch || statusFilter || priorityFilter || labelFilter.length > 0 || milestoneFilter,
+		statusFilter || priorityFilter || labelFilter.length > 0 || milestoneFilter,
 	);
 	const totalTasks = sortedBaseTasks.length;
 
 	useEffect(() => {
-		const paramQuery = searchParams.get("query") ?? "";
 		const paramStatus = searchParams.get("status") ?? "";
 		const paramPriority = (searchParams.get("priority") as SearchPriorityFilter | null) ?? "";
 		const paramMilestone = searchParams.get("milestone") ?? "";
@@ -276,9 +273,6 @@ const TaskList: React.FC<TaskListProps> = ({
 		}
 		const normalizedLabels = paramLabels.map((label) => label.trim()).filter((label) => label.length > 0);
 
-		if (paramQuery !== searchValue) {
-			setSearchValue(paramQuery);
-		}
 		if (paramStatus !== statusFilter) {
 			setStatusFilter(paramStatus);
 		}
@@ -316,7 +310,7 @@ const TaskList: React.FC<TaskListProps> = ({
 		};
 
 		const shouldUseApi =
-			Boolean(normalizedSearch) || Boolean(statusFilter) || Boolean(priorityFilter) || labelFilter.length > 0;
+			Boolean(statusFilter) || Boolean(priorityFilter) || labelFilter.length > 0;
 
 		if (!hasActiveFilters) {
 			return;
@@ -333,7 +327,6 @@ const TaskList: React.FC<TaskListProps> = ({
 			}
 			try {
 				const results = await apiClient.search({
-					query: normalizedSearch || undefined,
 					types: ["task"],
 					status: statusFilter || undefined,
 					priority: (priorityFilter || undefined) as SearchPriorityFilter | undefined,
@@ -361,29 +354,23 @@ const TaskList: React.FC<TaskListProps> = ({
 		};
 	}, [
 		hasActiveFilters,
-		normalizedSearch,
 		priorityFilter,
 		statusFilter,
 		labelFilter,
-			tasks,
-			milestoneFilter,
-			sortedBaseTasks,
-			milestoneAliasToCanonical,
-			archivedMilestoneKeys,
-		]);
+		tasks,
+		milestoneFilter,
+		sortedBaseTasks,
+		milestoneAliasToCanonical,
+		archivedMilestoneKeys,
+	]);
 
 	const syncUrl = (
-		nextQuery: string,
 		nextStatus: string,
 		nextPriority: "" | SearchPriorityFilter,
 		nextLabels: string[],
 		nextMilestone: string,
 	) => {
 		const params = new URLSearchParams();
-		const trimmedQuery = nextQuery.trim();
-		if (trimmedQuery) {
-			params.set("query", trimmedQuery);
-		}
 		if (nextStatus) {
 			params.set("status", nextStatus);
 		}
@@ -401,39 +388,33 @@ const TaskList: React.FC<TaskListProps> = ({
 		setSearchParams(params, { replace: true });
 	};
 
-	const handleSearchChange = (value: string) => {
-		setSearchValue(value);
-		syncUrl(value, statusFilter, priorityFilter, labelFilter, milestoneFilter);
-	};
-
 	const handleStatusChange = (value: string) => {
 		setStatusFilter(value);
-		syncUrl(searchValue, value, priorityFilter, labelFilter, milestoneFilter);
+		syncUrl(value, priorityFilter, labelFilter, milestoneFilter);
 	};
 
 	const handlePriorityChange = (value: "" | SearchPriorityFilter) => {
 		setPriorityFilter(value);
-		syncUrl(searchValue, statusFilter, value, labelFilter, milestoneFilter);
+		syncUrl(statusFilter, value, labelFilter, milestoneFilter);
 	};
 
 	const handleLabelChange = (next: string[]) => {
 		const normalized = next.map((label) => label.trim()).filter((label) => label.length > 0);
 		setLabelFilter(normalized);
-		syncUrl(searchValue, statusFilter, priorityFilter, normalized, milestoneFilter);
+		syncUrl(statusFilter, priorityFilter, normalized, milestoneFilter);
 	};
 
 	const handleMilestoneChange = (value: string) => {
 		setMilestoneFilter(value);
-		syncUrl(searchValue, statusFilter, priorityFilter, labelFilter, value);
+		syncUrl(statusFilter, priorityFilter, labelFilter, value);
 	};
 
 	const handleClearFilters = () => {
-		setSearchValue("");
 		setStatusFilter("");
 		setPriorityFilter("");
 		setLabelFilter([]);
 		setMilestoneFilter("");
-		syncUrl("", "", "", [], "");
+		syncUrl("", "", [], "");
 		setDisplayTasks(sortedBaseTasks);
 		setError(null);
 	};
@@ -648,32 +629,6 @@ const TaskList: React.FC<TaskListProps> = ({
 
 				<div className="flex flex-wrap items-center gap-3 justify-between">
 					<div className="flex flex-wrap items-center gap-3 flex-1 min-w-0">
-						<div className="relative flex-1 basis-[200px] min-w-[180px] max-w-[280px]">
-							<span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400 dark:text-gray-500">
-								<svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-								</svg>
-							</span>
-						<input
-							type="text"
-							value={searchValue}
-							onChange={(event) => handleSearchChange(event.target.value)}
-							placeholder="Search tasks"
-							className="w-full pl-10 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200"
-						/>
-						{searchValue && (
-								<button
-									type="button"
-									onClick={() => handleSearchChange("")}
-									className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
-								>
-									<svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-								</svg>
-							</button>
-						)}
-						</div>
-
 					<select
 						value={statusFilter}
 						onChange={(event) => handleStatusChange(event.target.value)}


### PR DESCRIPTION
## Summary
- make the kanban board filter bar visibly labeled and add accessible labels for assignee, label, and priority controls
- remove the duplicate All Tasks local free-text search input and its query URL/search plumbing
- keep board URL-backed filters and All Tasks structured filters intact

## Tests
- bun test src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx src/test/web-task-column-sort.test.tsx
- bunx tsc --noEmit
- bun run check .
- local browser server asset smoke at http://localhost:6431 confirmed board filter labels are bundled and the Search tasks input placeholder is absent