### PR TITLE
fix: handle EEXIST in ensureBacklogStructure for Windows OneDrive (Bun bug)

### DIFF
--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1,4 +1,4 @@
-import { mkdir, rename, unlink } from "node:fs/promises";
+import { mkdir, rename, stat, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import matter from "gray-matter";
 import lockfile from "proper-lockfile";
@@ -211,13 +211,13 @@ export class FileSystem {
 			join(backlogDir, DEFAULT_DIRECTORIES.DECISIONS),
 		];
 
-		//		for (const dir of directories) {
-		//			await mkdir(dir, { recursive: true });
-		//		}
 		for (const dir of directories) {
-			await mkdir(dir, { recursive: true }).catch((err: NodeJS.ErrnoException) => {
-				if (err.code !== "EEXIST") throw err;
-			});
+			try {
+				await mkdir(dir, { recursive: true });
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+				if (!(await stat(dir)).isDirectory()) throw error;
+			}
 		}
 	}
 

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -211,8 +211,13 @@ export class FileSystem {
 			join(backlogDir, DEFAULT_DIRECTORIES.DECISIONS),
 		];
 
+		//		for (const dir of directories) {
+		//			await mkdir(dir, { recursive: true });
+		//		}
 		for (const dir of directories) {
-			await mkdir(dir, { recursive: true });
+			await mkdir(dir, { recursive: true }).catch((err: NodeJS.ErrnoException) => {
+				if (err.code !== "EEXIST") throw err;
+			});
 		}
 	}
 

--- a/src/test/filesystem.test.ts
+++ b/src/test/filesystem.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as fsPromises from "node:fs/promises";
 import { mkdir, readdir, rename, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { FileSystem } from "../file-system/operations.ts";
@@ -40,6 +41,82 @@ describe("FileSystem", () => {
 			for (const dir of expectedDirs) {
 				const stats = await stat(dir);
 				expect(stats.isDirectory()).toBe(true);
+			}
+		});
+
+		it("should ignore EEXIST for existing directories", async () => {
+			const projectDir = join(TEST_DIR, "onedrive-project");
+			const expectedDirs = [
+				join(projectDir, "backlog"),
+				join(projectDir, "backlog", "tasks"),
+				join(projectDir, "backlog", "drafts"),
+				join(projectDir, "backlog", "completed"),
+				join(projectDir, "backlog", "archive", "tasks"),
+				join(projectDir, "backlog", "archive", "drafts"),
+				join(projectDir, "backlog", "milestones"),
+				join(projectDir, "backlog", "archive", "milestones"),
+				join(projectDir, "backlog", "docs"),
+				join(projectDir, "backlog", "decisions"),
+			];
+
+			for (const dir of expectedDirs) {
+				await mkdir(dir, { recursive: true });
+			}
+
+			const realMkdir = fsPromises.mkdir;
+			const existingDirs = new Set(expectedDirs);
+			const mkdirSpy = spyOn(fsPromises, "mkdir").mockImplementation(async (path, options) => {
+				if (existingDirs.has(String(path))) {
+					const error = new Error("file already exists") as NodeJS.ErrnoException;
+					error.code = "EEXIST";
+					throw error;
+				}
+
+				await realMkdir(path, options);
+			});
+
+			try {
+				const { FileSystem: MockedFileSystem } = await import(
+					`../file-system/operations.ts?eexist-directories=${Date.now()}`
+				);
+				const oneDriveFilesystem = new MockedFileSystem(projectDir);
+
+				await oneDriveFilesystem.ensureBacklogStructure();
+
+				for (const dir of expectedDirs) {
+					const stats = await stat(dir);
+					expect(stats.isDirectory()).toBe(true);
+				}
+			} finally {
+				mkdirSpy.mockRestore();
+			}
+		});
+
+		it("should not ignore EEXIST when the path is not a directory", async () => {
+			const projectDir = join(TEST_DIR, "file-conflict-project");
+			const backlogDir = join(projectDir, "backlog");
+			const tasksPath = join(backlogDir, "tasks");
+			await mkdir(backlogDir, { recursive: true });
+			await Bun.write(tasksPath, "not a directory");
+
+			const realMkdir = fsPromises.mkdir;
+			const mkdirSpy = spyOn(fsPromises, "mkdir").mockImplementation(async (path, options) => {
+				if (String(path) === tasksPath) {
+					const error = new Error("file already exists") as NodeJS.ErrnoException;
+					error.code = "EEXIST";
+					throw error;
+				}
+
+				await realMkdir(path, options);
+			});
+
+			try {
+				const { FileSystem: MockedFileSystem } = await import(`../file-system/operations.ts?eexist-file=${Date.now()}`);
+				const conflictFilesystem = new MockedFileSystem(projectDir);
+
+				await expect(conflictFilesystem.ensureBacklogStructure()).rejects.toMatchObject({ code: "EEXIST" });
+			} finally {
+				mkdirSpy.mockRestore();
 			}
 		});
 	});


### PR DESCRIPTION
## Problem

  `backlog browser`, `backlog task list`, and other write commands fail with `EEXIST` when the project is located inside
   a Microsoft OneDrive-synced directory on Windows.

  ❌ Failed to start server: EEXIST: file already exists, mkdir '\backlog'

  ## Root Cause

  OneDrive directories on Windows have the `ReparsePoint` NTFS attribute set. This can be verified with:

  ```powershell
  (Get-Item "C:\Users\...\OneDrive\project\backlog").Attributes
  # Returns: Directory, Archive, ReadOnly, ReparsePoint

  (Get-Item "C:\Users\...\local\project\backlog").Attributes
  # Returns: Directory

  Bun has a bug where mkdir with { recursive: true } does not silently ignore EEXIST when the target directory is a
  ReparsePoint. This contradicts the expected behavior and differs from Node.js:

  // Bun — fails with EEXIST on OneDrive (ReparsePoint)
  await mkdir('C:/Users/.../OneDrive/project/backlog', { recursive: true })
  // ERROR: EEXIST file already exists

  // Node.js — works correctly on the same path
  await mkdir('C:/Users/.../OneDrive/project/backlog', { recursive: true })
  // SUCCESS

  Since ensureBacklogStructure() relies on mkdir with { recursive: true } silently succeeding when directories already
  exist, every write command fails on OneDrive paths under Bun.

  Fix

  Explicitly catch and ignore EEXIST errors in ensureBacklogStructure() as a workaround for the Bun bug:

  for (const dir of directories) {
      await mkdir(dir, { recursive: true }).catch((err: NodeJS.ErrnoException) => {
          if (err.code !== 'EEXIST') throw err;
      });
  }

 ## Reproduction

  Tested on two machines with Windows 11 and Bun v1.3.14. The failure is consistent and reproducible:

  - Projects on regular local paths (with or without spaces) work correctly.
  - Projects inside OneDrive-synced directories fail with `EEXIST` on any write command.

  The difference can be observed via the `ReparsePoint` attribute present on OneDrive directories:

  ```powershell
  (Get-Item "C:\Users\...\OneDrive\project\backlog").Attributes
  # Returns: Directory, Archive, ReadOnly, ReparsePoint

  (Get-Item "C:\Users\...\local\project\backlog").Attributes
  # Returns: Directory

  Bun's mkdir with { recursive: true } raises EEXIST when the target directory is a ReparsePoint, instead of silently
  succeeding as expected. Node.js handles this correctly on the same path.
  ```

  Testing

  Tested on two machines running Windows 11 with Bun v1.3.14 (Windows x64 baseline), one with OneDrive for Business and
  one with OneDrive Personal. After applying the fix, backlog task list and backlog browser work correctly from OneDrive
   directories.
  ```