### PR TITLE
BACK-469 - TUI theme-adaptive rendering: remove hardcoded colors, add scroll improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             # Windows runners hit Bun/file-system resource pressure under the default parallelism.
-            bun test --timeout=30000 --max-concurrency=4 --reporter=junit --reporter-outfile=test-results.xml
+            bun test --isolate --timeout=30000 --max-concurrency=4 --reporter=junit --reporter-outfile=test-results.xml
           else
-            # Run tests with increased timeout to handle Bun shell operations
-            bun test --timeout=10000 --reporter=junit --reporter-outfile=test-results.xml
+            # Isolate test files because some suites intentionally mutate global process state.
+            bun test --isolate --timeout=10000 --reporter=junit --reporter-outfile=test-results.xml
           fi
         shell: bash
       - name: Run interactive TUI regression tests

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ tmp/
 test-benchmark-report.json
 
 .conductor
+
+# TUI screenshot captures
+.tui-screenshots

--- a/backlog/tasks/back-469 - TUI-theme-adaptive-rendering-remove-hardcoded-colors-add-scroll-improvements.md
+++ b/backlog/tasks/back-469 - TUI-theme-adaptive-rendering-remove-hardcoded-colors-add-scroll-improvements.md
@@ -1,0 +1,84 @@
+---
+id: BACK-469
+title: 'TUI theme-adaptive rendering: remove hardcoded colors, add scroll improvements'
+status: In Progress
+assignee:
+  - '@claude'
+created_date: '2026-02-21 08:42'
+updated_date: '2026-05-31 00:00'
+labels:
+  - ui
+  - board
+  - ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Comprehensive TUI improvement for terminal theme compatibility and quality of life.
+
+**Theme-adaptive colors (inverse video):**
+- Remove all hardcoded `fg: "white"` and `bg: "black"` from screen/container elements across the TUI
+- Switch all highlight/selection styling to `inverse: true` + `bold: true` instead of named ANSI colors — works on any terminal theme including monochrome palettes (e.g. Ghostty Retro)
+- Board active highlight: inverse + bold; move mode: inverse + cyan bg
+- Filter header focus/blur: inverse + bold instead of hardcoded blue/cyan/black
+- Generic list selected rows: inverse + bold instead of bg: blue
+- Filter popups (status/priority/milestone single-select + label multi-select): selected option and hover use inverse + bold instead of bg: blue/fg: white, so the highlight is visible on any theme
+- Esc button on popups: inverse + bold
+- Change semantic "white" to "gray" for status icons (To Do), heading level 3, and priority fallback
+- Code path highlighting changed from gray to cyan for better visibility across themes
+- Filter header blur handlers clear inverse/bold instead of forcing black/white
+
+**Scroll improvements:**
+- Added PGUP/PGDN/Home/End keybindings to standalone scrollable viewer, popup detail viewer, and board lanes
+- Added Ctrl+D/Ctrl+U to board lanes and generic list for vim consistency
+- Shared `addScrollKeys()` helper in tui.ts for scrollable text widgets
+- Generic list gets PGUP/PGDN/Ctrl+D/Ctrl+U/Home/End with proper selectedIndex tracking
+- Added scrollbar indicators (inverse block) to standalone viewer, popup detail viewer, detail pane, label picker, and generic list (opt-out via `scrollbar: false`)
+- Task list pane skips scrollbar for visual consistency with board swimlanes
+
+**Filter navigation fix:**
+- Status/priority selectors: down arrow only exits to task list when at last item (was exiting immediately on any down press)
+
+**TUI screenshot comparison tool (`tools/tui-screenshot-compare.sh`):**
+- Bash script for capturing before/after TUI screenshots and generating visual comparisons
+- Auto-capture mode: launches TUI in Terminal.app and/or Ghostty, navigates views via System Events keystrokes, captures windows by CGWindowID (Swift + CoreGraphics)
+- Captures 4 views per terminal: board, task list, detail pane focused, filters focused
+- Manual fallback mode (`--manual`) for click-to-capture when auto-detection fails
+- Compare command generates static PNG (vertical stack), animated APNG, and GIF for each view
+- Uses ffmpeg for image normalization (width padding), label overlays (drawtext), and animation (concat)
+- Multi-terminal support: captures in both Terminal.app and Ghostty by default for cross-terminal visual comparison
+- Output organized by terminal: `.tui-screenshots/<label>/<terminal>/<view>.png`
+- Configurable via `RENDER_DELAY` and `NAV_DELAY` env vars
+- `.tui-screenshots/` added to `.gitignore`
+
+**Files modified:** tui.ts, board.ts, generic-list.ts, filter-header.ts, filter-popup.ts, task-viewer-with-search.ts, loading.ts, overview-tui.ts, status-icon.ts, heading.ts, code-path.ts + corresponding tests, tools/tui-screenshot-compare.sh, .gitignore
+
+**Note (rebase onto upstream/main):** Upstream replaced the inline label picker in task-viewer-with-search.ts with a shared `filter-popup.ts` (single/multi-select popups). The inverse-video treatment from this task was re-applied to that new file so filter-panel highlights remain theme-adaptive.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All highlight/selection styling uses inverse video instead of hardcoded ANSI colors
+- [ ] #2 Board active: inverse+bold; move mode: inverse+cyan; inactive: cleared
+- [ ] #3 Filter header focus uses inverse+bold; blur clears inverse+bold
+- [ ] #4 No hardcoded fg: "white" or bg: "black" in TUI text/container styles (backdrop overlays excluded)
+- [ ] #5 Semantic colors use "gray" instead of "white" for neutral/muted elements
+- [ ] #6 Code paths styled with cyan instead of gray for cross-theme visibility
+- [ ] #7 PGUP/PGDN/Home/End work in standalone viewer, popup viewer, board lanes, and generic list
+- [ ] #8 Ctrl+D/Ctrl+U work in board lanes and generic list
+- [ ] #9 Scrollbar indicators on scrollable content areas (except task list pane)
+- [ ] #10 Status/priority filter selectors allow full down-arrow navigation before exiting
+- [ ] #11 All tests pass
+- [ ] #12 Screenshot tool auto-captures board, tasklist, detail, and filters views in Terminal and Ghostty
+- [ ] #13 Screenshot compare command generates static PNG, animated APNG, and GIF comparisons
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [ ] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-469 - TUI-theme-adaptive-rendering-remove-hardcoded-colors-add-scroll-improvements.md
+++ b/backlog/tasks/back-469 - TUI-theme-adaptive-rendering-remove-hardcoded-colors-add-scroll-improvements.md
@@ -3,9 +3,9 @@ id: BACK-469
 title: 'TUI theme-adaptive rendering: remove hardcoded colors, add scroll improvements'
 status: In Progress
 assignee:
-  - '@claude'
+  - '@codex'
 created_date: '2026-02-21 08:42'
-updated_date: '2026-05-31 00:00'
+updated_date: '2026-06-07 19:42'
 labels:
   - ui
   - board
@@ -76,9 +76,29 @@ Comprehensive TUI improvement for terminal theme compatibility and quality of li
 - [ ] #13 Screenshot compare command generates static PNG, animated APNG, and GIF comparisons
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Review-fix pass for PR #670:
+1. In src/ui/board.ts, apply the same interaction guards used by arrow navigation to the new PageUp/PageDown/Home/End board handlers so they do not mutate board selection while filter controls, filter popups, or modals are active.
+2. In src/ui/components/generic-list.ts, route page/home/end navigation through the existing highlighted-index path so grouped lists preserve display-index mapping, highlighted row rendering, and highlight callbacks.
+3. In tools/tui-screenshot-compare.sh, move dependency checks into subcommand-specific checks so usage/help is always available, compare only requires compare dependencies, manual capture only requires screencapture, and auto capture checks Ghostty/tmux/Swift/build binary requirements.
+4. Add focused tests for the generic-list grouped navigation regression and script dependency behavior where practical, then run targeted tests plus typecheck/lint.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review fixes applied for PR #670:
+- Board PageUp/PageDown/Home/End now respect filter, popup, and modal focus guards and use selectColumnRow to keep the active-row marker in sync.
+- GenericList page/home/end navigation now uses setHighlightedIndex so grouped display-index mappings remain correct.
+- Screenshot comparison helper dependency checks are now subcommand-specific, so usage/help is not blocked by missing Ghostty.
+Verification: bun test src/test/generic-list-selection.test.ts src/test/tui-screenshot-compare-script.test.ts; bunx tsc --noEmit; bun run check .; ./tools/tui-screenshot-compare.sh; bun test.
+<!-- SECTION:NOTES:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/test/generic-list-selection.test.ts
+++ b/src/test/generic-list-selection.test.ts
@@ -4,7 +4,9 @@ import { GenericList } from "../ui/components/generic-list.ts";
 import { createScreen } from "../ui/tui.ts";
 
 type RenderedList = ListInterface & {
+	emit: (event: string, ch?: string, key?: { name: string }) => boolean;
 	ritems: string[];
+	selected?: number;
 };
 
 function withTtyScreen(run: (screen: ScreenInterface) => void): void {
@@ -47,6 +49,35 @@ describe("GenericList selection rendering", () => {
 			expect(listBox.ritems[1]).toBe("TASK-2");
 			expect(list.getSelectedIndex()).toBe(1);
 			expect(highlighted.at(-1)).toBe(1);
+
+			list.destroy();
+		});
+	});
+
+	it("uses display-index mapping for page navigation in grouped lists", () => {
+		withTtyScreen((screen) => {
+			const highlighted: number[] = [];
+			const list = new GenericList({
+				parent: screen,
+				items: [
+					{ id: "TASK-1", group: "One" },
+					{ id: "TASK-2", group: "One" },
+					{ id: "TASK-3", group: "Two" },
+				],
+				groupBy: (item: { group?: string }) => item.group ?? "",
+				itemRenderer: (item) => item.id,
+				onHighlight: (_item, index) => {
+					highlighted.push(index);
+				},
+				showHelp: false,
+			});
+
+			const listBox = list.getListBox() as RenderedList;
+			listBox.emit("key end", "", { name: "end" });
+
+			expect(list.getSelectedIndex()).toBe(2);
+			expect(listBox.selected).toBe(4);
+			expect(highlighted.at(-1)).toBe(2);
 
 			list.destroy();
 		});

--- a/src/test/status-icon.test.ts
+++ b/src/test/status-icon.test.ts
@@ -24,7 +24,7 @@ describe("Status Icon Component", () => {
 		test("returns correct style for To Do status", () => {
 			const style = getStatusStyle("To Do");
 			expect(style.icon).toBe("○");
-			expect(style.color).toBe("white");
+			expect(style.color).toBe("default");
 		});
 
 		test("returns correct style for Review status", () => {
@@ -42,7 +42,7 @@ describe("Status Icon Component", () => {
 		test("returns default style for unknown status", () => {
 			const style = getStatusStyle("Unknown Status");
 			expect(style.icon).toBe("○");
-			expect(style.color).toBe("white");
+			expect(style.color).toBe("default");
 		});
 	});
 
@@ -51,13 +51,13 @@ describe("Status Icon Component", () => {
 			expect(getStatusColor("Done")).toBe("green");
 			expect(getStatusColor("In Progress")).toBe("yellow");
 			expect(getStatusColor("Blocked")).toBe("red");
-			expect(getStatusColor("To Do")).toBe("white");
+			expect(getStatusColor("To Do")).toBe("default");
 			expect(getStatusColor("Review")).toBe("blue");
 			expect(getStatusColor("Testing")).toBe("cyan");
 		});
 
 		test("returns default color for unknown status", () => {
-			expect(getStatusColor("Unknown")).toBe("white");
+			expect(getStatusColor("Unknown")).toBe("default");
 		});
 	});
 

--- a/src/test/tui-screenshot-compare-script.test.ts
+++ b/src/test/tui-screenshot-compare-script.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { $ } from "bun";
+
+describe("TUI screenshot comparison script", () => {
+	it("shows usage without requiring Ghostty", async () => {
+		const result = await $`bash tools/tui-screenshot-compare.sh`
+			.env({ ...process.env, GHOSTTY_BIN: "/definitely/not/ghostty" })
+			.quiet()
+			.nothrow();
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain("Usage:");
+	});
+});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -440,7 +440,7 @@ export async function renderBoardTui(
 					mouse: true,
 					scrollable: true,
 					tags: true,
-					style: { selected: { fg: "white" } },
+					style: { selected: {} },
 				});
 
 				const renderedItems = getFormattedItems(columnData.tasks);
@@ -487,9 +487,22 @@ export async function renderBoardTui(
 
 		const setColumnActiveState = (column: ColumnView | undefined, active: boolean) => {
 			if (!column) return;
-			const listStyle = column.list.style as { selected?: { bg?: string } };
-			// In move mode, use green highlight for the moving task
-			if (listStyle.selected) listStyle.selected.bg = moveOp && active ? "green" : active ? "blue" : undefined;
+			const listStyle = column.list.style as {
+				selected?: { bg?: string; fg?: string; inverse?: boolean; bold?: boolean };
+			};
+			if (listStyle.selected) {
+				if (active) {
+					listStyle.selected.inverse = true;
+					listStyle.selected.bold = !moveOp;
+					listStyle.selected.bg = moveOp ? "cyan" : undefined;
+					listStyle.selected.fg = moveOp ? "black" : undefined;
+				} else {
+					listStyle.selected.inverse = false;
+					listStyle.selected.bold = false;
+					listStyle.selected.bg = undefined;
+					listStyle.selected.fg = undefined;
+				}
+			}
 			const boxStyle = column.box.style as { border?: { fg?: string } };
 			if (boxStyle.border) boxStyle.border.fg = active ? "yellow" : "gray";
 			syncColumnSelectionDisplay(column, active);
@@ -981,6 +994,51 @@ export async function renderBoardTui(
 				selectColumnRow(column, nextIndex, true);
 				screen.render();
 			}
+		});
+
+		const lanePageAmount = () => {
+			const column = columns[currentCol];
+			if (!column) return 0;
+			const height = typeof column.list.height === "number" ? column.list.height : 0;
+			return height > 0 ? Math.max(1, height - 1) : 5;
+		};
+
+		screen.key(["pageup", "C-u"], () => {
+			if (popupOpen || moveOp) return;
+			const column = columns[currentCol];
+			if (!column) return;
+			const selected = column.list.selected ?? 0;
+			const nextIndex = Math.max(0, selected - lanePageAmount());
+			column.list.select(nextIndex);
+			screen.render();
+		});
+
+		screen.key(["pagedown", "C-d"], () => {
+			if (popupOpen || moveOp) return;
+			const column = columns[currentCol];
+			if (!column) return;
+			const selected = column.list.selected ?? 0;
+			const total = column.tasks.length;
+			if (total === 0) return;
+			const nextIndex = Math.min(total - 1, selected + lanePageAmount());
+			column.list.select(nextIndex);
+			screen.render();
+		});
+
+		screen.key(["home"], () => {
+			if (popupOpen || moveOp) return;
+			const column = columns[currentCol];
+			if (!column || column.tasks.length === 0) return;
+			column.list.select(0);
+			screen.render();
+		});
+
+		screen.key(["end"], () => {
+			if (popupOpen || moveOp) return;
+			const column = columns[currentCol];
+			if (!column || column.tasks.length === 0) return;
+			column.list.select(column.tasks.length - 1);
+			screen.render();
 		});
 
 		const openTaskEditor = async (task: Task) => {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -1003,41 +1003,44 @@ export async function renderBoardTui(
 			return height > 0 ? Math.max(1, height - 1) : 5;
 		};
 
+		const isBoardLaneNavigationBlocked = () =>
+			popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters" || Boolean(moveOp);
+
 		screen.key(["pageup", "C-u"], () => {
-			if (popupOpen || moveOp) return;
+			if (isBoardLaneNavigationBlocked()) return;
 			const column = columns[currentCol];
 			if (!column) return;
 			const selected = column.list.selected ?? 0;
 			const nextIndex = Math.max(0, selected - lanePageAmount());
-			column.list.select(nextIndex);
+			selectColumnRow(column, nextIndex, true);
 			screen.render();
 		});
 
 		screen.key(["pagedown", "C-d"], () => {
-			if (popupOpen || moveOp) return;
+			if (isBoardLaneNavigationBlocked()) return;
 			const column = columns[currentCol];
 			if (!column) return;
 			const selected = column.list.selected ?? 0;
 			const total = column.tasks.length;
 			if (total === 0) return;
 			const nextIndex = Math.min(total - 1, selected + lanePageAmount());
-			column.list.select(nextIndex);
+			selectColumnRow(column, nextIndex, true);
 			screen.render();
 		});
 
 		screen.key(["home"], () => {
-			if (popupOpen || moveOp) return;
+			if (isBoardLaneNavigationBlocked()) return;
 			const column = columns[currentCol];
 			if (!column || column.tasks.length === 0) return;
-			column.list.select(0);
+			selectColumnRow(column, 0, true);
 			screen.render();
 		});
 
 		screen.key(["end"], () => {
-			if (popupOpen || moveOp) return;
+			if (isBoardLaneNavigationBlocked()) return;
 			const column = columns[currentCol];
 			if (!column || column.tasks.length === 0) return;
-			column.list.select(column.tasks.length - 1);
+			selectColumnRow(column, column.tasks.length - 1, true);
 			screen.render();
 		});
 

--- a/src/ui/components/filter-header.ts
+++ b/src/ui/components/filter-header.ts
@@ -440,9 +440,7 @@ export class FilterHeader {
 			mouse: true,
 			keys: true,
 			style: {
-				fg: "white",
-				bg: "black",
-				focus: { fg: "black", bg: "cyan", bold: true },
+				focus: { inverse: true, bold: true },
 			},
 		});
 		this.elements.push(this.searchInput);
@@ -536,9 +534,7 @@ export class FilterHeader {
 			mouse: true,
 			keys: true,
 			style: {
-				fg: "white",
-				bg: "black",
-				focus: { fg: "black", bg: "cyan" },
+				focus: { inverse: true, bold: true },
 			},
 		});
 		this.elements.push(button);
@@ -555,16 +551,16 @@ export class FilterHeader {
 		button.on("focus", () => {
 			this.currentFocus = field;
 			this.setBorderColor("yellow");
-			const style = button.style as { bg?: string; fg?: string };
-			style.bg = "blue";
-			style.fg = "white";
+			const style = button.style as { bg?: string; fg?: string; inverse?: boolean; bold?: boolean };
+			style.inverse = true;
+			style.bold = true;
 			this.onFocusChange?.(field);
 		});
 
 		button.on("blur", () => {
-			const style = button.style as { bg?: string; fg?: string };
-			style.bg = "black";
-			style.fg = "white";
+			const style = button.style as { bg?: string; fg?: string; inverse?: boolean; bold?: boolean };
+			style.inverse = false;
+			style.bold = false;
 		});
 
 		button.key(["enter", "space"], () => {

--- a/src/ui/components/filter-popup.ts
+++ b/src/ui/components/filter-popup.ts
@@ -92,7 +92,7 @@ export function createPopupChrome(options: PopupChromeOptions): {
 		right: 1,
 		width: 5,
 		height: 1,
-		style: { fg: "white", bg: "blue" },
+		style: { inverse: true, bold: true },
 	});
 
 	const helpBox = box({
@@ -165,8 +165,8 @@ export async function openSingleSelectFilterPopup(options: {
 			scrollable: true,
 			style: {
 				bg: "default",
-				selected: { bg: "blue", fg: "white" },
-				item: { bg: "default", hover: { bg: "blue" } },
+				selected: { inverse: true, bold: true },
+				item: { bg: "default", hover: { inverse: true } },
 			},
 		});
 
@@ -263,8 +263,8 @@ export async function openMultiSelectFilterPopup(options: {
 			showHelp: false,
 			style: {
 				bg: "default",
-				item: { fg: "white", bg: "default" },
-				selected: { fg: "white", bg: "blue" },
+				item: { bg: "default" },
+				selected: { inverse: true, bold: true },
 			},
 			keys: {
 				cancel: ["C-]"],

--- a/src/ui/components/generic-list.ts
+++ b/src/ui/components/generic-list.ts
@@ -316,10 +316,7 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 			const total = this.filteredItems.length;
 			if (total === 0) return;
 			const clamped = Math.max(0, Math.min(total - 1, nextIndex));
-			this.listBox.select(clamped);
-			this.selectedIndex = clamped;
-			this.onHighlight?.(this.filteredItems[clamped] ?? null, clamped);
-			this.getScreen()?.render?.();
+			this.setHighlightedIndex(clamped, { render: true });
 		};
 
 		const pageAmount = () => {

--- a/src/ui/components/generic-list.ts
+++ b/src/ui/components/generic-list.ts
@@ -44,12 +44,13 @@ export interface GenericListOptions<T extends GenericListItem> {
 	};
 	style?: {
 		border?: { fg: string };
-		selected?: { fg: string; bg: string };
-		item?: { fg: string; bg?: string };
+		selected?: { fg?: string; bg?: string; inverse?: boolean; bold?: boolean };
+		item?: { fg?: string; bg?: string };
 		focus?: { border: { fg: string } };
 		bg?: string;
 	};
 	showHelp?: boolean;
+	scrollbar?: boolean;
 }
 
 export interface GenericListController<T extends GenericListItem> {
@@ -140,7 +141,7 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 		// Create screen if not provided
 		if (!this.options.parent) {
 			this.screen = createScreen({
-				style: { fg: "white", bg: "black" },
+				style: {},
 			});
 		}
 
@@ -149,8 +150,8 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 		// Default styling
 		const defaultStyle = {
 			border: { fg: "blue" },
-			selected: { fg: "white", bg: "blue" },
-			item: { fg: "white" },
+			selected: { inverse: true, bold: true },
+			item: {},
 			focus: { border: { fg: "yellow" } },
 		};
 
@@ -177,6 +178,7 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 			mouse: true,
 			scrollable: true,
 			alwaysScroll: false,
+			...(this.options.scrollbar !== false ? { scrollbar: { ch: " ", inverse: true } } : {}),
 		});
 
 		this.refreshList();
@@ -310,8 +312,33 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 			this.setHighlightedIndex(sel < total - 1 ? sel + 1 : 0, { render: true });
 		};
 
+		const moveTo = (nextIndex: number) => {
+			const total = this.filteredItems.length;
+			if (total === 0) return;
+			const clamped = Math.max(0, Math.min(total - 1, nextIndex));
+			this.listBox.select(clamped);
+			this.selectedIndex = clamped;
+			this.onHighlight?.(this.filteredItems[clamped] ?? null, clamped);
+			this.getScreen()?.render?.();
+		};
+
+		const pageAmount = () => {
+			const height = typeof this.listBox.height === "number" ? this.listBox.height : 0;
+			return height > 0 ? Math.max(1, height - 3) : 5;
+		};
+
 		this.listBox.key(["up", "k"], moveUp);
 		this.listBox.key(["down", "j"], moveDown);
+		this.listBox.key(["pageup", "C-u"], () => {
+			const sel = typeof this.selectedIndex === "number" ? this.selectedIndex : 0;
+			moveTo(sel - pageAmount());
+		});
+		this.listBox.key(["pagedown", "C-d"], () => {
+			const sel = typeof this.selectedIndex === "number" ? this.selectedIndex : 0;
+			moveTo(sel + pageAmount());
+		});
+		this.listBox.key(["home"], () => moveTo(0));
+		this.listBox.key(["end"], () => moveTo(this.filteredItems.length - 1));
 
 		this.listBox.on("select item", (_item: unknown, displayIndex: unknown) => {
 			if (this.updatingListSelection) return;

--- a/src/ui/loading.ts
+++ b/src/ui/loading.ts
@@ -187,7 +187,7 @@ export async function withLoadingScreen<T>(message: string, operation: () => Pro
 			height: 1,
 			align: "center",
 			content: message,
-			style: { fg: "white" },
+			style: {},
 		});
 	}
 
@@ -255,7 +255,7 @@ export async function createLoadingScreen(initialMessage: string): Promise<Loadi
 		width: "100%-6", // Account for borders + padding (2 borders + 4 padding)
 		height: "100%-2", // Account for top and bottom borders
 		tags: true,
-		style: { fg: "white" },
+		style: {},
 		wrap: true, // Ensure long lines wrap instead of extending beyond width
 	});
 

--- a/src/ui/overview-tui.ts
+++ b/src/ui/overview-tui.ts
@@ -32,9 +32,7 @@ export async function renderOverviewTui(statistics: TaskStatistics, projectName:
 			height: 3,
 			content: `{center}{bold}${projectName} - Project Overview{/bold}{/center}`,
 			tags: true,
-			style: {
-				fg: "white",
-			},
+			style: {},
 		});
 
 		// Status Overview Section (Top Left)

--- a/src/ui/status-icon.ts
+++ b/src/ui/status-icon.ts
@@ -15,13 +15,13 @@ export function getStatusStyle(status: string): StatusStyle {
 		Done: { icon: "✔", color: "green" },
 		"In Progress": { icon: "◒", color: "yellow" },
 		Blocked: { icon: "●", color: "red" },
-		"To Do": { icon: "○", color: "white" },
+		"To Do": { icon: "○", color: "default" },
 		Review: { icon: "◆", color: "blue" },
 		Testing: { icon: "▣", color: "cyan" },
 	};
 
 	// Return the mapped style or default for unknown statuses
-	return statusMap[status] || { icon: "○", color: "white" };
+	return statusMap[status] || { icon: "○", color: "default" };
 }
 
 /**
@@ -40,6 +40,14 @@ export function getStatusColor(status: string): string {
  */
 export function getStatusIcon(status: string): string {
 	return getStatusStyle(status).icon;
+}
+
+/**
+ * Wrap text in blessed color tags. "default" emits {default-fg} (SGR 39 = terminal default).
+ * Returns text as-is if color is empty.
+ */
+export function wrapStatusColor(text: string, color: string): string {
+	return color ? `{${color}-fg}${text}{/}` : text;
 }
 
 /**

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -32,8 +32,8 @@ import { openHelpPopup } from "./components/help-popup.ts";
 import { formatFooterContent } from "./footer-content.ts";
 import { formatHeading } from "./heading.ts";
 import { createLoadingScreen } from "./loading.ts";
-import { formatStatusWithIcon, getStatusColor } from "./status-icon.ts";
-import { createScreen } from "./tui.ts";
+import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-icon.ts";
+import { addScrollKeys, createScreen } from "./tui.ts";
 
 function getPriorityDisplay(priority?: "high" | "medium" | "low"): string {
 	switch (priority) {
@@ -760,6 +760,7 @@ export async function viewTaskEnhanced(
 			items: filteredTasks,
 			selectedIndex: initialIndex,
 			border: false,
+			scrollbar: false,
 			top: 1,
 			left: 1,
 			width: "100%-4",
@@ -775,7 +776,7 @@ export async function viewTaskEnhanced(
 				const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 				const branchText = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
 
-				const content = `{${statusColor}-fg}${statusIcon}{/} {bold}${task.id}{/bold} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
+				const content = `${wrapStatusColor(statusIcon, statusColor)} {bold}${task.id}{/bold} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
 				// Dim cross-branch tasks to indicate read-only status
 				return isCrossBranch ? `{gray-fg}${content}{/}` : content;
 			},
@@ -991,6 +992,8 @@ export async function viewTaskEnhanced(
 			wrap: true,
 			padding: { left: 1, right: 1, top: 0, bottom: 0 },
 			content: detailContent.bodyContent.join("\n"),
+			scrollbar: { ch: " ", inverse: true },
+			style: { scrollbar: { bg: "gray" } },
 		});
 
 		configureDetailBox(bodyContainer);
@@ -1325,7 +1328,7 @@ function generateDetailContent(
 	resolveMilestoneLabel?: (milestone: string) => string,
 ): { headerContent: string[]; bodyContent: string[] } {
 	const headerContent = [
-		` {${getStatusColor(task.status)}-fg}${formatStatusWithIcon(task.status)}{/} {bold}{blue-fg}${task.id}{/blue-fg}{/bold} - ${task.title}`,
+		` ${wrapStatusColor(formatStatusWithIcon(task.status), getStatusColor(task.status))} {bold}{blue-fg}${task.id}{/blue-fg}{/bold} - ${task.title}`,
 	];
 
 	// Add cross-branch indicator if task is from another branch
@@ -1565,7 +1568,7 @@ export async function createTaskPopup(
 		right: 1,
 		width: 5,
 		height: 1,
-		style: { fg: "white", bg: "blue" },
+		style: { inverse: true, bold: true },
 	});
 
 	const contentArea = scrollabletext({
@@ -1581,7 +1584,11 @@ export async function createTaskPopup(
 		wrap: true,
 		padding: { left: 1, right: 1, top: 0, bottom: 0 },
 		content: bodyContent.join("\n"),
+		scrollbar: { ch: " ", inverse: true },
+		style: { scrollbar: { bg: "gray" } },
 	});
+
+	addScrollKeys(contentArea, screen);
 
 	const closePopup = () => {
 		popup.destroy();

--- a/src/ui/tui.ts
+++ b/src/ui/tui.ts
@@ -37,9 +37,62 @@ function normalizeToError(value: unknown): Error {
 	return new Error(String(value ?? "Unknown screen error"));
 }
 
+/**
+ * Add pageup/pagedown/home/end scroll keybindings to a scrollable widget.
+ * Blessed's built-in `keys: true` / `vi: true` only handle arrow keys and
+ * Ctrl+D/U — this fills in the standard terminal navigation keys.
+ */
+export function addScrollKeys(
+	widget: { height?: number | string; key: (keys: string[], fn: () => boolean | undefined) => void },
+	screen: ScreenInterface,
+): void {
+	const scrollable = widget as unknown as {
+		scroll?: (offset: number) => void;
+		setScroll?: (offset: number) => void;
+		setScrollPerc?: (perc: number) => void;
+	};
+
+	const pageAmount = () => {
+		const height = typeof widget.height === "number" ? widget.height : 0;
+		return height > 0 ? Math.max(1, height - 3) : 0;
+	};
+
+	widget.key(["pageup"], () => {
+		const delta = pageAmount();
+		if (delta > 0) {
+			scrollable.scroll?.(-delta);
+			screen.render();
+		}
+		return false;
+	});
+	widget.key(["pagedown"], () => {
+		const delta = pageAmount();
+		if (delta > 0) {
+			scrollable.scroll?.(delta);
+			screen.render();
+		}
+		return false;
+	});
+	widget.key(["home"], () => {
+		scrollable.setScroll?.(0);
+		screen.render();
+		return false;
+	});
+	widget.key(["end"], () => {
+		scrollable.setScrollPerc?.(100);
+		screen.render();
+		return false;
+	});
+}
+
 export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterface {
 	const program: ProgramInterface = createProgram({ tput: false });
 	const screen = blessedScreen({ smartCSR: true, program, fullUnicode: true, ...options });
+
+	if (process.env.DEBUG) {
+		const tputColors = (screen as unknown as { tput?: { colors?: number } }).tput?.colors;
+		console.error(`[TUI debug] tput.colors=${tputColors}, TERM=${process.env.TERM}`);
+	}
 
 	// Windows runners occasionally surface file system watcher errors as plain objects
 	// (rather than Error instances). Blessed rethrows unhandled "error" events by
@@ -75,7 +128,7 @@ export async function scrollableViewer(content: string): Promise<void> {
 
 	return new Promise<void>((resolve) => {
 		const screen = createScreen({
-			style: { fg: "white", bg: "black" },
+			style: {},
 		});
 
 		const viewer = box({
@@ -90,7 +143,11 @@ export async function scrollableViewer(content: string): Promise<void> {
 			height: "100%",
 			padding: { left: 1, right: 1 },
 			wrap: true,
+			scrollbar: { ch: " ", inverse: true },
+			style: { scrollbar: { bg: "gray" } },
 		});
+
+		addScrollKeys(viewer, screen);
 
 		screen.key(["escape", "q", "C-c"], () => {
 			screen.destroy();

--- a/tools/tui-screenshot-compare.sh
+++ b/tools/tui-screenshot-compare.sh
@@ -57,16 +57,29 @@ all_pairings() { printf '%s\n' "${PAIRINGS:-$DEFAULT_PAIRINGS}"; }
 
 pairing_field() { echo "$1" | cut -d'|' -f"$2"; }
 
-check_deps() {
+check_auto_capture_deps() {
 	local missing=()
 	command -v screencapture &>/dev/null || missing+=("screencapture")
-	command -v ffmpeg &>/dev/null || missing+=("ffmpeg")
 	command -v swift &>/dev/null || missing+=("swift")
 	command -v tmux &>/dev/null || missing+=("tmux")
 	if (( ${#missing[@]} > 0 )); then
-		die "Missing required tools (macOS only): ${missing[*]}"
+		die "Missing required auto-capture tools (macOS only): ${missing[*]}"
 	fi
 	[[ -x "$GHOSTTY_BIN" ]] || die "Ghostty not found at ${GHOSTTY_BIN} (set GHOSTTY_BIN)."
+}
+
+check_manual_capture_deps() {
+	command -v screencapture &>/dev/null || die "Missing required manual capture tool (macOS only): screencapture"
+}
+
+check_compare_deps() {
+	local missing=()
+	command -v ffmpeg &>/dev/null || missing+=("ffmpeg")
+	command -v ffprobe &>/dev/null || missing+=("ffprobe")
+	command -v bc &>/dev/null || missing+=("bc")
+	if (( ${#missing[@]} > 0 )); then
+		die "Missing required compare tools: ${missing[*]}"
+	fi
 }
 
 # Print the CGWindowID of the Ghostty window with an exact title match.
@@ -387,21 +400,22 @@ do_compare() {
 
 # --- Main ---
 
-check_deps
-
 case "${1:-}" in
 	capture)
 		if [[ "${2:-}" == "--manual" ]]; then
 			[[ -n "${3:-}" ]] || die "Usage: $0 capture --manual <label>"
+			check_manual_capture_deps
 			do_capture_manual "$3"
 		else
 			[[ -n "${2:-}" ]] || die "Usage: $0 capture <label> [pairing-key...]"
+			check_auto_capture_deps
 			label="$2"; shift 2
 			do_capture "$label" "$@"
 		fi
 		;;
 	compare)
 		[[ -n "${2:-}" && -n "${3:-}" ]] || die "Usage: $0 compare <before-label> <after-label>"
+		check_compare_deps
 		do_compare "$2" "$3"
 		;;
 	*)

--- a/tools/tui-screenshot-compare.sh
+++ b/tools/tui-screenshot-compare.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# TUI Screenshot Comparison Tool (Ghostty theme/font matrix)
+#
+# Captures the TUI across several Ghostty theme + font pairings, then stitches
+# a left/right (before|after) comparison per screen for PR review.
+#
+# Typical flow:
+#   git checkout main           && bun run build && ./tools/tui-screenshot-compare.sh capture main
+#   git checkout <pr-branch>    && bun run build && ./tools/tui-screenshot-compare.sh capture pr
+#   ./tools/tui-screenshot-compare.sh compare main pr
+#
+# Usage:
+#   ./tools/tui-screenshot-compare.sh capture <label> [pairing-key...]
+#   ./tools/tui-screenshot-compare.sh capture --manual <label>
+#   ./tools/tui-screenshot-compare.sh compare <before-label> <after-label>
+
+PROJECT_DIR="$(pwd)"
+SCREENSHOT_DIR=".tui-screenshots"
+FRAME_DURATION="1.5"
+
+# Launch + render tuning (env-overridable)
+BACKLOG_BIN="${BACKLOG_BIN:-${PROJECT_DIR}/dist/backlog}"
+GHOSTTY_BIN="${GHOSTTY_BIN:-/Applications/Ghostty.app/Contents/MacOS/ghostty}"
+FONT_SIZE="${FONT_SIZE:-14}"
+COLS="${COLS:-100}"
+ROWS="${ROWS:-32}"
+DECORATION="${DECORATION:-false}"
+RENDER_DELAY="${RENDER_DELAY:-6}"
+NAV_DELAY="${NAV_DELAY:-1}"
+
+VIEWS=("board" "tasklist" "detail" "filters" "filterpopup")
+
+# First available label font (ImageMagick needs an explicit font path on macOS).
+for LABEL_FONT in \
+	/System/Library/Fonts/Supplemental/Arial.ttf \
+	/System/Library/Fonts/Helvetica.ttc \
+	/Library/Fonts/Arial.ttf; do
+	[[ -f "$LABEL_FONT" ]] && break
+done
+
+# Theme/font pairings: "key|theme|font-family". Override via PAIRINGS env
+# (newline-separated, same format). Keys must be filesystem-safe slugs.
+DEFAULT_PAIRINGS="\
+mocha-sfmono|Catppuccin Mocha|SF Mono
+gruvbox-plex|Gruvbox Dark|IBM Plex Mono
+solarized-menlo|iTerm2 Solarized Light|Menlo
+retro-berkeley|Retro|Berkeley Mono"
+
+# --- Helpers ---
+
+die() { echo "Error: $1" >&2; exit 1; }
+
+# Emit each configured pairing as a "key|theme|font" line.
+all_pairings() { printf '%s\n' "${PAIRINGS:-$DEFAULT_PAIRINGS}"; }
+
+pairing_field() { echo "$1" | cut -d'|' -f"$2"; }
+
+check_deps() {
+	local missing=()
+	command -v screencapture &>/dev/null || missing+=("screencapture")
+	command -v ffmpeg &>/dev/null || missing+=("ffmpeg")
+	command -v swift &>/dev/null || missing+=("swift")
+	command -v tmux &>/dev/null || missing+=("tmux")
+	if (( ${#missing[@]} > 0 )); then
+		die "Missing required tools (macOS only): ${missing[*]}"
+	fi
+	[[ -x "$GHOSTTY_BIN" ]] || die "Ghostty not found at ${GHOSTTY_BIN} (set GHOSTTY_BIN)."
+}
+
+# Print the CGWindowID of the Ghostty window with an exact title match.
+# We launch each capture window with a unique locked --title, so this targets
+# the right window even when many Ghostty windows are open. Reading window
+# titles requires Screen Recording permission.
+ghostty_window_id_by_title() {
+	local title="$1"
+	swift -e "
+import CoreGraphics
+guard let list = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] else { exit(0) }
+for w in list {
+	guard let owner = w[\"kCGWindowOwnerName\"] as? String, owner == \"Ghostty\",
+	      let layer = w[\"kCGWindowLayer\"] as? Int, layer == 0,
+	      let wid = w[\"kCGWindowNumber\"] as? Int,
+	      let name = w[\"kCGWindowName\"] as? String, name == \"${title}\" else { continue }
+	print(wid); exit(0)
+}
+" 2>/dev/null
+}
+
+# Launch a new Ghostty window with the given theme/font/title running a command.
+# --title locks the window title (Ghostty ignores the program's title escapes),
+# making the window uniquely targetable.
+open_ghostty_window() {
+	local theme="$1" font="$2" title="$3" cmd="$4"
+	# config-default-files=false ignores the user's Ghostty config so our --theme
+	# actually applies (an explicit background/palette in their config would
+	# otherwise override it). window-save-state=never stops macOS state
+	# restoration from also opening a phantom shell window with our locked title.
+	open -na "Ghostty" --args \
+		"--config-default-files=false" \
+		"--window-save-state=never" \
+		"--title=${title}" \
+		"--theme=${theme}" \
+		"--font-family=${font}" \
+		"--font-size=${FONT_SIZE}" \
+		"--window-width=${COLS}" \
+		"--window-height=${ROWS}" \
+		"--window-decoration=${DECORATION}" \
+		-e bash -lc "$cmd"
+}
+
+capture_window() {
+	local wid="$1" output="$2" attempt
+	# screencapture -l can transiently fail ("could not create image from window")
+	# when the window is briefly occluded; retry a few times.
+	for attempt in 1 2 3 4; do
+		screencapture -l "$wid" -x -o "$output" 2>/dev/null
+		[[ -s "$output" ]] && return 0
+		sleep 0.5
+	done
+	echo "    WARN: could not capture $(basename "$output")" >&2
+	return 1
+}
+
+# --- Auto Capture (single pairing) ---
+
+capture_pairing() {
+	local key="$1" theme="$2" font="$3" dir="$4"
+
+	echo ""
+	echo "--- ${key}  (theme: ${theme}, font: ${font}) ---"
+	local out="${dir}/${key}"
+	mkdir -p "$out"
+
+	local title="backlogshot-$$-${key}"
+	local sock="backlogshot_$$_${key//-/_}"
+	local launcher="${TMPDIR:-/tmp}/${sock}.sh"
+
+	# The TUI runs inside an isolated tmux server (-L <sock>) so navigation is
+	# driven with `tmux send-keys` targeted at that session only — it never
+	# sends keystrokes to other windows. The launcher hides the tmux status bar
+	# so the screenshot is just the TUI.
+	{
+		echo "tmux set -g status off"
+		printf 'cd %q\n' "$PROJECT_DIR"
+		printf 'exec %q board view\n' "$BACKLOG_BIN"
+	} > "$launcher"
+	local tui_cmd="tmux -L ${sock} new-session -s s -x ${COLS} -y ${ROWS} bash ${launcher}"
+
+	# Clean up the tmux server + launcher on any exit from this pairing.
+	cleanup_pairing() { tmux -L "$sock" kill-server 2>/dev/null || true; rm -f "$launcher"; }
+
+	# Launch and locate the window by its locked title, retrying if macOS fails
+	# to bring up the window (occasional under heavy repeated launches). Each
+	# attempt cleans up its partial instance first. screencapture -l later grabs
+	# the window by ID without focus, so we never steal focus from your windows.
+	local wid="" attempt
+	for attempt in 1 2 3; do
+		echo "  Launching TUI in Ghostty (attempt ${attempt})..."
+		open_ghostty_window "$theme" "$font" "$title" "$tui_cmd"
+		sleep "$RENDER_DELAY"
+		wid=$(ghostty_window_id_by_title "$title")
+		[[ -n "$wid" ]] && break
+		echo "  No window appeared; retrying..."
+		tmux -L "$sock" kill-server 2>/dev/null || true
+		sleep 2
+	done
+	if [[ -z "$wid" ]]; then
+		echo "  ERROR: Could not find window titled '${title}' after ${attempt} attempts. Skipping."
+		cleanup_pairing
+		return 1
+	fi
+	echo "  Window ID: ${wid}"
+
+	echo "  [1/5] Board view..."
+	capture_window "$wid" "${out}/board.png"
+
+	echo "  [2/5] Task list view..."
+	tmux -L "$sock" send-keys -t s Tab 2>/dev/null || true
+	sleep "$NAV_DELAY"
+	capture_window "$wid" "${out}/tasklist.png"
+
+	echo "  [3/5] Detail view..."
+	tmux -L "$sock" send-keys -t s Right 2>/dev/null || true
+	sleep "$NAV_DELAY"
+	capture_window "$wid" "${out}/detail.png"
+
+	echo "  [4/5] Filters (search) view..."
+	tmux -L "$sock" send-keys -t s -l "/" 2>/dev/null || true
+	sleep "$NAV_DELAY"
+	capture_window "$wid" "${out}/filters.png"
+
+	# Status filter popup — showcases the inverse-video highlight on the
+	# selected option. Escape leaves the search field first, then 's' opens it.
+	echo "  [5/5] Filter popup..."
+	tmux -L "$sock" send-keys -t s Escape 2>/dev/null || true
+	sleep 0.4
+	tmux -L "$sock" send-keys -t s -l "s" 2>/dev/null || true
+	sleep "$NAV_DELAY"
+	capture_window "$wid" "${out}/filterpopup.png"
+
+	cleanup_pairing
+	echo "  Saved to ${out}/"
+}
+
+do_capture() {
+	local label="$1"; shift
+	local wanted=("$@")
+
+	local dir="${SCREENSHOT_DIR}/${label}"
+	mkdir -p "$dir"
+
+	echo "=== Capturing TUI screenshots: ${label} ==="
+	echo "Binary: ${BACKLOG_BIN}"
+	[[ -x "$BACKLOG_BIN" ]] || die "Backlog binary not found at ${BACKLOG_BIN}. Run 'bun run build' (or set BACKLOG_BIN)."
+
+	while IFS= read -r line; do
+		[[ -n "$line" ]] || continue
+		local key theme font
+		key=$(pairing_field "$line" 1)
+		theme=$(pairing_field "$line" 2)
+		font=$(pairing_field "$line" 3)
+
+		# If specific pairing keys were requested, skip the rest.
+		if (( ${#wanted[@]} > 0 )); then
+			local match=0
+			for w in "${wanted[@]}"; do [[ "$w" == "$key" ]] && match=1; done
+			(( match )) || continue
+		fi
+
+		capture_pairing "$key" "$theme" "$font" "$dir" || true
+		# Brief cooldown so rapid successive instance launches don't get throttled.
+		sleep 2
+	done <<< "$(all_pairings)"
+
+	echo ""
+	echo "Done. Screenshots saved to ${dir}/"
+}
+
+# --- Manual Capture ---
+
+do_capture_manual() {
+	local label="$1"
+	local dir="${SCREENSHOT_DIR}/${label}/manual"
+	mkdir -p "$dir"
+
+	local descs=("Board view" "Task list view" "Task detail (detail pane focused)" "Filters (search focused)" "Status filter popup (press s)")
+
+	echo "=== Manual capture: ${label} ==="
+	echo "For each screen, navigate to the view in the TUI, then click its window to capture."
+	echo ""
+
+	for i in "${!VIEWS[@]}"; do
+		local view="${VIEWS[$i]}"
+		echo "[$((i+1))/${#VIEWS[@]}] ${descs[$i]}"
+		echo "  Press Enter when ready, then click the TUI window."
+		read -r
+		screencapture -w "${dir}/${view}.png"
+		[[ -f "${dir}/${view}.png" ]] && echo "  Saved: ${dir}/${view}.png" || echo "  Warning: capture may have been cancelled."
+		echo ""
+	done
+
+	echo "Done. Screenshots saved to ${dir}/"
+}
+
+# --- Compare ---
+
+# Pad two images to a shared bounding box (max width x max height), top-left aligned.
+pad_to_same_box() {
+	local img_a="$1" img_b="$2" out_a="$3" out_b="$4"
+	local w_a h_a w_b h_b
+	w_a=$(ffprobe -v error -select_streams v:0 -show_entries stream=width  -of csv=p=0 "$img_a")
+	h_a=$(ffprobe -v error -select_streams v:0 -show_entries stream=height -of csv=p=0 "$img_a")
+	w_b=$(ffprobe -v error -select_streams v:0 -show_entries stream=width  -of csv=p=0 "$img_b")
+	h_b=$(ffprobe -v error -select_streams v:0 -show_entries stream=height -of csv=p=0 "$img_b")
+	local max_w=$(( w_a > w_b ? w_a : w_b ))
+	local max_h=$(( h_a > h_b ? h_a : h_b ))
+	ffmpeg -y -loglevel error -i "$img_a" -vf "pad=${max_w}:${max_h}:0:0:black" -frames:v 1 "$out_a"
+	ffmpeg -y -loglevel error -i "$img_b" -vf "pad=${max_w}:${max_h}:0:0:black" -frames:v 1 "$out_b"
+}
+
+add_label() {
+	local input="$1" output="$2" text="$3"
+	# Prefer ImageMagick (ffmpeg's drawtext filter is often unavailable — it
+	# needs libfreetype). ImageMagick needs an explicit font path on macOS.
+	# Fall back to an unlabelled copy so stitching still works.
+	if command -v magick &>/dev/null && [[ -f "$LABEL_FONT" ]]; then
+		if magick "$input" -font "$LABEL_FONT" -gravity NorthWest -pointsize 28 -fill white \
+			-undercolor '#000000A0' -annotate +18+10 " ${text} " "$output" 2>/dev/null; then
+			return 0
+		fi
+	fi
+	cp "$input" "$output"
+}
+
+do_compare() {
+	local before_label="$1" after_label="$2"
+	local before_dir="${SCREENSHOT_DIR}/${before_label}"
+	local after_dir="${SCREENSHOT_DIR}/${after_label}"
+	local out_dir="${SCREENSHOT_DIR}/compare-${before_label}-${after_label}"
+
+	[[ -d "$before_dir" ]] || die "No screenshots found for '${before_label}'. Run capture first."
+	[[ -d "$after_dir" ]]  || die "No screenshots found for '${after_label}'. Run capture first."
+
+	mkdir -p "$out_dir"
+	local tmpdir; tmpdir=$(mktemp -d)
+	trap 'rm -rf "$tmpdir"' EXIT
+
+	echo "=== Generating comparisons: ${before_label} (left) vs ${after_label} (right) ==="
+
+	# Pairings present in both captures.
+	local pairings=()
+	for d in "${before_dir}"/*/; do
+		[[ -d "$d" ]] || continue
+		local p; p=$(basename "$d")
+		[[ -d "${after_dir}/${p}" ]] && pairings+=("$p")
+	done
+	(( ${#pairings[@]} > 0 )) || pairings=(".")
+
+	for p in "${pairings[@]}"; do
+		local b_dir="${before_dir}/${p}" a_dir="${after_dir}/${p}" p_out="${out_dir}"
+		if [[ "$p" != "." ]]; then
+			p_out="${out_dir}/${p}"
+			echo ""
+			echo "--- ${p} ---"
+		fi
+		mkdir -p "$p_out"
+
+		for view in "${VIEWS[@]}"; do
+			local before_img="${b_dir}/${view}.png" after_img="${a_dir}/${view}.png"
+			[[ -f "$before_img" ]] || { echo "  Skipping ${view}: no 'before' image."; continue; }
+			[[ -f "$after_img" ]]  || { echo "  Skipping ${view}: no 'after' image."; continue; }
+
+			echo "  Processing: ${view}..."
+
+			local pb="${tmpdir}/${p}-${view}-b.png" pa="${tmpdir}/${p}-${view}-a.png"
+			pad_to_same_box "$before_img" "$after_img" "$pb" "$pa"
+
+			local lb="${tmpdir}/${p}-${view}-bl.png" la="${tmpdir}/${p}-${view}-al.png"
+			add_label "$pb" "$lb" "Before (${before_label})"
+			add_label "$pa" "$la" "After (${after_label})"
+
+			# Side-by-side: left = before, right = after.
+			ffmpeg -y -loglevel error -i "$lb" -i "$la" \
+				-filter_complex "[0][1]hstack=inputs=2" -frames:v 1 "${p_out}/${view}-compare.png"
+
+			# Animated toggle (same-position flip) for spotting subtle diffs.
+			# Non-fatal: the static side-by-side PNG is the primary artifact.
+			local fps; fps=$(echo "scale=4; 1 / ${FRAME_DURATION}" | bc)
+			ffmpeg -y -loglevel error -framerate "$fps" -i "$lb" -framerate "$fps" -i "$la" \
+				-filter_complex "[0][1]concat=n=2:v=1:a=0,format=rgba" -f apng -plays 0 \
+				"${p_out}/${view}-toggle.apng" 2>/dev/null || true
+			ffmpeg -y -loglevel error -framerate "$fps" -i "$lb" -framerate "$fps" -i "$la" \
+				-filter_complex "[0][1]concat=n=2:v=1:a=0,format=rgb24" \
+				"${p_out}/${view}-toggle.gif" 2>/dev/null || true
+
+			echo "    ${p_out}/${view}-compare.png"
+		done
+
+		# Combined contact sheet: stack this pairing's view comparisons into one
+		# tall image, each section titled with the view name. Easy to embed in a PR.
+		if command -v magick &>/dev/null; then
+			local sheet_parts=()
+			for view in "${VIEWS[@]}"; do
+				local vc="${p_out}/${view}-compare.png"
+				[[ -f "$vc" ]] || continue
+				local titled="${tmpdir}/${p}-${view}-titled.png"
+				if [[ -f "$LABEL_FONT" ]] && magick "$vc" -font "$LABEL_FONT" -gravity North \
+					-background '#111111' -splice 0x44 -fill white -pointsize 26 \
+					-annotate +0+8 "${view}" "$titled" 2>/dev/null; then
+					sheet_parts+=("$titled")
+				else
+					sheet_parts+=("$vc")
+				fi
+			done
+			if (( ${#sheet_parts[@]} > 0 )) && \
+				magick "${sheet_parts[@]}" -append "${p_out}/contact-sheet.png" 2>/dev/null; then
+				echo "  Contact sheet: ${p_out}/contact-sheet.png"
+			fi
+		fi
+	done
+
+	echo ""
+	echo "Done. Comparisons saved to ${out_dir}/"
+}
+
+# --- Main ---
+
+check_deps
+
+case "${1:-}" in
+	capture)
+		if [[ "${2:-}" == "--manual" ]]; then
+			[[ -n "${3:-}" ]] || die "Usage: $0 capture --manual <label>"
+			do_capture_manual "$3"
+		else
+			[[ -n "${2:-}" ]] || die "Usage: $0 capture <label> [pairing-key...]"
+			label="$2"; shift 2
+			do_capture "$label" "$@"
+		fi
+		;;
+	compare)
+		[[ -n "${2:-}" && -n "${3:-}" ]] || die "Usage: $0 compare <before-label> <after-label>"
+		do_compare "$2" "$3"
+		;;
+	*)
+		cat <<-USAGE
+		TUI Screenshot Comparison Tool (Ghostty theme/font matrix)
+
+		Usage:
+		  $0 capture <label> [pairing-key...]     Auto-capture across theme/font pairings
+		  $0 capture --manual <label>             Manual capture (click-to-select)
+		  $0 compare <before-label> <after-label> Stitch left|right comparison images
+
+		Default pairings (key | theme | font):
+		$(all_pairings | sed 's/^/  /')
+
+		Auto-capture launches the TUI (via the compiled ${BACKLOG_BIN##*/} binary) inside an
+		isolated tmux session in a new Ghostty window per pairing, navigates the
+		views (board, task list, detail, filters) via tmux send-keys, and screenshots
+		each by window ID. Navigation never sends keystrokes to your other windows.
+		Requires Screen Recording permission (for screencapture + reading window titles)
+		for the terminal app you run this from.
+
+		Typical PR flow:
+		  git checkout main        && bun run build && $0 capture main
+		  git checkout <pr-branch> && bun run build && $0 capture pr
+		  $0 compare main pr
+
+		Examples:
+		  $0 capture pr                       # all pairings
+		  $0 capture pr retro-berkeley        # one pairing only
+		  $0 capture --manual pr              # manual click-to-capture
+		  $0 compare main pr                  # generate left|right comparisons
+
+		Environment:
+		  BACKLOG_BIN   TUI binary to launch (default: ./dist/backlog)
+		  GHOSTTY_BIN   Ghostty executable path
+		  PAIRINGS      Override pairing list ("key|theme|font" lines)
+		  FONT_SIZE=14  Font size for all captures
+		  COLS=100 ROWS=32   Window size in cells (keeps before/after aligned)
+		  DECORATION=false   Ghostty window-decoration
+		  RENDER_DELAY=6     Seconds to wait for initial TUI render (raise if the
+		                     board's "Loading tasks" screen is captured)
+		  NAV_DELAY=1        Seconds to wait after each navigation
+
+		Output structure:
+		  ${SCREENSHOT_DIR}/<label>/<pairing-key>/board.png
+		  ${SCREENSHOT_DIR}/compare-<before>-<after>/<pairing-key>/board-compare.png
+		USAGE
+		;;
+esac


### PR DESCRIPTION
## Summary

Replaces hardcoded ANSI colors in the TUI with inverse video so highlights render correctly on **any** terminal theme, including monochrome palettes (e.g. Ghostty Retro) where the old `bg: blue` / `fg: white` styling made selected text unreadable.

## Changes

- **Theme-adaptive highlights** — board active row, filter-header focus/blur, filter popups (status / priority / milestone / labels) + the Esc badge, generic-list selection, and the task viewer all use `inverse + bold` instead of named colors.
- **Muted elements** use `gray` instead of `white`; code paths use `cyan` for cross-theme contrast.
- **Scroll improvements** — PGUP/PGDN/Home/End and Ctrl-D/Ctrl-U across standalone/popup viewers, board lanes, and the generic list; scrollbar indicators; shared `addScrollKeys()` helper.
- **Filter navigation** — status/priority selectors exit to the task list on `down` only when at the last item.
- **Tooling** — `tools/tui-screenshot-compare.sh` captures the TUI across Ghostty theme/font pairings and stitches before/after comparison images (used for the screenshots below).
(optional - I can remove if not wanted)

## Screenshots — before (`main`, left) vs after (this PR, right)

Each contact sheet stacks all five views (board, task list, detail, filters, filter popup) for one theme + font pairing. The monochrome **Retro** pairing shows the fix most clearly: on `main` the selected filter option renders as a solid block that hides its text; with this PR inverse video keeps it readable.

### Catppuccin Mocha · SF Mono

<img width="3432" height="5580" alt="contact-sheet" src="https://github.com/user-attachments/assets/cee375d4-b091-4f78-9db4-338956f86ef9" />



### Gruvbox Dark · IBM Plex Mono

<img width="3432" height="6060" alt="contact-sheet" src="https://github.com/user-attachments/assets/5de9de64-dd52-4495-836f-658b1323049f" />


### Solarized Light · Menlo

<img width="3432" height="5580" alt="contact-sheet" src="https://github.com/user-attachments/assets/d14012c5-109e-4332-9e24-552a06a653c2" />

### Retro · Berkeley Mono

<img width="3432" height="5740" alt="contact-sheet" src="https://github.com/user-attachments/assets/fe09831e-50d2-4266-8c19-e8f788291a75" />

