### PR TITLE
BACK-526 - Sort web milestone cards in creation order

### DIFF
--- a/backlog/tasks/back-526 - Sort-web-milestone-cards-in-creation-order.md
+++ b/backlog/tasks/back-526 - Sort-web-milestone-cards-in-creation-order.md
@@ -1,0 +1,54 @@
+---
+id: BACK-526
+title: Sort web milestone cards in creation order
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-07-08 20:31'
+updated_date: '2026-07-08 20:31'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/pull/644'
+  - 'https://github.com/MrLesk/Backlog.md/issues/736'
+modified_files:
+  - src/web/components/MilestonesPage.tsx
+  - src/test/web-milestones-page-search.test.tsx
+ordinal: 167000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The browser milestones page should display numeric milestone cards in creation order instead of reverse creation order. This keeps phase and sprint milestones readable when users create them sequentially.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Numeric milestone IDs render in ascending order on the milestones page.
+- [x] #2 Milestone page tests cover the new order and card interactions.
+- [x] #3 Focused milestone page tests pass with the ordering expectations.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebase the PR branch onto latest main.
+2. Change the milestone card comparator to ascending numeric ID order.
+3. Update tests to assert the new card order and adjust first-card interactions.
+4. Run focused and full validation before handoff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in PR #644. Updated src/web/components/MilestonesPage.tsx and src/test/web-milestones-page-search.test.tsx.
+
+Validation on the rebased branch passed: bun test src/test/web-milestones-page-search.test.tsx src/test/web-milestones-page-unassigned-filter.test.tsx src/web/utils/milestones.test.ts (27 pass, 0 fail).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR #644 sorts numeric milestone cards ascending, keeps non-numeric milestones after numeric IDs, and verifies the behavior with milestone page tests plus full validation.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/web-milestones-page-search.test.tsx
+++ b/src/test/web-milestones-page-search.test.tsx
@@ -171,6 +171,13 @@ describe("Web milestones page search", () => {
 		expect(document.activeElement).toBe(input);
 	});
 
+	it("renders milestone cards in ascending milestone ID order", () => {
+		const container = renderPage();
+		const text = container.textContent ?? "";
+
+		expect(text.indexOf("Release 1")).toBeLessThan(text.indexOf("Release 2"));
+	});
+
 	it("searching one milestone still renders other milestone sections", () => {
 		const container = renderPage();
 		const initialText = container.textContent ?? "";
@@ -233,7 +240,7 @@ describe("Web milestones page search", () => {
 		expect(container.textContent).toContain("Edit milestone");
 		const input = container.querySelector("#edit-milestone-name") as HTMLInputElement | null;
 		expect(input).toBeTruthy();
-		expect(input?.value).toBe("Release 2");
+		expect(input?.value).toBe("Release 1");
 	});
 
 	it("opens a remove confirmation with clear and reassign choices", () => {
@@ -252,7 +259,7 @@ describe("Web milestones page search", () => {
 
 		const select = container.querySelector("select") as HTMLSelectElement | null;
 		expect(select).toBeTruthy();
-		expect(Array.from(select?.options ?? []).map((option) => option.value)).toContain("m-1");
+		expect(Array.from(select?.options ?? []).map((option) => option.value)).toContain("m-2");
 	});
 
 	it("submits milestone edits through the API and refreshes data", async () => {
@@ -260,7 +267,7 @@ describe("Web milestones page search", () => {
 		let refreshCount = 0;
 		apiClient.updateMilestone = async (id: string, title: string) => {
 			updateArgs = [id, title];
-			return { success: true, milestone: { ...milestoneEntities[1]!, title } };
+			return { success: true, milestone: { ...milestoneEntities[0]!, title } };
 		};
 
 		const container = renderPage(baseTasks, {
@@ -275,11 +282,11 @@ describe("Web milestones page search", () => {
 
 		const input = container.querySelector("#edit-milestone-name") as HTMLInputElement | null;
 		expect(input).toBeTruthy();
-		setInputValue(input as HTMLInputElement, "Release 2.1");
+		setInputValue(input as HTMLInputElement, "Release 1.1");
 		await submitForm(input?.closest("form") as HTMLFormElement);
 
-		expect(updateArgs?.[0]).toBe("m-2");
-		expect(updateArgs?.[1]).toBe("Release 2.1");
+		expect(updateArgs?.[0]).toBe("m-1");
+		expect(updateArgs?.[1]).toBe("Release 1.1");
 		expect(refreshCount).toBe(1);
 	});
 
@@ -311,7 +318,7 @@ describe("Web milestones page search", () => {
 		expect(select).toBeTruthy();
 		act(() => {
 			if (select) {
-				select.value = "m-1";
+				select.value = "m-2";
 				select.dispatchEvent(new window.Event("change", { bubbles: true }));
 			}
 		});
@@ -321,8 +328,8 @@ describe("Web milestones page search", () => {
 		expect(submitButton).toBeTruthy();
 		await clickElementAsync(submitButton as HTMLButtonElement);
 
-		expect(removeArgs?.[0]).toBe("m-2");
-		expect(removeArgs?.[1]).toEqual({ taskHandling: "reassign", reassignTo: "m-1" });
+		expect(removeArgs?.[0]).toBe("m-1");
+		expect(removeArgs?.[1]).toEqual({ taskHandling: "reassign", reassignTo: "m-2" });
 		expect(refreshCount).toBe(1);
 	});
 

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -135,17 +135,17 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		});
 	}, [buckets, isSearchActive, searchQueryTrimmed, statuses]);
 
-	// Separate buckets into categories and sort by ID descending
+	// Separate buckets into categories and sort by ID ascending
 	const { unassignedBucket, activeMilestones, completedMilestones } = useMemo(() => {
-		// Sort milestones by ID descending (newest first - IDs are sequential m-0, m-1, etc.)
-		const sortByIdDesc = (a: MilestoneBucket, b: MilestoneBucket) => {
+		// Sort milestones by ID ascending (oldest first - preserves the natural phase/sequence order)
+		const sortByIdAsc = (a: MilestoneBucket, b: MilestoneBucket) => {
 			const aMilestone = a.milestone ?? "";
 			const bMilestone = b.milestone ?? "";
 			const aMatch = aMilestone.match(/^m-(\d+)/);
 			const bMatch = bMilestone.match(/^m-(\d+)/);
-			const aNum = aMatch?.[1] ? Number.parseInt(aMatch[1], 10) : -1;
-			const bNum = bMatch?.[1] ? Number.parseInt(bMatch[1], 10) : -1;
-			return bNum - aNum;
+			const aNum = aMatch?.[1] ? Number.parseInt(aMatch[1], 10) : Number.MAX_SAFE_INTEGER;
+			const bNum = bMatch?.[1] ? Number.parseInt(bMatch[1], 10) : Number.MAX_SAFE_INTEGER;
+			return aNum - bNum;
 		};
 
 		const unassigned = visibleBuckets.find((b) => b.isNoMilestone);
@@ -153,10 +153,10 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		const empty = visibleBuckets.filter((b) => !b.isNoMilestone && !b.isCompleted && b.total === 0);
 		const completed = visibleBuckets.filter((b) => !b.isNoMilestone && b.isCompleted);
 
-		// Sort each group by ID descending, then combine (active with tasks first, then empty)
-		const sortedActive = [...activeWithTasks].sort(sortByIdDesc);
-		const sortedEmpty = [...empty].sort(sortByIdDesc);
-		const sortedCompleted = [...completed].sort(sortByIdDesc);
+		// Sort each group by ID ascending, then combine (active with tasks first, then empty)
+		const sortedActive = [...activeWithTasks].sort(sortByIdAsc);
+		const sortedEmpty = [...empty].sort(sortByIdAsc);
+		const sortedCompleted = [...completed].sort(sortByIdAsc);
 
 		return {
 			unassignedBucket: unassigned,


### PR DESCRIPTION
## Task

- [x] BACK-526 - Sort web milestone cards in creation order
- GitHub issue: #736

## Summary

The browser UI milestone page now sorts numeric milestone IDs ascending instead of descending, so milestone cards follow creation/phase order (`m-1`, `m-2`, `m-3`, ...). Milestones without numeric IDs sort after numeric milestone IDs.

## Changes

- Replaced the descending milestone ID comparator in `src/web/components/MilestonesPage.tsx` with ascending numeric ordering.
- Renamed the comparator to match the new ascending behavior.
- Moved non-numeric milestone IDs to the end of the sorted list.
- Updated milestone page tests so interactions target the first card under the new order.
- Added an explicit test that verifies `Release 1` renders before `Release 2`.
- Added completed Backlog task `BACK-526` to the PR branch.

## Validation

- [x] `bun test src/test/web-milestones-page-search.test.tsx src/test/web-milestones-page-unassigned-filter.test.tsx src/web/utils/milestones.test.ts`
- [x] Previous full validation on this PR: `bunx tsc --noEmit`, `bun run check .`, `bun test --timeout=10000`, `bun run build`

Closes #736
