### PR TITLE
BACK-463 - Align web task filters between board and all tasks

### DIFF
--- a/backlog/tasks/back-463 - Align-web-task-filters-between-board-and-all-tasks.md
+++ b/backlog/tasks/back-463 - Align-web-task-filters-between-board-and-all-tasks.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-463
 title: Align web task filters between board and all tasks
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-03 19:15'
-updated_date: '2026-05-03 19:15'
+updated_date: '2026-05-03 19:21'
 labels:
   - web
   - filters
@@ -27,11 +27,11 @@ Follow-up to manual BACK-441 testing. Remove the duplicate local free-text `Sear
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All Tasks no longer renders a local `Search tasks` input or writes `query` from that page's local controls.
-- [ ] #2 All Tasks structured filters for status, priority, milestone, labels, cleanup, and clear filters still work.
-- [ ] #3 Kanban board assignee, label, and priority filters use the same dropdown sizing/style family as the All Tasks page controls.
-- [ ] #4 Kanban board filters sit beside the `All Tasks` / `Milestone` lane mode switch and keep URL persistence for `assignee`, `label`, and `priority`.
-- [ ] #5 Focused web tests cover the removed All Tasks search input and the board filter placement/styling behavior.
+- [x] #1 All Tasks no longer renders a local `Search tasks` input or writes `query` from that page's local controls.
+- [x] #2 All Tasks structured filters for status, priority, milestone, labels, cleanup, and clear filters still work.
+- [x] #3 Kanban board assignee, label, and priority filters use the same dropdown sizing/style family as the All Tasks page controls.
+- [x] #4 Kanban board filters sit beside the `All Tasks` / `Milestone` lane mode switch and keep URL persistence for `assignee`, `label`, and `priority`.
+- [x] #5 Focused web tests cover the removed All Tasks search input and the board filter placement/styling behavior.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,9 +44,33 @@ Follow-up to manual BACK-441 testing. Remove the duplicate local free-text `Sear
 5. Run targeted web tests, typecheck, Biome, and a local source browser/server smoke before opening the PR.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Removed the All Tasks local `Search tasks` input and query-specific state/API plumbing, leaving status, priority, milestone, label, cleanup, and clear-filter controls intact.
+
+Moved Board assignee/label/priority filters beside the lane mode switch and aligned their select styling with the All Tasks dropdown sizing/focus treatment. URL-backed filter semantics remain unchanged.
+
+Verification: `bun test src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx`, `bunx tsc --noEmit`, and `bun run check .` all pass. Local server smoke on port 6431 served the updated bundle; Chrome DevTools attach was unavailable in this session.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Summary:
+- Removed the duplicate All Tasks local `Search tasks` input and query-specific local filter plumbing so the page relies on the global web search.
+- Moved Kanban board assignee, label, and priority filters into the header controls beside `All Tasks` / `Milestone`, using the same All Tasks dropdown sizing/focus style family while preserving URL params.
+- Added focused tests for the removed All Tasks input and Board filter placement/styling.
+
+Tests:
+- `bun test src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx`
+- `bunx tsc --noEmit`
+- `bun run check .`
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -152,6 +152,31 @@ const expectVisibleTasks = (container: HTMLElement, expected: string[]) => {
 	}
 };
 
+const expectBoardFiltersInHeader = (container: HTMLElement) => {
+	const toolbar = container.querySelector("[aria-label='Board view controls']");
+	expect(toolbar).toBeTruthy();
+	expect(toolbar?.textContent).toContain("All Tasks");
+	expect(toolbar?.textContent).toContain("Milestone");
+
+	const boardFilters = toolbar?.querySelector("[aria-label='Board filters']");
+	expect(boardFilters).toBeTruthy();
+
+	for (const ariaLabel of [
+		"Filter board by assignee",
+		"Filter board by label",
+		"Filter board by priority",
+	]) {
+		const select = container.querySelector(`select[aria-label='${ariaLabel}']`) as HTMLSelectElement | null;
+		expect(select).toBeTruthy();
+		expect(toolbar?.contains(select)).toBe(true);
+		expect(select?.className).toContain("min-w-[140px]");
+		expect(select?.className).toContain("h-10");
+		expect(select?.className).toContain("rounded-lg");
+		expect(select?.className).toContain("border-gray-300");
+		expect(select?.className).toContain("focus:ring-stone-500");
+	}
+};
+
 afterEach(() => {
 	if (activeRoot) {
 		act(() => {
@@ -165,6 +190,7 @@ describe("Web board filters", () => {
 	it("filters board cards by assignee, label, and priority while updating URL params", async () => {
 		const container = renderBoardPage();
 
+		expectBoardFiltersInHeader(container);
 		expectVisibleTasks(container, ["Fix login bug", "Write docs", "Improve board", "Triage unassigned issue"]);
 
 		await setSelectValue(getSelectByFirstOption(container, "All assignees"), "alice");

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -146,6 +146,12 @@ afterEach(() => {
 });
 
 describe("TaskList labels filter menu", () => {
+	it("does not render a duplicate local task search input", () => {
+		const container = renderTaskList(["/?query=docs"]);
+
+		expect(container.querySelector("input[placeholder='Search tasks']")).toBeNull();
+	});
+
 	it("renders the labels menu above the sticky table header", async () => {
 		const container = renderTaskList();
 		const labelsButton = getLabelsButton(container);

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -35,6 +35,12 @@ const PRIORITY_OPTIONS = [
   { label: 'Low', value: 'low' },
 ] as const;
 
+const BOARD_FILTER_SELECT_CLASS =
+  'min-w-[140px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200';
+
+const BOARD_FILTER_BUTTON_CLASS =
+  'h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg whitespace-nowrap transition-colors duration-200 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700';
+
 const Board: React.FC<BoardProps> = ({
   onEditTask,
   onNewTask,
@@ -435,92 +441,95 @@ const Board: React.FC<BoardProps> = ({
         </div>
       )}
       <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-3">
           <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-colors duration-200">Kanban Board</h2>
-          <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-1 bg-gray-50 dark:bg-gray-800/50 transition-colors duration-200">
-            <button
-              type="button"
-              onClick={() => onLaneChange('none')}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 ${
-                laneMode === 'none'
-                  ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
-                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
-              }`}
-            >
-              All Tasks
-            </button>
-            <button
-              type="button"
-              onClick={() => onLaneChange('milestone')}
-              disabled={!hasTasksWithMilestones}
-              title={!hasTasksWithMilestones ? 'No tasks have milestones. Assign milestones to tasks first.' : 'Group tasks by milestone'}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 ${
-                !hasTasksWithMilestones
-                  ? 'text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50'
-                  : laneMode === 'milestone'
+          <div className="flex flex-wrap items-center gap-3" role="toolbar" aria-label="Board view controls">
+            <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-1 bg-gray-50 dark:bg-gray-800/50 transition-colors duration-200">
+              <button
+                type="button"
+                onClick={() => onLaneChange('none')}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 ${
+                  laneMode === 'none'
                     ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
                     : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
-              }`}
-            >
-              Milestone
-            </button>
+                }`}
+              >
+                All Tasks
+              </button>
+              <button
+                type="button"
+                onClick={() => onLaneChange('milestone')}
+                disabled={!hasTasksWithMilestones}
+                title={!hasTasksWithMilestones ? 'No tasks have milestones. Assign milestones to tasks first.' : 'Group tasks by milestone'}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 ${
+                  !hasTasksWithMilestones
+                    ? 'text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50'
+                    : laneMode === 'milestone'
+                      ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                Milestone
+              </button>
+            </div>
+            {onFiltersChange && (
+              <div className="flex flex-wrap items-center gap-3" aria-label="Board filters">
+                <select
+                  aria-label="Filter board by assignee"
+                  value={filterAssignee}
+                  onChange={e => onFiltersChange({ assignee: e.target.value, label: filterLabel, priority: filterPriority })}
+                  className={BOARD_FILTER_SELECT_CLASS}
+                >
+                  <option value="">All assignees</option>
+                  <option value="__unassigned__">Unassigned</option>
+                  {uniqueAssignees.map(a => (
+                    <option key={a} value={a}>{a}</option>
+                  ))}
+                </select>
+
+                <select
+                  aria-label="Filter board by label"
+                  value={filterLabel}
+                  onChange={e => onFiltersChange({ assignee: filterAssignee, label: e.target.value, priority: filterPriority })}
+                  className={BOARD_FILTER_SELECT_CLASS}
+                >
+                  <option value="">All labels</option>
+                  {uniqueLabels.map(l => (
+                    <option key={l} value={l}>{l}</option>
+                  ))}
+                </select>
+
+                <select
+                  aria-label="Filter board by priority"
+                  value={filterPriority}
+                  onChange={e => onFiltersChange({ assignee: filterAssignee, label: filterLabel, priority: e.target.value })}
+                  className={BOARD_FILTER_SELECT_CLASS}
+                >
+                  {PRIORITY_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+
+                {hasActiveFilters && (
+                  <button
+                    type="button"
+                    onClick={() => onFiltersChange({ assignee: '', label: '', priority: '' })}
+                    className={BOARD_FILTER_BUTTON_CLASS}
+                  >
+                    Clear filters
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         </div>
-	        <button
-	          className="inline-flex items-center px-4 py-2 bg-blue-500 dark:bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 dark:focus:ring-blue-500 dark:focus:ring-offset-gray-800 transition-colors duration-200"
-	          onClick={onNewTask}
-	        >
-	          + New Task
+        <button
+          className="inline-flex items-center px-4 py-2 bg-blue-500 dark:bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 dark:focus:ring-blue-500 dark:focus:ring-offset-gray-800 transition-colors duration-200"
+          onClick={onNewTask}
+        >
+          + New Task
         </button>
       </div>
-
-      {/* Filter bar */}
-      {onFiltersChange && (
-        <div className="flex items-center gap-3 mb-6 flex-wrap">
-          <select
-            value={filterAssignee}
-            onChange={e => onFiltersChange({ assignee: e.target.value, label: filterLabel, priority: filterPriority })}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
-          >
-            <option value="">All assignees</option>
-            <option value="__unassigned__">Unassigned</option>
-            {uniqueAssignees.map(a => (
-              <option key={a} value={a}>{a}</option>
-            ))}
-          </select>
-
-          <select
-            value={filterLabel}
-            onChange={e => onFiltersChange({ assignee: filterAssignee, label: e.target.value, priority: filterPriority })}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
-          >
-            <option value="">All labels</option>
-            {uniqueLabels.map(l => (
-              <option key={l} value={l}>{l}</option>
-            ))}
-          </select>
-
-          <select
-            value={filterPriority}
-            onChange={e => onFiltersChange({ assignee: filterAssignee, label: filterLabel, priority: e.target.value })}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:focus:ring-blue-500 transition-colors duration-200"
-          >
-            {PRIORITY_OPTIONS.map(opt => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
-            ))}
-          </select>
-
-          {hasActiveFilters && (
-            <button
-              type="button"
-              onClick={() => onFiltersChange({ assignee: '', label: '', priority: '' })}
-              className="px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 border border-gray-200 dark:border-gray-700 rounded-md hover:border-gray-300 dark:hover:border-gray-600 bg-white dark:bg-gray-800 transition-colors duration-200"
-            >
-              Clear filters
-            </button>
-          )}
-        </div>
-      )}
 
       {laneMode === 'milestone' ? (
         <div className="space-y-6">

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -90,7 +90,6 @@ const TaskList: React.FC<TaskListProps> = ({
 	onRefreshData,
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
-	const [searchValue, setSearchValue] = useState(() => searchParams.get("query") ?? "");
 	const [statusFilter, setStatusFilter] = useState(() => searchParams.get("status") ?? "");
 	const [priorityFilter, setPriorityFilter] = useState<"" | SearchPriorityFilter>(
 		() => (searchParams.get("priority") as SearchPriorityFilter | null) ?? "",
@@ -258,14 +257,12 @@ const TaskList: React.FC<TaskListProps> = ({
 		const uniqueMilestones = Array.from(new Set([...availableMilestones.map((m) => m.trim()).filter(Boolean)]));
 		return uniqueMilestones;
 	}, [availableMilestones]);
-	const normalizedSearch = searchValue.trim();
 	const hasActiveFilters = Boolean(
-		normalizedSearch || statusFilter || priorityFilter || labelFilter.length > 0 || milestoneFilter,
+		statusFilter || priorityFilter || labelFilter.length > 0 || milestoneFilter,
 	);
 	const totalTasks = sortedBaseTasks.length;
 
 	useEffect(() => {
-		const paramQuery = searchParams.get("query") ?? "";
 		const paramStatus = searchParams.get("status") ?? "";
 		const paramPriority = (searchParams.get("priority") as SearchPriorityFilter | null) ?? "";
 		const paramMilestone = searchParams.get("milestone") ?? "";
@@ -276,9 +273,6 @@ const TaskList: React.FC<TaskListProps> = ({
 		}
 		const normalizedLabels = paramLabels.map((label) => label.trim()).filter((label) => label.length > 0);
 
-		if (paramQuery !== searchValue) {
-			setSearchValue(paramQuery);
-		}
 		if (paramStatus !== statusFilter) {
 			setStatusFilter(paramStatus);
 		}
@@ -316,7 +310,7 @@ const TaskList: React.FC<TaskListProps> = ({
 		};
 
 		const shouldUseApi =
-			Boolean(normalizedSearch) || Boolean(statusFilter) || Boolean(priorityFilter) || labelFilter.length > 0;
+			Boolean(statusFilter) || Boolean(priorityFilter) || labelFilter.length > 0;
 
 		if (!hasActiveFilters) {
 			return;
@@ -333,7 +327,6 @@ const TaskList: React.FC<TaskListProps> = ({
 			}
 			try {
 				const results = await apiClient.search({
-					query: normalizedSearch || undefined,
 					types: ["task"],
 					status: statusFilter || undefined,
 					priority: (priorityFilter || undefined) as SearchPriorityFilter | undefined,
@@ -361,29 +354,23 @@ const TaskList: React.FC<TaskListProps> = ({
 		};
 	}, [
 		hasActiveFilters,
-		normalizedSearch,
 		priorityFilter,
 		statusFilter,
 		labelFilter,
-			tasks,
-			milestoneFilter,
-			sortedBaseTasks,
-			milestoneAliasToCanonical,
-			archivedMilestoneKeys,
-		]);
+		tasks,
+		milestoneFilter,
+		sortedBaseTasks,
+		milestoneAliasToCanonical,
+		archivedMilestoneKeys,
+	]);
 
 	const syncUrl = (
-		nextQuery: string,
 		nextStatus: string,
 		nextPriority: "" | SearchPriorityFilter,
 		nextLabels: string[],
 		nextMilestone: string,
 	) => {
 		const params = new URLSearchParams();
-		const trimmedQuery = nextQuery.trim();
-		if (trimmedQuery) {
-			params.set("query", trimmedQuery);
-		}
 		if (nextStatus) {
 			params.set("status", nextStatus);
 		}
@@ -401,39 +388,33 @@ const TaskList: React.FC<TaskListProps> = ({
 		setSearchParams(params, { replace: true });
 	};
 
-	const handleSearchChange = (value: string) => {
-		setSearchValue(value);
-		syncUrl(value, statusFilter, priorityFilter, labelFilter, milestoneFilter);
-	};
-
 	const handleStatusChange = (value: string) => {
 		setStatusFilter(value);
-		syncUrl(searchValue, value, priorityFilter, labelFilter, milestoneFilter);
+		syncUrl(value, priorityFilter, labelFilter, milestoneFilter);
 	};
 
 	const handlePriorityChange = (value: "" | SearchPriorityFilter) => {
 		setPriorityFilter(value);
-		syncUrl(searchValue, statusFilter, value, labelFilter, milestoneFilter);
+		syncUrl(statusFilter, value, labelFilter, milestoneFilter);
 	};
 
 	const handleLabelChange = (next: string[]) => {
 		const normalized = next.map((label) => label.trim()).filter((label) => label.length > 0);
 		setLabelFilter(normalized);
-		syncUrl(searchValue, statusFilter, priorityFilter, normalized, milestoneFilter);
+		syncUrl(statusFilter, priorityFilter, normalized, milestoneFilter);
 	};
 
 	const handleMilestoneChange = (value: string) => {
 		setMilestoneFilter(value);
-		syncUrl(searchValue, statusFilter, priorityFilter, labelFilter, value);
+		syncUrl(statusFilter, priorityFilter, labelFilter, value);
 	};
 
 	const handleClearFilters = () => {
-		setSearchValue("");
 		setStatusFilter("");
 		setPriorityFilter("");
 		setLabelFilter([]);
 		setMilestoneFilter("");
-		syncUrl("", "", "", [], "");
+		syncUrl("", "", [], "");
 		setDisplayTasks(sortedBaseTasks);
 		setError(null);
 	};
@@ -648,70 +629,44 @@ const TaskList: React.FC<TaskListProps> = ({
 
 				<div className="flex flex-wrap items-center gap-3 justify-between">
 					<div className="flex flex-wrap items-center gap-3 flex-1 min-w-0">
-						<div className="relative flex-1 basis-[200px] min-w-[180px] max-w-[280px]">
-							<span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400 dark:text-gray-500">
-								<svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-								</svg>
-							</span>
-						<input
-							type="text"
-							value={searchValue}
-							onChange={(event) => handleSearchChange(event.target.value)}
-							placeholder="Search tasks"
-							className="w-full pl-10 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200"
-						/>
-						{searchValue && (
-								<button
-									type="button"
-									onClick={() => handleSearchChange("")}
-									className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
-								>
-									<svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-										<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-								</svg>
-							</button>
-						)}
-						</div>
+						<select
+							value={statusFilter}
+							onChange={(event) => handleStatusChange(event.target.value)}
+							className="min-w-[140px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200"
+						>
+							<option value="">All statuses</option>
+							{availableStatuses.map((status) => (
+								<option key={status} value={status}>
+									{status}
+								</option>
+							))}
+						</select>
 
-					<select
-						value={statusFilter}
-						onChange={(event) => handleStatusChange(event.target.value)}
-						className="min-w-[140px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200"
-					>
-						<option value="">All statuses</option>
-						{availableStatuses.map((status) => (
-							<option key={status} value={status}>
-								{status}
-							</option>
-						))}
-					</select>
+						<select
+							value={priorityFilter}
+							onChange={(event) => handlePriorityChange(event.target.value as "" | SearchPriorityFilter)}
+							className="min-w-[140px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200"
+						>
+							{PRIORITY_OPTIONS.map((option) => (
+								<option key={option.value || "all"} value={option.value}>
+									{option.label}
+								</option>
+							))}
+						</select>
 
-					<select
-						value={priorityFilter}
-						onChange={(event) => handlePriorityChange(event.target.value as "" | SearchPriorityFilter)}
-						className="min-w-[140px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200"
-					>
-						{PRIORITY_OPTIONS.map((option) => (
-							<option key={option.value || "all"} value={option.value}>
-								{option.label}
-							</option>
-						))}
-					</select>
-
-					<select
-						value={milestoneFilter}
-						onChange={(event) => handleMilestoneChange(event.target.value)}
-						className="min-w-[160px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200"
-					>
-						<option value="">All milestones</option>
-						<option value="__none">No milestone</option>
-						{milestoneOptions.map((milestone) => (
-							<option key={milestone} value={milestone}>
-								{getMilestoneLabel(milestone, milestoneEntities)}
-							</option>
-						))}
-					</select>
+						<select
+							value={milestoneFilter}
+							onChange={(event) => handleMilestoneChange(event.target.value)}
+							className="min-w-[160px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200"
+						>
+							<option value="">All milestones</option>
+							<option value="__none">No milestone</option>
+							{milestoneOptions.map((milestone) => (
+								<option key={milestone} value={milestone}>
+									{getMilestoneLabel(milestone, milestoneEntities)}
+								</option>
+							))}
+						</select>
 
 					<div className="relative">
 						<button


### PR DESCRIPTION
## Summary
- Remove the duplicate local `Search tasks` input from the All Tasks page and its query-specific local filter plumbing.
- Move Kanban assignee/label/priority filters beside the `All Tasks` / `Milestone` switch and align them to the All Tasks dropdown style family.
- Add focused tests for the removed All Tasks search input and Board filter placement/styling.

## Tests
- `bun test src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx`
- `bunx tsc --noEmit`
- `bun run check .`

## Notes
- Local server smoke on port 6431 served the updated bundle. Chrome DevTools attach was unavailable in this session.