### PR TITLE
BACK-464 - Use shared multi-label filter dropdown on board

### DIFF
--- a/backlog/tasks/back-464 - Use-shared-multi-label-filter-dropdown-on-board.md
+++ b/backlog/tasks/back-464 - Use-shared-multi-label-filter-dropdown-on-board.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-464
 title: Use shared multi-label filter dropdown on board
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-03 19:30'
-updated_date: '2026-05-03 19:30'
+updated_date: '2026-05-03 19:34'
 labels:
   - web
   - filters
@@ -16,6 +16,7 @@ modified_files:
   - src/web/components/TaskList.tsx
   - src/web/components/Board.tsx
   - src/web/components/BoardPage.tsx
+  - src/web/App.tsx
   - src/test/web-task-list-labels-menu.test.tsx
   - src/test/web-board-filters.test.tsx
 priority: high
@@ -29,12 +30,12 @@ Follow-up to BACK-463. The Kanban board label filter should not be a weaker sing
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All Tasks continues to render the same multi-select Labels dropdown behavior and visual treatment as before.
-- [ ] #2 Kanban board uses the same shared Labels dropdown component instead of a native single-select label filter.
-- [ ] #3 Kanban board supports selecting multiple labels and persists them in URL params using repeated `label` params, matching All Tasks filter semantics where possible.
-- [ ] #4 Kanban board label filtering shows tasks that include any selected label, preserving existing assignee and priority filter behavior.
-- [ ] #5 Clear filters clears all selected board labels along with assignee and priority filters.
-- [ ] #6 Focused web tests cover shared All Tasks labels behavior and multi-label Kanban board filtering/URL persistence.
+- [x] #1 All Tasks continues to render the same multi-select Labels dropdown behavior and visual treatment as before.
+- [x] #2 Kanban board uses the same shared Labels dropdown component instead of a native single-select label filter.
+- [x] #3 Kanban board supports selecting multiple labels and persists them in URL params using repeated `label` params, matching All Tasks filter semantics where possible.
+- [x] #4 Kanban board label filtering shows tasks that include any selected label, preserving existing assignee and priority filter behavior.
+- [x] #5 Clear filters clears all selected board labels along with assignee and priority filters.
+- [x] #6 Focused web tests cover shared All Tasks labels behavior and multi-label Kanban board filtering/URL persistence.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,9 +49,34 @@ Follow-up to BACK-463. The Kanban board label filter should not be a weaker sing
 6. Update focused tests for All Tasks parity and Kanban multi-label filtering/URL persistence, then run targeted tests, typecheck, and Biome.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extracted the All Tasks labels menu into a shared `LabelFilterDropdown` component and replaced the inline All Tasks implementation with it.
+
+Replaced the Kanban board native single-label select with the shared multi-select labels dropdown. Board filters now carry `labels: string[]`, write repeated `label` URL params, read repeated `label` plus legacy `labels` CSV params, and match tasks that contain any selected label.
+
+Verification: `bun test src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx`, `bunx tsc --noEmit`, and `bun run check .` all pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Summary:
+- Extracted the All Tasks labels dropdown into a shared `LabelFilterDropdown` component.
+- Reused that shared multi-select dropdown in both All Tasks and the Kanban board.
+- Changed Board/BoardPage label filtering from a single string to `labels: string[]`, with repeated `label` URL params and any-selected-label matching.
+- Updated focused web tests to cover no native Board label select, multi-label URL persistence, label OR filtering, and existing All Tasks dropdown behavior.
+
+Tests:
+- `bun test src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx`
+- `bunx tsc --noEmit`
+- `bun run check .`
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -89,7 +89,7 @@ const setupDom = (url = "http://localhost/board") => {
 
 const renderBoardPage = (
 	url?: string,
-	options: { tasks?: Task[]; statuses?: string[] } = {},
+	options: { tasks?: Task[]; statuses?: string[]; availableLabels?: string[] } = {},
 ): HTMLElement => {
 	setupDom(url);
 	const container = document.getElementById("root");
@@ -104,6 +104,7 @@ const renderBoardPage = (
 					tasks={renderedTasks}
 					statuses={renderedStatuses}
 					milestones={[]}
+					availableLabels={options.availableLabels ?? ["bug", "docs", "enhancement"]}
 					milestoneEntities={[]}
 					archivedMilestones={[]}
 					isLoading={false}
@@ -140,6 +141,13 @@ const clickElement = async (element: Element) => {
 	});
 };
 
+const toggleCheckbox = async (checkbox: HTMLInputElement) => {
+	await act(async () => {
+		checkbox.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+		await Promise.resolve();
+	});
+};
+
 const expectVisibleTasks = (container: HTMLElement, expected: string[]) => {
 	const text = container.textContent ?? "";
 	for (const title of expected) {
@@ -161,11 +169,7 @@ const expectBoardFiltersInHeader = (container: HTMLElement) => {
 	const boardFilters = toolbar?.querySelector("[aria-label='Board filters']");
 	expect(boardFilters).toBeTruthy();
 
-	for (const ariaLabel of [
-		"Filter board by assignee",
-		"Filter board by label",
-		"Filter board by priority",
-	]) {
+	for (const ariaLabel of ["Filter board by assignee", "Filter board by priority"]) {
 		const select = container.querySelector(`select[aria-label='${ariaLabel}']`) as HTMLSelectElement | null;
 		expect(select).toBeTruthy();
 		expect(toolbar?.contains(select)).toBe(true);
@@ -175,6 +179,30 @@ const expectBoardFiltersInHeader = (container: HTMLElement) => {
 		expect(select?.className).toContain("border-gray-300");
 		expect(select?.className).toContain("focus:ring-stone-500");
 	}
+
+	expect(container.querySelector("select[aria-label='Filter board by label']")).toBeNull();
+	const labelsButton = getBoardLabelsButton(container);
+	expect(toolbar?.contains(labelsButton)).toBe(true);
+	expect(labelsButton.className).toContain("min-w-[200px]");
+	expect(labelsButton.className).toContain("rounded-lg");
+	expect(labelsButton.className).toContain("border-gray-300");
+	expect(labelsButton.className).toContain("focus:ring-stone-500");
+};
+
+const getBoardLabelsButton = (container: HTMLElement): HTMLButtonElement => {
+	const button = container.querySelector("button[aria-controls='board-labels-filter-menu']");
+	expect(button).toBeTruthy();
+	return button as HTMLButtonElement;
+};
+
+const getBoardLabelCheckbox = (container: HTMLElement, label: string): HTMLInputElement => {
+	const labelElement = Array.from(container.querySelectorAll("#board-labels-filter-menu label")).find(
+		(element) => element.textContent?.trim() === label,
+	);
+	expect(labelElement).toBeTruthy();
+	const checkbox = labelElement?.querySelector("input[type='checkbox']");
+	expect(checkbox).toBeTruthy();
+	return checkbox as HTMLInputElement;
 };
 
 afterEach(() => {
@@ -197,20 +225,39 @@ describe("Web board filters", () => {
 		expect(new URLSearchParams(window.location.search).get("assignee")).toBe("alice");
 		expectVisibleTasks(container, ["Fix login bug", "Improve board"]);
 
-		await setSelectValue(getSelectByFirstOption(container, "All labels"), "bug");
-		expect(new URLSearchParams(window.location.search).get("label")).toBe("bug");
+		await clickElement(getBoardLabelsButton(container));
+		await toggleCheckbox(getBoardLabelCheckbox(container, "bug"));
+		expect(new URLSearchParams(window.location.search).getAll("label")).toEqual(["bug"]);
 		expectVisibleTasks(container, ["Fix login bug"]);
+
+		await toggleCheckbox(getBoardLabelCheckbox(container, "enhancement"));
+		expect(new URLSearchParams(window.location.search).getAll("label")).toEqual(["bug", "enhancement"]);
+		expect(getBoardLabelsButton(container).textContent).toContain("2 selected");
+		expectVisibleTasks(container, ["Fix login bug", "Improve board"]);
 
 		await setSelectValue(getSelectByFirstOption(container, "All priorities"), "high");
 		expect(new URLSearchParams(window.location.search).get("priority")).toBe("high");
 		expectVisibleTasks(container, ["Fix login bug"]);
 	});
 
+	it("matches configured label casing against task labels", async () => {
+		const container = renderBoardPage(undefined, {
+			availableLabels: ["Bug", "Docs", "enhancement"],
+		});
+
+		await clickElement(getBoardLabelsButton(container));
+		await toggleCheckbox(getBoardLabelCheckbox(container, "Bug"));
+
+		expect(new URLSearchParams(window.location.search).getAll("label")).toEqual(["Bug"]);
+		expect(getBoardLabelsButton(container).textContent).toContain("Bug");
+		expectVisibleTasks(container, ["Fix login bug", "Triage unassigned issue"]);
+	});
+
 	it("reads filters from URL params and clears them", async () => {
 		const container = renderBoardPage("http://localhost/board?assignee=alice&label=bug&priority=high");
 
 		expect(getSelectByFirstOption(container, "All assignees").value).toBe("alice");
-		expect(getSelectByFirstOption(container, "All labels").value).toBe("bug");
+		expect(getBoardLabelsButton(container).textContent).toContain("bug");
 		expect(getSelectByFirstOption(container, "All priorities").value).toBe("high");
 		expectVisibleTasks(container, ["Fix login bug"]);
 
@@ -222,7 +269,7 @@ describe("Web board filters", () => {
 
 		const searchParams = new URLSearchParams(window.location.search);
 		expect(searchParams.get("assignee")).toBeNull();
-		expect(searchParams.get("label")).toBeNull();
+		expect(searchParams.getAll("label")).toEqual([]);
 		expect(searchParams.get("priority")).toBeNull();
 		expectVisibleTasks(container, ["Fix login bug", "Write docs", "Improve board", "Triage unassigned issue"]);
 	});

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -498,6 +498,7 @@ function App() {
                 onRefreshData={refreshData}
                 statuses={statuses}
                 milestones={milestones}
+                availableLabels={availableLabels}
                 milestoneEntities={milestoneEntities}
                 archivedMilestones={archivedMilestones}
                 isLoading={isLoading}

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -2,10 +2,12 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { type Milestone, type Task } from '../../types';
 import { apiClient, type ReorderTaskPayload } from '../lib/api';
 import { buildLanes, DEFAULT_LANE_KEY, groupTasksByLaneAndStatus, type LaneMode } from '../lib/lanes';
+import { collectAvailableLabels, labelsToLower } from '../../utils/label-filter';
 import { collectArchivedMilestoneKeys, milestoneKey } from '../utils/milestones';
 import { getTerminalStatus } from '../../utils/terminal-status';
 import TaskColumn from './TaskColumn';
 import CleanupModal from './CleanupModal';
+import LabelFilterDropdown from './LabelFilterDropdown';
 import { SuccessToast } from './SuccessToast';
 
 interface BoardProps {
@@ -17,15 +19,16 @@ interface BoardProps {
   statuses: string[];
   isLoading: boolean;
   milestones: string[];
+  availableLabels: string[];
   milestoneEntities: Milestone[];
   archivedMilestones: Milestone[];
   laneMode: LaneMode;
   onLaneChange: (mode: LaneMode) => void;
   milestoneFilter?: string | null;
   filterAssignee?: string;
-  filterLabel?: string;
+  filterLabels?: string[];
   filterPriority?: string;
-  onFiltersChange?: (filters: { assignee: string; label: string; priority: string }) => void;
+  onFiltersChange?: (filters: { assignee: string; labels: string[]; priority: string }) => void;
 }
 
 const PRIORITY_OPTIONS = [
@@ -49,13 +52,14 @@ const Board: React.FC<BoardProps> = ({
   onRefreshData,
   statuses,
   isLoading,
+  availableLabels,
   milestoneEntities,
   archivedMilestones,
   laneMode,
   onLaneChange,
   milestoneFilter,
   filterAssignee = '',
-  filterLabel = '',
+  filterLabels = [],
   filterPriority = '',
   onFiltersChange,
 }) => {
@@ -213,17 +217,17 @@ const Board: React.FC<BoardProps> = ({
     return Array.from(seen).sort((a, b) => a.localeCompare(b));
   }, [tasks]);
 
-  const uniqueLabels = useMemo(() => {
-    const seen = new Set<string>();
-    for (const task of tasks) {
-      for (const l of task.labels) {
-        if (l.trim()) seen.add(l.trim());
-      }
-    }
-    return Array.from(seen).sort((a, b) => a.localeCompare(b));
-  }, [tasks]);
+  const uniqueLabels = useMemo(
+    () => collectAvailableLabels(tasks, availableLabels),
+    [tasks, availableLabels]
+  );
 
-  const hasActiveFilters = filterAssignee !== '' || filterLabel !== '' || filterPriority !== '';
+  const normalizedFilterLabels = useMemo(
+    () => filterLabels.map(label => label.trim()).filter(label => label.length > 0),
+    [filterLabels]
+  );
+
+  const hasActiveFilters = filterAssignee !== '' || normalizedFilterLabels.length > 0 || filterPriority !== '';
 
   // Filter tasks by milestone when milestoneFilter is set, then apply assignee/label/priority filters
   const filteredTasks = useMemo(() => {
@@ -236,14 +240,15 @@ const Board: React.FC<BoardProps> = ({
     } else if (filterAssignee) {
       result = result.filter(task => task.assignee.some(a => a.trim() === filterAssignee));
     }
-    if (filterLabel) {
-      result = result.filter(task => task.labels.some(l => l.trim() === filterLabel));
+    if (normalizedFilterLabels.length > 0) {
+      const selectedLabels = new Set(labelsToLower(normalizedFilterLabels));
+      result = result.filter(task => labelsToLower(task.labels).some(label => selectedLabels.has(label)));
     }
     if (filterPriority) {
       result = result.filter(task => task.priority === filterPriority);
     }
     return result;
-  }, [tasks, milestoneFilter, canonicalMilestoneFilter, milestoneAliasToCanonical, filterAssignee, filterLabel, filterPriority]);
+  }, [tasks, milestoneFilter, canonicalMilestoneFilter, milestoneAliasToCanonical, filterAssignee, normalizedFilterLabels, filterPriority]);
 
   // Handle highlighting a task (opening its edit popup)
   useEffect(() => {
@@ -477,7 +482,7 @@ const Board: React.FC<BoardProps> = ({
                 <select
                   aria-label="Filter board by assignee"
                   value={filterAssignee}
-                  onChange={e => onFiltersChange({ assignee: e.target.value, label: filterLabel, priority: filterPriority })}
+                  onChange={e => onFiltersChange({ assignee: e.target.value, labels: normalizedFilterLabels, priority: filterPriority })}
                   className={BOARD_FILTER_SELECT_CLASS}
                 >
                   <option value="">All assignees</option>
@@ -487,22 +492,18 @@ const Board: React.FC<BoardProps> = ({
                   ))}
                 </select>
 
-                <select
-                  aria-label="Filter board by label"
-                  value={filterLabel}
-                  onChange={e => onFiltersChange({ assignee: filterAssignee, label: e.target.value, priority: filterPriority })}
-                  className={BOARD_FILTER_SELECT_CLASS}
-                >
-                  <option value="">All labels</option>
-                  {uniqueLabels.map(l => (
-                    <option key={l} value={l}>{l}</option>
-                  ))}
-                </select>
+                <LabelFilterDropdown
+                  availableLabels={uniqueLabels}
+                  selectedLabels={normalizedFilterLabels}
+                  onChange={labels => onFiltersChange({ assignee: filterAssignee, labels, priority: filterPriority })}
+                  menuId="board-labels-filter-menu"
+                  className="min-w-[200px]"
+                />
 
                 <select
                   aria-label="Filter board by priority"
                   value={filterPriority}
-                  onChange={e => onFiltersChange({ assignee: filterAssignee, label: filterLabel, priority: e.target.value })}
+                  onChange={e => onFiltersChange({ assignee: filterAssignee, labels: normalizedFilterLabels, priority: e.target.value })}
                   className={BOARD_FILTER_SELECT_CLASS}
                 >
                   {PRIORITY_OPTIONS.map(opt => (
@@ -513,7 +514,7 @@ const Board: React.FC<BoardProps> = ({
                 {hasActiveFilters && (
                   <button
                     type="button"
-                    onClick={() => onFiltersChange({ assignee: '', label: '', priority: '' })}
+                    onClick={() => onFiltersChange({ assignee: '', labels: [], priority: '' })}
                     className={BOARD_FILTER_BUTTON_CLASS}
                   >
                     Clear filters

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -11,6 +11,7 @@ interface BoardPageProps {
 	onRefreshData?: () => Promise<void>;
 	statuses: string[];
 	milestones: string[];
+	availableLabels: string[];
 	milestoneEntities: Milestone[];
 	archivedMilestones: Milestone[];
 	isLoading: boolean;
@@ -23,6 +24,7 @@ export default function BoardPage({
 	onRefreshData,
 	statuses,
 	milestones,
+	availableLabels,
 	milestoneEntities,
 	archivedMilestones,
 	isLoading,
@@ -85,17 +87,20 @@ export default function BoardPage({
 		}, { replace: true });
 	};
 
-	const handleFiltersChange = (filters: { assignee: string; label: string; priority: string }) => {
+	const handleFiltersChange = (filters: { assignee: string; labels: string[]; priority: string }) => {
 		setSearchParams(params => {
 			if (filters.assignee) {
 				params.set('assignee', filters.assignee);
 			} else {
 				params.delete('assignee');
 			}
-			if (filters.label) {
-				params.set('label', filters.label);
-			} else {
-				params.delete('label');
+			params.delete('label');
+			params.delete('labels');
+			for (const label of filters.labels) {
+				const normalized = label.trim();
+				if (normalized) {
+					params.append('label', normalized);
+				}
 			}
 			if (filters.priority) {
 				params.set('priority', filters.priority);
@@ -107,7 +112,10 @@ export default function BoardPage({
 	};
 
 	const filterAssignee = searchParams.get('assignee') ?? '';
-	const filterLabel = searchParams.get('label') ?? '';
+	const filterLabels = [
+		...searchParams.getAll('label'),
+		...searchParams.getAll('labels').flatMap((value) => value.split(',')),
+	].map((label) => label.trim()).filter((label) => label.length > 0);
 	const filterPriority = searchParams.get('priority') ?? '';
 
 	return (
@@ -123,11 +131,12 @@ export default function BoardPage({
 				milestoneEntities={milestoneEntities}
 				archivedMilestones={archivedMilestones}
 				isLoading={isLoading}
+				availableLabels={availableLabels}
 				laneMode={laneMode}
 				onLaneChange={handleLaneChange}
 				milestoneFilter={milestoneFilter}
 				filterAssignee={filterAssignee}
-				filterLabel={filterLabel}
+				filterLabels={filterLabels}
 				filterPriority={filterPriority}
 				onFiltersChange={handleFiltersChange}
 			/>

--- a/src/web/components/LabelFilterDropdown.tsx
+++ b/src/web/components/LabelFilterDropdown.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from "react";
+
+interface LabelFilterDropdownProps {
+	availableLabels: string[];
+	selectedLabels: string[];
+	onChange: (labels: string[]) => void;
+	menuId: string;
+	className?: string;
+}
+
+export default function LabelFilterDropdown({
+	availableLabels,
+	selectedLabels,
+	onChange,
+	menuId,
+	className = "min-w-[200px]",
+}: LabelFilterDropdownProps) {
+	const [isOpen, setIsOpen] = useState(false);
+	const buttonRef = useRef<HTMLButtonElement | null>(null);
+	const menuRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (!isOpen) return;
+		const handleClickOutside = (event: MouseEvent) => {
+			const target = event.target as Node;
+			if (
+				buttonRef.current &&
+				menuRef.current &&
+				!buttonRef.current.contains(target) &&
+				!menuRef.current.contains(target)
+			) {
+				setIsOpen(false);
+			}
+		};
+		document.addEventListener("mousedown", handleClickOutside);
+		return () => document.removeEventListener("mousedown", handleClickOutside);
+	}, [isOpen]);
+
+	const toggleLabel = (label: string) => {
+		const next = selectedLabels.includes(label)
+			? selectedLabels.filter((item) => item !== label)
+			: [...selectedLabels, label];
+		onChange(next);
+	};
+
+	return (
+		<div className="relative">
+			<button
+				type="button"
+				ref={buttonRef}
+				onClick={() => setIsOpen((open) => !open)}
+				aria-expanded={isOpen}
+				aria-controls={menuId}
+				className={`${className} py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200 text-left`}
+			>
+				<div className="flex items-center justify-between gap-2">
+					<span>Labels</span>
+					<span className="text-xs text-gray-500 dark:text-gray-400">
+						{selectedLabels.length === 0
+							? "All"
+							: selectedLabels.length === 1
+								? selectedLabels[0]
+								: `${selectedLabels.length} selected`}
+					</span>
+				</div>
+			</button>
+			{isOpen && (
+				<div
+					id={menuId}
+					ref={menuRef}
+					className="absolute z-50 mt-2 w-[220px] max-h-56 overflow-y-auto rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg"
+				>
+					{availableLabels.length === 0 ? (
+						<div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No labels</div>
+					) : (
+						availableLabels.map((label) => {
+							const isSelected = selectedLabels.includes(label);
+							return (
+								<label
+									key={label}
+									className="flex items-center gap-2 px-3 py-2 text-sm text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+								>
+									<input
+										type="checkbox"
+										checked={isSelected}
+										onChange={() => toggleLabel(label)}
+										className="h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500"
+									/>
+									<span className="truncate">{label}</span>
+								</label>
+							);
+						})
+					)}
+					{selectedLabels.length > 0 && (
+						<button
+							type="button"
+							className="w-full text-left px-3 py-2 text-xs text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 border-t border-gray-200 dark:border-gray-700"
+							onClick={() => {
+								onChange([]);
+								setIsOpen(false);
+							}}
+						>
+							Clear label filter
+						</button>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -12,6 +12,7 @@ import { isTerminalStatus } from "../../utils/terminal-status.ts";
 import { collectArchivedMilestoneKeys, getMilestoneLabel, milestoneKey } from "../utils/milestones";
 import { formatStoredUtcDateForCompactDisplay, parseStoredUtcDate } from "../utils/date-display";
 import CleanupModal from "./CleanupModal";
+import LabelFilterDropdown from "./LabelFilterDropdown";
 import { SuccessToast } from "./SuccessToast";
 
 interface TaskListProps {
@@ -106,11 +107,8 @@ const TaskList: React.FC<TaskListProps> = ({
 	const [error, setError] = useState<string | null>(null);
 	const [showCleanupModal, setShowCleanupModal] = useState(false);
 	const [cleanupSuccessMessage, setCleanupSuccessMessage] = useState<string | null>(null);
-	const [showLabelsMenu, setShowLabelsMenu] = useState(false);
 	const [sortColumn, setSortColumn] = useState<TaskSortColumn>("id");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
-	const labelsButtonRef = useRef<HTMLButtonElement | null>(null);
-	const labelsMenuRef = useRef<HTMLDivElement | null>(null);
 	const tableHeaderScrollRef = useRef<HTMLDivElement | null>(null);
 	const tableBodyScrollRef = useRef<HTMLDivElement | null>(null);
 	const isSyncingTableScrollRef = useRef(false);
@@ -419,23 +417,6 @@ const TaskList: React.FC<TaskListProps> = ({
 		setError(null);
 	};
 
-	useEffect(() => {
-		if (!showLabelsMenu) return;
-		const handleClickOutside = (event: MouseEvent) => {
-			const target = event.target as Node;
-			if (
-				labelsButtonRef.current &&
-				labelsMenuRef.current &&
-				!labelsButtonRef.current.contains(target) &&
-				!labelsMenuRef.current.contains(target)
-			) {
-				setShowLabelsMenu(false);
-			}
-		};
-		document.addEventListener("mousedown", handleClickOutside);
-		return () => document.removeEventListener("mousedown", handleClickOutside);
-	}, [showLabelsMenu]);
-
 	const handleCleanupSuccess = async (movedCount: number) => {
 		setShowCleanupModal(false);
 		setCleanupSuccessMessage(`Successfully moved ${movedCount} task${movedCount !== 1 ? 's' : ''} to completed folder`);
@@ -668,73 +649,12 @@ const TaskList: React.FC<TaskListProps> = ({
 							))}
 						</select>
 
-					<div className="relative">
-						<button
-							type="button"
-							ref={labelsButtonRef}
-							onClick={() => setShowLabelsMenu((open) => !open)}
-							aria-expanded={showLabelsMenu}
-							aria-controls="task-list-labels-menu"
-							className="min-w-[200px] py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200 text-left"
-						>
-							<div className="flex items-center justify-between gap-2">
-								<span>Labels</span>
-								<span className="text-xs text-gray-500 dark:text-gray-400">
-									{labelFilter.length === 0
-										? "All"
-										: labelFilter.length === 1
-											? labelFilter[0]
-											: `${labelFilter.length} selected`}
-								</span>
-							</div>
-						</button>
-						{showLabelsMenu && (
-							<div
-								id="task-list-labels-menu"
-								ref={labelsMenuRef}
-								className="absolute z-50 mt-2 w-[220px] max-h-56 overflow-y-auto rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg"
-							>
-								{mergedAvailableLabels.length === 0 ? (
-									<div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No labels</div>
-								) : (
-									mergedAvailableLabels.map((label) => {
-										const isSelected = labelFilter.includes(label);
-										return (
-											<label
-												key={label}
-												className="flex items-center gap-2 px-3 py-2 text-sm text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
-											>
-												<input
-													type="checkbox"
-													checked={isSelected}
-													onChange={() => {
-														const next = isSelected
-															? labelFilter.filter((item) => item !== label)
-															: [...labelFilter, label];
-														handleLabelChange(next);
-													}}
-													className="h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500"
-												/>
-												<span className="truncate">{label}</span>
-											</label>
-										);
-									})
-								)}
-								{labelFilter.length > 0 && (
-									<button
-										type="button"
-										className="w-full text-left px-3 py-2 text-xs text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 border-t border-gray-200 dark:border-gray-700"
-										onClick={() => {
-											handleLabelChange([]);
-											setShowLabelsMenu(false);
-										}}
-									>
-										Clear label filter
-									</button>
-								)}
-							</div>
-						)}
-					</div>
+						<LabelFilterDropdown
+							availableLabels={mergedAvailableLabels}
+							selectedLabels={labelFilter}
+							onChange={handleLabelChange}
+							menuId="task-list-labels-menu"
+						/>
 
 					</div>
 


### PR DESCRIPTION
## Summary
- Extract the All Tasks labels dropdown into a shared `LabelFilterDropdown` component.
- Reuse the shared multi-select labels dropdown on the Kanban board instead of the native single-select label filter.
- Persist Board labels as repeated `label` URL params and filter by any selected label while preserving assignee/priority behavior.
- Pass configured `availableLabels` into Board so the dropdown has the same label source family as All Tasks.

## Tests
- `bun test src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx`
- `bunx tsc --noEmit`
- `bun run check .`