### PR TITLE
BACK-473 - handle port congestion for backlog browser

### DIFF
--- a/backlog/tasks/back-473 - handle-port-congestion-for-backlog-browser.md
+++ b/backlog/tasks/back-473 - handle-port-congestion-for-backlog-browser.md
@@ -3,12 +3,18 @@ id: BACK-473
 title: handle port congestion for backlog browser
 status: Done
 assignee:
-  - '@claude'
+  - '@codex'
 created_date: '2026-05-08 14:29'
-updated_date: '2026-05-13 18:52'
+updated_date: '2026-07-08 19:55'
 labels:
   - webui
 dependencies: []
+modified_files:
+  - src/server/index.ts
+  - src/cli.ts
+  - src/test/server-port.test.ts
+  - src/test/cli-browser-port.test.ts
+  - src/test/test-utils.ts
 ordinal: 166000
 ---
 
@@ -34,326 +40,41 @@ oh, and check if port is free before starting the backlog browser mode anyway. t
 - [x] #3 If user accepts (Y/enter), server starts on the suggested port successfully
 - [x] #4 If user declines (n/N), process exits cleanly with code 0
 - [x] #5 isPortAvailable() and findNextAvailablePort() are exported from src/server/index.ts and unit-tested (min 3 cases, ≥1 error/edge case)
-- [ ] #6 --non-interactive flag skips prompt and auto-selects next free port
+- [x] #6 --non-interactive flag skips prompt and auto-selects next free port
+- [x] #7 findNextAvailablePort stops at port 65535 and fails cleanly when no available port exists
+- [x] #8 Non-TTY or explicitly non-interactive browser startup does not wait for a prompt
+- [x] #9 Port availability tests avoid fixed high ports that can collide on shared machines
 <!-- AC:END -->
-
-
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-## Implementation Plan (pre-approved, executor can start immediately)
-
-### Architecture
-
-Keep `BacklogServer.start()` pure — accepts a port, tries to bind, throws on failure.
-Put all pre-check and interactive retry UX in the CLI browser command action (`src/cli.ts`).
-This keeps the server class testable without stdin mocking.
-
-### Env / Tooling Constraints (non-negotiable)
-
-- **All code reads/writes via Serena MCP** — `mcp__plugin_serena_serena__read_file`, `replace_content`, `replace_symbol_body`, `insert_after_symbol`. Never use Read/Edit/Write tools or grep via Bash for source code.
-- **Backlog CLI**: `/home/jo/kit/claude-code-llm-kram/Backlog.md/dist/backlog` (absolute path only; `~/.bun/bin/backlog` is unreliable)
-- **Bash only for**: git ops, `bun test`, backlog CLI
-- **Tests**: always `bun test --only-failures 2>&1` — never bare `bun test`
-- **TDD strictly**: write failing tests (RED) before any implementation; confirm RED before writing impl code
-- **AC/DoD check-off**: check each item immediately after implementing+verifying it, not batch at end
-- **`--final-summary` is mandatory** at task close — always with Heredoc
-
----
-
-### Step 0: Worktree + Backlog Setup
-
-```bash
-# Verify upstream-master == origin/main (zero delta expected)
-git fetch
-git log upstream-master..origin/main --oneline
-git log origin/main..upstream-master --oneline
-
-# Create worktree
-git worktree add ./worktrees/back-473-port-congestion upstream-master
-cd ./worktrees/back-473-port-congestion && bun i --frozen-lockfile
-```
-
-Activate Serena on the worktree **before editing any files**:
-```
-mcp__plugin_serena_serena__activate_project({ project: "/home/jo/kit/claude-code-llm-kram/Backlog.md/worktrees/back-473-port-congestion" })
-```
-
-Mark task In Progress:
-```bash
-BACKLOG=/home/jo/kit/claude-code-llm-kram/Backlog.md/dist/backlog
-$BACKLOG task edit BACK-473 --status "In Progress" --assignee "@claude"
-```
-
----
-
-### Step 1: Write Failing Tests First (RED)
-
-Create `src/test/server-port.test.ts`:
-
-```typescript
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import net from "net";
-import { findNextAvailablePort, isPortAvailable } from "../server/index.ts";
-
-describe("isPortAvailable", () => {
-  it("returns true for a free port", async () => {
-    const result = await isPortAvailable(49999);
-    expect(result).toBe(true);
-  });
-
-  it("returns false when a server already occupies the port", async () => {
-    const srv = net.createServer();
-    await new Promise<void>((resolve) => srv.listen(50001, "127.0.0.1", () => resolve()));
-    try {
-      const result = await isPortAvailable(50001);
-      expect(result).toBe(false);
-    } finally {
-      await new Promise<void>((resolve) => srv.close(() => resolve()));
-    }
-  });
-
-  it("returns false for port 0 (out-of-range for browser use)", async () => {
-    const result = await isPortAvailable(0);
-    expect(result).toBe(false);
-  });
-});
-
-describe("findNextAvailablePort", () => {
-  it("returns startPort when it is free", async () => {
-    const port = await findNextAvailablePort(49990);
-    expect(port).toBe(49990);
-  });
-
-  it("skips occupied ports and returns first free one", async () => {
-    const srv = net.createServer();
-    await new Promise<void>((resolve) => srv.listen(49985, "127.0.0.1", () => resolve()));
-    try {
-      const port = await findNextAvailablePort(49985);
-      expect(port).toBeGreaterThan(49985);
-    } finally {
-      await new Promise<void>((resolve) => srv.close(() => resolve()));
-    }
-  });
-});
-```
-
-Confirm RED:
-```bash
-bun test src/test/server-port.test.ts --only-failures 2>&1
-```
-(Should fail with "isPortAvailable is not exported" or similar)
-
----
-
-### Step 2: Implement Helpers in `src/server/index.ts` (GREEN)
-
-Add after the existing imports at the top of `src/server/index.ts`:
-
-```typescript
-import net from "net";
-
-export async function isPortAvailable(port: number): Promise<boolean> {
-  if (port < 1 || port > 65535) return false;
-  return new Promise((resolve) => {
-    const srv = net.createServer();
-    srv.listen(port, "127.0.0.1", () => srv.close(() => resolve(true)));
-    srv.on("error", () => resolve(false));
-  });
-}
-
-export async function findNextAvailablePort(startPort: number): Promise<number> {
-  let port = startPort;
-  while (!(await isPortAvailable(port))) port++;
-  return port;
-}
-```
-
-Confirm GREEN:
-```bash
-bun test src/test/server-port.test.ts --only-failures 2>&1
-```
-
-Check off AC #5:
-```bash
-$BACKLOG task edit BACK-473 --check-ac 5
-```
-
----
-
-### Step 3: Update CLI Browser Command (`src/cli.ts`)
-
-Current browser command action is at approximately line 3857 in `src/cli.ts`. Read the surrounding context with Serena first to get exact line numbers.
-
-The current code has:
-```typescript
-const port = Number.parseInt(options.port || defaultPort.toString(), 10);
-if (Number.isNaN(port) || port < 1 || port > 65535) { ... }
-await server.start(port, options.open !== false);
-```
-
-Changes needed:
-1. Change `const port` → `let port` (needs reassignment on retry)
-2. Add import for `isPortAvailable` and `findNextAvailablePort` from `./server/index.ts` (check if already imported)
-3. Add import for `readline` from `"readline"` (Node built-in, available in Bun)
-4. Insert port pre-check block **after** the port validation check and **before** `await server.start(...)`:
-
-```typescript
-// Pre-check port availability and offer interactive retry
-if (!(await isPortAvailable(port))) {
-  const nextPort = await findNextAvailablePort(port + 1);
-  const answer = await new Promise<string>((resolve) => {
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    rl.question(
-      `\n⚠️  Port ${port} is already in use.\n💡 Port ${nextPort} is available. Start on port ${nextPort}? [Y/n] `,
-      (ans) => {
-        rl.close();
-        resolve(ans.trim().toLowerCase());
-      }
-    );
-  });
-  if (answer === "" || answer === "y") {
-    port = nextPort;
-  } else {
-    console.log("Aborted.");
-    process.exit(0);
-  }
-}
-```
-
-Check off AC #1–4 as each behavior is wired up:
-```bash
-$BACKLOG task edit BACK-473 --check-ac 1
-$BACKLOG task edit BACK-473 --check-ac 2
-$BACKLOG task edit BACK-473 --check-ac 3
-$BACKLOG task edit BACK-473 --check-ac 4
-```
-
----
-
-### Step 4: Simplify EADDRINUSE Catch in `src/server/index.ts`
-
-The catch block in `BacklogServer.start()` (around line 463–481 in the original file) currently:
-- Detects EADDRINUSE
-- Prints `port+1` suggestion
-- Exits with code 1
-
-Since the CLI now handles the UX before `start()` is called, simplify to:
-```typescript
-if (errorCode === "EADDRINUSE" || errorMessage?.includes("address already in use")) {
-  console.error(`\n❌ Error: Port ${finalPort} is already in use. Use --port to specify a different port.\n`);
-  process.exit(1);
-}
-```
-(Remove the suggestions block — CLI handles that now.)
-
----
-
-### Step 5: Verify Everything
-
-```bash
-# Type check (DoD #1)
-bunx tsc --noEmit
-$BACKLOG task edit BACK-473 --check-dod 1
-
-# Lint/format (DoD #2)
-bun run check .
-$BACKLOG task edit BACK-473 --check-dod 2
-
-# Full test suite (DoD #3)
-bun test --only-failures 2>&1
-$BACKLOG task edit BACK-473 --check-dod 3
-```
-
----
-
-### Step 6: Commit + PR
-
-```bash
-cd ./worktrees/back-473-port-congestion
-git checkout -b tasks/back-473-port-congestion
-git add src/server/index.ts src/cli.ts src/test/server-port.test.ts
-git commit -m "$(cat <<'EOF'
-BACK-473 - handle port congestion for backlog browser
-
-Add isPortAvailable() and findNextAvailablePort() to server/index.ts,
-pre-check port in CLI browser command, prompt user to start on next
-free port if taken. Simplify EADDRINUSE catch (UX now in CLI).
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
-EOF
-)"
-git push origin tasks/back-473-port-congestion
-gh pr create --title "BACK-473 - handle port congestion for backlog browser" \
-  --body "$(cat <<'EOF'
-## Summary
-- Add `isPortAvailable()` and `findNextAvailablePort()` helpers to `src/server/index.ts`
-- Pre-check port availability in CLI browser command before calling `server.start()`
-- If port is taken: suggest next free port, prompt user interactively (readline), start there if accepted
-- Simplify EADDRINUSE catch block in `BacklogServer.start()` (UX handled upstream in CLI)
-- Unit tests for port helpers (5 cases, including 2 error/edge cases)
-
-## Test plan
-- [ ] `bun test src/test/server-port.test.ts --only-failures` passes
-- [ ] `bun test --only-failures` — no new failures
-- [ ] `bunx tsc --noEmit` passes
-- [ ] `bun run check .` passes
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
-
----
-
-### Step 7: Finalize Task
-
-```bash
-$BACKLOG task edit BACK-473 \
-  --notes "$(cat <<'EOF'
-Files changed:
-- src/server/index.ts: added isPortAvailable(), findNextAvailablePort() exports; simplified EADDRINUSE catch block
-- src/cli.ts: added pre-check + readline interactive retry loop in browser command; changed const port → let port
-- src/test/server-port.test.ts: NEW - 5 unit tests for port helpers (3 for isPortAvailable, 2 for findNextAvailablePort)
-
-net module available in Bun via Node compat layer — no extra deps needed.
-EOF
-)" \
-  --final-summary "$(cat <<'EOF'
-Implemented proactive port availability check and interactive retry UX for backlog browser.
-Server stays pure (throws on error); CLI handles user interaction via readline.
-Commit: (fill in shorthash from git log --oneline -1)
-EOF
-)" \
-  --status Done
-```
-
----
-
-### Files Summary
-
-| File | Change |
-|------|--------|
-| `src/server/index.ts` | Add `isPortAvailable()` + `findNextAvailablePort()` exports; simplify catch |
-| `src/cli.ts` | Pre-check + readline prompt in browser command; `const` → `let` for port |
-| `src/test/server-port.test.ts` | NEW: 5 unit tests for port helpers |
+1. Inspect the existing browser command and port helper implementation against the PR review feedback.
+2. Bound port scanning so values above 65535 return a clean failure instead of looping.
+3. Make browser startup non-interactive by default in non-TTY/headless contexts while preserving prompts for interactive terminals.
+4. Replace fixed-port tests with ephemeral-port helpers and add coverage for max-port/no-port and headless behavior.
+5. Run focused tests, typecheck, and Biome check.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Files changed:
-- src/server/index.ts: added isPortAvailable(), findNextAvailablePort() exports; simplified EADDRINUSE catch block
-- src/cli.ts: added pre-check + readline interactive retry loop in browser command; changed const port → let port
-- src/test/server-port.test.ts: NEW - 5 unit tests for port helpers (3 for isPortAvailable, 2 for findNextAvailablePort)
+Review follow-up for PR #651:
+- Bounded findNextAvailablePort() to the valid browser port range and return null when no port can be selected.
+- Browser startup now treats non-TTY/headless runs like --non-interactive, avoiding readline prompts that automation cannot answer.
+- Replaced fixed high-port tests with OS-assigned ephemeral ports and added coverage for bounded/no-port behavior.
+- Added a CLI subprocess test proving non-TTY browser startup auto-selects another port without prompting.
+
+Validation:
+- bun test src/test/server-port.test.ts src/test/cli-browser-port.test.ts: 8 pass.
+- bunx tsc --noEmit: pass.
+- bunx biome check src/cli.ts src/server/index.ts src/test/server-port.test.ts src/test/cli-browser-port.test.ts src/test/test-utils.ts: pass.
+- bun test: 1250 pass, 2 skip, 1 unrelated timeout in src/test/cli-priority-filtering.test.ts (case insensitive priority filtering); isolated rerun times out at the same 5s budget.
+- bun run check .: blocked by existing package.json indentation formatting, outside the touched files.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented proactive port availability check and interactive retry UX for backlog browser.
-Server stays pure (throws on error); CLI handles user interaction via readline.
-Commit: 00caebb - BACK-473 - handle port congestion for backlog browser
-PR: https://github.com/MrLesk/Backlog.md/pull/651
+Implemented the PR #651 requested changes: port scanning now stops at 65535 and fails cleanly, non-TTY/headless browser startup no longer prompts, and tests use ephemeral ports with coverage for bounded scans and non-interactive behavior. Verified focused tests, TypeScript, and scoped Biome; full-suite/check caveats are recorded in implementation notes.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-473 - handle-port-congestion-for-backlog-browser.md
+++ b/backlog/tasks/back-473 - handle-port-congestion-for-backlog-browser.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-05-08 14:29'
-updated_date: '2026-05-13 17:53'
+updated_date: '2026-05-13 18:52'
 labels:
   - webui
 dependencies: []
@@ -34,7 +34,10 @@ oh, and check if port is free before starting the backlog browser mode anyway. t
 - [x] #3 If user accepts (Y/enter), server starts on the suggested port successfully
 - [x] #4 If user declines (n/N), process exits cleanly with code 0
 - [x] #5 isPortAvailable() and findNextAvailablePort() are exported from src/server/index.ts and unit-tested (min 3 cases, ≥1 error/edge case)
+- [ ] #6 --non-interactive flag skips prompt and auto-selects next free port
 <!-- AC:END -->
+
+
 
 ## Implementation Plan
 

--- a/backlog/tasks/back-473 - handle-port-congestion-for-backlog-browser.md
+++ b/backlog/tasks/back-473 - handle-port-congestion-for-backlog-browser.md
@@ -1,0 +1,356 @@
+---
+id: BACK-473
+title: handle port congestion for backlog browser
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-05-08 14:29'
+updated_date: '2026-05-13 17:53'
+labels:
+  - webui
+dependencies: []
+ordinal: 166000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+If port 6420 is taken, ask user to try a different one. Ideally just increment port number (e.g. 6421), check if free and start if user accepts this.
+
+oh, and check if port is free before starting the backlog browser mode anyway. this seems to not happen correctly O_o
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Port is checked for availability before Bun.serve() is called (proactive check, not just catching EADDRINUSE)
+- [x] #2 If port is taken, user is shown the next available port (port+1 or higher) and asked to confirm interactively
+- [x] #3 If user accepts (Y/enter), server starts on the suggested port successfully
+- [x] #4 If user declines (n/N), process exits cleanly with code 0
+- [x] #5 isPortAvailable() and findNextAvailablePort() are exported from src/server/index.ts and unit-tested (min 3 cases, ≥1 error/edge case)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Implementation Plan (pre-approved, executor can start immediately)
+
+### Architecture
+
+Keep `BacklogServer.start()` pure — accepts a port, tries to bind, throws on failure.
+Put all pre-check and interactive retry UX in the CLI browser command action (`src/cli.ts`).
+This keeps the server class testable without stdin mocking.
+
+### Env / Tooling Constraints (non-negotiable)
+
+- **All code reads/writes via Serena MCP** — `mcp__plugin_serena_serena__read_file`, `replace_content`, `replace_symbol_body`, `insert_after_symbol`. Never use Read/Edit/Write tools or grep via Bash for source code.
+- **Backlog CLI**: `/home/jo/kit/claude-code-llm-kram/Backlog.md/dist/backlog` (absolute path only; `~/.bun/bin/backlog` is unreliable)
+- **Bash only for**: git ops, `bun test`, backlog CLI
+- **Tests**: always `bun test --only-failures 2>&1` — never bare `bun test`
+- **TDD strictly**: write failing tests (RED) before any implementation; confirm RED before writing impl code
+- **AC/DoD check-off**: check each item immediately after implementing+verifying it, not batch at end
+- **`--final-summary` is mandatory** at task close — always with Heredoc
+
+---
+
+### Step 0: Worktree + Backlog Setup
+
+```bash
+# Verify upstream-master == origin/main (zero delta expected)
+git fetch
+git log upstream-master..origin/main --oneline
+git log origin/main..upstream-master --oneline
+
+# Create worktree
+git worktree add ./worktrees/back-473-port-congestion upstream-master
+cd ./worktrees/back-473-port-congestion && bun i --frozen-lockfile
+```
+
+Activate Serena on the worktree **before editing any files**:
+```
+mcp__plugin_serena_serena__activate_project({ project: "/home/jo/kit/claude-code-llm-kram/Backlog.md/worktrees/back-473-port-congestion" })
+```
+
+Mark task In Progress:
+```bash
+BACKLOG=/home/jo/kit/claude-code-llm-kram/Backlog.md/dist/backlog
+$BACKLOG task edit BACK-473 --status "In Progress" --assignee "@claude"
+```
+
+---
+
+### Step 1: Write Failing Tests First (RED)
+
+Create `src/test/server-port.test.ts`:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import net from "net";
+import { findNextAvailablePort, isPortAvailable } from "../server/index.ts";
+
+describe("isPortAvailable", () => {
+  it("returns true for a free port", async () => {
+    const result = await isPortAvailable(49999);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when a server already occupies the port", async () => {
+    const srv = net.createServer();
+    await new Promise<void>((resolve) => srv.listen(50001, "127.0.0.1", () => resolve()));
+    try {
+      const result = await isPortAvailable(50001);
+      expect(result).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => srv.close(() => resolve()));
+    }
+  });
+
+  it("returns false for port 0 (out-of-range for browser use)", async () => {
+    const result = await isPortAvailable(0);
+    expect(result).toBe(false);
+  });
+});
+
+describe("findNextAvailablePort", () => {
+  it("returns startPort when it is free", async () => {
+    const port = await findNextAvailablePort(49990);
+    expect(port).toBe(49990);
+  });
+
+  it("skips occupied ports and returns first free one", async () => {
+    const srv = net.createServer();
+    await new Promise<void>((resolve) => srv.listen(49985, "127.0.0.1", () => resolve()));
+    try {
+      const port = await findNextAvailablePort(49985);
+      expect(port).toBeGreaterThan(49985);
+    } finally {
+      await new Promise<void>((resolve) => srv.close(() => resolve()));
+    }
+  });
+});
+```
+
+Confirm RED:
+```bash
+bun test src/test/server-port.test.ts --only-failures 2>&1
+```
+(Should fail with "isPortAvailable is not exported" or similar)
+
+---
+
+### Step 2: Implement Helpers in `src/server/index.ts` (GREEN)
+
+Add after the existing imports at the top of `src/server/index.ts`:
+
+```typescript
+import net from "net";
+
+export async function isPortAvailable(port: number): Promise<boolean> {
+  if (port < 1 || port > 65535) return false;
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.listen(port, "127.0.0.1", () => srv.close(() => resolve(true)));
+    srv.on("error", () => resolve(false));
+  });
+}
+
+export async function findNextAvailablePort(startPort: number): Promise<number> {
+  let port = startPort;
+  while (!(await isPortAvailable(port))) port++;
+  return port;
+}
+```
+
+Confirm GREEN:
+```bash
+bun test src/test/server-port.test.ts --only-failures 2>&1
+```
+
+Check off AC #5:
+```bash
+$BACKLOG task edit BACK-473 --check-ac 5
+```
+
+---
+
+### Step 3: Update CLI Browser Command (`src/cli.ts`)
+
+Current browser command action is at approximately line 3857 in `src/cli.ts`. Read the surrounding context with Serena first to get exact line numbers.
+
+The current code has:
+```typescript
+const port = Number.parseInt(options.port || defaultPort.toString(), 10);
+if (Number.isNaN(port) || port < 1 || port > 65535) { ... }
+await server.start(port, options.open !== false);
+```
+
+Changes needed:
+1. Change `const port` → `let port` (needs reassignment on retry)
+2. Add import for `isPortAvailable` and `findNextAvailablePort` from `./server/index.ts` (check if already imported)
+3. Add import for `readline` from `"readline"` (Node built-in, available in Bun)
+4. Insert port pre-check block **after** the port validation check and **before** `await server.start(...)`:
+
+```typescript
+// Pre-check port availability and offer interactive retry
+if (!(await isPortAvailable(port))) {
+  const nextPort = await findNextAvailablePort(port + 1);
+  const answer = await new Promise<string>((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(
+      `\n⚠️  Port ${port} is already in use.\n💡 Port ${nextPort} is available. Start on port ${nextPort}? [Y/n] `,
+      (ans) => {
+        rl.close();
+        resolve(ans.trim().toLowerCase());
+      }
+    );
+  });
+  if (answer === "" || answer === "y") {
+    port = nextPort;
+  } else {
+    console.log("Aborted.");
+    process.exit(0);
+  }
+}
+```
+
+Check off AC #1–4 as each behavior is wired up:
+```bash
+$BACKLOG task edit BACK-473 --check-ac 1
+$BACKLOG task edit BACK-473 --check-ac 2
+$BACKLOG task edit BACK-473 --check-ac 3
+$BACKLOG task edit BACK-473 --check-ac 4
+```
+
+---
+
+### Step 4: Simplify EADDRINUSE Catch in `src/server/index.ts`
+
+The catch block in `BacklogServer.start()` (around line 463–481 in the original file) currently:
+- Detects EADDRINUSE
+- Prints `port+1` suggestion
+- Exits with code 1
+
+Since the CLI now handles the UX before `start()` is called, simplify to:
+```typescript
+if (errorCode === "EADDRINUSE" || errorMessage?.includes("address already in use")) {
+  console.error(`\n❌ Error: Port ${finalPort} is already in use. Use --port to specify a different port.\n`);
+  process.exit(1);
+}
+```
+(Remove the suggestions block — CLI handles that now.)
+
+---
+
+### Step 5: Verify Everything
+
+```bash
+# Type check (DoD #1)
+bunx tsc --noEmit
+$BACKLOG task edit BACK-473 --check-dod 1
+
+# Lint/format (DoD #2)
+bun run check .
+$BACKLOG task edit BACK-473 --check-dod 2
+
+# Full test suite (DoD #3)
+bun test --only-failures 2>&1
+$BACKLOG task edit BACK-473 --check-dod 3
+```
+
+---
+
+### Step 6: Commit + PR
+
+```bash
+cd ./worktrees/back-473-port-congestion
+git checkout -b tasks/back-473-port-congestion
+git add src/server/index.ts src/cli.ts src/test/server-port.test.ts
+git commit -m "$(cat <<'EOF'
+BACK-473 - handle port congestion for backlog browser
+
+Add isPortAvailable() and findNextAvailablePort() to server/index.ts,
+pre-check port in CLI browser command, prompt user to start on next
+free port if taken. Simplify EADDRINUSE catch (UX now in CLI).
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+git push origin tasks/back-473-port-congestion
+gh pr create --title "BACK-473 - handle port congestion for backlog browser" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `isPortAvailable()` and `findNextAvailablePort()` helpers to `src/server/index.ts`
+- Pre-check port availability in CLI browser command before calling `server.start()`
+- If port is taken: suggest next free port, prompt user interactively (readline), start there if accepted
+- Simplify EADDRINUSE catch block in `BacklogServer.start()` (UX handled upstream in CLI)
+- Unit tests for port helpers (5 cases, including 2 error/edge cases)
+
+## Test plan
+- [ ] `bun test src/test/server-port.test.ts --only-failures` passes
+- [ ] `bun test --only-failures` — no new failures
+- [ ] `bunx tsc --noEmit` passes
+- [ ] `bun run check .` passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Step 7: Finalize Task
+
+```bash
+$BACKLOG task edit BACK-473 \
+  --notes "$(cat <<'EOF'
+Files changed:
+- src/server/index.ts: added isPortAvailable(), findNextAvailablePort() exports; simplified EADDRINUSE catch block
+- src/cli.ts: added pre-check + readline interactive retry loop in browser command; changed const port → let port
+- src/test/server-port.test.ts: NEW - 5 unit tests for port helpers (3 for isPortAvailable, 2 for findNextAvailablePort)
+
+net module available in Bun via Node compat layer — no extra deps needed.
+EOF
+)" \
+  --final-summary "$(cat <<'EOF'
+Implemented proactive port availability check and interactive retry UX for backlog browser.
+Server stays pure (throws on error); CLI handles user interaction via readline.
+Commit: (fill in shorthash from git log --oneline -1)
+EOF
+)" \
+  --status Done
+```
+
+---
+
+### Files Summary
+
+| File | Change |
+|------|--------|
+| `src/server/index.ts` | Add `isPortAvailable()` + `findNextAvailablePort()` exports; simplify catch |
+| `src/cli.ts` | Pre-check + readline prompt in browser command; `const` → `let` for port |
+| `src/test/server-port.test.ts` | NEW: 5 unit tests for port helpers |
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Files changed:
+- src/server/index.ts: added isPortAvailable(), findNextAvailablePort() exports; simplified EADDRINUSE catch block
+- src/cli.ts: added pre-check + readline interactive retry loop in browser command; changed const port → let port
+- src/test/server-port.test.ts: NEW - 5 unit tests for port helpers (3 for isPortAvailable, 2 for findNextAvailablePort)
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented proactive port availability check and interactive retry UX for backlog browser.
+Server stays pure (throws on error); CLI handles user interaction via readline.
+Commit: 00caebb - BACK-473 - handle port congestion for backlog browser
+PR: https://github.com/MrLesk/Backlog.md/pull/651
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3841,7 +3841,7 @@ program
 	.action(async (options) => {
 		try {
 			const cwd = await requireProjectRoot();
-			const { BacklogServer } = await import("./server/index.ts");
+			const { BacklogServer, findNextAvailablePort, isPortAvailable } = await import("./server/index.ts");
 			const server = new BacklogServer(cwd);
 
 			// Load config to get default port
@@ -3849,10 +3849,30 @@ program
 			const config = await core.filesystem.loadConfig();
 			const defaultPort = config?.defaultPort ?? 6420;
 
-			const port = Number.parseInt(options.port || defaultPort.toString(), 10);
+			let port = Number.parseInt(options.port || defaultPort.toString(), 10);
 			if (Number.isNaN(port) || port < 1 || port > 65535) {
 				console.error("Invalid port number. Must be between 1 and 65535.");
 				process.exit(1);
+			}
+
+			// Pre-check port availability and offer interactive retry
+			if (!(await isPortAvailable(port))) {
+				const nextPort = await findNextAvailablePort(port + 1);
+				const rl = createInterface({ input, output: process.stdout });
+				const answer = (
+					await rl.question(
+						`\n⚠️  Port ${port} is already in use.\n💡 Port ${nextPort} is available. Start on port ${nextPort}? [Y/n] `,
+					)
+				)
+					.trim()
+					.toLowerCase();
+				rl.close();
+				if (answer === "" || answer === "y") {
+					port = nextPort;
+				} else {
+					console.log("Aborted.");
+					process.exit(0);
+				}
 			}
 
 			await server.start(port, options.open !== false);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3838,6 +3838,7 @@ program
 	.description("open browser interface for task management (press Ctrl+C or Cmd+C to stop)")
 	.option("-p, --port <port>", "port to run server on")
 	.option("--no-open", "don't automatically open browser")
+	.option("--non-interactive", "automatically use next free port without asking")
 	.action(async (options) => {
 		try {
 			const cwd = await requireProjectRoot();
@@ -3858,20 +3859,25 @@ program
 			// Pre-check port availability and offer interactive retry
 			if (!(await isPortAvailable(port))) {
 				const nextPort = await findNextAvailablePort(port + 1);
-				const rl = createInterface({ input, output: process.stdout });
-				const answer = (
-					await rl.question(
-						`\n⚠️  Port ${port} is already in use.\n💡 Port ${nextPort} is available. Start on port ${nextPort}? [Y/n] `,
-					)
-				)
-					.trim()
-					.toLowerCase();
-				rl.close();
-				if (answer === "" || answer === "y") {
+				if (options.nonInteractive) {
+					console.log(`⚠️  Port ${port} is already in use. Using port ${nextPort} instead.`);
 					port = nextPort;
 				} else {
-					console.log("Aborted.");
-					process.exit(0);
+					const rl = createInterface({ input, output: process.stdout });
+					const answer = (
+						await rl.question(
+							`\n⚠️  Port ${port} is already in use.\n💡 Port ${nextPort} is available. Start on port ${nextPort}? [Y/n] `,
+						)
+					)
+						.trim()
+						.toLowerCase();
+					rl.close();
+					if (answer === "" || answer === "y") {
+						port = nextPort;
+					} else {
+						console.log("Aborted.");
+						process.exit(0);
+					}
 				}
 			}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3859,7 +3859,13 @@ program
 			// Pre-check port availability and offer interactive retry
 			if (!(await isPortAvailable(port))) {
 				const nextPort = await findNextAvailablePort(port + 1);
-				if (options.nonInteractive) {
+				if (nextPort === null) {
+					console.error(`No available port found after ${port}. Use --port to specify an available port.`);
+					process.exit(1);
+				}
+
+				const shouldPromptForPort = !options.nonInteractive && hasInteractiveTTY;
+				if (!shouldPromptForPort) {
 					console.log(`⚠️  Port ${port} is already in use. Using port ${nextPort} instead.`);
 					port = nextPort;
 				} else {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -187,9 +187,11 @@ export function markHtmlBundleNoStore(bundle: Bun.HTMLBundle): Bun.HTMLBundle {
 }
 
 const spaIndexHtml = markHtmlBundleNoStore(indexHtml);
+const MIN_PORT = 1;
+const MAX_PORT = 65535;
 
 export async function isPortAvailable(port: number): Promise<boolean> {
-	if (port < 1 || port > 65535) return false;
+	if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) return false;
 	return new Promise((resolve) => {
 		const srv = net.createServer();
 		srv.listen(port, "127.0.0.1", () => srv.close(() => resolve(true)));
@@ -197,10 +199,17 @@ export async function isPortAvailable(port: number): Promise<boolean> {
 	});
 }
 
-export async function findNextAvailablePort(startPort: number): Promise<number> {
-	let port = startPort;
-	while (!(await isPortAvailable(port))) port++;
-	return port;
+export async function findNextAvailablePort(startPort: number, maxPort = MAX_PORT): Promise<number | null> {
+	if (!Number.isInteger(startPort) || !Number.isInteger(maxPort)) return null;
+
+	const firstPort = Math.max(startPort, MIN_PORT);
+	const lastPort = Math.min(maxPort, MAX_PORT);
+	for (let port = firstPort; port <= lastPort; port++) {
+		if (await isPortAvailable(port)) {
+			return port;
+		}
+	}
+	return null;
 }
 
 export class BacklogServer {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,3 +1,4 @@
+import net from "node:net";
 import { dirname, join } from "node:path";
 import type { Server, ServerWebSocket } from "bun";
 import { $ } from "bun";
@@ -186,6 +187,21 @@ export function markHtmlBundleNoStore(bundle: Bun.HTMLBundle): Bun.HTMLBundle {
 }
 
 const spaIndexHtml = markHtmlBundleNoStore(indexHtml);
+
+export async function isPortAvailable(port: number): Promise<boolean> {
+	if (port < 1 || port > 65535) return false;
+	return new Promise((resolve) => {
+		const srv = net.createServer();
+		srv.listen(port, "127.0.0.1", () => srv.close(() => resolve(true)));
+		srv.on("error", () => resolve(false));
+	});
+}
+
+export async function findNextAvailablePort(startPort: number): Promise<number> {
+	let port = startPort;
+	while (!(await isPortAvailable(port))) port++;
+	return port;
+}
 
 export class BacklogServer {
 	private core: Core;
@@ -465,16 +481,7 @@ export class BacklogServer {
 			const errorCode = (error as { code?: string })?.code;
 			const errorMessage = (error as Error)?.message;
 			if (errorCode === "EADDRINUSE" || errorMessage?.includes("address already in use")) {
-				console.error(`\n❌ Error: Port ${finalPort} is already in use.\n`);
-				console.log("💡 Suggestions:");
-				console.log(`   1. Try a different port: backlog browser --port ${finalPort + 1}`);
-				console.log(`   2. Find what's using port ${finalPort}:`);
-				if (process.platform === "darwin" || process.platform === "linux") {
-					console.log(`      Run: lsof -i :${finalPort}`);
-				} else if (process.platform === "win32") {
-					console.log(`      Run: netstat -ano | findstr :${finalPort}`);
-				}
-				console.log("   3. Or kill the process using the port and try again\n");
+				console.error(`\n❌ Error: Port ${finalPort} is already in use. Use --port to specify a different port.\n`);
 				process.exit(1);
 			}
 

--- a/src/test/cli-browser-port.test.ts
+++ b/src/test/cli-browser-port.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { type ChildProcessByStdio, spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { Readable } from "node:stream";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import {
+	closeServer,
+	createUniqueTestDir,
+	initializeTestProject,
+	listenOnEphemeralPort,
+	safeCleanup,
+} from "./test-utils.ts";
+
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+type BrowserProcess = ChildProcessByStdio<null, Readable, Readable>;
+
+let TEST_DIR: string;
+
+async function waitForOutput(child: BrowserProcess, expected: string): Promise<string> {
+	let output = "";
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			cleanup();
+			reject(new Error(`Timed out waiting for "${expected}". Output:\n${output}`));
+		}, 10000);
+		const onData = (chunk: Buffer) => {
+			output += chunk.toString();
+			if (output.includes(expected)) {
+				cleanup();
+				resolve(output);
+			}
+		};
+		const onExit = (code: number | null) => {
+			cleanup();
+			reject(new Error(`Process exited with code ${code} before "${expected}". Output:\n${output}`));
+		};
+		const cleanup = () => {
+			clearTimeout(timer);
+			child.stdout.off("data", onData);
+			child.stderr.off("data", onData);
+			child.off("exit", onExit);
+		};
+
+		child.stdout.on("data", onData);
+		child.stderr.on("data", onData);
+		child.once("exit", onExit);
+	});
+}
+
+async function stopChild(child: BrowserProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	await new Promise<void>((resolve) => {
+		const timer = setTimeout(() => {
+			if (child.exitCode === null && child.signalCode === null) {
+				child.kill("SIGKILL");
+			}
+			resolve();
+		}, 2000);
+		child.once("exit", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+		child.kill();
+	});
+}
+
+describe("browser command port selection", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-cli-browser-port");
+		await mkdir(TEST_DIR, { recursive: true });
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await initializeTestProject(core, "Browser Port Test");
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("auto-selects the next available port without prompting in non-TTY runs", async () => {
+		const { server, port } = await listenOnEphemeralPort();
+		const child = spawn("bun", [CLI_PATH, "browser", "--port", String(port), "--no-open"], {
+			cwd: TEST_DIR,
+			env: { ...process.env, NO_COLOR: "1" },
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		try {
+			const output = await waitForOutput(child, `Port ${port} is already in use. Using port`);
+			expect(output).not.toContain("Start on port");
+		} finally {
+			await stopChild(child);
+			await closeServer(server);
+		}
+	});
+});

--- a/src/test/server-port.test.ts
+++ b/src/test/server-port.test.ts
@@ -1,21 +1,23 @@
 import { describe, expect, it } from "bun:test";
-import net from "node:net";
 import { findNextAvailablePort, isPortAvailable } from "../server/index.ts";
+import { closeServer, listenOnEphemeralPort } from "./test-utils.ts";
 
 describe("isPortAvailable", () => {
 	it("returns true for a free port", async () => {
-		const result = await isPortAvailable(49999);
+		const { server, port } = await listenOnEphemeralPort();
+		await closeServer(server);
+
+		const result = await isPortAvailable(port);
 		expect(result).toBe(true);
 	});
 
 	it("returns false when a server already occupies the port", async () => {
-		const srv = net.createServer();
-		await new Promise<void>((resolve) => srv.listen(50001, "127.0.0.1", () => resolve()));
+		const { server, port } = await listenOnEphemeralPort();
 		try {
-			const result = await isPortAvailable(50001);
+			const result = await isPortAvailable(port);
 			expect(result).toBe(false);
 		} finally {
-			await new Promise<void>((resolve) => srv.close(() => resolve()));
+			await closeServer(server);
 		}
 	});
 
@@ -27,18 +29,36 @@ describe("isPortAvailable", () => {
 
 describe("findNextAvailablePort", () => {
 	it("returns startPort when it is free", async () => {
-		const port = await findNextAvailablePort(49990);
-		expect(port).toBe(49990);
+		const { server, port } = await listenOnEphemeralPort();
+		await closeServer(server);
+
+		const result = await findNextAvailablePort(port);
+		expect(result).toBe(port);
 	});
 
 	it("skips occupied ports and returns first free one", async () => {
-		const srv = net.createServer();
-		await new Promise<void>((resolve) => srv.listen(49985, "127.0.0.1", () => resolve()));
+		const { server, port } = await listenOnEphemeralPort();
 		try {
-			const port = await findNextAvailablePort(49985);
-			expect(port).toBeGreaterThan(49985);
+			const result = await findNextAvailablePort(port, Math.min(port + 50, 65535));
+			expect(result).not.toBeNull();
+			expect(result).toBeGreaterThan(port);
 		} finally {
-			await new Promise<void>((resolve) => srv.close(() => resolve()));
+			await closeServer(server);
 		}
+	});
+
+	it("returns null when every port in the bounded range is occupied", async () => {
+		const { server, port } = await listenOnEphemeralPort();
+		try {
+			const result = await findNextAvailablePort(port, port);
+			expect(result).toBeNull();
+		} finally {
+			await closeServer(server);
+		}
+	});
+
+	it("returns null when the scan would start beyond the maximum browser port", async () => {
+		const result = await findNextAvailablePort(65536);
+		expect(result).toBeNull();
 	});
 });

--- a/src/test/server-port.test.ts
+++ b/src/test/server-port.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import net from "node:net";
+import { findNextAvailablePort, isPortAvailable } from "../server/index.ts";
+
+describe("isPortAvailable", () => {
+	it("returns true for a free port", async () => {
+		const result = await isPortAvailable(49999);
+		expect(result).toBe(true);
+	});
+
+	it("returns false when a server already occupies the port", async () => {
+		const srv = net.createServer();
+		await new Promise<void>((resolve) => srv.listen(50001, "127.0.0.1", () => resolve()));
+		try {
+			const result = await isPortAvailable(50001);
+			expect(result).toBe(false);
+		} finally {
+			await new Promise<void>((resolve) => srv.close(() => resolve()));
+		}
+	});
+
+	it("returns false for port 0 (out-of-range for browser use)", async () => {
+		const result = await isPortAvailable(0);
+		expect(result).toBe(false);
+	});
+});
+
+describe("findNextAvailablePort", () => {
+	it("returns startPort when it is free", async () => {
+		const port = await findNextAvailablePort(49990);
+		expect(port).toBe(49990);
+	});
+
+	it("skips occupied ports and returns first free one", async () => {
+		const srv = net.createServer();
+		await new Promise<void>((resolve) => srv.listen(49985, "127.0.0.1", () => resolve()));
+		try {
+			const port = await findNextAvailablePort(49985);
+			expect(port).toBeGreaterThan(49985);
+		} finally {
+			await new Promise<void>((resolve) => srv.close(() => resolve()));
+		}
+	});
+});

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -5,6 +5,7 @@
 
 import { randomUUID } from "node:crypto";
 import { rm } from "node:fs/promises";
+import net from "node:net";
 import { join } from "node:path";
 import type { Core } from "../core/backlog.ts";
 import { initializeProject as initializeProjectShared } from "../core/init.ts";
@@ -83,6 +84,34 @@ export function getPlatformTimeout(baseTimeout = 5000): number {
  */
 export function getExitCode(result: { status: number | null; error?: Error }): number {
 	return result.status ?? (result.error ? 1 : 0);
+}
+
+export async function listenOnEphemeralPort(): Promise<{ server: net.Server; port: number }> {
+	const server = net.createServer();
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("Expected TCP server address");
+	}
+	return { server, port: address.port };
+}
+
+export async function closeServer(server: net.Server): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => {
+			if (error) {
+				reject(error);
+				return;
+			}
+			resolve();
+		});
+	});
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `isPortAvailable()` and `findNextAvailablePort()` helpers to `src/server/index.ts`
- Pre-check port availability in CLI browser command before calling `server.start()`
- If port is taken: suggest next free port, prompt user interactively (readline), start there if accepted
- Simplify EADDRINUSE catch block in `BacklogServer.start()` (UX handled upstream in CLI)
- Unit tests for port helpers (5 cases, including 2 error/edge cases)

## Test plan
- [ ] `bun test src/test/server-port.test.ts` passes (5/5)
- [ ] `bun test` — no new failures (1244 pass, 2 skip, 4 pre-existing fail)
- [ ] `bunx tsc --noEmit` passes
- [ ] `bun run check .` passes