### PR TITLE
BACK-466 - Add win32-arm64 (Windows on ARM) prebuilt binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
             target: bun-darwin-arm64
           - os: windows-latest
             target: bun-windows-x64-baseline
+          - os: windows-latest
+            target: bun-windows-arm64
     runs-on: ${{ matrix.os }}
     env:
       BIN: backlog-bin${{ contains(matrix.target,'windows') && '.exe' || '' }}
@@ -111,7 +113,8 @@ jobs:
                 "backlog.md-linux-arm64": "'$TAG'",
                 "backlog.md-darwin-x64" : "'$TAG'",
                 "backlog.md-darwin-arm64": "'$TAG'",
-                "backlog.md-windows-x64": "'$TAG'"
+                "backlog.md-windows-x64": "'$TAG'",
+                "backlog.md-windows-arm64": "'$TAG'"
               }' package.json > dist/package.json
           cp LICENSE README.md dist/ 2>/dev/null || true
       - uses: actions/setup-node@v5
@@ -157,6 +160,10 @@ jobs:
             package: backlog.md-windows-x64
             os: win32
             cpu: x64
+          - target: bun-windows-arm64
+            package: backlog.md-windows-arm64
+            os: win32
+            cpu: arm64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -282,6 +289,7 @@ jobs:
             "backlog.md-darwin-x64"
             "backlog.md-darwin-arm64"
             "backlog.md-windows-x64"
+            "backlog.md-windows-arm64"
           )
 
           for pkg in "${PACKAGES[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,14 +108,7 @@ jobs:
               .files = ["cli.js","resolveBinary.cjs","postuninstall.cjs","package.json","README.md","LICENSE"] |
               .scripts = {"postuninstall": "node postuninstall.cjs"} |
               .repository = {"type":"git","url":"https://github.com/MrLesk/Backlog.md"} |
-              .optionalDependencies = {
-                "backlog.md-linux-x64"  : "'$TAG'",
-                "backlog.md-linux-arm64": "'$TAG'",
-                "backlog.md-darwin-x64" : "'$TAG'",
-                "backlog.md-darwin-arm64": "'$TAG'",
-                "backlog.md-windows-x64": "'$TAG'",
-                "backlog.md-windows-arm64": "'$TAG'"
-              }' package.json > dist/package.json
+              .optionalDependencies |= map_values("'$TAG'")' package.json > dist/package.json
           cp LICENSE README.md dist/ 2>/dev/null || true
       - uses: actions/setup-node@v5
         with:

--- a/backlog/tasks/back-466 - Add-win32-arm64-Windows-on-ARM-prebuilt-binary.md
+++ b/backlog/tasks/back-466 - Add-win32-arm64-Windows-on-ARM-prebuilt-binary.md
@@ -1,0 +1,75 @@
+---
+id: BACK-466
+title: Add win32-arm64 (Windows on ARM) prebuilt binary
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-05-30 14:05'
+updated_date: '2026-05-30 17:39'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/657'
+modified_files:
+  - .github/workflows/release.yml
+  - package.json
+  - scripts/postuninstall.cjs
+  - src/test/resolveBinary.test.ts
+  - biome.json
+priority: high
+ordinal: 24000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Windows on ARM (e.g. Snapdragon Surface devices) users get `Binary package not installed for win32-arm64.` on every command after `npm i -g backlog.md`, because no `backlog.md-windows-arm64` platform package is built or published. Reported in GitHub issue #657.
+
+The binary resolver (`scripts/resolveBinary.cjs`) and launcher (`scripts/cli.cjs`) already handle arbitrary platform/arch generically, so no runtime code changes are needed. Bun v1.3.10+ (the release pipeline uses 1.3.11) natively cross-compiles to `bun-windows-arm64` (verified locally: produces an Aarch64 PE32+ executable). The fix is purely additive packaging/release config.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Release pipeline builds a bun-windows-arm64 standalone binary and publishes a backlog.md-windows-arm64 npm package (os win32, cpu arm64) on tagged release
+- [x] #2 backlog.md-windows-arm64 is declared in optionalDependencies in both the source package.json and the npm-publish job's generated package.json
+- [x] #3 postuninstall cleanup list and the verify-platform-packages metadata wait list include backlog.md-windows-arm64
+- [x] #4 resolveBinary test asserts getPackageName('win32','arm64') === 'backlog.md-windows-arm64'
+- [x] #5 bun test, bunx tsc --noEmit, and bun run check . all pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Packaging/release config only — no runtime code (resolver/launcher in scripts/ are already arch-generic). Bun ≥1.3.10 (pipeline uses 1.3.11) cross-compiles bun-windows-arm64.
+
+1. .github/workflows/release.yml:
+   - build matrix: add { os: windows-latest, target: bun-windows-arm64 }.
+   - publish-binaries matrix: add { target: bun-windows-arm64, package: backlog.md-windows-arm64, os: win32, cpu: arm64 }.
+   - verify-platform-packages metadata list: add backlog.md-windows-arm64.
+   - npm-publish: derive published versions from source via `.optionalDependencies |= map_values("$TAG")` instead of a hardcoded list (single source of truth).
+2. package.json: list all 6 platform packages (incl backlog.md-windows-arm64) in optionalDependencies with "*".
+3. scripts/postuninstall.cjs: add backlog.md-windows-arm64 to the cleanup list.
+4. src/test/resolveBinary.test.ts: assert getPackageName("win32","arm64") === "backlog.md-windows-arm64".
+5. biome.json: override **/package.json to space/2 (match the jq-written file; stops the pre-commit hook from reformatting it to tabs).
+
+One-time bootstrap (maintainer, before the first release that references it): npm trusted publishing (OIDC) cannot create a brand-new package, so backlog.md-windows-arm64 must be published manually once and have a trusted publisher configured on npmjs.com. Otherwise the release breaks broadly: publish-binaries fails on the new package, verify-platform-packages times out, and the main backlog.md npm-publish (which needs it) is skipped.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verified locally: bun cross-compiles bun-windows-arm64 to an Aarch64 PE32+ binary; the simulated publish jq emits all 6 platforms at the exact tag; `bun run check .` clean (287 files); resolveBinary test 3/3; frozen+isolated `bun install` exits 0 (windows-arm64 "*" only warns 404 until first publish — harmless); bun.lock/bun.nix untouched. Design follows the esbuild/@biomejs/biome/turbo/bun and Bun-compiled muxinc/cli pattern: a single platform list in the manifest, with a shim that resolves and spawns the matching binary. Known follow-ups (out of scope): bun.lock pins platform packages at a stale 1.14.4 (artifact of "*" versions); publish-binaries lacks fail-fast:false so one platform failure can cancel the others.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+PR #664 (https://github.com/MrLesk/Backlog.md/pull/664) closes issue #657. Adds a native bun-windows-arm64 build + backlog.md-windows-arm64 platform package so the CLI runs on Windows on ARM instead of failing with "Binary package not installed for win32-arm64." Packaging/release config only — no runtime code. The npm-publish job now derives optionalDependencies from the single source list in package.json via map_values("$TAG"); also adds a biome.json package.json 2-space override. Requires a one-time manual bootstrap publish of backlog.md-windows-arm64 + trusted-publisher setup (npm OIDC can't first-publish a new package), after which CI releases handle it.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/biome.json
+++ b/biome.json
@@ -37,5 +37,14 @@
 		"formatter": {
 			"quoteStyle": "double"
 		}
-	}
+	},
+	"overrides": [
+		{
+			"includes": ["**/package.json"],
+			"formatter": {
+				"indentStyle": "space",
+				"indentWidth": 2
+			}
+		}
+	]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "backlog.md-darwin-x64": "*",
         "backlog.md-linux-arm64": "*",
         "backlog.md-linux-x64": "*",
+        "backlog.md-windows-arm64": "*",
         "backlog.md-windows-x64": "*",
       },
     },
@@ -394,6 +395,8 @@
     "backlog.md-linux-arm64": ["backlog.md-linux-arm64@1.14.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-efMv+NVoC5MkRfHg6rvSEw+MAjMF6w+FUjLtMuOtAR4vdL8sVUNqHgi9zsjQ6glnnz9/JBFtnYjjkRCozZuYuw=="],
 
     "backlog.md-linux-x64": ["backlog.md-linux-x64@1.14.4", "", { "os": "linux", "cpu": "x64" }, "sha512-h3RT7jMqFZqQ/Sf49oB7ggqGJ2+p53nIqW544Ue+6RLL7VOmXieLU+hQlG5sh1rACbg22Y5gOhpvdnVvNgfiMA=="],
+
+    "backlog.md-windows-arm64": ["backlog.md-windows-arm64@1.45.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-LCotlXCwS5b+K3aYeeoIP78jYT3Af9NKOcvLZ9B8J/74MwWWOv3qM5CWwXqxSw2Rat62TtdvAkQfS7pQHyny2w=="],
 
     "backlog.md-windows-x64": ["backlog.md-windows-x64@1.14.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8gpi4GVY7wW6Ci8tXfHuodoXFPY4I2hsmOFMK7ggmhhImThALoaw2MTPoJbbFAXS0x5t9lL0R5toufZcmcJwyA=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -1146,6 +1146,12 @@
     url = "https://registry.npmjs.org/backlog.md-linux-x64/-/backlog.md-linux-x64-1.14.4.tgz";
     hash = "sha512-h3RT7jMqFZqQ/Sf49oB7ggqGJ2+p53nIqW544Ue+6RLL7VOmXieLU+hQlG5sh1rACbg22Y5gOhpvdnVvNgfiMA==";
   };
+  "backlog.md-windows-arm64" = {
+    out_path = "backlog.md-windows-arm64";
+    name = "backlog.md-windows-arm64@1.45.1";
+    url = "https://registry.npmjs.org/backlog.md-windows-arm64/-/backlog.md-windows-arm64-1.45.1.tgz";
+    hash = "sha512-LCotlXCwS5b+K3aYeeoIP78jYT3Af9NKOcvLZ9B8J/74MwWWOv3qM5CWwXqxSw2Rat62TtdvAkQfS7pQHyny2w==";
+  };
   "backlog.md-windows-x64" = {
     out_path = "backlog.md-windows-x64";
     name = "backlog.md-windows-x64@1.14.4";

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "backlog.md-darwin-x64": "*",
     "backlog.md-linux-arm64": "*",
     "backlog.md-linux-x64": "*",
-    "backlog.md-windows-arm64": "*",
     "backlog.md-windows-x64": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "backlog.md-darwin-x64": "*",
     "backlog.md-linux-arm64": "*",
     "backlog.md-linux-x64": "*",
+    "backlog.md-windows-arm64": "*",
     "backlog.md-windows-x64": "*"
   },
   "devDependencies": {

--- a/scripts/postuninstall.cjs
+++ b/scripts/postuninstall.cjs
@@ -8,6 +8,7 @@ const platformPackages = [
 	"backlog.md-linux-arm64",
 	"backlog.md-darwin-x64",
 	"backlog.md-darwin-arm64",
+	"backlog.md-windows-arm64",
 	"backlog.md-windows-x64",
 ];
 

--- a/src/test/resolveBinary.test.ts
+++ b/src/test/resolveBinary.test.ts
@@ -8,6 +8,10 @@ describe("getPackageName", () => {
 		expect(getPackageName("win32", "x64")).toBe("backlog.md-windows-x64");
 	});
 
+	it("maps win32 arm64 to windows-arm64 package", () => {
+		expect(getPackageName("win32", "arm64")).toBe("backlog.md-windows-arm64");
+	});
+
 	it("returns linux name unchanged", () => {
 		expect(getPackageName("linux", "arm64")).toBe("backlog.md-linux-arm64");
 	});


### PR DESCRIPTION
## Summary
Windows on ARM (Snapdragon) users hit `Binary package not installed for win32-arm64.` on every command, because no `backlog.md-windows-arm64` platform package is built or published. Bun ≥1.3.10 (the release pipeline already uses 1.3.11) cross-compiles the `bun-windows-arm64` target natively, and the binary resolver/launcher are already arch-generic — so this is **packaging/release config only, no runtime code**.

- `release.yml`: add `bun-windows-arm64` to the build matrix, the `publish-binaries` matrix, the generated `optionalDependencies`, and the platform-package metadata verify list
- `package.json` + `scripts/postuninstall.cjs`: declare and clean up `backlog.md-windows-arm64`
- `src/test/resolveBinary.test.ts`: assert `getPackageName("win32","arm64") === "backlog.md-windows-arm64"`
- `biome.json`: add a `**/package.json` override to format it at 2-space, matching the `jq`-written file produced by the release `sync-version` job (removes the pre-existing tab/space churn on commit)

## Test plan
- [x] `bun test src/test/resolveBinary.test.ts` (3/3 pass)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run check .` clean (287 files; `package.json` now passes as 2-space)
- [x] Confirmed `bun build --compile --target=bun-windows-arm64` produces an Aarch64 PE32+ Windows binary locally
- [ ] First real `bun-windows-arm64` build runs on the next tagged release (matrix only executes on tag push)
- [ ] Optional: validate `npm i -g backlog.md` on a Windows-on-ARM device post-release

Closes #657