### PR TITLE
BACK-527 - Add ordinal sorting to task list views

### DIFF
--- a/backlog/tasks/back-527 - Add-ordinal-sorting-to-task-list-views.md
+++ b/backlog/tasks/back-527 - Add-ordinal-sorting-to-task-list-views.md
@@ -1,0 +1,59 @@
+---
+id: BACK-527
+title: Add ordinal sorting to task list views
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-07-08 20:33'
+updated_date: '2026-07-08 20:34'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/pull/645'
+  - 'https://github.com/MrLesk/Backlog.md/issues/643'
+modified_files:
+  - src/web/components/TaskList.tsx
+  - src/cli.ts
+  - src/test/cli-task-list-ordinal-sort.test.ts
+  - src/test/web-task-list-labels-menu.test.tsx
+  - src/test/cli-priority-filtering.test.ts
+  - src/test/cli.test.ts
+ordinal: 167000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The browser task list and CLI list commands should expose ordinal sorting so users can review tasks in the same deliberate sequence used by the board view.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The browser task list exposes a sortable ordinal column.
+- [x] #2 CLI task and draft list commands accept --sort ordinal.
+- [x] #3 Focused CLI and browser tests pass for ordinal sorting behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebase the PR branch onto latest main.
+2. Add ordinal as a supported browser list sort column.
+3. Add ordinal as a valid CLI list sort field and update help text.
+4. Add focused tests for browser and CLI ordinal sorting.
+5. Run focused and full validation before handoff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in PR #645. Updated src/web/components/TaskList.tsx, src/cli.ts, and focused CLI/Web tests.
+
+Validation on the rebased branch passed: bun test --timeout=10000 src/test/cli-task-list-ordinal-sort.test.ts src/test/cli-priority-filtering.test.ts src/test/web-task-list-labels-menu.test.tsx (19 pass, 0 fail).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR #645 adds ordinal sorting to the browser task list and CLI list commands, with focused tests for ordinal column rendering, sort behavior, and CLI sort validation.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,6 +170,8 @@ const MCP_CLIENT_INSTRUCTION_MAP: Record<string, AgentInstructionFile> = {
 
 const DOCUMENT_SEARCH_QUERY_MAX_LENGTH = 200;
 const DOCUMENT_SEARCH_LIMIT_MAX = 100;
+const TASK_SORT_FIELDS = ["priority", "id", "ordinal"];
+const TASK_SORT_FIELD_LIST = TASK_SORT_FIELDS.join(", ");
 
 async function openUrlInBrowser(url: string): Promise<void> {
 	let cmd: string[];
@@ -2029,7 +2031,7 @@ addHelpSchema(taskCmd.command("list"), {
 		},
 		{ name: "search", type: "String", description: "Search task title, description, notes, comments, and metadata" },
 		{ name: "limit", type: "Positive integer", description: "Maximum tasks to display after sorting" },
-		{ name: "sort", type: choiceType(["priority", "id"]), description: "Task ordering before applying limit" },
+		{ name: "sort", type: choiceType(TASK_SORT_FIELDS), description: "Task ordering before applying limit" },
 	],
 	output: "Interactive task list or plain text with --plain",
 	examples: [
@@ -2052,7 +2054,7 @@ addHelpSchema(taskCmd.command("list"), {
 	)
 	.option("--search <query>", "search task title, description, notes, comments, and metadata")
 	.option("--limit <number>", "limit tasks displayed after sorting")
-	.option("--sort <field>", "sort tasks by field (priority, id)")
+	.option("--sort <field>", `sort tasks by field (${TASK_SORT_FIELD_LIST})`)
 	.option("--plain", "use plain text output instead of interactive UI")
 	.action(async (options) => {
 		const cwd = await requireProjectRoot();
@@ -2112,10 +2114,9 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 
 		if (options.sort) {
-			const validSortFields = ["priority", "id"];
 			const sortField = options.sort.toLowerCase();
-			if (!validSortFields.includes(sortField)) {
-				console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id`);
+			if (!TASK_SORT_FIELDS.includes(sortField)) {
+				console.error(`Invalid sort field: ${options.sort}. Valid values are: ${TASK_SORT_FIELD_LIST}`);
 				process.exitCode = 1;
 				cleanup();
 				return;
@@ -2145,10 +2146,9 @@ addHelpSchema(taskCmd.command("list"), {
 
 			let sortedTasks = tasks;
 			if (options.sort) {
-				const validSortFields = ["priority", "id"];
 				const sortField = options.sort.toLowerCase();
-				if (!validSortFields.includes(sortField)) {
-					console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id`);
+				if (!TASK_SORT_FIELDS.includes(sortField)) {
+					console.error(`Invalid sort field: ${options.sort}. Valid values are: ${TASK_SORT_FIELD_LIST}`);
 					process.exitCode = 1;
 					cleanup();
 					return;
@@ -2317,10 +2317,9 @@ addHelpSchema(taskCmd.command("list"), {
 
 				let sortedTasks = tasks;
 				if (options.sort) {
-					const validSortFields = ["priority", "id"];
 					const sortField = options.sort.toLowerCase();
-					if (!validSortFields.includes(sortField)) {
-						throw new Error(`Invalid sort field: ${options.sort}. Valid values are: priority, id`);
+					if (!TASK_SORT_FIELDS.includes(sortField)) {
+						throw new Error(`Invalid sort field: ${options.sort}. Valid values are: ${TASK_SORT_FIELD_LIST}`);
 					}
 					sortedTasks = sortTasks(tasks, sortField);
 				} else {
@@ -3026,7 +3025,7 @@ const draftCmd = program.command("draft");
 draftCmd
 	.command("list")
 	.description("list all drafts")
-	.option("--sort <field>", "sort drafts by field (priority, id)")
+	.option("--sort <field>", `sort drafts by field (${TASK_SORT_FIELD_LIST})`)
 	.option("--plain", "use plain text output")
 	.action(async (options: { plain?: boolean; sort?: string }) => {
 		const cwd = await requireProjectRoot();
@@ -3044,10 +3043,9 @@ draftCmd
 		let sortedDrafts = drafts;
 
 		if (options.sort) {
-			const validSortFields = ["priority", "id"];
 			const sortField = options.sort.toLowerCase();
-			if (!validSortFields.includes(sortField)) {
-				console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id`);
+			if (!TASK_SORT_FIELDS.includes(sortField)) {
+				console.error(`Invalid sort field: ${options.sort}. Valid values are: ${TASK_SORT_FIELD_LIST}`);
 				process.exitCode = 1;
 				return;
 			}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1844,7 +1844,7 @@ taskCmd
 	.option("-m, --milestone <milestone>", "filter tasks by milestone (closest match, case-insensitive)")
 	.option("-p, --parent <taskId>", "filter tasks by parent task ID")
 	.option("--priority <priority>", "filter tasks by priority (high, medium, low)")
-	.option("--sort <field>", "sort tasks by field (priority, id)")
+	.option("--sort <field>", "sort tasks by field (priority, id, ordinal)")
 	.option("--plain", "use plain text output instead of interactive UI")
 	.action(async (options) => {
 		const cwd = await requireProjectRoot();
@@ -1883,10 +1883,10 @@ taskCmd
 		}
 
 		if (options.sort) {
-			const validSortFields = ["priority", "id"];
+			const validSortFields = ["priority", "id", "ordinal"];
 			const sortField = options.sort.toLowerCase();
 			if (!validSortFields.includes(sortField)) {
-				console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id`);
+				console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id, ordinal`);
 				process.exitCode = 1;
 				cleanup();
 				return;
@@ -1912,10 +1912,10 @@ taskCmd
 
 			let sortedTasks = tasks;
 			if (options.sort) {
-				const validSortFields = ["priority", "id"];
+				const validSortFields = ["priority", "id", "ordinal"];
 				const sortField = options.sort.toLowerCase();
 				if (!validSortFields.includes(sortField)) {
-					console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id`);
+					console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id, ordinal`);
 					process.exitCode = 1;
 					cleanup();
 					return;
@@ -2066,10 +2066,10 @@ taskCmd
 
 				let sortedTasks = tasks;
 				if (options.sort) {
-					const validSortFields = ["priority", "id"];
+					const validSortFields = ["priority", "id", "ordinal"];
 					const sortField = options.sort.toLowerCase();
 					if (!validSortFields.includes(sortField)) {
-						throw new Error(`Invalid sort field: ${options.sort}. Valid values are: priority, id`);
+						throw new Error(`Invalid sort field: ${options.sort}. Valid values are: priority, id, ordinal`);
 					}
 					sortedTasks = sortTasks(tasks, sortField);
 				} else {
@@ -2593,7 +2593,7 @@ const draftCmd = program.command("draft");
 draftCmd
 	.command("list")
 	.description("list all drafts")
-	.option("--sort <field>", "sort drafts by field (priority, id)")
+	.option("--sort <field>", "sort drafts by field (priority, id, ordinal)")
 	.option("--plain", "use plain text output")
 	.action(async (options: { plain?: boolean; sort?: string }) => {
 		const cwd = await requireProjectRoot();
@@ -2611,10 +2611,10 @@ draftCmd
 		let sortedDrafts = drafts;
 
 		if (options.sort) {
-			const validSortFields = ["priority", "id"];
+			const validSortFields = ["priority", "id", "ordinal"];
 			const sortField = options.sort.toLowerCase();
 			if (!validSortFields.includes(sortField)) {
-				console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id`);
+				console.error(`Invalid sort field: ${options.sort}. Valid values are: priority, id, ordinal`);
 				process.exitCode = 1;
 				return;
 			}

--- a/src/test/cli-priority-filtering.test.ts
+++ b/src/test/cli-priority-filtering.test.ts
@@ -76,7 +76,7 @@ describe("CLI Priority Filtering", () => {
 		const result = await $`bun run cli task list --sort invalid --plain`.nothrow().quiet();
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr.toString()).toContain("Invalid sort field: invalid");
-		expect(result.stderr.toString()).toContain("Valid values are: priority, id");
+		expect(result.stderr.toString()).toContain("Valid values are: priority, id, ordinal");
 	});
 
 	test("task list combines priority filter with status filter", async () => {

--- a/src/test/cli-task-list-ordinal-sort.test.ts
+++ b/src/test/cli-task-list-ordinal-sort.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+const cliPath = join(process.cwd(), "src", "cli.ts");
+
+const createTask = (overrides: Partial<Task>): Task => ({
+	id: "task-1",
+	title: "Task",
+	status: "To Do",
+	assignee: [],
+	labels: [],
+	dependencies: [],
+	createdDate: "2026-01-01",
+	...overrides,
+});
+
+const expectInOrder = (output: string, ids: string[]) => {
+	let previousPosition = -1;
+	for (const id of ids) {
+		const position = output.indexOf(id);
+		expect(position).toBeGreaterThanOrEqual(0);
+		expect(position).toBeGreaterThan(previousPosition);
+		previousPosition = position;
+	}
+};
+
+describe("CLI task list ordinal sorting", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-task-list-ordinal-sort");
+		await rm(TEST_DIR, { recursive: true, force: true });
+		await mkdir(TEST_DIR, { recursive: true });
+
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await initializeTestProject(core, "Task List Ordinal Sort Test");
+
+		await core.createTask(createTask({ id: "task-1", title: "No ordinal" }), false);
+		await core.createTask(createTask({ id: "task-2", title: "Second ordinal", ordinal: 20 }), false);
+		await core.createTask(createTask({ id: "task-3", title: "First ordinal", ordinal: 10 }), false);
+		await core.createTask(createTask({ id: "task-4", title: "Tied ordinal", ordinal: 20 }), false);
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("orders tasks by ordinal before task ID and leaves missing ordinals last", async () => {
+		const result = await $`bun ${cliPath} task list --sort ordinal --plain`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		expectInOrder(result.stdout.toString(), ["TASK-3", "TASK-2", "TASK-4", "TASK-1"]);
+	});
+
+	it("shows ordinal in the invalid sort field message", async () => {
+		const result = await $`bun ${cliPath} task list --sort invalid --plain`.cwd(TEST_DIR).nothrow().quiet();
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr.toString()).toContain("Invalid sort field: invalid");
+		expect(result.stderr.toString()).toContain("Valid values are: priority, id, ordinal");
+	});
+});

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -275,7 +275,7 @@ describe("CLI Integration", () => {
 			expect(listHelp).toContain("labels: Comma-separated strings");
 			expect(listHelp).toContain("search: String");
 			expect(listHelp).toContain("limit: Positive integer");
-			expect(listHelp).toContain("sort: one of: priority, id");
+			expect(listHelp).toContain("sort: one of: priority, id, ordinal");
 			expect(listHelp).toContain('backlog task list --labels frontend,bug --search "login" --limit 10 --plain');
 			expect(editHelp).toContain("taskId: Task ID");
 			expect(editHelp).toContain("status: one of configured statuses: To Do, In Progress, Done");

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -135,6 +135,9 @@ const getZIndexClass = (element: Element): number | null => {
 	return value ? Number.parseInt(value, 10) : null;
 };
 
+const getRenderedTaskIds = (container: HTMLElement): string[] =>
+	Array.from(container.querySelectorAll("tbody tr td:first-child")).map((cell) => cell.textContent?.trim() ?? "");
+
 afterEach(() => {
 	globalThis.fetch = originalFetch;
 	if (activeRoot) {
@@ -150,6 +153,34 @@ describe("TaskList labels filter menu", () => {
 		const container = renderTaskList(["/?query=docs"]);
 
 		expect(container.querySelector("input[placeholder='Search tasks']")).toBeNull();
+	});
+
+	it("renders and sorts by ordinal with task ID as the tie-breaker", async () => {
+		const container = renderTaskList(undefined, {
+			tasks: [
+				createTask({ id: "task-1", title: "No ordinal" }),
+				createTask({ id: "task-2", title: "Tied ordinal A", ordinal: 20 }),
+				createTask({ id: "task-3", title: "First ordinal", ordinal: 10 }),
+				createTask({ id: "task-4", title: "Tied ordinal B", ordinal: 20 }),
+			],
+		});
+
+		const ordinalButton = Array.from(container.querySelectorAll("button")).find((button) =>
+			button.textContent?.includes("Ordinal"),
+		);
+		expect(ordinalButton).toBeTruthy();
+
+		await clickElement(ordinalButton as HTMLButtonElement);
+		await waitFor(() => getRenderedTaskIds(container)[0] === "task-3");
+
+		expect(getRenderedTaskIds(container)).toEqual(["task-3", "task-2", "task-4", "task-1"]);
+		expect(container.querySelector("th[aria-sort='ascending']")?.textContent).toContain("Ordinal");
+
+		await clickElement(ordinalButton as HTMLButtonElement);
+		await waitFor(() => getRenderedTaskIds(container)[0] === "task-2");
+
+		expect(getRenderedTaskIds(container)).toEqual(["task-2", "task-4", "task-3", "task-1"]);
+		expect(container.querySelector("th[aria-sort='descending']")?.textContent).toContain("Ordinal");
 	});
 
 	it("renders the labels menu above the sticky table header", async () => {

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -35,7 +35,7 @@ const PRIORITY_OPTIONS: Array<{ label: string; value: "" | SearchPriorityFilter 
 	{ label: "Low", value: "low" },
 ];
 
-type TaskSortColumn = "id" | "title" | "status" | "priority" | "milestone" | "created";
+type TaskSortColumn = "id" | "title" | "status" | "priority" | "ordinal" | "milestone" | "created";
 type SortDirection = "asc" | "desc";
 
 const PRIORITY_RANK: Record<string, number> = {
@@ -510,6 +510,7 @@ const TaskList: React.FC<TaskListProps> = ({
 			<col style={{ width: "28rem" }} />
 			<col style={{ width: "8rem" }} />
 			<col style={{ width: "7rem" }} />
+			<col style={{ width: "7rem" }} />
 			<col style={{ width: "11rem" }} />
 			<col style={{ width: "11rem" }} />
 			<col style={{ width: "11rem" }} />
@@ -543,6 +544,18 @@ const TaskList: React.FC<TaskListProps> = ({
 					result = withDirection(rankA - rankB);
 					break;
 				}
+				case "ordinal": {
+					const aOrd = a.ordinal;
+					const bOrd = b.ordinal;
+					if (typeof aOrd === "number" && typeof bOrd === "number") {
+						result = withDirection(aOrd - bOrd);
+					} else if (typeof aOrd === "number") {
+						result = -1;
+					} else if (typeof bOrd === "number") {
+						result = 1;
+					}
+					break;
+				}
 				case "milestone": {
 					const milestoneA = getMilestoneLabel(a.milestone, milestoneEntities);
 					const milestoneB = getMilestoneLabel(b.milestone, milestoneEntities);
@@ -566,6 +579,7 @@ const TaskList: React.FC<TaskListProps> = ({
 			}
 
 			if (result !== 0) return result;
+			if (sortColumn === "ordinal") return compareTaskIdsAscending(a, b);
 			return compareTaskIdsAscending(b, a);
 		});
 	}, [displayTasks, milestoneEntities, sortColumn, sortDirection]);
@@ -726,6 +740,7 @@ const TaskList: React.FC<TaskListProps> = ({
 										{renderSortableHeader("Title", "title")}
 										{renderSortableHeader("Status", "status")}
 										{renderSortableHeader("Priority", "priority")}
+										{renderSortableHeader("Ordinal", "ordinal")}
 										<th className="px-3 py-2">Labels</th>
 										<th className="px-3 py-2">Assignee</th>
 										{renderSortableHeader("Milestone", "milestone")}
@@ -798,6 +813,9 @@ const TaskList: React.FC<TaskListProps> = ({
 												) : (
 													<span className="text-xs text-gray-300 dark:text-gray-600">—</span>
 												)}
+											</td>
+											<td className="px-3 py-2.5 text-xs font-mono text-gray-500 dark:text-gray-400 whitespace-nowrap">
+												{task.ordinal !== undefined ? task.ordinal : <span className="text-gray-300 dark:text-gray-600">—</span>}
 											</td>
 											<td className="px-3 py-2.5">
 												{visibleLabels.length > 0 ? (

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -34,7 +34,7 @@ const PRIORITY_OPTIONS: Array<{ label: string; value: "" | SearchPriorityFilter 
 	{ label: "Low", value: "low" },
 ];
 
-type TaskSortColumn = "id" | "title" | "status" | "priority" | "milestone" | "created";
+type TaskSortColumn = "id" | "title" | "status" | "priority" | "ordinal" | "milestone" | "created";
 type SortDirection = "asc" | "desc";
 
 const PRIORITY_RANK: Record<string, number> = {
@@ -508,6 +508,7 @@ const TaskList: React.FC<TaskListProps> = ({
 			<col style={{ width: "28rem" }} />
 			<col style={{ width: "8rem" }} />
 			<col style={{ width: "7rem" }} />
+			<col style={{ width: "7rem" }} />
 			<col style={{ width: "11rem" }} />
 			<col style={{ width: "11rem" }} />
 			<col style={{ width: "11rem" }} />
@@ -539,6 +540,18 @@ const TaskList: React.FC<TaskListProps> = ({
 					const rankA = PRIORITY_RANK[(a.priority ?? "").toLowerCase()] ?? 0;
 					const rankB = PRIORITY_RANK[(b.priority ?? "").toLowerCase()] ?? 0;
 					result = withDirection(rankA - rankB);
+					break;
+				}
+				case "ordinal": {
+					const aOrd = a.ordinal;
+					const bOrd = b.ordinal;
+					if (typeof aOrd === "number" && typeof bOrd === "number") {
+						result = withDirection(aOrd - bOrd);
+					} else if (typeof aOrd === "number") {
+						result = -1; // tasks with ordinal come first
+					} else if (typeof bOrd === "number") {
+						result = 1;
+					}
 					break;
 				}
 				case "milestone": {
@@ -724,6 +737,7 @@ const TaskList: React.FC<TaskListProps> = ({
 										{renderSortableHeader("Title", "title")}
 										{renderSortableHeader("Status", "status")}
 										{renderSortableHeader("Priority", "priority")}
+										{renderSortableHeader("Ordinal", "ordinal")}
 										<th className="px-3 py-2">Labels</th>
 										<th className="px-3 py-2">Assignee</th>
 										{renderSortableHeader("Milestone", "milestone")}
@@ -796,6 +810,9 @@ const TaskList: React.FC<TaskListProps> = ({
 												) : (
 													<span className="text-xs text-gray-300 dark:text-gray-600">—</span>
 												)}
+											</td>
+											<td className="px-3 py-2.5 text-xs font-mono text-gray-500 dark:text-gray-400 whitespace-nowrap">
+												{task.ordinal !== undefined ? task.ordinal : <span className="text-gray-300 dark:text-gray-600">—</span>}
 											</td>
 											<td className="px-3 py-2.5">
 												{visibleLabels.length > 0 ? (


### PR DESCRIPTION
## Task

- [x] BACK-527 - Add ordinal sorting to task list views
- GitHub issue: #643

## Summary

The task list view now exposes ordinal ordering, matching the manual task sequence already respected by the board view. Users can sort by ordinal in the browser table and via CLI list commands.

## Changes

**`src/web/components/TaskList.tsx`**
- Added `"ordinal"` as a supported task sort column.
- Added a sortable **Ordinal** table column between Priority and Labels.
- Displays each task ordinal value, or `-` when unset.
- Sorts tasks with ordinal values by numeric ordinal and places tasks without ordinals after them.
- Preserves existing non-ordinal list sorting behavior.

**`src/cli.ts`**
- Added `ordinal` to valid task and draft list sort fields.
- Updated task and draft list help text to advertise `priority`, `id`, and `ordinal`.

**Tests and Task**
- Added CLI coverage for `--sort ordinal` and invalid-sort messaging.
- Added web list coverage for ordinal column rendering and sort behavior.
- Added completed Backlog task `BACK-527` to the PR branch.

## Validation

- [x] `bun test --timeout=10000 src/test/cli-task-list-ordinal-sort.test.ts src/test/cli-priority-filtering.test.ts src/test/web-task-list-labels-menu.test.tsx`
- [x] Previous full validation on this PR: `bunx tsc --noEmit`, `bun run check .`, `bun test --timeout=10000`, `bun run build`

Closes #643
