### PR TITLE
BACK-465 - Fix Windows MCP document tool hangs

### DIFF
--- a/backlog/tasks/back-465 - Fix-Windows-MCP-document-tool-hangs.md
+++ b/backlog/tasks/back-465 - Fix-Windows-MCP-document-tool-hangs.md
@@ -1,0 +1,67 @@
+---
+id: BACK-465
+title: Fix Windows MCP document tool hangs
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-05-07 17:32'
+updated_date: '2026-05-07 17:41'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/640'
+modified_files:
+  - src/commands/mcp.ts
+  - src/git/operations.ts
+  - src/test/mcp-stdio-exit.test.ts
+priority: high
+ordinal: 23000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+GitHub issue #640 reports that backlog.md 1.45.0 hangs indefinitely on Windows when MCP clients call document_create through 'backlog.cmd mcp start --cwd <project>'. Version 1.44.0 returns promptly in the same project. Reproduce the Windows MCP document-tool hang, identify the blocking path, and ship a regression-tested fix without changing the public MCP document-tool contract.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 MCP document_create returns promptly on Windows when the server is started with --cwd and the client does not provide roots.
+- [x] #2 MCP document list/view/update paths continue to work and do not regress while using the same root-resolution behavior.
+- [x] #3 A regression test covers the Windows/no-client-roots scenario or equivalent root-discovery fallback that caused the hang.
+- [x] #4 Relevant targeted tests, type-checking, and lint/check commands pass or any environment blocker is documented.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce issue #640 with a real MCP StdioClientTransport client using no roots capability and 'mcp start --cwd <initialized project>'.
+2. Fix the Windows-specific premature stdio shutdown path in the MCP CLI command without changing MCP document tool schemas or handlers.
+3. Add a regression test that uses stdio transport, no client roots, and verifies document_create returns after listTools.
+4. Run targeted MCP stdio/document tests, type-checking, and Biome checks; update BACK-465 acceptance criteria/final summary before PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced on Windows with a real StdioClientTransport client: connect and listTools succeed, then the server logs 'Received stdio, shutting down MCP server...' and document_create times out. This points to the CLI mcp start stdin close handler, not the document handler itself; direct mcp-documents and mcp-roots-discovery tests pass.
+
+Implemented the fix by ignoring stdin 'close' as a shutdown signal on Windows and by changing isGitRepository to run git rev-parse with stdin ignored via Bun.spawn. This keeps MCP stdio sessions alive and prevents git repository detection from inheriting MCP stdio pipes during document ID generation.
+
+Validation: bun test src/test/mcp-stdio-exit.test.ts --timeout=15000 passed; bun test src/test/mcp-documents.test.ts src/test/mcp-roots-discovery.test.ts --timeout=15000 passed; bun test src/test/git.test.ts src/test/no-remote-preflight.test.ts --timeout=15000 passed; bunx tsc --noEmit passed; bunx biome check src/commands/mcp.ts src/git/operations.ts src/test/mcp-stdio-exit.test.ts passed. Full bun run check . was attempted and failed on this Windows checkout due pre-existing CRLF formatting diagnostics across many unmodified files, so changed-file Biome validation was used for this PR.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixes GitHub issue #640 by addressing two Windows stdio blockers in the MCP path. First, mcp start no longer treats stdin 'close' as a shutdown signal on Windows because that event can fire while the MCP stdio pipe is still active. Second, isGitRepository now runs git rev-parse through Bun.spawn with stdin ignored, matching the existing execGit pattern and preventing git repository detection from inheriting MCP stdio pipes during document ID generation. Added a stdio-level regression test that connects without roots, lists tools, and verifies document_create returns through mcp start --cwd.
+
+Validation passed for the stdio regression test, MCP document/root tests, git/no-remote tests, TypeScript, and targeted Biome checks on changed TS files. The full bun run check . command was attempted but is blocked in this Windows checkout by pre-existing CRLF diagnostics across unmodified files.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-465 - Fix-Windows-MCP-document-tool-hangs.md
+++ b/backlog/tasks/back-465 - Fix-Windows-MCP-document-tool-hangs.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-05-07 17:32'
-updated_date: '2026-05-07 17:41'
+updated_date: '2026-05-07 18:13'
 labels: []
 dependencies: []
 references:
@@ -14,6 +14,7 @@ modified_files:
   - src/commands/mcp.ts
   - src/git/operations.ts
   - src/test/mcp-stdio-exit.test.ts
+  - src/test/git.test.ts
 priority: high
 ordinal: 23000
 ---
@@ -49,14 +50,18 @@ Reproduced on Windows with a real StdioClientTransport client: connect and listT
 Implemented the fix by ignoring stdin 'close' as a shutdown signal on Windows and by changing isGitRepository to run git rev-parse with stdin ignored via Bun.spawn. This keeps MCP stdio sessions alive and prevents git repository detection from inheriting MCP stdio pipes during document ID generation.
 
 Validation: bun test src/test/mcp-stdio-exit.test.ts --timeout=15000 passed; bun test src/test/mcp-documents.test.ts src/test/mcp-roots-discovery.test.ts --timeout=15000 passed; bun test src/test/git.test.ts src/test/no-remote-preflight.test.ts --timeout=15000 passed; bunx tsc --noEmit passed; bunx biome check src/commands/mcp.ts src/git/operations.ts src/test/mcp-stdio-exit.test.ts passed. Full bun run check . was attempted and failed on this Windows checkout due pre-existing CRLF formatting diagnostics across many unmodified files, so changed-file Biome validation was used for this PR.
+
+Review follow-up from PR #641: Codex correctly noted that replacing the old try/catch with direct Bun.spawn made isGitRepository reject if the child process cannot be created, such as missing git or invalid cwd. Plan: wrap the Bun.spawn call and exited await in try/catch, return false on any failure, and add a regression test for an invalid working directory while keeping stdin ignored.
+
+Review follow-up implemented: restored isGitRepository's false-on-failure behavior by wrapping Bun.spawn and the exit await in try/catch while keeping stdin ignored. Added a regression test for a missing working directory returning false. Validation: bun test src/test/git.test.ts src/test/no-remote-preflight.test.ts --timeout=15000 passed; bun test src/test/mcp-stdio-exit.test.ts --timeout=15000 passed; bunx biome check --write src/git/operations.ts src/test/git.test.ts passed; bunx tsc --noEmit passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixes GitHub issue #640 by addressing two Windows stdio blockers in the MCP path. First, mcp start no longer treats stdin 'close' as a shutdown signal on Windows because that event can fire while the MCP stdio pipe is still active. Second, isGitRepository now runs git rev-parse through Bun.spawn with stdin ignored, matching the existing execGit pattern and preventing git repository detection from inheriting MCP stdio pipes during document ID generation. Added a stdio-level regression test that connects without roots, lists tools, and verifies document_create returns through mcp start --cwd.
+Fixes GitHub issue #640 by addressing Windows stdio blockers in the MCP path. mcp start no longer treats stdin 'close' as a shutdown signal on Windows, and isGitRepository now runs git rev-parse through Bun.spawn with stdin ignored so repository detection does not inherit MCP stdio pipes during document ID generation.
 
-Validation passed for the stdio regression test, MCP document/root tests, git/no-remote tests, TypeScript, and targeted Biome checks on changed TS files. The full bun run check . command was attempted but is blocked in this Windows checkout by pre-existing CRLF diagnostics across unmodified files.
+Review follow-up: restored the previous tolerant behavior for Git detection by returning false when Bun.spawn cannot create the child process or the git check otherwise fails, and added a regression test for an invalid working directory. Validation passed for the stdio regression test, MCP document/root tests, git/no-remote tests, TypeScript, and targeted Biome checks on changed TS files. The full bun run check . command was previously attempted but is blocked in this Windows checkout by pre-existing CRLF diagnostics across unmodified files.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -71,7 +71,10 @@ function registerStartCommand(mcpCmd: Command): void {
 
 				const handleStdioClose = () => shutdown("stdio");
 				process.stdin.once("end", handleStdioClose);
-				process.stdin.once("close", handleStdioClose);
+				if (process.platform !== "win32") {
+					// On Windows, stdin can emit "close" while the MCP stdio pipe is still usable.
+					process.stdin.once("close", handleStdioClose);
+				}
 
 				const handlePipeError = (error: unknown) => {
 					const code =

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -749,14 +749,18 @@ export class GitOperations {
 }
 
 export async function isGitRepository(projectRoot: string): Promise<boolean> {
-	const subprocess = Bun.spawn(["git", "rev-parse", "--git-dir"], {
-		cwd: projectRoot,
-		stdin: "ignore",
-		stdout: "ignore",
-		stderr: "ignore",
-	});
+	try {
+		const subprocess = Bun.spawn(["git", "rev-parse", "--git-dir"], {
+			cwd: projectRoot,
+			stdin: "ignore",
+			stdout: "ignore",
+			stderr: "ignore",
+		});
 
-	return (await subprocess.exited) === 0;
+		return (await subprocess.exited) === 0;
+	} catch {
+		return false;
+	}
 }
 
 export async function initializeGitRepository(projectRoot: string): Promise<void> {

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -749,12 +749,14 @@ export class GitOperations {
 }
 
 export async function isGitRepository(projectRoot: string): Promise<boolean> {
-	try {
-		await $`git rev-parse --git-dir`.cwd(projectRoot).quiet();
-		return true;
-	} catch {
-		return false;
-	}
+	const subprocess = Bun.spawn(["git", "rev-parse", "--git-dir"], {
+		cwd: projectRoot,
+		stdin: "ignore",
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+
+	return (await subprocess.exited) === 0;
 }
 
 export async function initializeGitRepository(projectRoot: string): Promise<void> {

--- a/src/test/git.test.ts
+++ b/src/test/git.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
 import { GitOperations, isGitRepository } from "../git/operations.ts";
 
 describe("Git Operations", () => {
@@ -10,6 +11,11 @@ describe("Git Operations", () => {
 
 		it("should return false for /tmp directory", async () => {
 			const result = await isGitRepository("/tmp");
+			expect(result).toBe(false);
+		});
+
+		it("should return false when the working directory cannot be spawned", async () => {
+			const result = await isGitRepository(join(process.cwd(), "tmp", "missing-git-cwd"));
 			expect(result).toBe(false);
 		});
 	});

--- a/src/test/mcp-stdio-exit.test.ts
+++ b/src/test/mcp-stdio-exit.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Core } from "../core/backlog.ts";
+import { initializeProject } from "../core/init.ts";
 import { createUniqueTestDir, getPlatformTimeout, isWindows, safeCleanup, sleep } from "./test-utils.ts";
 
 const CLI_PATH = join(process.cwd(), "src", "cli.ts");
@@ -64,6 +68,39 @@ function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): Promis
 	});
 }
 
+function withTimeout<T>(operation: Promise<T>, label: string, timeoutMs: number, details: () => string): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			reject(new Error(`${label} timed out after ${timeoutMs}ms.${details()}`));
+		}, timeoutMs);
+
+		operation.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timer);
+				reject(error);
+			},
+		);
+	});
+}
+
+function getText(content: unknown): string {
+	if (!Array.isArray(content)) {
+		return "";
+	}
+
+	const item = content[0];
+	if (!item || typeof item !== "object" || !("text" in item)) {
+		return "";
+	}
+
+	const text = (item as { text?: unknown }).text;
+	return typeof text === "string" ? text : "";
+}
+
 describe("MCP stdio shutdown", () => {
 	const itIfNotWindows = isWindows() ? it.skip : it;
 
@@ -95,5 +132,56 @@ describe("MCP stdio shutdown", () => {
 		const result = await waitForExit(child, timeout);
 		expect(result.code).toBe(0);
 		expect(result.signal).toBeNull();
+	});
+
+	it("keeps stdio sessions alive after listing tools so document calls can respond", async () => {
+		const timeout = getPlatformTimeout(5000);
+		const core = new Core(TEST_DIR);
+		await initializeProject(core, {
+			projectName: "MCP Stdio Document Project",
+			integrationMode: "none",
+			agentInstructions: [],
+			advancedConfig: { autoCommit: false },
+		});
+		await core.disposeContentStore();
+
+		let stderr = "";
+		const transport = new StdioClientTransport({
+			command: "bun",
+			args: [CLI_PATH, "mcp", "start", "--cwd", TEST_DIR, "--debug"],
+			cwd: process.cwd(),
+			stderr: "pipe",
+		});
+		transport.stderr?.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		const client = new Client({ name: "MCP Stdio Document Test", version: "1.0.0" }, { capabilities: {} });
+
+		try {
+			await withTimeout(client.connect(transport), "connect", timeout, () => ` stderr:\n${stderr}`);
+
+			const tools = await withTimeout(client.listTools(), "listTools", timeout, () => ` stderr:\n${stderr}`);
+			expect(tools.tools.map((tool) => tool.name)).toContain("document_create");
+
+			const result = await withTimeout(
+				client.callTool({
+					name: "document_create",
+					arguments: {
+						title: "Stdio Repro Doc",
+						content: "Created through stdio transport.",
+					},
+				}),
+				"document_create",
+				timeout,
+				() => ` stderr:\n${stderr}`,
+			);
+
+			const text = getText(result.content);
+			expect(text).toContain("Document created successfully.");
+			expect(text).toContain("Document doc-1 - Stdio Repro Doc");
+		} finally {
+			await client.close().catch(() => {});
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #640.

This PR fixes two Windows stdio blockers in the MCP document path:

- `mcp start` no longer treats stdin `close` as a shutdown signal on Windows, because that event can fire while the MCP stdio pipe is still active.
- `isGitRepository` now runs `git rev-parse --git-dir` through `Bun.spawn` with stdin ignored, matching the existing `execGit` safety pattern so git repository detection does not inherit MCP stdio pipes during document ID generation.

It also adds a stdio-level regression test that connects without client roots, lists tools, and verifies `document_create` returns through `mcp start --cwd`.

## Validation

- `bun test src/test/mcp-stdio-exit.test.ts --timeout=15000`
- `bun test src/test/mcp-documents.test.ts src/test/mcp-roots-discovery.test.ts --timeout=15000`
- `bun test src/test/git.test.ts src/test/no-remote-preflight.test.ts --timeout=15000`
- `bunx tsc --noEmit`
- `bunx biome check src/commands/mcp.ts src/git/operations.ts src/test/mcp-stdio-exit.test.ts`

`bun run check .` was attempted, but this Windows checkout reports pre-existing CRLF formatting diagnostics across many unmodified files. The changed TS files pass targeted Biome validation.