### PR TITLE
BACK-466 - Add Vim jump and half-page motions to TUI board columns

### DIFF
--- a/backlog/tasks/back-466 - Add-Vim-jump-and-half-page-motions-to-TUI-board-columns.md
+++ b/backlog/tasks/back-466 - Add-Vim-jump-and-half-page-motions-to-TUI-board-columns.md
@@ -1,0 +1,119 @@
+---
+id: BACK-466
+title: Add Vim jump and half-page motions to TUI board columns
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-05-27 07:39'
+updated_date: '2026-05-27 08:26'
+labels:
+  - tui
+  - enhancement
+dependencies: []
+references:
+  - src/ui/board.ts
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Vim users navigating the terminal Kanban board (`backlog board`) can currently only move the selection one row at a time within a status column (`j`/`k`). For long columns this is slow. Add the familiar Vim vertical-navigation motions so users can jump to the top/bottom of a column and move by half-pages, matching the muscle memory of the existing `h/j/k/l` bindings.
+
+Scope is the focused status column's task list in the TUI board only. Half-page semantics match Vim exactly (`Ctrl+d`/`Ctrl+u` = half page; full-page `Ctrl+f`/`Ctrl+b` is intentionally out of scope to avoid disturbing the existing `Ctrl+f` search shortcut). Bindings are identical across macOS/Linux/Windows.
+
+Primary code area: src/ui/board.ts (existing key handlers and the column selection helper).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 In the TUI board, with a focused column containing multiple tasks, pressing gg selects the first task and Shift+G selects the last task
+- [x] #2 Ctrl+d moves the selection down by half the column's visible height and Ctrl+u moves it up by half; both clamp at the column's first/last task and never transfer focus to the search box
+- [x] #3 gg triggers only when a second g is pressed within a short timeout window; a single g performs no action
+- [x] #4 All four motions are no-ops when the focused column is empty
+- [x] #5 In move mode (relocating a task), gg/Shift+G/Ctrl+d/Ctrl+u reposition the move target to top/bottom/half-page within the valid target range (including the append-at-end slot)
+- [x] #6 The new keys are listed in the board help popup opened with ?
+- [x] #7 Existing j/k boundary-to-search behavior remains unchanged
+- [x] #8 Automated tests cover the new navigation and move-mode motions alongside the existing board-navigation tests
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Approach
+
+Keep the index math in a pure, exported, unit-tested helper (mirrors the existing `shouldMoveFromListBoundaryToSearch` / `resolveSearchExitTargetIndex` pattern) and make the board key handlers thin wrappers that call it, then route the result through the existing `selectColumnRow` (navigation) or `moveOp.targetIndex` (move mode) paths so clamping comes for free.
+
+### 1. Pure helper — `src/ui/task-viewer-with-search.ts`
+Add alongside the sibling navigation helpers:
+```ts
+export type VimVerticalMotion = "top" | "bottom" | "halfPageDown" | "halfPageUp";
+export function resolveVimMotionIndex(
+  motion, currentIndex, totalItems, visibleHeight,
+): number
+```
+- `totalItems <= 0` → 0 (callers already no-op on empty columns).
+- `half = max(1, floor(visibleHeight / 2))`.
+- top → 0; bottom → totalItems-1; halfPageDown → min(last, current+half); halfPageUp → max(0, current-half).
+- Pure and fully clamped; identical for navigation and move mode.
+
+### 2. Key handlers — `src/ui/board.ts`
+Add four `screen.key(...)` handlers near the existing `up/k` and `down/j` handlers, each guarded by the same `if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;` preamble:
+- `gg`: bind `["g"]` with a double-press detector — track `lastGPress` timestamp; only fire `top` when a second `g` lands within ~400ms; a lone `g` is a no-op. No existing `g` binding to conflict with (verified).
+- `G`: bind `["S-g"]` → `bottom`.
+- `C-d` → `halfPageDown`; `C-u` → `halfPageUp`.
+
+Each handler:
+- visibleHeight = `typeof column.list.height === "number" ? column.list.height : column.tasks.length` (sequences.ts:251 pattern; safe fallback).
+- Navigation mode: `selectColumnRow(column, resolveVimMotionIndex(motion, list.selected ?? 0, column.tasks.length, visibleHeight), true); screen.render();`
+- Move mode (`moveOp`): `moveOp.targetIndex = resolveVimMotionIndex(motion, moveOp.targetIndex, column.tasks.length, visibleHeight); renderView();` (column.tasks already includes the ghost append slot, so range matches current j/k move logic).
+- Clamp-in-column only — never set `pendingSearchWrap` / focus search, so existing j/k boundary→search behavior is untouched.
+
+### 3. Help popup — `src/ui/components/help-popup.ts`
+Add to `BOARD_SHORTCUTS`:
+- `{ key: "gg/G", desc: "Jump to top / bottom of column" }`
+- `{ key: "C-d/u", desc: "Half-page down / up" }`
+(Popup is 20 rows tall / 15 entries today — fits.)
+
+### 4. Tests — `src/test/`
+Unit-test `resolveVimMotionIndex` (the testable surface; existing board tests are pure-function tests, not screen-driven): top, bottom, half-page down/up clamping at both ends, empty list, odd vs even visibleHeight rounding, and visibleHeight=1 → half=1.
+
+## Out of scope
+Full-page `Ctrl+f`/`Ctrl+b` (would clash with the `Ctrl+f` search shortcut). Footer hint line left unchanged; discoverability handled via the help popup.
+
+## Validation
+`bunx tsc --noEmit`, `bun run check .`, `bun test` (and the board test files).
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Vim-style vertical motions to the TUI board's focused column.
+
+**Behavior**
+- `gg` jumps to the first task (two `g` presses within a 400ms window; a lone `g` is a no-op).
+- `G` (`S-g`) jumps to the last task.
+- `Ctrl+d` / `Ctrl+u` move the selection down/up by half the column's visible height.
+- All four clamp inside the column and never hand focus to the search box, leaving the existing `j`/`k` boundary→search behavior untouched.
+- In move mode they reposition the move target (top/bottom/half-page) within the valid range (including the append-at-end slot).
+
+**Implementation**
+- `src/ui/task-viewer-with-search.ts`: new pure, exported `resolveVimMotionIndex(motion, currentIndex, totalItems, visibleHeight)` (+ `VimVerticalMotion` type) that does all clamped index math — mirrors the existing `shouldMoveFromListBoundaryToSearch` / `resolveSearchExitTargetIndex` helpers.
+- `src/ui/board.ts`: four thin `screen.key` handlers + a shared `applyVimMotion` closure that reads the list's rendered height (falling back to task count) and routes through `selectColumnRow` (navigation) or `moveOp.targetIndex` (move mode).
+- `src/ui/components/help-popup.ts`: added `gg/G` and `C-d/u` rows to the board shortcuts.
+- `src/test/board-vim-motion.test.ts`: unit tests for the helper (top/bottom, half-page clamping both ends, empty list, odd-height rounding, tiny-height minimum step).
+
+**Testing note**
+Tests target the pure index helper (the testable surface), consistent with the existing board tests which are pure-function rather than screen-driven. The `gg` double-press timing and move-mode wiring are exercised through the shared helper but not via a simulated blessed screen.
+
+**Validation**: `bunx tsc --noEmit`, `bun run check .` (changed files), and full `bun test` (1250 pass / 0 fail) all pass.
+
+**Out of scope**: full-page `Ctrl+f`/`Ctrl+b` (would clash with the existing `Ctrl+f` search shortcut).
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/test/board-vim-motion.test.ts
+++ b/src/test/board-vim-motion.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { resolveVimMotionIndex } from "../ui/task-viewer-with-search.ts";
+
+describe("resolveVimMotionIndex", () => {
+	const visibleHeight = 10; // half-page = 5
+
+	it("top always returns the first index", () => {
+		expect(resolveVimMotionIndex("top", 7, 20, visibleHeight)).toBe(0);
+		expect(resolveVimMotionIndex("top", 0, 20, visibleHeight)).toBe(0);
+	});
+
+	it("bottom always returns the last index", () => {
+		expect(resolveVimMotionIndex("bottom", 0, 20, visibleHeight)).toBe(19);
+		expect(resolveVimMotionIndex("bottom", 19, 20, visibleHeight)).toBe(19);
+	});
+
+	it("halfPageDown advances by half the visible height and clamps at the end", () => {
+		expect(resolveVimMotionIndex("halfPageDown", 0, 20, visibleHeight)).toBe(5);
+		expect(resolveVimMotionIndex("halfPageDown", 17, 20, visibleHeight)).toBe(19);
+		expect(resolveVimMotionIndex("halfPageDown", 19, 20, visibleHeight)).toBe(19);
+	});
+
+	it("halfPageUp retreats by half the visible height and clamps at the start", () => {
+		expect(resolveVimMotionIndex("halfPageUp", 19, 20, visibleHeight)).toBe(14);
+		expect(resolveVimMotionIndex("halfPageUp", 3, 20, visibleHeight)).toBe(0);
+		expect(resolveVimMotionIndex("halfPageUp", 0, 20, visibleHeight)).toBe(0);
+	});
+
+	it("returns 0 for an empty list regardless of motion", () => {
+		expect(resolveVimMotionIndex("top", 0, 0, visibleHeight)).toBe(0);
+		expect(resolveVimMotionIndex("bottom", 0, 0, visibleHeight)).toBe(0);
+		expect(resolveVimMotionIndex("halfPageDown", 0, 0, visibleHeight)).toBe(0);
+		expect(resolveVimMotionIndex("halfPageUp", 0, 0, visibleHeight)).toBe(0);
+	});
+
+	it("rounds the half-page size down for odd visible heights", () => {
+		// floor(9 / 2) = 4
+		expect(resolveVimMotionIndex("halfPageDown", 0, 20, 9)).toBe(4);
+		expect(resolveVimMotionIndex("halfPageUp", 10, 20, 9)).toBe(6);
+	});
+
+	it("moves by at least one row when the visible height is tiny", () => {
+		// floor(1 / 2) = 0, but the step is clamped to a minimum of 1
+		expect(resolveVimMotionIndex("halfPageDown", 0, 20, 1)).toBe(1);
+		expect(resolveVimMotionIndex("halfPageUp", 5, 20, 1)).toBe(4);
+		expect(resolveVimMotionIndex("halfPageDown", 0, 20, 0)).toBe(1);
+	});
+});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -22,7 +22,9 @@ import { getStatusIcon } from "./status-icon.ts";
 import {
 	createTaskPopup,
 	resolveSearchExitTargetIndex,
+	resolveVimMotionIndex,
 	shouldMoveFromListBoundaryToSearch,
+	type VimVerticalMotion,
 } from "./task-viewer-with-search.ts";
 import { createScreen } from "./tui.ts";
 import { stripBlessedFgTags } from "./utils/strip-tags.ts";
@@ -982,6 +984,47 @@ export async function renderBoardTui(
 				screen.render();
 			}
 		});
+
+		// Vim-style vertical motions within the focused column: gg/G jump to
+		// top/bottom, Ctrl+d/Ctrl+u move by half a page. All clamp inside the
+		// column (never fall through to search) and also drive move mode.
+		const applyVimMotion = (motion: VimVerticalMotion) => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
+			const column = columns[currentCol];
+			if (!column) return;
+			const listHeight = (column.list as { height?: number | string }).height;
+			const visibleHeight = typeof listHeight === "number" && listHeight > 0 ? listHeight : column.tasks.length;
+
+			if (moveOp) {
+				moveOp.targetIndex = resolveVimMotionIndex(motion, moveOp.targetIndex, column.tasks.length, visibleHeight);
+				renderView();
+				return;
+			}
+
+			if (column.tasks.length === 0) return;
+			const selected = column.list.selected ?? 0;
+			const nextIndex = resolveVimMotionIndex(motion, selected, column.tasks.length, visibleHeight);
+			selectColumnRow(column, nextIndex, true);
+			screen.render();
+		};
+
+		// `gg` is a two-key sequence: a second `g` within the timeout jumps to
+		// the top; a lone `g` is a no-op.
+		let lastGPress = 0;
+		const GG_TIMEOUT_MS = 400;
+		screen.key(["g"], () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
+			const now = Date.now();
+			if (now - lastGPress <= GG_TIMEOUT_MS) {
+				lastGPress = 0;
+				applyVimMotion("top");
+			} else {
+				lastGPress = now;
+			}
+		});
+		screen.key(["S-g", "G"], () => applyVimMotion("bottom"));
+		screen.key(["C-d"], () => applyVimMotion("halfPageDown"));
+		screen.key(["C-u"], () => applyVimMotion("halfPageUp"));
 
 		const openTaskEditor = async (task: Task) => {
 			try {

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -17,6 +17,8 @@ const BOARD_SHORTCUTS: Shortcut[] = [
 	{ key: "I", desc: "Filter by Milestone" },
 	{ key: "←→", desc: "Navigate columns" },
 	{ key: "↑↓", desc: "Navigate tasks" },
+	{ key: "gg/G", desc: "Jump to top / bottom of column" },
+	{ key: "C-d/u", desc: "Half-page down / up" },
 	{ key: "Enter", desc: "View task details" },
 	{ key: "E", desc: "Edit task" },
 	{ key: "M", desc: "Move task (Status/Order)" },

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -127,6 +127,37 @@ export function resolveSearchExitTargetIndex(
 	return currentIndex;
 }
 
+export type VimVerticalMotion = "top" | "bottom" | "halfPageDown" | "halfPageUp";
+
+/**
+ * Resolve the target index for a Vim-style vertical motion within a list/column.
+ * Pure and fully clamped, so callers (board navigation and move mode) get safe
+ * indices regardless of the current position. `visibleHeight` is the rendered
+ * row count used to size half-page jumps.
+ */
+export function resolveVimMotionIndex(
+	motion: VimVerticalMotion,
+	currentIndex: number,
+	totalItems: number,
+	visibleHeight: number,
+): number {
+	if (totalItems <= 0) {
+		return 0;
+	}
+	const last = totalItems - 1;
+	const half = Math.max(1, Math.floor(visibleHeight / 2));
+	switch (motion) {
+		case "top":
+			return 0;
+		case "bottom":
+			return last;
+		case "halfPageDown":
+			return Math.min(last, currentIndex + half);
+		case "halfPageUp":
+			return Math.max(0, currentIndex - half);
+	}
+}
+
 export function resolveFilterExitPane(
 	preferredPane: PaneFocus,
 	hasTaskList: boolean,


### PR DESCRIPTION
## Summary

Adds familiar Vim vertical-navigation motions to the focused column of the terminal Kanban board (`backlog board`), extending the existing `h/j/k/l` bindings:

| Key | Action |
|-----|--------|
| `gg` | Jump to the first task in the column (two `g` presses within 400ms; a lone `g` is a no-op) |
| `G` | Jump to the last task |
| `Ctrl+d` | Move selection down half the column's visible height |
| `Ctrl+u` | Move selection up half the column's visible height |

All four motions **clamp inside the column** and never hand focus to the search box, so the existing `j`/`k` boundary→search behavior is unchanged. They also work in **move mode**, repositioning the move target (top/bottom/half-page) within the valid range.

Full-page `Ctrl+f`/`Ctrl+b` is intentionally out of scope to avoid clashing with the existing `Ctrl+f` search shortcut.

## Implementation

- **`src/ui/task-viewer-with-search.ts`** — new pure, exported `resolveVimMotionIndex(motion, currentIndex, totalItems, visibleHeight)` (+ `VimVerticalMotion` type) that does all clamped index math, mirroring the existing `shouldMoveFromListBoundaryToSearch` / `resolveSearchExitTargetIndex` helpers.
- **`src/ui/board.ts`** — four thin `screen.key` handlers + a shared `applyVimMotion` closure that reads the list's rendered height (falling back to task count) and routes through `selectColumnRow` (navigation) or `moveOp.targetIndex` (move mode).
- **`src/ui/components/help-popup.ts`** — added `gg/G` and `C-d/u` rows to the board shortcuts.
- **`src/test/board-vim-motion.test.ts`** — unit tests for the helper (top/bottom, half-page clamping both ends, empty list, odd-height rounding, tiny-height minimum step).

## Testing

- `bunx tsc --noEmit` — passes
- `bun run check .` (changed files) — passes
- `bun test` — 1250 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)