### PR TITLE
feat(board): hide empty status columns when configured (BACK-466)

### DIFF
--- a/backlog/tasks/back-466 - Hide-empty-status-columns-on-Board-when-no-tasks.md
+++ b/backlog/tasks/back-466 - Hide-empty-status-columns-on-Board-when-no-tasks.md
@@ -1,0 +1,25 @@
+---
+id: BACK-466
+title: Hide empty status columns on Board when no tasks
+status: To Do
+assignee: []
+created_date: '2026-05-26 03:02'
+labels:
+  - ui
+  - enhancement
+dependencies: []
+ordinal: 24000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When a board column has no tasks, hide it to reduce clutter. To preserve drag-and-drop usability, empty columns reappear while a task is being dragged so they remain valid drop targets. Add a new `hideEmptyColumns` boolean to `BacklogConfig` (default false) so existing users see no change; opt-in users get the cleaner board. Surface the toggle in the Settings page.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [ ] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3428,6 +3428,9 @@ configCmd
 				case "autoOpenBrowser":
 					console.log(config.autoOpenBrowser?.toString() || "");
 					break;
+				case "hideEmptyColumns":
+					console.log(config.hideEmptyColumns?.toString() || "false");
+					break;
 				case "remoteOperations":
 					console.log(config.remoteOperations?.toString() || "");
 					break;
@@ -3452,7 +3455,7 @@ configCmd
 				default:
 					console.error(`Unknown config key: ${key}`);
 					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
+						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
 					);
 					process.exit(1);
 			}
@@ -3516,6 +3519,18 @@ configCmd
 						config.autoOpenBrowser = false;
 					} else {
 						console.error("autoOpenBrowser must be true or false");
+						process.exit(1);
+					}
+					break;
+				}
+				case "hideEmptyColumns": {
+					const boolValue = value.toLowerCase();
+					if (boolValue === "true" || boolValue === "1" || boolValue === "yes") {
+						config.hideEmptyColumns = true;
+					} else if (boolValue === "false" || boolValue === "0" || boolValue === "no") {
+						config.hideEmptyColumns = false;
+					} else {
+						console.error("hideEmptyColumns must be true or false");
 						process.exit(1);
 					}
 					break;
@@ -3643,7 +3658,7 @@ configCmd
 				default:
 					console.error(`Unknown config key: ${key}`);
 					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, dateFormat, maxColumnWidth, autoOpenBrowser, defaultPort, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
+						"Available keys: defaultEditor, projectName, defaultStatus, dateFormat, maxColumnWidth, autoOpenBrowser, hideEmptyColumns, defaultPort, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
 					);
 					process.exit(1);
 			}
@@ -3682,6 +3697,7 @@ configCmd
 			console.log(`  dateFormat: ${config.dateFormat}`);
 			console.log(`  maxColumnWidth: ${config.maxColumnWidth || "(not set)"}`);
 			console.log(`  autoOpenBrowser: ${config.autoOpenBrowser ?? "(not set)"}`);
+			console.log(`  hideEmptyColumns: ${config.hideEmptyColumns ?? "(not set)"}`);
 			console.log(`  defaultPort: ${config.defaultPort ?? "(not set)"}`);
 			console.log(`  remoteOperations: ${config.remoteOperations ?? "(not set)"}`);
 			console.log(`  autoCommit: ${config.autoCommit ?? "(not set)"}`);

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1384,6 +1384,9 @@ ${description || `Milestone: ${title}`}`,
 				case "auto_open_browser":
 					config.autoOpenBrowser = value.toLowerCase() === "true";
 					break;
+				case "hide_empty_columns":
+					config.hideEmptyColumns = value.toLowerCase() === "true";
+					break;
 				case "default_port":
 					config.defaultPort = Number.parseInt(value, 10);
 					break;
@@ -1436,6 +1439,7 @@ ${description || `Milestone: ${title}`}`,
 			maxColumnWidth: config.maxColumnWidth,
 			defaultEditor: config.defaultEditor,
 			autoOpenBrowser: config.autoOpenBrowser,
+			hideEmptyColumns: config.hideEmptyColumns,
 			defaultPort: config.defaultPort,
 			remoteOperations: config.remoteOperations,
 			autoCommit: config.autoCommit,
@@ -1466,6 +1470,7 @@ ${description || `Milestone: ${title}`}`,
 			...(config.maxColumnWidth ? [`max_column_width: ${config.maxColumnWidth}`] : []),
 			...(config.defaultEditor ? [`default_editor: "${config.defaultEditor}"`] : []),
 			...(typeof config.autoOpenBrowser === "boolean" ? [`auto_open_browser: ${config.autoOpenBrowser}`] : []),
+			...(typeof config.hideEmptyColumns === "boolean" ? [`hide_empty_columns: ${config.hideEmptyColumns}`] : []),
 			...(config.defaultPort ? [`default_port: ${config.defaultPort}`] : []),
 			...(typeof config.remoteOperations === "boolean" ? [`remote_operations: ${config.remoteOperations}`] : []),
 			...(typeof config.autoCommit === "boolean" ? [`auto_commit: ${config.autoCommit}`] : []),

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -164,6 +164,19 @@ describe("Config commands", () => {
 		expect(portOutput.trim()).toBe("7001");
 	});
 
+	it("round-trips hideEmptyColumns through config get/set/list", async () => {
+		const defaultGet = await $`bun ${CLI_PATH} config get hideEmptyColumns`.cwd(TEST_DIR).text();
+		expect(defaultGet.trim()).toBe("false");
+
+		await $`bun ${CLI_PATH} config set hideEmptyColumns true`.cwd(TEST_DIR).quiet();
+
+		const afterSet = await $`bun ${CLI_PATH} config get hideEmptyColumns`.cwd(TEST_DIR).text();
+		expect(afterSet.trim()).toBe("true");
+
+		const listOutput = await $`bun ${CLI_PATH} config list`.cwd(TEST_DIR).text();
+		expect(listOutput).toContain("hideEmptyColumns: true");
+	});
+
 	it("surfaces milestones in config get/list from milestone files", async () => {
 		await core.filesystem.createMilestone("Release 1");
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -294,6 +294,8 @@ export interface BacklogConfig {
 	defaultEditor?: string;
 	autoOpenBrowser?: boolean;
 	defaultPort?: number;
+	/** When true, hide board columns whose status has no tasks. Columns reappear while a task is being dragged so they remain valid drop targets. Defaults to false. */
+	hideEmptyColumns?: boolean;
 	remoteOperations?: boolean;
 	autoCommit?: boolean;
 	/** Disable all Git integration for filesystem-only projects. */

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -502,6 +502,7 @@ function App() {
                 milestoneEntities={milestoneEntities}
                 archivedMilestones={archivedMilestones}
                 isLoading={isLoading}
+                hideEmptyColumns={config?.hideEmptyColumns ?? false}
               />
             }
           />

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -29,6 +29,7 @@ interface BoardProps {
   filterLabels?: string[];
   filterPriority?: string;
   onFiltersChange?: (filters: { assignee: string; labels: string[]; priority: string }) => void;
+  hideEmptyColumns?: boolean;
 }
 
 const PRIORITY_OPTIONS = [
@@ -62,6 +63,7 @@ const Board: React.FC<BoardProps> = ({
   filterLabels = [],
   filterPriority = '',
   onFiltersChange,
+  hideEmptyColumns = false,
 }) => {
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [dragSourceStatus, setDragSourceStatus] = useState<string | null>(null);
@@ -392,6 +394,19 @@ const Board: React.FC<BoardProps> = ({
     return lanes.filter(l => laneTaskCount(l.key) > 0);
   }, [laneMode, lanes, laneMetadataTasksByLane]);
 
+  // When hideEmptyColumns is on, filter out status columns with no tasks across all visible lanes.
+  // While a task is being dragged we keep every column visible so empty statuses remain drop targets.
+  const isDragging = dragSourceStatus !== null;
+  const visibleStatuses = useMemo(() => {
+    if (!hideEmptyColumns || isDragging) return statuses;
+    return statuses.filter(status => {
+      for (const statusMap of displayTasksByLane.values()) {
+        if ((statusMap.get(status) ?? []).length > 0) return true;
+      }
+      return false;
+    });
+  }, [hideEmptyColumns, isDragging, statuses, displayTasksByLane]);
+
   // Only show lane headers when multiple lanes exist
   const shouldShowLaneHeaders = useMemo(() => {
     if (laneMode !== 'milestone') return false;
@@ -583,8 +598,8 @@ const Board: React.FC<BoardProps> = ({
                 {/* Lane content - columns */}
                 {!isCollapsed && (
                   <div className="p-4">
-                    <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${statuses.length}, minmax(0, 1fr))` }}>
-                      {statuses.map((status) => (
+                    <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${visibleStatuses.length}, minmax(0, 1fr))` }}>
+                      {visibleStatuses.map((status) => (
                         <div key={`${lane.key}-${status}`} className="min-w-0">
                           <TaskColumn
                             title={status}
@@ -618,7 +633,7 @@ const Board: React.FC<BoardProps> = ({
       ) : (
         <div className="overflow-x-auto pb-2">
           <div className="flex flex-row flex-nowrap gap-4 w-full">
-            {statuses.map((status) => (
+            {visibleStatuses.map((status) => (
               <div key={status} className="flex-1 min-w-[16rem]">
                 <TaskColumn
                   title={status}

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -15,6 +15,7 @@ interface BoardPageProps {
 	milestoneEntities: Milestone[];
 	archivedMilestones: Milestone[];
 	isLoading: boolean;
+	hideEmptyColumns?: boolean;
 }
 
 export default function BoardPage({
@@ -28,6 +29,7 @@ export default function BoardPage({
 	milestoneEntities,
 	archivedMilestones,
 	isLoading,
+	hideEmptyColumns,
 }: BoardPageProps) {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [highlightTaskId, setHighlightTaskId] = useState<string | null>(null);
@@ -139,6 +141,7 @@ export default function BoardPage({
 				filterLabels={filterLabels}
 				filterPriority={filterPriority}
 				onFiltersChange={handleFiltersChange}
+				hideEmptyColumns={hideEmptyColumns}
 			/>
 		</div>
 	);

--- a/src/web/components/Settings.tsx
+++ b/src/web/components/Settings.tsx
@@ -355,6 +355,26 @@ const Settings: React.FC = () => {
 									</div>
 								</label>
 							</div>
+
+							<div>
+								<label className="flex items-center justify-between">
+									<div>
+										<span className="text-sm font-medium text-gray-700 dark:text-gray-300">Hide Empty Columns</span>
+										<p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+											Hide board columns whose status has no tasks. Columns reappear while dragging a task so they remain valid drop targets.
+										</p>
+									</div>
+									<div className="relative inline-flex items-center cursor-pointer">
+										<input
+											type="checkbox"
+											checked={config.hideEmptyColumns ?? false}
+											onChange={(e) => handleInputChange('hideEmptyColumns', e.target.checked)}
+											className="sr-only peer"
+										/>
+										<div className="w-11 h-6 bg-gray-200 dark:bg-gray-700 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-circle peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-circle after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-500"></div>
+									</div>
+								</label>
+							</div>
 						</div>
 					</div>
 


### PR DESCRIPTION
## Summary

Adds `hideEmptyColumns` to `BacklogConfig` (default `false`). When enabled, the kanban board hides status columns whose status currently has no tasks. To preserve drag-and-drop usability, empty columns reappear while a task is being dragged, so they remain valid drop targets — when the drag ends, the empty column hides again.

Why opt-in and default off:
- Existing users see no change. Their boards continue to render every status column even when empty.
- Users who hit "wall of empty columns" friction (common when a project uses 5+ statuses and most tasks live in 1–2 of them) can enable it without affecting anyone else.

The mechanism mirrors the existing empty-lane filter in milestone mode (`Board.tsx` already filters `visibleLanes`), so it's consistent with how upstream already treats empty groupings.

## Where it appears

- **Settings UI**: General Settings → "Hide Empty Columns" toggle, right after "Auto Open Browser".
- **CLI**:
  - `backlog config get hideEmptyColumns`
  - `backlog config set hideEmptyColumns true|false`
  - `backlog config list` (shows the field with current value)
- **YAML**: `hide_empty_columns: true` in `backlog/config.yml`.

## Implementation notes

- New optional boolean on `BacklogConfig`. Mirrored everywhere `autoOpenBrowser` is touched *except* the init-wizard plumbing — this is a discover-in-Settings preference, not an init choice. Defaulting to `false` means a missing field behaves correctly without migration.
- `Board.tsx` computes `visibleStatuses` via `useMemo`. When `hideEmptyColumns` is on and no drag is active, it filters `statuses` to those with at least one task in any visible lane (using the same `displayTasksByLane` map already used for rendering — no extra traversal). Otherwise it returns `statuses` unchanged.
- Drag-aware reveal uses the existing `dragSourceStatus` state (already wired by `TaskColumn`'s `onDragStart` / `onDragEnd`). No new state.
- Grid template (`gridTemplateColumns: repeat(N, ...)`) and the flex fallback both use `visibleStatuses.length`, so layout collapses cleanly when columns are hidden.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check <changed files>` — clean
- [x] Full `bun test` — 1244 pass / 0 fail (2 skipped; interactive PTY tests gated by env var)
- [x] New test in `src/test/config-commands.test.ts`: round-trips `hideEmptyColumns` via `config set/get/list` subprocess invocations
- [x] Manual smoke: `/api/config` PUT round-trips `hideEmptyColumns: true` and persists to disk

Manual verification I'd suggest before merge:
- [ ] Toggle setting on a board with mixed-statuses tasks, watch empty columns disappear
- [ ] Drag a task — confirm empty columns reappear during drag and hide again on drop
- [ ] Milestone-grouped view: confirm visible-status filter is consistent across lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)