### PR TITLE
BACK-491/492/493/494/495/496 - Gantt views, actual dates, shared task sorting (split 8/9 of #669)

### DIFF
--- a/backlog/milestones/m-7 - ganttview.md
+++ b/backlog/milestones/m-7 - ganttview.md
@@ -1,0 +1,11 @@
+---
+id: m-7
+title: GanttView
+planned_start: '2026-05-25'
+planned_end: '2026-05-31'
+actual_start: '2026-05-25 16:00'
+actual_end: '2026-05-28 17:17'
+---
+## Description
+
+Milestone: GanttView

--- a/backlog/tasks/back-491 - Add-smart-Gantt-View.md
+++ b/backlog/tasks/back-491 - Add-smart-Gantt-View.md
@@ -1,0 +1,197 @@
+---
+id: BACK-491
+title: Add Smart Gantt View
+status: Done
+assignee:
+  - '@kimi'
+created_date: '2026-05-27 02:05'
+updated_date: '2026-05-28 00:35'
+labels: []
+dependencies: []
+references:
+  - src/server/index.ts
+  - src/web/App.tsx
+  - src/web/components/GanttView.tsx
+  - src/web/components/SideNavigation.tsx
+  - src/web/locales/en.ts
+  - src/web/locales/ja.ts
+  - src/web/locales/zh-CN.ts
+  - src/web/locales/zh-TW.ts
+priority: high
+ordinal: 35400
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a Gantt timeline view to the Backlog.md Web UI, rendered purely with React/CSS based on existing date fields and dependency relationships, to fill the gap in project time-dimension visualization.
+
+## Background
+
+The current Backlog.md task model already contains a large amount of real business data:
+- Required fields: task ID (id), task title (title), creation time (createdDate)
+- Optional fields: planned start time (plannedStart), planned end time (plannedEnd), update time (updatedDate), task dependency relationships (dependencies)
+
+The existing system lacks timeline visualization capabilities, with the following problems:
+1. Most existing tasks have no planned dates, only creation/update times, making it impossible to visually inspect task cycles
+2. A small number of planned tasks have clear start/end times, but cannot be visualized in a schedule
+3. Task dependency relationships are recorded as plain text, with no graphical linkage, making it difficult to identify critical paths
+4. Lack of a global time view, unable to quickly switch between day/week/month/quarter/year to observe project rhythm
+
+## Goals
+
+1. Add a /gantt route page with a standard layout of task list on the left + timeline on the right
+2. Establish automated time value resolution rules, compatible with unplanned tasks that only have createdDate
+3. Support 5 levels of time granularity switching: Day / Week / Month / Quarter / Year
+4. Solve the display problem where single-date tasks are compressed into thin lines in large-span views
+5. Support task dependency visualization arrows based on dependencies
+6. Automatically apply a minimum width fallback for tasks without planned start/end times to ensure interface interactivity
+
+## Page Layout
+
+### Left: Five-Column Fixed Table
+- Task ID
+- Task Title
+- Start Time (resolved effective start time)
+- End Time (resolved effective end time)
+- Action (Detail button, click to open task detail modal)
+- Header sorting: the first four columns support click sorting, only changing frontend display order without affecting actual task data. Sorting interaction is consistent with the "All Tasks" page: double-arrow icons (↑/↓), inactive gray, active highlight, three-state equal-width borders to avoid header jitter.
+
+### Right: Dynamic Gantt Timeline Area
+- Top time granularity switcher (Day / Week / Month / Quarter / Year)
+- Dynamic scale timeline
+- Task time bar rendering (based on resolved start/end times)
+- Task dependency arrow overlay (SVG or CSS)
+
+## Core: Task Start/End Time Resolution Rules (Mandatory Priority)
+
+### Start Time Resolution Rules
+1. If plannedStart exists → use planned start time first
+2. If no planned start time → use the date part of createdDate (YYYY-MM-DD)
+
+### End Time Resolution Rules
+1. If plannedEnd exists → use planned end time first
+2. If no planned end time but updatedDate exists → use the date part of updatedDate (YYYY-MM-DD)
+3. If only createdDate exists (no planned time and no update time) → enable dynamic minimum width fallback
+
+## Minimum Width Fallback Mechanism (Solving Single-Point Task Compression)
+
+Prohibit tasks from rendering as 0 width under any view, adopting a "view-granularity-matched dynamic duration fallback" strategy:
+- Day view: fallback minimum duration = 4 hours (visual width, facilitating vertical staggering of multiple tasks on the same day)
+- Week view: fallback minimum duration = 1 day
+- Month view: fallback minimum duration = 1 day
+- Quarter / Year view: fallback fixed visual pixel width (ensuring visible color blocks, e.g. 8px)
+
+Fallback logic: only automatically filled when a task has only creation time (no plannedStart/End, no updatedDate), without affecting normal tasks with complete planned times or update times.
+
+Note: The "4 hours" in day view is a pure frontend visual strategy. Since date fields are Date-only, the frontend renders single-day tasks with an offset from the day's start and a duration of approximately 4 hours visual width, allowing multiple tasks on the same day to be vertically staggered without completely overlapping.
+
+## Same-Day Multi-Task Rendering Rules
+
+1. Tasks with only creation time in day view: naturally form horizontal staggering through dynamic minimum width (approximately 4 hours visual width), avoiding complete overlap of same-day tasks
+2. No horizontal squeezing, ensuring multiple tasks can be distinguished in detailed views
+3. Automatic visual hierarchy aggregation in large-span views to keep the interface clean
+
+## Time Granularity Switching
+
+Supports 5 levels of one-click switching:
+- Day view: suitable for viewing dense development task arrangements in recent days
+- Week view: suitable for iteration progress review
+- Month view: suitable for monthly project retrospectives
+- Quarter view: suitable for medium/long-term project overviews
+- Year view: suitable for annual project big-picture overview
+
+Switching characteristics:
+- Automatically recalculates task positions and minimum widths when switching granularity
+- Timeline scale, step size, and zoom ratio automatically adapt
+- Hover detail tooltips automatically enabled in large-span views
+
+## Task Dependency Visualization (Simple Network Diagram)
+
+1. Read the Task's dependencies field (predecessor task ID list)
+2. Overlay arrow connection lines on top of the Gantt layer (SVG absolute positioning overlay)
+3. Connection rule: predecessor task end position → successor task start position
+4. Multiple dependencies automatically stagger to prevent tangling (Bezier curves or polylines)
+5. Dependency arrows adaptively follow time granularity scaling
+
+## Interaction Details
+
+1. Task bar hover: display complete information (ID, title, start/end time, whether fallback rendering)
+2. Single-point task hover in large-span views: display real planned time (if any)
+3. Support clicking task bars to highlight their dependency chain (predecessor/successor tasks highlighted, others faded to 30%)
+4. Timeline supports drag-to-pan (swipe left/right to view more time)
+5. Left table "Detail" button click opens task detail modal (reusing existing TaskDetailsModal)
+6. Left table sorting state changes, right Gantt bars re-layout according to new order
+
+## Input Data (Fully Reuses Existing Fields, No New Fields Needed)
+
+- id — Task ID
+- title — Task Title
+- plannedStart — Planned start time (optional, Date-only)
+- plannedEnd — Planned end time (optional, Date-only)
+- createdDate — Creation time (required, YYYY-MM-DD HH:MM)
+- dependencies — Predecessor task ID list (optional, string[])
+- status — Task status
+- priority — Priority
+- milestone — Associated milestone
+
+## Engineering Requirements
+
+1. Route registration: add /gantt route in src/web/App.tsx
+2. Navigation entry: add "Gantt" navigation item in src/web/components/SideNavigation.tsx
+3. Internationalization: supplement all new UI text key-values in src/web/locales/{en,ja,zh-CN,zh-TW}.ts
+4. Theme adaptation: all colors use Tailwind CSS dark: variants, supporting dark mode
+5. Component location: create new src/web/components/GanttView.tsx (main page) and necessary sub-components
+
+## Out of Scope
+
+1. No new database/fields
+2. No manual drag-to-change time support (future iteration)
+3. No complex critical path calculation (future iteration)
+4. No external Gantt chart library introduced (keep pure React/CSS rendering)
+
+This feature is a pure frontend visualization enhancement, without modifying any underlying data structures. The technical solution follows existing wiki decisions: pure React/CSS rendering based on resolved start time, end time, and task dependency relationships.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Five-level time granularity switching works normally, view adapts without errors
+- [x] #2 All time boundary scenarios render correctly (plannedStart/End, createdDate/updatedDate, createdDate-only fallback)
+- [x] #3 Same-day multiple tasks do not overlap, independently interactive
+- [x] #4 Task dependency arrows display accurately and follow zoom scaling
+- [x] #5 Single-point tasks remain visible in year/quarter views, do not disappear, hover info correct
+- [x] #6 Left list info and right Gantt bar time resolution logic completely consistent
+- [x] #7 All elements visually normal in dark mode
+- [x] #8 Left table detail button click correctly opens existing task detail modal, clicking task bar highlights dependency chain
+- [x] #9 Left table four-column sorting works normally, right Gantt bars re-layout after sorting
+- [x] #10 Same-day multiple tasks in day view horizontally stagger through dynamic minimum width, independently clickable
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Create GanttView.tsx main component: implement left task list table + right timeline dual-panel layout, including five-level granularity switching, task bar rendering, dependency arrow SVG overlay, hover tooltip, drag-to-pan, Today marker line, and other complete interactions.
+2. Register /gantt route in App.tsx and pass tasks and onEditTask.
+3. Add "Gantt" navigation entry in SideNavigation.tsx (expanded/collapsed two forms) and dedicated icon.
+4. Add /gantt to server route table index.ts to support SPA direct refresh.
+5. Supplement gantt namespace internationalization key-values in en/ja/zh-CN/zh-TW four languages.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Pure React/CSS rendering, zero external Gantt chart library dependencies.
+- Time resolution priority: plannedStart → createdDate; plannedEnd → updatedDate → createdDate+1d (fallback).
+- Fallback tasks marked with * in list, tooltip labeled fallback.
+- Day view pxPerDay=90, tasks with only creation time naturally form horizontal staggering through dynamic minimum width, avoiding complete overlap of same-day tasks.
+- Dependency arrows use SVG cubic-bezier, horizontal lead-in + curve + arrow, supporting click-to-highlight upstream/downstream chain (other tasks/arrows faded to 30%).
+- Timeline drag-to-pan calculates deltaDays via mouse events to derive viewStart/viewEnd; left and right panel scroll events synchronized bidirectionally.
+- Header sorting reuses "All Tasks" double-arrow interaction pattern, right Gantt bars recalculate positions after sortedTasks updates.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-491 - Add-smart-Gantt-View.md
+++ b/backlog/tasks/back-491 - Add-smart-Gantt-View.md
@@ -5,8 +5,9 @@ status: Done
 assignee:
   - '@kimi'
 created_date: '2026-05-27 02:05'
-updated_date: '2026-05-28 00:35'
+updated_date: '2026-05-28 09:58'
 labels: []
+milestone: m-7
 dependencies: []
 references:
   - src/server/index.ts

--- a/backlog/tasks/back-492 - Add-actualStart-and-actualEnd-fields-for-tasks-with-auto-population-on-status-change.md
+++ b/backlog/tasks/back-492 - Add-actualStart-and-actualEnd-fields-for-tasks-with-auto-population-on-status-change.md
@@ -46,6 +46,27 @@ Users can manually override these values via CLI commands and Web UI.
 - [x] #9 The two fields are optional; absence must not break existing tasks or frontmatter files.
 <!-- AC:END -->
 
+## Implementation Plan
+
+<!-- SECTION:IMPLEMENTATION_PLAN:BEGIN -->
+1. Add `actualStart`/`actualEnd` to TypeScript types (`Task`, `TaskCreateInput`, `TaskUpdateInput`, `TaskEditArgs`).
+2. Extend markdown parser/serializer to read/write `actual_start`/`actual_end` frontmatter fields.
+3. Implement auto-population in `core/backlog.ts` `updateTask`: detect status transitions to in-progress / terminal and set fields if empty.
+4. Add CLI flags (`--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end`) for create/edit commands.
+5. Add server API and MCP tool support.
+6. Add Web UI `datetime-local` inputs; later fix timezone consistency with `createdDate` via `storedUtcToDateTimeLocal`/`dateTimeLocalToStoredUtc`.
+7. Add i18n labels, plain-text formatter output, agent guidelines update, and tests.
+<!-- SECTION:IMPLEMENTATION_PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Storage format follows `createdDate` convention (`YYYY-MM-DD HH:MM`, UTC) for minute-level precision.
+- `isInProgressStatus()` uses case-insensitive match on "inprogress" to support localized status names.
+- Auto-population only fires when the field is empty, preserving any manual override.
+- Web UI timezone fix (BACK-492 follow-up): `datetime-local` inputs now correctly convert between UTC storage and local display, matching `createdDate` behavior.
+<!-- SECTION:NOTES:END -->
+
 ## Related Tasks
 
 - [[BACK-493]] — Milestone-level `actualStart` / `actualEnd` support (deferred follow-up).

--- a/backlog/tasks/back-492 - Add-actualStart-and-actualEnd-fields-for-tasks-with-auto-population-on-status-change.md
+++ b/backlog/tasks/back-492 - Add-actualStart-and-actualEnd-fields-for-tasks-with-auto-population-on-status-change.md
@@ -1,0 +1,98 @@
+---
+id: BACK-492
+title: Add actualStart and actualEnd fields for tasks with auto-population on status change
+status: Done
+assignee:
+  - '@kimi'
+created_date: '2026-05-28 01:15'
+updated_date: '2026-05-28 02:55'
+labels: []
+dependencies: []
+
+references: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Introduce optional `actualStart` and `actualEnd` date fields for tasks to track when work actually began and finished.
+
+**Auto-population rules:**
+- When a task's status changes to an in-progress status (e.g., "In Progress"), if `actualStart` is empty, it is automatically set to the current date-time.
+- When a task's status changes to a terminal/Done status, if `actualEnd` is empty, it is automatically set to the current date-time.
+
+Users can manually override these values via CLI commands and Web UI.
+
+**Storage semantics:**
+- `actualStart` and `actualEnd` are stored as **date-time** (`YYYY-MM-DD HH:MM`, UTC) in frontmatter, same format as `createdDate`.
+
+**Scope:**
+- Add fields to **task** types, markdown parser/serializer, core business logic, CLI, Web UI, server API, MCP tools, i18n, tests, and agent guidelines.
+- Milestone support is intentionally out of scope for this task; see dependency [[BACK-493]].
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 Tasks support optional `actualStart` and `actualEnd` end-to-end: types, create/edit flows, markdown frontmatter persistence, and load/save parsing.
+- [x] #2 Status change auto-population: when transitioning to an in-progress status, `actualStart` is set to current date-time if empty. When transitioning to a terminal/Done status, `actualEnd` is set to current date-time if empty.
+- [x] #3 CLI supports `--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end` flags on task create and edit commands.
+- [x] #4 Web UI and server API support `actualStart` and `actualEnd` in create / edit / view paths.
+- [x] #5 MCP task schemas and handlers support `actualStart` and `actualEnd`.
+- [x] #6 i18n labels added for all 4 locales (en, ja, zh-CN, zh-TW).
+- [x] #7 Plain text formatter displays `actualStart` and `actualEnd` where applicable.
+- [x] #8 Agent guidelines updated to mention the new fields.
+- [x] #9 The two fields are optional; absence must not break existing tasks or frontmatter files.
+<!-- AC:END -->
+
+## Related Tasks
+
+- [[BACK-493]] — Milestone-level `actualStart` / `actualEnd` support (deferred follow-up).
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Successfully implemented `actualStart` and `actualEnd` fields across all 12 layers of the Backlog.md surface stack.
+
+**Key decisions:**
+- Storage format follows `createdDate` convention (`YYYY-MM-DD HH:MM`, UTC) rather than the date-only format used by `plannedStart`/`plannedEnd`. This provides minute-level precision for tracking real work timestamps.
+- Auto-population uses `isInProgressStatus()` (case-insensitive match on "inprogress") and `isTerminalStatus()` (last configured status) to determine trigger conditions.
+- Auto-population only fires when the field is empty, respecting any user-provided override.
+- Web UI uses `datetime-local` inputs for `actualStart`/`actualEnd` while keeping `date` inputs for `plannedStart`/`plannedEnd`/`dueDate`.
+- Web UI datetime-local inputs correctly convert between stored UTC values and local timezone display, ensuring `actualStart`/`actualEnd` appear consistent with `createdDate` in the UI.
+
+**Files modified (20):**
+- `src/types/index.ts` — added to Task, TaskCreateInput, TaskUpdateInput
+- `src/types/task-edit-args.ts` — added to TaskEditArgs
+- `src/markdown/parser.ts` — parse `actual_start`/`actual_end` from frontmatter
+- `src/markdown/serializer.ts` — serialize to frontmatter
+- `src/core/backlog.ts` — auto-populate on status change + pass-through in create/edit
+- `src/utils/status.ts` — added `isInProgressStatus()` helper
+- `src/utils/task-edit-builder.ts` — map CLI args to update input
+- `src/cli.ts` — added flags for create/edit + wired into create handler
+- `src/formatters/task-plain-text.ts` — display fields in `--plain` output
+- `src/server/index.ts` — API create/update handlers
+- `src/mcp/tools/tasks/handlers.ts` — create handler passes new fields
+- `src/mcp/utils/schema-generators.ts` — JSON schema for MCP tools
+- `src/web/components/TaskDetailsModal.tsx` — form inputs with datetime-local
+- `src/web/locales/{en,ja,zh-CN,zh-TW}.ts` — i18n labels
+- `src/commands/task-wizard.ts` — wizard support for new fields
+- `src/guidelines/agent-guidelines.md` — updated example frontmatter
+- `src/web/utils/date-display.ts` — added `storedUtcToDateTimeLocal` / `dateTimeLocalToStoredUtc` helpers for timezone-aware datetime-local binding
+- `src/web/utils/date-display.test.ts` — unit tests for UTC ↔ local conversion helpers
+
+**Verification:**
+- `bunx tsc --noEmit` ✅
+- `bun test src/test/markdown.test.ts` ✅ 36/36 passed
+- `bun test src/web/utils/date-display.test.ts` ✅ 15/15 passed
+- CLI end-to-end: To Do → In Progress auto-filled `actualStart`; In Progress → Done auto-filled `actualEnd` ✅
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-492 - Add-actualStart-and-actualEnd-fields-for-tasks-with-auto-population-on-status-change.md
+++ b/backlog/tasks/back-492 - Add-actualStart-and-actualEnd-fields-for-tasks-with-auto-population-on-status-change.md
@@ -1,16 +1,18 @@
 ---
 id: BACK-492
-title: Add actualStart and actualEnd fields for tasks with auto-population on status change
+title: >-
+  Add actualStart and actualEnd fields for tasks with auto-population on status
+  change
 status: Done
 assignee:
   - '@kimi'
 created_date: '2026-05-28 01:15'
-updated_date: '2026-05-28 02:55'
+updated_date: '2026-05-28 18:34'
 labels: []
+milestone: m-7
 dependencies: []
-
-references: []
 priority: medium
+ordinal: 41400
 ---
 
 ## Description

--- a/backlog/tasks/back-493 - Add-actualStart-and-actualEnd-support-for-milestones.md
+++ b/backlog/tasks/back-493 - Add-actualStart-and-actualEnd-support-for-milestones.md
@@ -1,16 +1,17 @@
 ---
 id: BACK-493
 title: Add actualStart and actualEnd support for milestones
-status: Draft
+status: Done
 assignee:
   - '@kimi'
 created_date: '2026-05-28 01:55'
-updated_date: '2026-05-28 02:58'
+updated_date: '2026-05-28 05:42'
 labels: []
 dependencies:
-  - 'BACK-492'
-references: []
+  - BACK-492
 priority: medium
+actual_start: '2026-05-28 04:00'
+actual_end: '2026-05-28 05:42'
 ---
 
 ## Description
@@ -41,16 +42,16 @@ Users can manually override these values via CLI and Web UI.
 ## Acceptance Criteria
 
 <!-- AC:BEGIN -->
-- [ ] #1 Milestones support optional `actualStart` and `actualEnd` end-to-end: types, create/edit flows, markdown frontmatter persistence, and load/save parsing.
-- [ ] #2 When a task under a milestone transitions to an in-progress status, the milestone's `actualStart` is auto-populated with current date-time if empty.
-- [ ] #3 When all tasks under a milestone are in a terminal/Done status, the milestone's `actualEnd` is auto-populated with current date-time if empty.
-- [ ] #4 CLI `milestone create` and `milestone edit` support `--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end`.
-- [ ] #5 Web UI and server API support `actualStart` and `actualEnd` in milestone create / edit / view paths.
-- [ ] #6 MCP milestone schemas and handlers support `actualStart` and `actualEnd`.
-- [ ] #7 i18n labels added for all 4 locales (en, ja, zh-CN, zh-TW).
-- [ ] #8 Web UI `datetime-local` inputs correctly convert between stored UTC values and local timezone display, consistent with task-level `actualStart`/`actualEnd` behavior.
-- [ ] #9 Agent guidelines updated to mention milestone actual date fields.
-- [ ] #10 The two fields are optional; absence must not break existing milestones or frontmatter files.
+- [x] #1 Milestones support optional `actualStart` and `actualEnd` end-to-end: types, create/edit flows, markdown frontmatter persistence, and load/save parsing.
+- [x] #2 When a task under a milestone transitions to an in-progress status, the milestone's `actualStart` is auto-populated with current date-time if empty.
+- [x] #3 When all tasks under a milestone are in a terminal/Done status, the milestone's `actualEnd` is auto-populated with current date-time if empty.
+- [x] #4 CLI `milestone create` and `milestone edit` support `--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end`.
+- [x] #5 Web UI and server API support `actualStart` and `actualEnd` in milestone create / edit / view paths.
+- [x] #6 MCP milestone schemas and handlers support `actualStart` and `actualEnd`.
+- [x] #7 i18n labels added for all 4 locales (en, ja, zh-CN, zh-TW).
+- [x] #8 Web UI `datetime-local` inputs correctly convert between stored UTC values and local timezone display, consistent with task-level `actualStart`/`actualEnd` behavior.
+- [x] #9 Agent guidelines updated to mention milestone actual date fields.
+- [x] #10 The two fields are optional; absence must not break existing milestones or frontmatter files.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -58,22 +59,28 @@ Users can manually override these values via CLI and Web UI.
 <!-- SECTION:IMPLEMENTATION_PLAN:BEGIN -->
 1. Extend `Milestone` type and milestone markdown parser/serializer with `actual_start`/`actual_end` frontmatter fields.
 2. Add milestone auto-population logic in `updateTask`: when a task under a milestone transitions to in-progress, set milestone `actualStart` if empty; when the last non-terminal task under a milestone becomes terminal, set milestone `actualEnd` if empty.
-3. Add CLI flags (`--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end`) to `milestone create` and `milestone edit`.
-4. Extend server API and MCP milestone handlers.
+3. Add `milestone create` CLI command and extend `milestone edit` with `--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end` flags.
+4. Extend server API (`handleCreateMilestone`, `handleUpdateMilestone`) and Web UI API client.
 5. Add Web UI `datetime-local` inputs for milestones, reusing `storedUtcToDateTimeLocal`/`dateTimeLocalToStoredUtc` from BACK-492 for timezone consistency.
-6. Add i18n labels, update agent guidelines, and write tests.
+6. Extend MCP milestone schemas and handlers; rename tool reference from `milestone_rename` to `milestone_edit` in hints, docs, and tests.
+7. Update agent guidelines to clarify that task-only milestone references do not create milestone files.
 <!-- SECTION:IMPLEMENTATION_PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-_(Deferred to implementation phase.)_
+- The CLI `milestone create` command did not exist before BACK-493; it was added to match the AC requirement for create-side date flags.
+- MCP tool name references (`milestone_rename` → `milestone_edit`) were updated in handler hints, agent guidelines, and `mcp-server.test.ts` to align with the actual registered tool name.
+- Milestone auto-population in `updateTask` uses `milestoneKey()` for case-insensitive matching between task milestone values and milestone IDs/titles.
+- When checking if all milestone tasks are terminal, `listTasks()` is called after saving the current task, so the current task's new terminal status is already reflected.
+- No new i18n labels were needed; `taskDetails.section.actualStart` / `actualEnd` from BACK-492 are reused for milestone modals.
+- Web UI `datetime-local` inputs follow the same UTC-storage/local-display convention as task `actualStart`/`actualEnd`.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/backlog/tasks/back-493 - Add-actualStart-and-actualEnd-support-for-milestones.md
+++ b/backlog/tasks/back-493 - Add-actualStart-and-actualEnd-support-for-milestones.md
@@ -5,11 +5,13 @@ status: Done
 assignee:
   - '@kimi'
 created_date: '2026-05-28 01:55'
-updated_date: '2026-05-28 05:42'
+updated_date: '2026-05-28 18:34'
 labels: []
+milestone: m-7
 dependencies:
   - BACK-492
 priority: medium
+ordinal: 42400
 actual_start: '2026-05-28 04:00'
 actual_end: '2026-05-28 05:42'
 ---

--- a/backlog/tasks/back-493 - Add-actualStart-and-actualEnd-support-for-milestones.md
+++ b/backlog/tasks/back-493 - Add-actualStart-and-actualEnd-support-for-milestones.md
@@ -1,0 +1,61 @@
+---
+id: BACK-493
+title: Add actualStart and actualEnd support for milestones
+status: Draft
+assignee:
+  - '@kimi'
+created_date: '2026-05-28 01:55'
+updated_date: '2026-05-28 01:55'
+labels: []
+dependencies:
+  - 'BACK-492'
+references: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend the `actualStart` and `actualEnd` fields introduced in BACK-492 to **milestones**, with auto-population driven by task status changes within the milestone.
+
+**Auto-population rules:**
+- When any task belonging to a milestone transitions to an in-progress status (e.g., "In Progress"), if the milestone's `actualStart` is empty, it is automatically set to the current date-time (`YYYY-MM-DD HH:MM`).
+- When the **last remaining non-terminal task** belonging to a milestone transitions to a terminal/Done status, if the milestone's `actualEnd` is empty, it is automatically set to the current date-time.
+
+Users can manually override these values via CLI and Web UI.
+
+**Scope:**
+- Add `actualStart` and `actualEnd` to `Milestone` type, markdown parser/serializer, and file-system operations.
+- Core business logic: hook into `updateTask` to detect milestone-level trigger conditions and cascade updates to the parent milestone.
+- CLI: `milestone create` and `milestone edit` flags (`--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end`).
+- Server API: milestone create/update handlers.
+- Web UI: milestone detail/edit forms with `datetime-local` inputs.
+- MCP: milestone schemas and handlers.
+- i18n labels for all 4 locales.
+- Tests and agent guidelines.
+
+**Out of scope for BACK-492:**
+- This work is intentionally deferred to a follow-up task so that BACK-492 can ship task-level actual dates first.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Milestones support optional `actualStart` and `actualEnd` end-to-end: types, create/edit flows, markdown frontmatter persistence, and load/save parsing.
+- [ ] #2 When a task under a milestone transitions to an in-progress status, the milestone's `actualStart` is auto-populated with current date-time if empty.
+- [ ] #3 When all tasks under a milestone are in a terminal/Done status, the milestone's `actualEnd` is auto-populated with current date-time if empty.
+- [ ] #4 CLI `milestone create` and `milestone edit` support `--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end`.
+- [ ] #5 Web UI and server API support `actualStart` and `actualEnd` in milestone create / edit / view paths.
+- [ ] #6 MCP milestone schemas and handlers support `actualStart` and `actualEnd`.
+- [ ] #7 i18n labels added for all 4 locales (en, ja, zh-CN, zh-TW).
+- [ ] #8 Agent guidelines updated to mention milestone actual date fields.
+- [ ] #9 The two fields are optional; absence must not break existing milestones or frontmatter files.
+<!-- AC:END -->
+
+## Definition of Done
+
+<!-- DOD:BEGIN -->
+- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [ ] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-493 - Add-actualStart-and-actualEnd-support-for-milestones.md
+++ b/backlog/tasks/back-493 - Add-actualStart-and-actualEnd-support-for-milestones.md
@@ -5,7 +5,7 @@ status: Draft
 assignee:
   - '@kimi'
 created_date: '2026-05-28 01:55'
-updated_date: '2026-05-28 01:55'
+updated_date: '2026-05-28 02:58'
 labels: []
 dependencies:
   - 'BACK-492'
@@ -29,7 +29,7 @@ Users can manually override these values via CLI and Web UI.
 - Core business logic: hook into `updateTask` to detect milestone-level trigger conditions and cascade updates to the parent milestone.
 - CLI: `milestone create` and `milestone edit` flags (`--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end`).
 - Server API: milestone create/update handlers.
-- Web UI: milestone detail/edit forms with `datetime-local` inputs.
+- Web UI: milestone detail/edit forms with `datetime-local` inputs, following the same UTC-storage/local-display convention established in BACK-492 (via `storedUtcToDateTimeLocal` / `dateTimeLocalToStoredUtc`).
 - MCP: milestone schemas and handlers.
 - i18n labels for all 4 locales.
 - Tests and agent guidelines.
@@ -48,9 +48,27 @@ Users can manually override these values via CLI and Web UI.
 - [ ] #5 Web UI and server API support `actualStart` and `actualEnd` in milestone create / edit / view paths.
 - [ ] #6 MCP milestone schemas and handlers support `actualStart` and `actualEnd`.
 - [ ] #7 i18n labels added for all 4 locales (en, ja, zh-CN, zh-TW).
-- [ ] #8 Agent guidelines updated to mention milestone actual date fields.
-- [ ] #9 The two fields are optional; absence must not break existing milestones or frontmatter files.
+- [ ] #8 Web UI `datetime-local` inputs correctly convert between stored UTC values and local timezone display, consistent with task-level `actualStart`/`actualEnd` behavior.
+- [ ] #9 Agent guidelines updated to mention milestone actual date fields.
+- [ ] #10 The two fields are optional; absence must not break existing milestones or frontmatter files.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:IMPLEMENTATION_PLAN:BEGIN -->
+1. Extend `Milestone` type and milestone markdown parser/serializer with `actual_start`/`actual_end` frontmatter fields.
+2. Add milestone auto-population logic in `updateTask`: when a task under a milestone transitions to in-progress, set milestone `actualStart` if empty; when the last non-terminal task under a milestone becomes terminal, set milestone `actualEnd` if empty.
+3. Add CLI flags (`--actual-start`, `--actual-end`, `--clear-actual-start`, `--clear-actual-end`) to `milestone create` and `milestone edit`.
+4. Extend server API and MCP milestone handlers.
+5. Add Web UI `datetime-local` inputs for milestones, reusing `storedUtcToDateTimeLocal`/`dateTimeLocalToStoredUtc` from BACK-492 for timezone consistency.
+6. Add i18n labels, update agent guidelines, and write tests.
+<!-- SECTION:IMPLEMENTATION_PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+_(Deferred to implementation phase.)_
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 

--- a/backlog/tasks/back-494 - Fix-task-edit-modal-keyboard-shortcuts-interfering-with-title-input.md
+++ b/backlog/tasks/back-494 - Fix-task-edit-modal-keyboard-shortcuts-interfering-with-title-input.md
@@ -4,11 +4,12 @@ title: Fix task edit modal keyboard shortcuts interfering with title input
 status: Done
 assignee:
   - '@kimi'
-created_date: '2026-05-28 02:31'
-updated_date: '2026-05-28 03:10'
+created_date: '2026-05-27 02:31'
+updated_date: '2026-05-28 18:34'
 labels: []
 dependencies: []
 priority: medium
+ordinal: 43400
 actual_start: '2026-05-28 03:38'
 actual_end: '2026-05-28 03:10'
 ---

--- a/backlog/tasks/back-494 - Fix-task-edit-modal-keyboard-shortcuts-interfering-with-title-input.md
+++ b/backlog/tasks/back-494 - Fix-task-edit-modal-keyboard-shortcuts-interfering-with-title-input.md
@@ -1,0 +1,82 @@
+---
+id: BACK-494
+title: Fix task edit modal keyboard shortcuts interfering with title input
+status: Done
+assignee:
+  - '@kimi'
+created_date: '2026-05-28 02:31'
+updated_date: '2026-05-28 03:10'
+labels: []
+dependencies: []
+priority: medium
+actual_start: '2026-05-28 03:38'
+actual_end: '2026-05-28 03:10'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The `TaskDetailsModal` component registers global `window` keydown listeners (capture phase) for shortcuts like `E` (edit), `C` (complete), `D` (demote), `P` (promote), `Ctrl+S` (save), and `Escape` (cancel). These shortcuts fire even when the user is typing into form inputs — most critically the **title input** — making it impossible to enter characters that match shortcut keys.
+
+**Affected shortcuts in `TaskDetailsModal.tsx`:**
+- `E` → switches to edit mode
+- `C` → completes a done-status task
+- `D` → demotes a non-done task
+- `P` → promotes a draft task
+- `Ctrl/Cmd+S` → saves in edit mode
+- `Escape` → cancels edit
+
+**Root cause:**
+The global `window.addEventListener("keydown", onKey, { capture: true })` handler does not check whether the event target is an `<input>`, `<textarea>`, or content-editable element before invoking `e.preventDefault()`.
+
+**Expected behavior:**
+When focus is inside any text-input element (title, description editor, criteria text, etc.), all modal-level shortcuts should be suppressed so the user's keystrokes reach the input normally.
+
+**Scope:**
+- Add an `isTypingTarget(event)` guard to the global keydown handler in `TaskDetailsModal.tsx`.
+- Ensure the guard covers `<input>`, `<textarea>`, and `contenteditable` elements.
+- Verify no other Web UI modals have the same issue.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 Typing the letter `E` into the task title input no longer triggers edit mode.
+- [x] #2 Typing the letters `C`, `D`, or `P` into any text input inside `TaskDetailsModal` does not trigger their respective actions.
+- [x] #3 `Ctrl/Cmd+S` and `Escape` are also suppressed when focus is inside a text-input element.
+- [x] #4 Shortcuts continue to work normally when focus is outside text-input elements (e.g. on the modal backdrop or non-input UI).
+- [x] #5 The fix uses a reusable `isTypingTarget` helper placed in a shared location (e.g. `src/web/utils/`).
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:IMPLEMENTATION_PLAN:BEGIN -->
+1. Inspect the global `keydown` listener in `TaskDetailsModal.tsx` to catalog all affected shortcuts.
+2. Create a reusable `isTypingTarget` helper in `src/web/utils/keyboard.ts` that detects `<input>`, `<textarea>`, and `contenteditable` elements using duck-typing (no DOM-only `instanceof` checks so tests run outside a browser).
+3. Add unit tests for `isTypingTarget` covering inputs, textareas, contenteditable, plain divs, null targets, and non-HTMLElement objects.
+4. Insert `if (isTypingTarget(e)) return;` at the top of the global `keydown` handler in `TaskDetailsModal.tsx`.
+5. Run TypeScript check, Biome check, and unit tests.
+<!-- SECTION:IMPLEMENTATION_PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Duck-typing instead of `instanceof HTMLElement`**
+The first version of `isTypingTarget` used `target instanceof HTMLElement`, which fails in Bun's test runner because `HTMLElement` is not defined outside a browser. Switched to duck-typing (`typeof target === "object"`, then read `.tagName` and `.isContentEditable`). This keeps the helper testable in Node/Bun while remaining fully compatible with real DOM elements in the browser.
+
+**Capture-phase listener left intact**
+The existing `window.addEventListener("keydown", onKey, { capture: true })` was kept as-is; only an early-return guard was added. This preserves the existing shortcut behavior for non-input focus (e.g. clicking the modal backdrop and pressing `E` still enters edit mode).
+
+**Files modified:**
+- `src/web/utils/keyboard.ts` — new helper
+- `src/web/utils/keyboard.test.ts` — unit tests
+- `src/web/components/TaskDetailsModal.tsx` — added guard + import
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-495 - Implement-tracking-Gantt-view-with-plan-vs-actual-comparison.md
+++ b/backlog/tasks/back-495 - Implement-tracking-Gantt-view-with-plan-vs-actual-comparison.md
@@ -1,0 +1,94 @@
+---
+id: BACK-495
+title: Implement tracking Gantt view with plan vs actual comparison
+status: Done
+assignee:
+  - '@kimi'
+created_date: '2026-05-28 08:32'
+updated_date: '2026-05-29 18:14'
+labels:
+  - gantt
+  - web-ui
+  - frontend
+  - tracking
+milestone: m-7
+dependencies:
+  - BACK-495.1
+  - BACK-495.2
+  - BACK-495.3
+  - BACK-495.4
+references:
+  - src/web/components/GanttView.tsx
+  - src/web/App.tsx
+  - src/web/locales/en.ts
+  - src/web/locales/zh-CN.ts
+priority: high
+ordinal: 153400
+planned_start: '2026-05-28'
+planned_end: '2026-05-29'
+actual_start: '2026-05-28 16:58'
+actual_end: '2026-05-28 18:55'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a tracking Gantt view to the Backlog.md Web UI that simultaneously displays planned time ranges (hatched border) and actual task progress (solid color bar) on the same row, enabling visual deviation tracking for early starts, normal progress, and delays.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+# Tracking Gantt Design
+
+## Background
+
+Backlog.md task data has three time states:
+
+1. **Newly created tasks**: only createdDate, no planned or actual time
+2. **Planned but not executed / in-progress tasks**: have plannedStart / plannedEnd, possibly with actualStart / actualEnd
+3. **Completed tasks**: have both planned and actual time
+
+Field evolution: BACK-491 only had plannedStart / plannedEnd / createdDate / updatedDate. actualStart / actualEnd were added later; the system auto-writes actualStart when status changes to "in progress" and actualEnd when status reaches a terminal state.
+
+The existing Gantt (BACK-491) draws all tasks as single-color bars using resolved effective time, making it impossible to distinguish "planned" vs "actual" or visually track progress deviations. This design introduces a **Tracking Gantt** that displays both planned and actual ranges on the same row.
+
+## Architecture
+
+- Left table time columns always display actual time
+- Gantt bars use a dual-layer structure: bottom actual bar (solid fill) + top plan border (hatched fill)
+- Dependency arrows use smart time resolution for connection points
+- Tooltip shows both planned and actual time
+- Legend explains all visual elements
+
+## Task Breakdown
+
+- BACK-495.1: Left table + time resolution engine
+- BACK-495.2: Dual-layer Gantt bar rendering (actual + plan border)
+- BACK-495.3: Tooltip, legend, and interaction enhancements
+- BACK-495.4: Smart dependency arrow time resolution
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Designed the overall tracking Gantt solution, supporting simultaneous display of planned and actual ranges on the same row.
+- Clarified drawing rules for three data states: creation time only / planned but no actual / planned with actual.
+- Defined dual-layer structure: bottom actual bar (status-colored solid fill) + top plan border (60° hatched fill).
+- Defined smart dependency arrow connection point selection logic.
+- Designed tooltip, legend, and interaction enhancements.
+- Defined minimum width fallback strategy (day view 4h, week/month 1d, quarter/year 8px).
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Tracking Gantt view is functional in the Web UI with plan vs actual comparison
+- [x] #2 All subtasks (BACK-495.1 ~ BACK-495.4) are completed, merged, and verified
+<!-- AC:END -->

--- a/backlog/tasks/back-495.1 - Update-left-table-and-actual-bar-time-resolution-for-tracking-Gantt.md
+++ b/backlog/tasks/back-495.1 - Update-left-table-and-actual-bar-time-resolution-for-tracking-Gantt.md
@@ -1,0 +1,95 @@
+---
+id: BACK-495.1
+title: Update left table and actual bar time resolution for tracking Gantt
+status: Done
+assignee: []
+created_date: '2026-05-28 08:32'
+updated_date: '2026-05-29 18:14'
+labels:
+  - gantt
+  - web-ui
+  - frontend
+milestone: m-7
+dependencies: []
+references:
+  - src/web/components/GanttView.tsx
+parent_task_id: BACK-495
+priority: high
+ordinal: 37400
+actual_start: '2026-05-28 17:15'
+actual_end: '2026-05-28 17:16'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Modify the left table to display four time columns (Planned Start, Planned End, Actual Start, Actual End). Add a toggle switch in the toolbar to show/hide plan time columns. Actual times display with hours/minutes when present; fallback to resolved time with * indicator when absent. Update the underlying time resolution engine in GanttView.tsx to support actualStart/actualEnd as primary fields. Ensure all column headers are properly internationalized.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Left Table Time Column Rules
+
+The "Start Time" and "End Time" columns in the left table always display actual time:
+
+| Priority | Actual Start | Actual End |
+|---|---|---|
+| 1 | actualStart | actualEnd |
+| 2 | createdDate | updatedDate |
+| 3 | createdDate | createdDate + 1d (fallback) |
+
+If a task has no actualStart / actualEnd, fallback to creation / update time, consistent with existing logic.
+
+## Time Resolution and Coordinate Calculation
+
+**Actual bar coordinates** (smart time resolution):
+1. actualStart → actualEnd (actual time first)
+2. If missing → fallback to createdDate / updatedDate
+3. If still missing (only createdDate, no updatedDate) → createdDate + minimum width fallback (day view 4h, week/month 1d, quarter/year 8px)
+
+**Plan border coordinates**:
+1. plannedStart → plannedEnd
+2. If missing → do not draw plan border layer
+
+### Minimum Width Fallback
+
+- Minimum width fallback is only enabled when "no actualStart/actualEnd and no updatedDate"; since createdDate is required, every task has at least creation time
+- Fallback strategy is consistent with existing logic (day view 4h, week/month 1d, quarter/year 8px)
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Extended ParsedTask interface with plannedStart/plannedEnd fields for plan border rendering.
+- Rewrote parseTasks to prioritize actualStart/actualEnd for the left table and actual bar, falling back to createdDate/updatedDate and minimum width.
+- Expanded left table from 2 time columns to 4: Planned Start, Planned End, Actual Start, Actual End.
+- Added showPlanTime toggle switch in toolbar; plan columns only visible when enabled.
+- Added showActualTime toggle switch in toolbar (default on); actual columns can be hidden.
+- Dynamic left panel width based on showPlanTime / showActualTime / hasCrossYearTasks.
+- formatDisplayDate now shows HH:MM when time component is non-zero; omits time for date-only planned dates.
+- Added i18n keys for new columns and toggles in en/ja/zh-CN/zh-TW.
+- Fixed parseDate to use T00:00:00 for date-only values, ensuring consistent local-time parsing.
+- getTimelineX now accepts snapToDay parameter: plan dates snap to 00:00 in non-day views, actual dates preserve time precision.
+- All time columns use truncate to prevent text overflow.
+- Cross-year tasks auto-detected; actual columns widen to w-44 (176px) when cross-year tasks exist.
+- Type-check and lint pass.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Left table renders 4 time columns (Planned Start, Planned End, Actual Start, Actual End)
+- [x] #2 showPlanTime and showActualTime toggles correctly show/hide columns
+- [x] #3 Time resolution correctly prioritizes actualStart/actualEnd → createdDate/updatedDate → minimum width fallback
+- [x] #4 Cross-year tasks are auto-detected and columns widen to prevent text overflow
+- [x] #5 parseDate handles date-only values as T00:00:00 local time without timezone shifts
+- [x] #6 getTimelineX supports snapToDay for plan dates while preserving actual time precision
+- [x] #7 All time columns use truncate to prevent text overflow
+<!-- AC:END -->

--- a/backlog/tasks/back-495.2 - Implement-dual-layer-Gantt-bar-rendering-actual-plan-border.md
+++ b/backlog/tasks/back-495.2 - Implement-dual-layer-Gantt-bar-rendering-actual-plan-border.md
@@ -1,0 +1,116 @@
+---
+id: BACK-495.2
+title: Implement dual-layer Gantt bar rendering (actual + plan border)
+status: Done
+assignee: []
+created_date: '2026-05-28 08:32'
+updated_date: '2026-05-29 18:14'
+labels:
+  - gantt
+  - web-ui
+  - frontend
+milestone: m-7
+dependencies:
+  - BACK-495.1
+references:
+  - src/web/components/GanttView.tsx
+parent_task_id: BACK-495
+priority: high
+ordinal: 38400
+actual_start: '2026-05-28 17:16'
+actual_end: '2026-05-28 17:17'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the dual-layer Gantt bar: bottom layer draws solid color bars based on actual time (status-colored), top layer draws plan borders with 60-degree hatched lines. Light mode: white 2px shadow + gray 1px border. Dark mode: gray 2px shadow + white 1px border. Plan and actual bars are independently positioned on the same row with z-axis overlay. Plan borders respect the showPlanTime toggle state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Gantt Bar Rendering: Dual-Layer Structure
+
+Each task row draws two independently positioned elements at the same y coordinate, stacked on the z-axis:
+
+### Bottom Layer: Actual Task Bar (Solid Fill)
+
+- Time coordinates: based on actualStart → actualEnd (or fallback creation/update time), independently calculating x position and width
+- Style: solid rectangle, color varies by task status
+  - In Progress → blue-500
+  - Done / Completed → emerald-500
+  - To Do → gray-400 / dark:gray-500
+  - Blocked → red-500
+  - Cancelled → gray-300 / dark:gray-600
+- Border radius: same as existing bars (rounded-md)
+- Height: 60%–70% of row height, vertically centered
+
+### Top Layer: Plan Border (Hatched Fill)
+
+- Time coordinates: based on plannedStart → plannedEnd, independently calculating x position and width
+- If a task has no planned time, do not draw the plan border layer
+- The plan border consists of two overlapping border layers at the exact same time coordinates:
+
+#### a. Thick Border (Shadow Layer)
+- Line width: 2px
+- Fill: evenly spaced 6px, -60° slanted line pattern
+- Light mode: white thick border creating depth shadow on light background
+- Dark mode: gray thick border creating depth shadow on dark background
+
+#### b. Thin Border (Final Plan Line)
+- Position: fully overlapping with thick border
+- Line width: 1px
+- Fill: evenly spaced 6px, -60° slanted line pattern
+- Light mode: gray thin border as the final visible plan line
+- Dark mode: white thin border as the final visible plan line
+
+### Z-Axis Overlay Effects
+
+The actual bar is drawn first on the bottom layer, and the plan border is drawn on top. Both are independently positioned according to their own time coordinates, naturally presenting the following deviation relationships:
+
+| Deviation Scenario | Condition | Visual Result |
+|---|---|---|
+| Early start | actualStart < plannedStart | Actual bar starts before the plan border on the left; left overflow is solid color (no hatching), overlap is color + hatching |
+| Normal | actualStart = plannedStart and actualEnd ≤ plannedEnd | Actual bar starts at the left edge of the plan border and extends inside; visible area is color + hatching, unreached tail is pure hatching |
+| Delay | actualEnd > plannedEnd | Actual bar exceeds the plan border on the right; right overflow is solid color (no hatching), overlap is color + hatching |
+
+### Drawing Behavior for Three Data States
+
+| Data State | Actual Bar | Plan Border | Visual Description |
+|---|---|---|---|
+| Only creation/update time (no planned time) | ✓ Drawn by createdDate / updatedDate | ✗ Not drawn | Solid color bar, consistent with existing logic |
+| Has planned time, no actualStart / actualEnd | ✓ Drawn by createdDate / updatedDate (or minimum width fallback) | ✓ Drawn by planned time | A very short actual bar inside (or next to) the plan border |
+| Has planned time + actualStart / actualEnd | ✓ Drawn by actual time positioning | ✓ Drawn by planned time positioning | Both independently positioned, z-axis overlay shows deviation |
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added planPositions useMemo to calculate plan border coordinates based on plannedStart/plannedEnd independently from actual bars.
+- Split task bar rendering into two layers: actual bars (bottom, status-colored solid) and plan borders (top, hatched lines with -60deg repeating-linear-gradient).
+- Plan border styling: light mode uses white 2px border (outer) + gray 1px border (inner); dark mode uses gray 2px border (outer) + white 1px border (inner).
+- Both layers independently positioned on same row with z-axis overlay; overlapping area shows color+hatched pattern, non-overlapping shows pure color or pure hatching.
+- Plan border layer has pointer-events-none so hover/click interactions work on actual bar layer.
+- Fallback tasks (no actualEnd) use minWidth fallback; non-fallback tasks use real duration with 4px minimum for visibility.
+- Status legend dynamically renders all unique statuses from current tasks with original casing.
+- Type-check and lint pass.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Dual-layer rendering: actual bars (bottom, status-colored) + plan borders (top, hatched)
+- [x] #2 Plan borders use -60deg repeating-linear-gradient with 2px outer + 1px inner borders
+- [x] #3 Light/dark mode border colors invert correctly (white/gray vs gray/white)
+- [x] #4 z-axis overlay correctly visualizes early start, normal progress, and delay deviations
+- [x] #5 Plan border layer uses pointer-events-none so clicks pass through to actual bars
+- [x] #6 Fallback tasks use minWidth兜底; non-fallback tasks render real duration with 4px minimum
+- [x] #7 Status legend dynamically groups all unique statuses with original casing
+<!-- AC:END -->

--- a/backlog/tasks/back-495.3 - Add-tooltip-legend-and-interaction-enhancements-for-tracking-Gantt.md
+++ b/backlog/tasks/back-495.3 - Add-tooltip-legend-and-interaction-enhancements-for-tracking-Gantt.md
@@ -1,0 +1,90 @@
+---
+id: BACK-495.3
+title: 'Add tooltip, legend and interaction enhancements for tracking Gantt'
+status: Done
+assignee: []
+created_date: '2026-05-28 08:33'
+updated_date: '2026-05-29 18:23'
+labels:
+  - gantt
+  - web-ui
+  - frontend
+milestone: m-7
+dependencies:
+  - BACK-495.2
+references:
+  - src/web/components/GanttView.tsx
+parent_task_id: BACK-495
+priority: medium
+ordinal: 39400
+actual_start: '2026-05-28 17:09'
+actual_end: '2026-05-28 17:12'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Enhance hover tooltip to display both planned and actual time ranges with deviation analysis. Add click highlighting that includes plan border layer. Add a legend to the toolbar explaining solid bars = actual time, hatched borders = planned time, arrows = dependencies.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Interaction Adjustments
+
+### Hover Tooltip
+
+Hovering over a task bar displays both planned and actual time:
+
+- Task ID and title
+- Planned time range (plannedStart → plannedEnd)
+- Actual time range (actualStart → actualEnd, with fallback indicator)
+- Status, priority, and other metadata
+
+### Click Highlighting
+
+- After clicking a task bar, highlighting logic remains unchanged (upstream/downstream tasks + dependency arrows highlighted, others dimmed to 30%)
+- Plan border layer participates in highlighting/dimming together
+
+### Legend
+
+Add a legend to the Gantt toolbar explaining:
+- Solid color bars = actual task time (grouped by status)
+- Hatched border = planned time range
+- Arrow = task dependency
+- Yellow * = estimated/fallback time (used when no actualEnd exists)
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Enhanced hover tooltip to display planned time range (when available) and actual time range with fallback indicator.
+- Click highlighting works on both actual bar and plan border layers via shared opacity state.
+- Added legend to toolbar showing: status-colored bars grouped by actual status, hatched border = Planned, arrow = Dependency, amber * = Fallback/estimated time.
+- Added fallback legend entry with amber bold asterisk.
+- Chinese i18n: fallback label changed from fallback to estimate.
+- Sort icons repositioned to the right of header labels with vertical centering.
+- Chinese/Japanese/English header labels use two-line layout (e.g., Planned\nStart, Actual\nStart).
+- Default sort changed to ID desc; default view changed to day.
+- Auto-select first task on load; auto-scroll timeline to selected task when switching views.
+- Selected task background deepened from bg-blue-50 to bg-blue-100.
+- Type-check and lint pass.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Tooltip displays planned range, actual range, and fallback indicator on hover
+- [x] #2 Click highlighting applies to both actual bars and plan borders
+- [x] #3 Legend shows status bars (grouped), plan border, dependency arrow, and fallback asterisk
+- [x] #4 Header labels use two-line layout; sort icons are right-aligned and vertically centered
+- [x] #5 Default view is day granularity with ID descending sort
+- [x] #6 First task auto-selected on load; timeline auto-scrolls to selected task on view switch
+- [x] #7 Selected task background is visually distinct (bg-blue-100 dark:bg-blue-900/40)
+<!-- AC:END -->

--- a/backlog/tasks/back-495.4 - Implement-smart-dependency-arrow-time-resolution-for-tracking-Gantt.md
+++ b/backlog/tasks/back-495.4 - Implement-smart-dependency-arrow-time-resolution-for-tracking-Gantt.md
@@ -1,0 +1,106 @@
+---
+id: BACK-495.4
+title: Implement smart dependency arrow time resolution for tracking Gantt
+status: Done
+assignee: []
+created_date: '2026-05-28 08:34'
+updated_date: '2026-05-29 18:23'
+labels:
+  - gantt
+  - web-ui
+  - frontend
+milestone: m-7
+dependencies:
+  - BACK-495.1
+references:
+  - src/web/components/GanttView.tsx
+parent_task_id: BACK-495
+priority: high
+ordinal: 40400
+actual_start: '2026-05-28 17:07'
+actual_end: '2026-05-28 17:08'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update dependency arrow rendering to use smart time resolution with fallback (actualStart/End -> createdDate/updatedDate -> minimum width). Arrow start point: use actual start if earlier than planned start, otherwise use planned start. Arrow end point: use planned end if resolved end is earlier than planned start, otherwise use resolved end.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+## Dependency Arrow Drawing Rules
+
+The start and end points of dependency arrows must first go through smart time resolution to obtain the "resolved effective time", then select connection points based on planned time deviation.
+
+### Smart Time Resolution (Arrow-Specific)
+
+**Resolved start time**:
+1. If actualStart exists → use actualStart
+2. Else if createdDate exists → use createdDate date portion
+3. Else → no valid start time (task does not participate in dependency connections)
+
+**Resolved end time**:
+1. If actualEnd exists → use actualEnd
+2. Else if updatedDate exists → use updatedDate date portion
+3. Else if createdDate exists → use createdDate + 1d (minimum width fallback)
+4. Else → no valid end time (task does not participate in dependency connections)
+
+### Start Side (Arrow Tail, Connecting Predecessor End)
+
+resolvedEnd = resolved end time (from fallback chain above)
+
+if (resolvedEnd < plannedStart) {
+  use plannedEnd as connection point
+} else {
+  use resolvedEnd as connection point
+}
+
+Logic: if the resolved end is earlier than planned start (rare, possibly data anomaly or strongly ahead of schedule), fall back to plannedEnd to maintain dependency chain continuity; otherwise use resolved end.
+
+### End Side (Arrow Head, Connecting Successor Start)
+
+resolvedStart = resolved start time (from fallback chain above)
+
+if (resolvedStart < plannedStart) {
+  use resolvedStart as connection point
+} else {
+  use plannedStart as connection point
+}
+
+Logic: if the actual/resolved start is earlier than planned, the arrow should connect to the earlier actual position; otherwise to the planned start position.
+
+### Arrow SVG Drawing Unchanged
+
+- Continue using SVG cubic-bezier curves
+- Horizontal entry + curve + arrow style remains unchanged
+- Multiple dependencies auto-offset to prevent tangling
+- Arrow color in tracking mode uses gray-500 (avoids clashing with status-colored bars)
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Implemented smart time resolution for dependency arrow connection points.
+- Arrow start point (predecessor end side): uses resolved end time; if resolved end < planned start, falls back to planned end.
+- Arrow end point (successor start side): uses resolved start time; if resolved start < planned start, uses resolved start, otherwise uses planned start.
+- Arrow color changed to gray-500 to avoid visual conflict with status-colored bars.
+- Type-check and lint pass.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Arrow start point uses resolved end; falls back to plannedEnd when resolved < plannedStart
+- [x] #2 Arrow end point uses resolved start when earlier than plannedStart, else plannedStart
+- [x] #3 Smart time resolution correctly applies fallback chain for arrow connection points
+- [x] #4 Arrow color is gray-500 to avoid visual conflict with status-colored bars
+- [x] #5 SVG cubic-bezier curves and multi-dependency offset logic remain intact
+<!-- AC:END -->

--- a/backlog/tasks/back-496 - Fix subtask grouping under parent task for ID sorting across all views.md
+++ b/backlog/tasks/back-496 - Fix subtask grouping under parent task for ID sorting across all views.md
@@ -1,0 +1,69 @@
+---
+id: BACK-496
+title: Fix subtask grouping under parent task for ID sorting across all views
+status: Done
+assignee:
+  - '@kimi'
+created_date: '2026-05-28 19:09'
+updated_date: '2026-05-28 23:09'
+labels: []
+dependencies: []
+ordinal: 154400
+actual_start: '2026-05-28 19:09'
+actual_end: '2026-05-28 19:26'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Subtasks were not correctly grouped under their parent tasks when sorting by ID in the All Tasks, Milestones, and Gantt views. The Board view handled this correctly by using compareTaskIds (supporting decimal IDs like task-495.4), while other views used extractTaskNumericId which only matched trailing digits, causing subtasks to sort far away from their parents.
+
+All four views (Board, All Tasks, Milestones, Gantt) now use groupSubtasksUnderParents to ensure subtasks appear immediately under their parent task, with internal subtask order following the overall sort direction (ascending/descending).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Subtasks appear immediately under parent task when sorting by ID in Board view
+- [x] #2 Subtasks appear immediately under parent task when sorting by ID in All Tasks view
+- [x] #3 Subtasks appear immediately under parent task when sorting by ID in Milestones view
+- [x] #4 Subtasks appear immediately under parent task when sorting by ID in Gantt view
+- [x] #5 Subtask order within group follows overall sort direction (ascending/descending)
+<!-- AC:END -->
+
+
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add groupSubtasksUnderParents utility to src/utils/task-sorting.ts with direction support.\n2. Replace extractTaskNumericId with compareTaskIds in TaskList, MilestonesPage, and GanttView.\n3. Apply groupSubtasksUnderParents during ID sorting in Board (TaskColumn), All Tasks (TaskList), Milestones (MilestonesPage), and Gantt (GanttView).\n4. Add unit tests for groupSubtasksUnderParents including direction reversal scenarios.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+groupSubtasksUnderParents works by iterating the already-sorted array, collecting children by parent ID into a Map, then rebuilding the output with each parent followed by its children. The direction parameter reverses children after compareFn sort to match overall ascending/descending order.\n\nTaskColumn.tsx (Board view) required special attention because its ID sort is a local column-level toggle separate from the default ordinal/date sort. The grouping is only applied when the user explicitly selects ID sort from the column menu.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed ID sorting behavior across all views to consistently group subtasks under their parent tasks.
+
+Root causes:
+1. TaskList, MilestonesPage, and GanttView used extractTaskNumericId (only matched trailing digits), causing decimal IDs like task-495.4 to be treated as 4 and sorted far from parent task-495.
+2. None of the views had subtask-to-parent grouping logic.
+
+Changes:
+1. Unified all four views to use compareTaskIds for proper decimal ID sorting.
+2. Added groupSubtasksUnderParents utility in src/utils/task-sorting.ts with direction support.
+3. Applied grouping to Board, All Tasks, Milestones, and Gantt views during ID sorting.
+4. Subtasks now appear under their parent task with internal order following the overall sort direction.
+5. Added unit tests covering groupSubtasksUnderParents behavior including direction reversal.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2912,6 +2912,44 @@ milestoneCmd
 	});
 
 milestoneCmd
+	.command("create <title>")
+	.description("create a new milestone")
+	.option("-d, --description <description>", "milestone description")
+	.option("--due-date <date>", "due date (YYYY-MM-DD)")
+	.option("--planned-start <date>", "planned start date (YYYY-MM-DD)")
+	.option("--planned-end <date>", "planned end date (YYYY-MM-DD)")
+	.option("--actual-start <date>", "actual start date (YYYY-MM-DD HH:MM)")
+	.option("--actual-end <date>", "actual end date (YYYY-MM-DD HH:MM)")
+	.action(
+		async (
+			title: string,
+			options: {
+				description?: string;
+				dueDate?: string;
+				plannedStart?: string;
+				plannedEnd?: string;
+				actualStart?: string;
+				actualEnd?: string;
+			},
+		) => {
+			const cwd = await requireProjectRoot();
+			const core = new Core(cwd);
+
+			const milestone = await core.filesystem.createMilestone(
+				title.trim(),
+				options.description,
+				options.dueDate,
+				options.plannedStart,
+				options.plannedEnd,
+				options.actualStart,
+				options.actualEnd,
+			);
+
+			console.log(`Created milestone "${milestone.title}" (${milestone.id}).`);
+		},
+	);
+
+milestoneCmd
 	.command("edit <name>")
 	.description("edit a milestone title, description, and/or dates")
 	.option("-t, --title <title>", "new milestone title")
@@ -2919,9 +2957,13 @@ milestoneCmd
 	.option("--due-date <date>", "due date (YYYY-MM-DD)")
 	.option("--planned-start <date>", "planned start date (YYYY-MM-DD)")
 	.option("--planned-end <date>", "planned end date (YYYY-MM-DD)")
+	.option("--actual-start <date>", "actual start date (YYYY-MM-DD HH:MM)")
+	.option("--actual-end <date>", "actual end date (YYYY-MM-DD HH:MM)")
 	.option("--clear-due-date", "clear due date")
 	.option("--clear-planned-start", "clear planned start date")
 	.option("--clear-planned-end", "clear planned end date")
+	.option("--clear-actual-start", "clear actual start date")
+	.option("--clear-actual-end", "clear actual end date")
 	.action(
 		async (
 			name: string,
@@ -2931,9 +2973,13 @@ milestoneCmd
 				dueDate?: string;
 				plannedStart?: string;
 				plannedEnd?: string;
+				actualStart?: string;
+				actualEnd?: string;
 				clearDueDate?: boolean;
 				clearPlannedStart?: boolean;
 				clearPlannedEnd?: boolean;
+				clearActualStart?: boolean;
+				clearActualEnd?: boolean;
 			},
 		) => {
 			const cwd = await requireProjectRoot();
@@ -2945,9 +2991,13 @@ milestoneCmd
 				options.dueDate ||
 				options.plannedStart ||
 				options.plannedEnd ||
+				options.actualStart ||
+				options.actualEnd ||
 				options.clearDueDate ||
 				options.clearPlannedStart ||
-				options.clearPlannedEnd;
+				options.clearPlannedEnd ||
+				options.clearActualStart ||
+				options.clearActualEnd;
 			if (!hasEditFlags) {
 				console.error(
 					"No edits specified. Use --title, --description, --due-date, --planned-start, --planned-end, --actual-start, --actual-end, or --clear-* options.",
@@ -2967,6 +3017,8 @@ milestoneCmd
 			const dueDate = options.clearDueDate ? "" : options.dueDate;
 			const plannedStart = options.clearPlannedStart ? "" : options.plannedStart;
 			const plannedEnd = options.clearPlannedEnd ? "" : options.plannedEnd;
+			const actualStart = options.clearActualStart ? "" : options.actualStart;
+			const actualEnd = options.clearActualEnd ? "" : options.actualEnd;
 
 			const result = await core.updateMilestone(
 				milestone.id,
@@ -2976,6 +3028,8 @@ milestoneCmd
 				plannedStart,
 				plannedEnd,
 				options.description,
+				actualStart,
+				actualEnd,
 			);
 
 			if (!result.success) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1480,6 +1480,8 @@ taskCmd
 	.option("--due-date <date>", "task due date (YYYY-MM-DD)")
 	.option("--planned-start <date>", "planned start date (YYYY-MM-DD)")
 	.option("--planned-end <date>", "planned end date (YYYY-MM-DD)")
+	.option("--actual-start <date>", "actual start date (YYYY-MM-DD HH:MM)")
+	.option("--actual-end <date>", "actual end date (YYYY-MM-DD HH:MM)")
 	.option("--draft")
 	.option("-p, --parent <taskId>", "specify parent task ID")
 	.option(
@@ -1589,6 +1591,11 @@ taskCmd
 				acceptanceCriteria: criteria.map((text) => ({ text, checked: false })),
 				definitionOfDoneAdd: toStringArray(options.dod),
 				disableDefinitionOfDoneDefaults: options.dodDefaults === false,
+				dueDate: typeof options.dueDate === "string" ? options.dueDate.trim() : undefined,
+				plannedStart: typeof options.plannedStart === "string" ? options.plannedStart.trim() : undefined,
+				plannedEnd: typeof options.plannedEnd === "string" ? options.plannedEnd.trim() : undefined,
+				actualStart: typeof options.actualStart === "string" ? options.actualStart.trim() : undefined,
+				actualEnd: typeof options.actualEnd === "string" ? options.actualEnd.trim() : undefined,
 			});
 
 			if (usePlainOutput) {
@@ -2138,11 +2145,15 @@ taskCmd
 	.option("-m, --milestone <milestone>", "assign task to milestone by ID or title")
 	.option("--clear-milestone", "clear task milestone assignment")
 	.option("--due-date <date>", "task due date (YYYY-MM-DD)")
+	.option("--actual-start <date>", "actual start date (YYYY-MM-DD HH:MM)")
+	.option("--actual-end <date>", "actual end date (YYYY-MM-DD HH:MM)")
 	.option("--planned-start <date>", "planned start date (YYYY-MM-DD)")
 	.option("--planned-end <date>", "planned end date (YYYY-MM-DD)")
 	.option("--clear-due-date", "clear task due date")
 	.option("--clear-planned-start", "clear planned start date")
 	.option("--clear-planned-end", "clear planned end date")
+	.option("--clear-actual-start", "clear actual start date")
+	.option("--clear-actual-end", "clear actual end date")
 	.option("--plain", "use plain text output after editing")
 	.option("--add-label <label>")
 	.option("--remove-label <label>")
@@ -2474,6 +2485,12 @@ taskCmd
 		if (typeof options.plannedEnd === "string") {
 			editArgs.plannedEnd = options.plannedEnd.trim();
 		}
+		if (typeof options.actualStart === "string") {
+			editArgs.actualStart = options.actualStart.trim();
+		}
+		if (typeof options.actualEnd === "string") {
+			editArgs.actualEnd = options.actualEnd.trim();
+		}
 		if (options.clearDueDate) {
 			editArgs.dueDate = "";
 		}
@@ -2482,6 +2499,12 @@ taskCmd
 		}
 		if (options.clearPlannedEnd) {
 			editArgs.plannedEnd = "";
+		}
+		if (options.clearActualStart) {
+			editArgs.actualStart = "";
+		}
+		if (options.clearActualEnd) {
+			editArgs.actualEnd = "";
 		}
 		if (acceptanceAdditions.length > 0) {
 			editArgs.acceptanceCriteriaAdd = acceptanceAdditions;
@@ -2927,7 +2950,7 @@ milestoneCmd
 				options.clearPlannedEnd;
 			if (!hasEditFlags) {
 				console.error(
-					"No edits specified. Use --title, --description, --due-date, --planned-start, --planned-end, or --clear-* options.",
+					"No edits specified. Use --title, --description, --due-date, --planned-start, --planned-end, --actual-start, --actual-end, or --clear-* options.",
 				);
 				process.exitCode = 1;
 				return;

--- a/src/commands/task-wizard.ts
+++ b/src/commands/task-wizard.ts
@@ -24,6 +24,8 @@ interface TaskWizardValues {
 	dueDate: string;
 	plannedStart: string;
 	plannedEnd: string;
+	actualStart: string;
+	actualEnd: string;
 }
 
 export interface TaskWizardTaskOption {
@@ -515,6 +517,8 @@ async function runTaskWizardValues(params: {
 			dueDate: values.dueDate,
 			plannedStart: values.plannedStart,
 			plannedEnd: values.plannedEnd,
+			actualStart: values.actualStart,
+			actualEnd: values.actualEnd,
 		};
 	} catch (error) {
 		if (error instanceof TaskWizardCancelledError) {
@@ -572,6 +576,8 @@ function toInitialWizardValues(input: { title?: string } & Partial<Task>): TaskW
 		dueDate: input.dueDate ?? "",
 		plannedStart: input.plannedStart ?? "",
 		plannedEnd: input.plannedEnd ?? "",
+		actualStart: input.actualStart ?? "",
+		actualEnd: input.actualEnd ?? "",
 	};
 }
 
@@ -621,6 +627,8 @@ export async function runTaskCreateWizard(
 		...(values.dueDate.trim().length > 0 && { dueDate: values.dueDate.trim() }),
 		...(values.plannedStart.trim().length > 0 && { plannedStart: values.plannedStart.trim() }),
 		...(values.plannedEnd.trim().length > 0 && { plannedEnd: values.plannedEnd.trim() }),
+		...(values.actualStart.trim().length > 0 && { actualStart: values.actualStart.trim() }),
+		...(values.actualEnd.trim().length > 0 && { actualEnd: values.actualEnd.trim() }),
 	};
 	return input;
 }
@@ -700,6 +708,12 @@ export async function runTaskEditWizard(
 	}
 	if (values.plannedEnd !== initial.plannedEnd) {
 		updateInput.plannedEnd = values.plannedEnd.trim();
+	}
+	if (values.actualStart !== initial.actualStart) {
+		updateInput.actualStart = values.actualStart.trim();
+	}
+	if (values.actualEnd !== initial.actualEnd) {
+		updateInput.actualEnd = values.actualEnd.trim();
 	}
 
 	const existingCriteria = (options.task.acceptanceCriteriaItems ?? [])

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1,6 +1,7 @@
 import { rename as moveFile, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
+import { milestoneKey } from "../core/milestones.ts";
 import { FileSystem } from "../file-system/operations.ts";
 import { GitOperations } from "../git/operations.ts";
 import {
@@ -1108,6 +1109,44 @@ export class Core {
 			if (isTerminalStatus(newStatus, statuses) && !isTerminalStatus(oldStatus, statuses) && !task.actualEnd) {
 				task.actualEnd = now;
 			}
+
+			// Milestone-level auto-population
+			const taskMilestone = task.milestone;
+			if (taskMilestone) {
+				const milestone = await this.fs.loadMilestone(taskMilestone);
+				if (milestone) {
+					const taskMilestoneKey = milestoneKey(taskMilestone);
+					if (isInProgressStatus(newStatus) && !isInProgressStatus(oldStatus) && !milestone.actualStart) {
+						await this.fs.updateMilestone(
+							milestone.id,
+							milestone.title,
+							undefined,
+							undefined,
+							undefined,
+							undefined,
+							now,
+							undefined,
+						);
+					}
+					if (isTerminalStatus(newStatus, statuses) && !isTerminalStatus(oldStatus, statuses) && !milestone.actualEnd) {
+						const allTasks = await this.fs.listTasks();
+						const milestoneTasks = allTasks.filter((t) => milestoneKey(t.milestone) === taskMilestoneKey);
+						const allTerminal = milestoneTasks.every((t) => isTerminalStatus(t.status, statuses));
+						if (allTerminal) {
+							await this.fs.updateMilestone(
+								milestone.id,
+								milestone.title,
+								undefined,
+								undefined,
+								undefined,
+								undefined,
+								undefined,
+								now,
+							);
+						}
+					}
+				}
+			}
 		}
 
 		await this.fs.saveTask(task);
@@ -2212,6 +2251,8 @@ export class Core {
 		plannedStart?: string,
 		plannedEnd?: string,
 		description?: string,
+		actualStart?: string,
+		actualEnd?: string,
 	): Promise<{
 		success: boolean;
 		sourcePath?: string;
@@ -2219,7 +2260,16 @@ export class Core {
 		milestone?: Milestone;
 		previousTitle?: string;
 	}> {
-		const result = await this.fs.updateMilestone(identifier, title, dueDate, plannedStart, plannedEnd, description);
+		const result = await this.fs.updateMilestone(
+			identifier,
+			title,
+			dueDate,
+			plannedStart,
+			plannedEnd,
+			description,
+			actualStart,
+			actualEnd,
+		);
 		if (!result.success) {
 			return result;
 		}

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -38,6 +38,7 @@ import {
 } from "../utils/milestone-filter.ts";
 import { buildIdRegex, extractAnyPrefix, getPrefixForType, normalizeId } from "../utils/prefix-config.ts";
 import {
+	isInProgressStatus,
 	getCanonicalStatus as resolveCanonicalStatus,
 	getValidStatuses as resolveValidStatuses,
 } from "../utils/status.ts";
@@ -1059,6 +1060,8 @@ export class Core {
 				...(input.dueDate && { dueDate: input.dueDate }),
 				...(input.plannedStart && { plannedStart: input.plannedStart }),
 				...(input.plannedEnd && { plannedEnd: input.plannedEnd }),
+				...(input.actualStart && { actualStart: input.actualStart }),
+				...(input.actualEnd && { actualEnd: input.actualEnd }),
 			};
 
 			const filePath = await this.writePreparedTask(task, isDraft);
@@ -1092,6 +1095,20 @@ export class Core {
 
 		// Always set updatedDate when updating a task
 		task.updatedDate = new Date().toISOString().slice(0, 16).replace("T", " ");
+
+		// Auto-populate actualStart / actualEnd on status changes
+		if (statusChanged) {
+			const now = new Date().toISOString().slice(0, 16).replace("T", " ");
+			const config = await this.fs.loadConfig();
+			const statuses = config?.statuses ?? DEFAULT_STATUSES;
+
+			if (isInProgressStatus(newStatus) && !isInProgressStatus(oldStatus) && !task.actualStart) {
+				task.actualStart = now;
+			}
+			if (isTerminalStatus(newStatus, statuses) && !isTerminalStatus(oldStatus, statuses) && !task.actualEnd) {
+				task.actualEnd = now;
+			}
+		}
 
 		await this.fs.saveTask(task);
 		// Keep any in-process ContentStore in sync for immediate UI/search freshness.
@@ -1226,6 +1243,22 @@ export class Core {
 				delete task.plannedEnd;
 			} else {
 				task.plannedEnd = next;
+			}
+		});
+
+		applyOptionalDateField(input.actualStart, task.actualStart, (next) => {
+			if (next === undefined) {
+				delete task.actualStart;
+			} else {
+				task.actualStart = next;
+			}
+		});
+
+		applyOptionalDateField(input.actualEnd, task.actualEnd, (next) => {
+			if (next === undefined) {
+				delete task.actualEnd;
+			} else {
+				task.actualEnd = next;
 			}
 		});
 

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1101,6 +1101,8 @@ export class FileSystem {
 		dueDate?: string,
 		plannedStart?: string,
 		plannedEnd?: string,
+		actualStart?: string,
+		actualEnd?: string,
 	): Promise<Milestone> {
 		return await this.withCreateLock(async () => {
 			const milestonesDir = await this.getMilestonesDir();
@@ -1155,6 +1157,8 @@ export class FileSystem {
 				...(dueDate !== undefined && { dueDate: dueDate.trim() || undefined }),
 				...(plannedStart !== undefined && { plannedStart: plannedStart.trim() || undefined }),
 				...(plannedEnd !== undefined && { plannedEnd: plannedEnd.trim() || undefined }),
+				...(actualStart !== undefined && { actualStart: actualStart.trim() || undefined }),
+				...(actualEnd !== undefined && { actualEnd: actualEnd.trim() || undefined }),
 			});
 
 			const filepath = join(milestonesDir, filename);
@@ -1176,6 +1180,8 @@ export class FileSystem {
 		plannedStart?: string,
 		plannedEnd?: string,
 		description?: string,
+		actualStart?: string,
+		actualEnd?: string,
 	): Promise<{
 		success: boolean;
 		sourcePath?: string;
@@ -1224,6 +1230,8 @@ export class FileSystem {
 				...(dueDate !== undefined && { dueDate: dueDate.trim() || undefined }),
 				...(plannedStart !== undefined && { plannedStart: plannedStart.trim() || undefined }),
 				...(plannedEnd !== undefined && { plannedEnd: plannedEnd.trim() || undefined }),
+				...(actualStart !== undefined && { actualStart: actualStart.trim() || undefined }),
+				...(actualEnd !== undefined && { actualEnd: actualEnd.trim() || undefined }),
 			});
 
 			if (sourcePath !== targetPath) {

--- a/src/formatters/task-plain-text.ts
+++ b/src/formatters/task-plain-text.ts
@@ -114,6 +114,12 @@ export function formatTaskPlainText(task: Task, options: TaskPlainTextOptions = 
 	if (task.plannedEnd) {
 		lines.push(`Planned End: ${formatDateForDisplay(task.plannedEnd)}`);
 	}
+	if (task.actualStart) {
+		lines.push(`Actual Start: ${formatDateForDisplay(task.actualStart)}`);
+	}
+	if (task.actualEnd) {
+		lines.push(`Actual End: ${formatDateForDisplay(task.actualEnd)}`);
+	}
 
 	if (task.labels?.length) {
 		lines.push(`Labels: ${task.labels.join(", ")}`);

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -114,6 +114,8 @@ labels: [backend, api]
 dueDate: 2026-06-15
 plannedStart: 2026-06-01
 plannedEnd: 2026-06-10
+actualStart: 2026-06-02 09:30
+actualEnd: 2026-06-09 17:00
 modified_files:
   - src/server/api.ts
   - src/web/components/TaskList.tsx
@@ -174,6 +176,10 @@ PR-style summary of what was implemented.
 | Clear Due Date          | `backlog task edit 42 --clear-due-date`                  |
 | Clear Planned Start     | `backlog task edit 42 --clear-planned-start`             |
 | Clear Planned End       | `backlog task edit 42 --clear-planned-end`               |
+| Actual Start            | `backlog task edit 42 --actual-start 2026-06-02 09:30`   |
+| Actual End              | `backlog task edit 42 --actual-end 2026-06-09 17:00`     |
+| Clear Actual Start      | `backlog task edit 42 --clear-actual-start`              |
+| Clear Actual End        | `backlog task edit 42 --clear-actual-end`                |
 | Description             | `backlog task edit 42 -d "New description"`              |
 | Add AC                  | `backlog task edit 42 --ac "New criterion"`              |
 | Add DoD                 | `backlog task edit 42 --dod "Ship notes"`                |
@@ -542,6 +548,10 @@ backlog search --modified-file src/server/api.ts --plain
 | Assign           | `backlog task edit 42 -a @sara`             |
 | Add labels       | `backlog task edit 42 -l backend,api`       |
 | Set priority     | `backlog task edit 42 --priority high`      |
+| Set actual start | `backlog task edit 42 --actual-start 2026-06-02 09:30` |
+| Set actual end   | `backlog task edit 42 --actual-end 2026-06-09 17:00` |
+
+> **Note on actual dates**: `actualStart` and `actualEnd` are automatically populated when you change a task's status (to "In Progress" and "Done" respectively). You do not need to set them manually unless the user explicitly requests it.
 
 ### Acceptance Criteria Management
 

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -753,18 +753,21 @@ backlog doc view doc-1
 
 Use Backlog.md public interfaces for milestone creation, listing, and archival so IDs, frontmatter, paths, and task relationships stay consistent.
 
+> **Important**: Assigning a milestone name to a task via `--milestone` only records the name on the task file; it **does not create a milestone file**. To create a milestone with an ID, dates, or other metadata, you must explicitly create it first using `milestone create` or `milestone_add`, then assign tasks to it.
+
 #### CLI Usage
 
 The CLI supports creating, listing, and archiving milestones.
 
 ```bash
-# Create a new milestone (saved under backlog/milestones/)
-backlog milestone add "Release 2.0" -d "Ship the v2.0 release"
+# Create a new milestone file explicitly (saved under backlog/milestones/)
+backlog milestone create "Release 2.0" -d "Ship the v2.0 release"
 
 # Edit a milestone (title, description, dates)
 backlog milestone edit "Release 2.0" -t "Release 2.1" -d "Updated scope"
 backlog milestone edit "Release 2.0" --due-date 2026-06-15
 backlog milestone edit "Release 2.0" --planned-start 2026-06-01 --planned-end 2026-06-10
+backlog milestone edit "Release 2.0" --actual-start "2026-06-02 09:30" --actual-end "2026-06-09 17:00"
 backlog milestone edit "Release 2.0" --clear-due-date --clear-planned-start
 
 # List active milestones (shows completion ratio)
@@ -805,8 +808,8 @@ backlog board --milestones
 
 #### MCP / API Usage
 
-- Use `milestone_add` to create milestones with title and optional description.
-- Use `milestone_rename` to rename a milestone and optionally update its date fields.
+- Use `milestone_add` to create milestones with title and optional description, actualStart, and actualEnd.
+- Use `milestone_edit` to rename a milestone and optionally update its date fields, including actualStart and actualEnd.
 - Use `milestone_archive` to archive a milestone.
 - Use `milestone_list` to list active and archived milestones.
 

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -244,6 +244,8 @@ export function parseMilestone(content: string): Milestone {
 		dueDate: frontmatter.due_date ? normalizeDate(frontmatter.due_date) : undefined,
 		plannedStart: frontmatter.planned_start ? normalizeDate(frontmatter.planned_start) : undefined,
 		plannedEnd: frontmatter.planned_end ? normalizeDate(frontmatter.planned_end) : undefined,
+		actualStart: frontmatter.actual_start ? normalizeDate(frontmatter.actual_start) : undefined,
+		actualEnd: frontmatter.actual_end ? normalizeDate(frontmatter.actual_end) : undefined,
 	};
 }
 

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -198,6 +198,8 @@ export function parseTask(content: string): Task {
 		dueDate: frontmatter.due_date ? normalizeDate(frontmatter.due_date) : undefined,
 		plannedStart: frontmatter.planned_start ? normalizeDate(frontmatter.planned_start) : undefined,
 		plannedEnd: frontmatter.planned_end ? normalizeDate(frontmatter.planned_end) : undefined,
+		actualStart: frontmatter.actual_start ? normalizeDate(frontmatter.actual_start) : undefined,
+		actualEnd: frontmatter.actual_end ? normalizeDate(frontmatter.actual_end) : undefined,
 	};
 }
 

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -170,6 +170,8 @@ export function serializeMilestone(milestone: Milestone): string {
 		...(milestone.dueDate && { due_date: milestone.dueDate }),
 		...(milestone.plannedStart && { planned_start: milestone.plannedStart }),
 		...(milestone.plannedEnd && { planned_end: milestone.plannedEnd }),
+		...(milestone.actualStart && { actual_start: milestone.actualStart }),
+		...(milestone.actualEnd && { actual_end: milestone.actualEnd }),
 	};
 
 	const content = milestone.rawContent?.trim() ? milestone.rawContent : `## Description\n\n${milestone.description}`;

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -70,6 +70,8 @@ export function serializeTask(task: Task): string {
 		...(task.dueDate && { due_date: task.dueDate }),
 		...(task.plannedStart && { planned_start: task.plannedStart }),
 		...(task.plannedEnd && { planned_end: task.plannedEnd }),
+		...(task.actualStart && { actual_start: task.actualStart }),
+		...(task.actualEnd && { actual_end: task.actualEnd }),
 	};
 
 	let contentBody = task.rawContent ?? "";

--- a/src/mcp/tools/milestones/handlers.ts
+++ b/src/mcp/tools/milestones/handlers.ts
@@ -14,6 +14,8 @@ import {
 export type MilestoneAddArgs = {
 	name: string;
 	description?: string;
+	actualStart?: string;
+	actualEnd?: string;
 };
 
 export type MilestoneEditArgs = {
@@ -24,6 +26,8 @@ export type MilestoneEditArgs = {
 	plannedStart?: string;
 	plannedEnd?: string;
 	description?: string;
+	actualStart?: string;
+	actualEnd?: string;
 };
 
 export type MilestoneRemoveArgs = {
@@ -331,7 +335,7 @@ export class MilestoneHandlers {
 			formatListBlock(`Archived milestone values still on tasks (${archivedTaskValues.length}):`, archivedTaskValues),
 		);
 		blocks.push(
-			"Hint: use milestone_add to create milestone files, milestone_rename / milestone_remove to manage, milestone_archive to archive.",
+			"Hint: use milestone_add to create milestone files, milestone_edit / milestone_remove to manage, milestone_archive to archive.",
 		);
 
 		return {
@@ -365,7 +369,15 @@ export class MilestoneHandlers {
 		}
 
 		// Create milestone file
-		const milestone = await this.core.filesystem.createMilestone(name, args.description);
+		const milestone = await this.core.filesystem.createMilestone(
+			name,
+			args.description,
+			undefined,
+			undefined,
+			undefined,
+			args.actualStart,
+			args.actualEnd,
+		);
 
 		return {
 			content: [
@@ -395,8 +407,18 @@ export class MilestoneHandlers {
 		const isPlannedStartChanged =
 			args.plannedStart !== undefined && args.plannedStart !== (sourceMilestone.plannedStart ?? "");
 		const isPlannedEndChanged = args.plannedEnd !== undefined && args.plannedEnd !== (sourceMilestone.plannedEnd ?? "");
+		const isActualStartChanged =
+			args.actualStart !== undefined && args.actualStart !== (sourceMilestone.actualStart ?? "");
+		const isActualEndChanged = args.actualEnd !== undefined && args.actualEnd !== (sourceMilestone.actualEnd ?? "");
 
-		if (!isTitleChanged && !isDueDateChanged && !isPlannedStartChanged && !isPlannedEndChanged) {
+		if (
+			!isTitleChanged &&
+			!isDueDateChanged &&
+			!isPlannedStartChanged &&
+			!isPlannedEndChanged &&
+			!isActualStartChanged &&
+			!isActualEndChanged
+		) {
 			return {
 				content: [
 					{
@@ -442,6 +464,8 @@ export class MilestoneHandlers {
 			args.plannedStart,
 			args.plannedEnd,
 			args.description,
+			args.actualStart,
+			args.actualEnd,
 		);
 		if (!renameResult.success || !renameResult.milestone) {
 			throw new BacklogToolError(`Failed to rename milestone "${sourceMilestone.title}".`, "INTERNAL_ERROR");
@@ -471,6 +495,8 @@ export class MilestoneHandlers {
 					undefined,
 					undefined,
 					undefined,
+					undefined,
+					undefined,
 				);
 				const rollbackDetails: string[] = [];
 				if (!rollbackRenameResult.success) {
@@ -494,7 +520,17 @@ export class MilestoneHandlers {
 			});
 		} catch {
 			const rollbackTaskFailures = await this.rollbackTaskMilestones(previousMilestones);
-			const rollbackRenameResult = await this.core.updateMilestone(sourceMilestone.id, sourceMilestone.title, false);
+			const rollbackRenameResult = await this.core.updateMilestone(
+				sourceMilestone.id,
+				sourceMilestone.title,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+			);
 			const rollbackDetails: string[] = [];
 			if (!rollbackRenameResult.success) {
 				rollbackDetails.push("failed to rollback milestone file rename");

--- a/src/mcp/tools/milestones/schemas.ts
+++ b/src/mcp/tools/milestones/schemas.ts
@@ -21,6 +21,14 @@ export const milestoneAddSchema: JsonSchema = {
 			maxLength: 2000,
 			description: "Optional description for the milestone",
 		},
+		actualStart: {
+			type: "string",
+			description: "Actual start date-time (YYYY-MM-DD HH:MM). Pass empty string to clear.",
+		},
+		actualEnd: {
+			type: "string",
+			description: "Actual end date-time (YYYY-MM-DD HH:MM). Pass empty string to clear.",
+		},
 	},
 	required: ["name"],
 	additionalProperties: false,
@@ -63,6 +71,14 @@ export const milestoneEditSchema: JsonSchema = {
 		plannedEnd: {
 			type: "string",
 			description: "Planned end date (YYYY-MM-DD). Pass empty string to clear.",
+		},
+		actualStart: {
+			type: "string",
+			description: "Actual start date-time (YYYY-MM-DD HH:MM). Pass empty string to clear.",
+		},
+		actualEnd: {
+			type: "string",
+			description: "Actual end date-time (YYYY-MM-DD HH:MM). Pass empty string to clear.",
 		},
 	},
 	required: ["from", "to"],

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -42,6 +42,8 @@ export type TaskCreateArgs = {
 	dueDate?: string;
 	plannedStart?: string;
 	plannedEnd?: string;
+	actualStart?: string;
+	actualEnd?: string;
 };
 
 export type TaskListArgs = {
@@ -131,6 +133,8 @@ export class TaskHandlers {
 				definitionOfDoneAdd: args.definitionOfDoneAdd,
 				disableDefinitionOfDoneDefaults: args.disableDefinitionOfDoneDefaults,
 				dueDate: args.dueDate,
+				actualStart: args.actualStart,
+				actualEnd: args.actualEnd,
 				plannedStart: args.plannedStart,
 				plannedEnd: args.plannedEnd,
 			});

--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -147,6 +147,16 @@ export function generateTaskCreateSchema(config: BacklogConfig): JsonSchema {
 				maxLength: 10,
 				description: "Planned end date in YYYY-MM-DD format",
 			},
+			actualStart: {
+				type: "string",
+				maxLength: 16,
+				description: "Actual start date in YYYY-MM-DD HH:MM format",
+			},
+			actualEnd: {
+				type: "string",
+				maxLength: 16,
+				description: "Actual end date in YYYY-MM-DD HH:MM format",
+			},
 		},
 		required: ["title"],
 		additionalProperties: false,
@@ -423,6 +433,16 @@ export function generateTaskEditSchema(config: BacklogConfig): JsonSchema {
 				type: "string",
 				maxLength: 10,
 				description: "Planned end date in YYYY-MM-DD format. Set to empty string to clear.",
+			},
+			actualStart: {
+				type: "string",
+				maxLength: 16,
+				description: "Actual start date in YYYY-MM-DD HH:MM format. Set to empty string to clear.",
+			},
+			actualEnd: {
+				type: "string",
+				maxLength: 16,
+				description: "Actual end date in YYYY-MM-DD HH:MM format. Set to empty string to clear.",
 			},
 		},
 		required: ["id"],

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1640,6 +1640,8 @@ export class BacklogServer {
 				dueDate?: string;
 				plannedStart?: string;
 				plannedEnd?: string;
+				actualStart?: string;
+				actualEnd?: string;
 			};
 			const title = body.title?.trim();
 
@@ -1690,6 +1692,8 @@ export class BacklogServer {
 				body.dueDate,
 				body.plannedStart,
 				body.plannedEnd,
+				body.actualStart,
+				body.actualEnd,
 			);
 			return Response.json(milestone, { status: 201 });
 		} catch (error) {
@@ -1717,6 +1721,8 @@ export class BacklogServer {
 				dueDate: typeof bodyJson.dueDate === "string" ? bodyJson.dueDate : undefined,
 				plannedStart: typeof bodyJson.plannedStart === "string" ? bodyJson.plannedStart : undefined,
 				plannedEnd: typeof bodyJson.plannedEnd === "string" ? bodyJson.plannedEnd : undefined,
+				actualStart: typeof bodyJson.actualStart === "string" ? bodyJson.actualStart : undefined,
+				actualEnd: typeof bodyJson.actualEnd === "string" ? bodyJson.actualEnd : undefined,
 			});
 			const milestone =
 				(await this.core.filesystem.loadMilestone(sourceMilestone?.id ?? milestoneId)) ??

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -316,6 +316,7 @@ export class BacklogServer {
 					"/tasks": spaIndexHtml,
 					"/milestones": spaIndexHtml,
 					"/drafts": spaIndexHtml,
+					"/gantt": spaIndexHtml,
 					"/documentation": spaIndexHtml,
 					"/documentation/*": spaIndexHtml,
 					"/decisions": spaIndexHtml,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -914,6 +914,8 @@ export class BacklogServer {
 				dueDate: typeof payload.dueDate === "string" ? payload.dueDate.trim() : undefined,
 				plannedStart: typeof payload.plannedStart === "string" ? payload.plannedStart.trim() : undefined,
 				plannedEnd: typeof payload.plannedEnd === "string" ? payload.plannedEnd.trim() : undefined,
+				actualStart: typeof payload.actualStart === "string" ? payload.actualStart.trim() : undefined,
+				actualEnd: typeof payload.actualEnd === "string" ? payload.actualEnd.trim() : undefined,
 			});
 			return Response.json(createdTask, { status: 201 });
 		} catch (error) {
@@ -1030,6 +1032,12 @@ export class BacklogServer {
 		}
 		if ("plannedStart" in updates && typeof updates.plannedStart === "string") {
 			updateInput.plannedStart = updates.plannedStart.trim();
+		}
+		if ("actualStart" in updates && typeof updates.actualStart === "string") {
+			updateInput.actualStart = updates.actualStart.trim();
+		}
+		if ("actualEnd" in updates && typeof updates.actualEnd === "string") {
+			updateInput.actualEnd = updates.actualEnd.trim();
 		}
 		if ("plannedEnd" in updates && typeof updates.plannedEnd === "string") {
 			updateInput.plannedEnd = updates.plannedEnd.trim();

--- a/src/test/markdown.test.ts
+++ b/src/test/markdown.test.ts
@@ -666,6 +666,23 @@ Description here.`;
 			expect(task.dueDate).toBeUndefined();
 			expect(task.plannedStart).toBeUndefined();
 			expect(task.plannedEnd).toBeUndefined();
+			expect(task.actualStart).toBeUndefined();
+			expect(task.actualEnd).toBeUndefined();
+		});
+
+		it("should parse actualStart and actualEnd as date-time", () => {
+			const content = `---
+id: task-1
+title: "Actual Date Task"
+status: "To Do"
+actual_start: 2026-06-02 09:30
+actual_end: 2026-06-09 17:00
+---
+
+Description here.`;
+			const task = parseTask(content);
+			expect(task.actualStart).toBe("2026-06-02 09:30");
+			expect(task.actualEnd).toBe("2026-06-09 17:00");
 		});
 	});
 
@@ -703,6 +720,8 @@ Description here.`;
 			expect(result).not.toContain("due_date");
 			expect(result).not.toContain("planned_start");
 			expect(result).not.toContain("planned_end");
+			expect(result).not.toContain("actual_start");
+			expect(result).not.toContain("actual_end");
 		});
 	});
 
@@ -726,6 +745,25 @@ Description here.`;
 			expect(parsed.dueDate).toBe("2026-06-15");
 			expect(parsed.plannedStart).toBe("2026-06-01");
 			expect(parsed.plannedEnd).toBe("2026-06-10");
+		});
+
+		it("should preserve actualStart and actualEnd through parse and serialize", () => {
+			const original: Task = {
+				id: "task-1",
+				title: "Actual Date Round Trip",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2026-01-01 12:00",
+				labels: [],
+				dependencies: [],
+				actualStart: "2026-06-02 09:30",
+				actualEnd: "2026-06-09 17:00",
+				rawContent: "Description here.",
+			};
+			const serialized = serializeTask(original);
+			const parsed = parseTask(serialized);
+			expect(parsed.actualStart).toBe("2026-06-02 09:30");
+			expect(parsed.actualEnd).toBe("2026-06-09 17:00");
 		});
 	});
 });

--- a/src/test/task-sorting.test.ts
+++ b/src/test/task-sorting.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { compareTaskIds, parseTaskId, sortByPriority, sortByTaskId, sortTasks } from "../utils/task-sorting.ts";
+import {
+	compareTaskIds,
+	groupSubtasksUnderParents,
+	parseTaskId,
+	sortByPriority,
+	sortByTaskId,
+	sortTasks,
+} from "../utils/task-sorting.ts";
 
 describe("parseTaskId", () => {
 	test("parses simple task IDs", () => {
@@ -169,6 +176,70 @@ describe("sortByPriority", () => {
 
 		// Original array order should be preserved
 		expect(tasks).toEqual(original);
+	});
+});
+
+describe("groupSubtasksUnderParents", () => {
+	test("groups subtasks under their parent in ID order", () => {
+		const tasks = [
+			{ id: "task-3", title: "Task 3" },
+			{ id: "task-2.1", title: "Subtask 2.1", parentTaskId: "task-2" },
+			{ id: "task-2", title: "Task 2" },
+			{ id: "task-1", title: "Task 1" },
+			{ id: "task-2.2", title: "Subtask 2.2", parentTaskId: "task-2" },
+		];
+
+		const grouped = groupSubtasksUnderParents(tasks, (a, b) => compareTaskIds(a.id, b.id));
+		expect(grouped.map((t) => t.id)).toEqual(["task-3", "task-2", "task-2.1", "task-2.2", "task-1"]);
+	});
+
+	test("places orphaned subtasks at top level when parent is missing", () => {
+		const tasks = [
+			{ id: "task-1", title: "Task 1" },
+			{ id: "task-2.1", title: "Orphan", parentTaskId: "task-2" },
+		];
+
+		const grouped = groupSubtasksUnderParents(tasks);
+		expect(grouped.map((t) => t.id)).toEqual(["task-1", "task-2.1"]);
+	});
+
+	test("uses custom getParentId when parentTaskId is nested", () => {
+		const tasks = [
+			{ id: "task-3", raw: { parentTaskId: undefined } },
+			{ id: "task-2.1", raw: { parentTaskId: "task-2" } },
+			{ id: "task-2", raw: { parentTaskId: undefined } },
+			{ id: "task-1", raw: { parentTaskId: undefined } },
+		];
+
+		const grouped = groupSubtasksUnderParents(
+			tasks,
+			(a, b) => compareTaskIds(a.id, b.id),
+			(item) => item.raw.parentTaskId,
+		);
+		expect(grouped.map((t) => t.id)).toEqual(["task-3", "task-2", "task-2.1", "task-1"]);
+	});
+
+	test("preserves original parent order when no comparator given", () => {
+		const tasks = [
+			{ id: "task-2", title: "Task 2" },
+			{ id: "task-1", title: "Task 1" },
+			{ id: "task-2.1", title: "Subtask 2.1", parentTaskId: "task-2" },
+		];
+
+		const grouped = groupSubtasksUnderParents(tasks);
+		expect(grouped.map((t) => t.id)).toEqual(["task-2", "task-2.1", "task-1"]);
+	});
+
+	test("reverses subtasks when direction is desc", () => {
+		const tasks = [
+			{ id: "task-2", title: "Task 2" },
+			{ id: "task-2.1", title: "Subtask 2.1", parentTaskId: "task-2" },
+			{ id: "task-2.3", title: "Subtask 2.3", parentTaskId: "task-2" },
+			{ id: "task-2.2", title: "Subtask 2.2", parentTaskId: "task-2" },
+		];
+
+		const grouped = groupSubtasksUnderParents(tasks, (a, b) => compareTaskIds(a.id, b.id), undefined, "desc");
+		expect(grouped.map((t) => t.id)).toEqual(["task-2", "task-2.3", "task-2.2", "task-2.1"]);
 	});
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,8 @@ export interface Task {
 	dueDate?: string;
 	plannedStart?: string;
 	plannedEnd?: string;
+	actualStart?: string;
+	actualEnd?: string;
 	// Metadata fields
 	lastModified?: Date;
 	source?: "local" | "remote" | "completed" | "local-branch";
@@ -127,6 +129,8 @@ export interface TaskCreateInput {
 	dueDate?: string;
 	plannedStart?: string;
 	plannedEnd?: string;
+	actualStart?: string;
+	actualEnd?: string;
 }
 
 export interface TaskUpdateInput {
@@ -163,6 +167,8 @@ export interface TaskUpdateInput {
 	dueDate?: string;
 	plannedStart?: string;
 	plannedEnd?: string;
+	actualStart?: string;
+	actualEnd?: string;
 	acceptanceCriteria?: AcceptanceCriterionInput[];
 	addAcceptanceCriteria?: Array<AcceptanceCriterionInput | string>;
 	removeAcceptanceCriteria?: number[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,8 @@ export interface Milestone {
 	dueDate?: string;
 	plannedStart?: string;
 	plannedEnd?: string;
+	actualStart?: string;
+	actualEnd?: string;
 }
 
 export const DOCUMENT_TYPE_VALUES = ["readme", "guide", "specification", "other"] as const;

--- a/src/types/task-edit-args.ts
+++ b/src/types/task-edit-args.ts
@@ -42,6 +42,8 @@ export interface TaskEditArgs {
 	dueDate?: string;
 	plannedStart?: string;
 	plannedEnd?: string;
+	actualStart?: string;
+	actualEnd?: string;
 }
 
 export type TaskEditRequest = TaskEditArgs & { id: string };

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -39,3 +39,15 @@ export async function getCanonicalStatus(input: string | undefined, core?: Core)
 export function formatValidStatuses(configuredStatuses: string[]): string {
 	return configuredStatuses.join(", ");
 }
+
+function normalizeStatusForComparison(status: string | null | undefined): string {
+	return (status ?? "").trim().toLowerCase().replace(/\s+/g, "");
+}
+
+/**
+ * Check if a status represents "in progress" (case-insensitive, space-insensitive).
+ * Matches "In Progress", "inprogress", "进行中", etc.
+ */
+export function isInProgressStatus(status: string | null | undefined): boolean {
+	return normalizeStatusForComparison(status) === "inprogress";
+}

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -226,6 +226,12 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	if (typeof args.plannedEnd === "string") {
 		updateInput.plannedEnd = args.plannedEnd.trim();
 	}
+	if (typeof args.actualStart === "string") {
+		updateInput.actualStart = args.actualStart.trim();
+	}
+	if (typeof args.actualEnd === "string") {
+		updateInput.actualEnd = args.actualEnd.trim();
+	}
 
 	return updateInput;
 }

--- a/src/utils/task-sorting.ts
+++ b/src/utils/task-sorting.ts
@@ -165,6 +165,54 @@ export function sortByOrdinalAndPriority<
 }
 
 /**
+ * Re-order a list so that subtasks appear immediately under their parent task.
+ * Parent tasks retain the order from the input array. Subtasks are sorted
+ * using the provided comparator (defaults to input order).
+ * When direction is "desc", subtasks are reversed after sorting.
+ */
+export function groupSubtasksUnderParents<T extends { id: string }>(
+	items: T[],
+	compareFn?: (a: T, b: T) => number,
+	getParentId?: (item: T) => string | undefined,
+	direction?: "asc" | "desc",
+): T[] {
+	const byId = new Map<string, T>();
+	for (const item of items) {
+		byId.set(item.id, item);
+	}
+
+	const topLevel: T[] = [];
+	const childrenByParent = new Map<string, T[]>();
+
+	for (const item of items) {
+		const parentId = getParentId?.(item) ?? ((item as Record<string, unknown>).parentTaskId as string | undefined);
+		const parent = parentId ? byId.get(parentId) : undefined;
+		if (parent) {
+			const existing = childrenByParent.get(parent.id) ?? [];
+			existing.push(item);
+			childrenByParent.set(parent.id, existing);
+			continue;
+		}
+		topLevel.push(item);
+	}
+
+	const ordered: T[] = [];
+	for (const task of topLevel) {
+		ordered.push(task);
+		const subs = childrenByParent.get(task.id) ?? [];
+		if (compareFn) {
+			subs.sort(compareFn);
+		}
+		if (direction === "desc") {
+			subs.reverse();
+		}
+		ordered.push(...subs);
+	}
+
+	return ordered;
+}
+
+/**
  * Sort tasks by a specified field with fallback to task ID sorting.
  * Supported fields: 'priority', 'id', 'ordinal'
  */

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -10,6 +10,7 @@ import DraftsList from './components/DraftsList';
 import Settings from './components/Settings';
 import Statistics from './components/Statistics';
 import MilestonesPage from './components/MilestonesPage';
+import GanttView from './components/GanttView';
 import TaskDetailsModal from './components/TaskDetailsModal';
 import InitializationScreen from './components/InitializationScreen';
 import { SuccessToast } from './components/SuccessToast';
@@ -576,6 +577,7 @@ function App() {
             <Route path="wiki/*" element={<WikiDetail />} />
             <Route path="statistics" element={<Statistics tasks={tasks} isLoading={isLoading} onEditTask={handleEditTask} projectName={projectName} />} />
             <Route path="settings" element={<Settings />} />
+            <Route path="gantt" element={<GanttView tasks={tasks} onEditTask={handleEditTask} />} />
           </Route>
         </Routes>
 

--- a/src/web/components/GanttView.tsx
+++ b/src/web/components/GanttView.tsx
@@ -5,7 +5,6 @@ import { useI18n } from "../hooks/useI18n";
 const DAY = 24 * 60 * 60 * 1000;
 const ROW_HEIGHT = 40;
 const HEADER_HEIGHT = 80;
-const LEFT_PANEL_WIDTH = 480;
 
 export type Granularity = "day" | "week" | "month" | "quarter" | "year";
 
@@ -22,7 +21,7 @@ const GRANULARITY_CONFIG: Record<Granularity, {
 	year: { pxPerDay: 350 / 365, minWidthPx: 8, minDurationDays: 0, columnWidth: 350 },
 };
 
-type GanttSortColumn = "id" | "title" | "start" | "end";
+type GanttSortColumn = "id" | "title" | "plannedStart" | "plannedEnd" | "actualStart" | "actualEnd";
 type SortDirection = "asc" | "desc";
 
 interface ParsedTask {
@@ -33,6 +32,8 @@ interface ParsedTask {
 	originalStart?: string;
 	originalEnd?: string;
 	isFallback: boolean;
+	plannedStart?: Date;
+	plannedEnd?: Date;
 	status: string;
 	priority?: "high" | "medium" | "low";
 	dependencies: string[];
@@ -54,7 +55,8 @@ interface GanttViewProps {
 
 function parseDate(dateStr?: string): Date | null {
 	if (!dateStr) return null;
-	const iso = dateStr.includes(" ") ? dateStr.replace(" ", "T") : `${dateStr}T00:00:00`;
+	const hasTime = dateStr.includes(" ");
+	const iso = hasTime ? dateStr.replace(" ", "T") : `${dateStr}T00:00:00`;
 	const d = new Date(iso);
 	return Number.isNaN(d.getTime()) ? null : d;
 }
@@ -63,14 +65,17 @@ function parseTasks(tasks: Task[]): ParsedTask[] {
 	return tasks.map((task) => {
 		const plannedStart = parseDate(task.plannedStart);
 		const plannedEnd = parseDate(task.plannedEnd);
+		const actualStart = parseDate(task.actualStart);
+		const actualEnd = parseDate(task.actualEnd);
 		const created = parseDate(task.createdDate);
 		const updated = parseDate(task.updatedDate);
 
+		// Actual time resolution (for left table and actual bar)
 		let start: Date;
 		let originalStart: string | undefined;
-		if (plannedStart) {
-			start = plannedStart;
-			originalStart = task.plannedStart;
+		if (actualStart) {
+			start = actualStart;
+			originalStart = task.actualStart;
 		} else if (created) {
 			start = created;
 			originalStart = task.createdDate;
@@ -81,9 +86,9 @@ function parseTasks(tasks: Task[]): ParsedTask[] {
 		let end: Date;
 		let originalEnd: string | undefined;
 		let isFallback = false;
-		if (plannedEnd) {
-			end = plannedEnd;
-			originalEnd = task.plannedEnd;
+		if (actualEnd) {
+			end = actualEnd;
+			originalEnd = task.actualEnd;
 		} else if (updated) {
 			end = updated;
 			originalEnd = task.updatedDate;
@@ -109,6 +114,8 @@ function parseTasks(tasks: Task[]): ParsedTask[] {
 			originalStart,
 			originalEnd,
 			isFallback,
+			plannedStart: plannedStart ?? undefined,
+			plannedEnd: plannedEnd ?? undefined,
 			status: task.status,
 			priority: task.priority,
 			dependencies: task.dependencies ?? [],
@@ -121,15 +128,24 @@ function formatShortDate(date: Date): string {
 	return `${date.getMonth() + 1}/${date.getDate()}`;
 }
 
-function formatDisplayDate(date: Date): string {
+function formatDisplayDate(date: Date, showTime = true): string {
 	const y = date.getFullYear();
 	const m = date.getMonth() + 1;
 	const d = date.getDate();
+	const hh = date.getHours();
+	const mm = date.getMinutes();
+	const hasTime = hh !== 0 || mm !== 0;
 	const now = new Date();
+	let result: string;
 	if (y === now.getFullYear()) {
-		return `${m}/${d}`;
+		result = `${m}/${d}`;
+	} else {
+		result = `${y}/${m}/${d}`;
 	}
-	return `${y}/${m}/${d}`;
+	if (showTime && hasTime) {
+		result += ` ${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
+	}
+	return result;
 }
 
 function getWeekStart(date: Date): Date {
@@ -291,13 +307,19 @@ function getTimelineColumns(viewStart: Date, viewEnd: Date, granularity: Granula
 	return columns;
 }
 
-function getTimelineX(date: Date, columns: TimelineColumn[], granularity: Granularity): number {
+function getTimelineX(date: Date, columns: TimelineColumn[], granularity: Granularity, snapToDay = false): number {
+	const normalizedDate = new Date(date);
+	if (snapToDay) normalizedDate.setHours(0, 0, 0, 0);
 	let x = 0;
 	for (const col of columns) {
-		if (date.getTime() >= col.end.getTime()) {
+		const colStart = new Date(col.start);
+		if (snapToDay) colStart.setHours(0, 0, 0, 0);
+		const colEnd = new Date(col.end);
+		if (snapToDay) colEnd.setHours(0, 0, 0, 0);
+		if (normalizedDate.getTime() >= colEnd.getTime()) {
 			x += GRANULARITY_CONFIG[granularity].columnWidth;
-		} else if (date.getTime() >= col.start.getTime()) {
-			const ratio = (date.getTime() - col.start.getTime()) / (col.end.getTime() - col.start.getTime());
+		} else if (normalizedDate.getTime() >= colStart.getTime()) {
+			const ratio = (normalizedDate.getTime() - colStart.getTime()) / (colEnd.getTime() - colStart.getTime());
 			x += ratio * GRANULARITY_CONFIG[granularity].columnWidth;
 			break;
 		}
@@ -340,9 +362,11 @@ function getTaskStatusColor(status: string): string {
 
 export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 	const { t } = useI18n();
-	const [granularity, setGranularity] = useState<Granularity>("week");
+	const [granularity, setGranularity] = useState<Granularity>("day");
 	const [sortColumn, setSortColumn] = useState<GanttSortColumn>("id");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+	const [showPlanTime, setShowPlanTime] = useState(false);
+	const [showActualTime, setShowActualTime] = useState(true);
 	const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
 	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
 	const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
@@ -355,6 +379,18 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 	const timelineContainerRef = useRef<HTMLDivElement>(null);
 
 	const parsedTasks = useMemo(() => parseTasks(tasks), [tasks]);
+	const currentYear = new Date().getFullYear();
+	const hasCrossYearTasks = useMemo(() => {
+		return parsedTasks.some((task) => {
+			const years = [
+				task.plannedStart?.getFullYear(),
+				task.plannedEnd?.getFullYear(),
+				task.start.getFullYear(),
+				task.end.getFullYear(),
+			];
+			return years.some((y) => y !== undefined && y !== currentYear);
+		});
+	}, [parsedTasks, currentYear]);
 
 	const sortedTasks = useMemo(() => {
 		const list = [...parsedTasks];
@@ -367,10 +403,16 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 				case "title":
 					cmp = a.title.localeCompare(b.title);
 					break;
-				case "start":
+				case "plannedStart":
+					cmp = (a.plannedStart?.getTime() ?? 0) - (b.plannedStart?.getTime() ?? 0);
+					break;
+				case "plannedEnd":
+					cmp = (a.plannedEnd?.getTime() ?? 0) - (b.plannedEnd?.getTime() ?? 0);
+					break;
+				case "actualStart":
 					cmp = a.start.getTime() - b.start.getTime();
 					break;
-				case "end":
+				case "actualEnd":
 					cmp = a.end.getTime() - b.end.getTime();
 					break;
 			}
@@ -379,11 +421,26 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 		return list;
 	}, [parsedTasks, sortColumn, sortDirection]);
 
+	const leftPanelWidth = useMemo(() => {
+		const base = hasCrossYearTasks ? 320 : 368;
+		const planWidth = hasCrossYearTasks ? 192 : 160;
+		const actualWidth = hasCrossYearTasks ? 352 : 256;
+		return base + (showPlanTime ? planWidth : 0) + (showActualTime ? actualWidth : 0);
+	}, [showPlanTime, showActualTime, hasCrossYearTasks]);
+
 	useEffect(() => {
 		const range = getInitialViewRange(sortedTasks, granularity);
 		setViewStart(range.start);
 		setViewEnd(range.end);
 	}, [sortedTasks, granularity]);
+
+	const hasAutoSelected = useRef(false);
+	useEffect(() => {
+		if (!hasAutoSelected.current && sortedTasks.length > 0 && !selectedTaskId) {
+			setSelectedTaskId(sortedTasks[0]?.id ?? null);
+			hasAutoSelected.current = true;
+		}
+	}, [sortedTasks, selectedTaskId]);
 
 	const config = GRANULARITY_CONFIG[granularity];
 	const columns = useMemo(() => getTimelineColumns(viewStart, viewEnd, granularity), [viewStart, viewEnd, granularity]);
@@ -392,16 +449,47 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 	const taskPositions = useMemo(() => {
 		const positions: Record<string, { x: number; y: number; width: number }> = {};
 		sortedTasks.forEach((task) => {
-			const x = getTimelineX(task.start, columns, granularity);
-			const endX = getTimelineX(task.end, columns, granularity);
+			const x = getTimelineX(task.start, columns, granularity, false);
+			const endX = getTimelineX(task.end, columns, granularity, false);
 			const rawWidth = endX - x;
-			const minWidth = config.minWidthPx;
-			const width = Math.max(rawWidth, minWidth);
+			const width = task.isFallback ? Math.max(rawWidth, config.minWidthPx) : Math.max(rawWidth, 4);
 			const y = HEADER_HEIGHT + sortedTasks.indexOf(task) * ROW_HEIGHT;
 			positions[task.id] = { x, y, width };
 		});
 		return positions;
 	}, [sortedTasks, columns, granularity, config]);
+
+	const planPositions = useMemo(() => {
+		const positions: Record<string, { x: number; y: number; width: number } | null> = {};
+		sortedTasks.forEach((task) => {
+			if (!task.plannedStart || !task.plannedEnd) {
+				positions[task.id] = null;
+				return;
+			}
+			const x = getTimelineX(task.plannedStart, columns, granularity, true);
+			const endX = getTimelineX(task.plannedEnd, columns, granularity, true);
+			const rawWidth = endX - x;
+			const width = Math.max(rawWidth, 2);
+			const y = HEADER_HEIGHT + sortedTasks.indexOf(task) * ROW_HEIGHT;
+			positions[task.id] = { x, y, width };
+		});
+		return positions;
+	}, [sortedTasks, columns, granularity, config]);
+
+	const scrollToTask = useCallback((taskId: string) => {
+		const pos = taskPositions[taskId];
+		if (pos && timelineContainerRef.current) {
+			const container = timelineContainerRef.current;
+			const targetScrollLeft = pos.x + pos.width / 2 - container.clientWidth / 2;
+			container.scrollTo({ left: Math.max(0, targetScrollLeft), behavior: "smooth" });
+		}
+	}, [taskPositions]);
+
+	useEffect(() => {
+		if (selectedTaskId) {
+			scrollToTask(selectedTaskId);
+		}
+	}, [selectedTaskId, granularity, scrollToTask]);
 
 	const highlightedIds = useMemo(() => {
 		if (!selectedTaskId) return new Set<string>();
@@ -447,7 +535,7 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 	const renderSortableHeader = useCallback((label: string, column: GanttSortColumn, widthClass: string) => (
 		<th className={`px-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider ${widthClass}`} style={{ height: HEADER_HEIGHT }} aria-sort={getSortAriaValue(column)}>
 			<div className="h-full flex items-end pb-2">
-				<button type="button" onClick={() => handleSortChange(column)} className="inline-flex items-center gap-1 hover:text-gray-700 dark:hover:text-gray-100">
+				<button type="button" onClick={() => handleSortChange(column)} className="inline-flex flex-row items-center hover:text-gray-700 dark:hover:text-gray-100 leading-tight whitespace-pre-line gap-1">
 					{label}
 					{renderSortIcon(column)}
 				</button>
@@ -518,28 +606,60 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 		<>
 			<style>{"\n\t\t\t\t.gantt-hide-scrollbar::-webkit-scrollbar { display: none; }\n\t\t\t"}</style>
 			<div className="flex flex-col h-full bg-white dark:bg-gray-900 transition-colors duration-200">
-				{/* Toolbar */}
-				<div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700">
-					<h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-						{(t as any).gantt?.title ?? "Gantt"}
-					</h2>
-					<div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
-						{granularityButtons.map((btn) => (
-							<button
-								key={btn.key}
-								type="button"
-								onClick={() => setGranularity(btn.key)}
-								className={`px-3 py-1 text-sm rounded-md transition-colors ${
-									granularity === btn.key
-										? "bg-white dark:bg-gray-700 text-blue-600 dark:text-blue-400 shadow-sm font-medium"
-										: "text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
-								}`}
-							>
-								{btn.label}
-							</button>
-						))}
+					{/* Toolbar */}
+					<div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700 gap-4">
+						<div className="flex items-center gap-4">
+							<h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+								{(t as any).gantt?.title ?? "Gantt"}
+							</h2>
+							<div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+								{granularityButtons.map((btn) => (
+									<button
+										key={btn.key}
+										type="button"
+										onClick={() => setGranularity(btn.key)}
+										className={`px-3 py-1 text-sm rounded-md transition-colors ${
+											granularity === btn.key
+												? "bg-white dark:bg-gray-700 text-blue-600 dark:text-blue-400 shadow-sm font-medium"
+												: "text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+										}`}
+									>
+										{btn.label}
+									</button>
+								))}
+							</div>
+						</div>
+						<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+							{Array.from(
+								tasks.reduce((map, task) => {
+									const lower = task.status.toLowerCase();
+									if (!map.has(lower)) map.set(lower, task.status);
+									return map;
+								}, new Map<string, string>()),
+							).map(([lower, original]) => (
+								<div key={lower} className="flex items-center gap-1">
+									<div className={`w-4 h-3 rounded-sm ${getTaskStatusColor(lower)}`} />
+									<span>{original}</span>
+								</div>
+							))}
+							<div className="flex items-center gap-1">
+								<div className="w-4 h-3 border border-gray-400 dark:border-white rounded-sm" style={{ backgroundImage: "repeating-linear-gradient(-60deg, transparent, transparent 2px, rgba(128,128,128,0.18) 2px, rgba(128,128,128,0.18) 3px)", backgroundSize: "4px 4px" }} />
+								<span>{(t as any).gantt?.legend?.planned ?? "Planned"}</span>
+							</div>
+							<div className="flex items-center gap-1">
+								<svg width="16" height="10" className="text-gray-500 dark:text-gray-400">
+									<line x1="0" y1="5" x2="12" y2="5" stroke="currentColor" strokeWidth="1.5" />
+									<polygon points="12,5 8,3 8,7" fill="currentColor" />
+								</svg>
+								<span>{(t as any).gantt?.legend?.dependency ?? "Dependency"}</span>
+							</div>
+							<div className="flex items-center gap-1">
+								<span className="text-amber-600 dark:text-amber-400 font-bold">*</span>
+								<span>{(t as any).gantt?.legend?.fallback ?? "Fallback"}</span>
+							</div>
+						</div>
 					</div>
-				</div>
+
 
 				{/* Main content */}
 				<div className="flex flex-1 overflow-hidden">
@@ -547,15 +667,37 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 					<div
 						ref={leftScrollRef}
 						className="flex-shrink-0 border-r border-gray-200 dark:border-gray-700 overflow-y-auto gantt-hide-scrollbar"
-						style={{ width: LEFT_PANEL_WIDTH, scrollbarWidth: "none" }}
+						style={{ width: leftPanelWidth, scrollbarWidth: "none" }}
 					>
 						<table className="w-full text-left border-collapse table-fixed">
-							<thead className="sticky top-0 bg-gray-50 dark:bg-gray-800 z-10" style={{ height: HEADER_HEIGHT }}>
+							<thead className="sticky top-0 bg-gray-50 dark:bg-gray-800 z-10 relative" style={{ height: HEADER_HEIGHT }}>
+								<div className="absolute top-2 left-2 flex items-center gap-3 z-20">
+									<label className="flex items-center gap-1 text-[11px] text-gray-600 dark:text-gray-300 cursor-pointer select-none whitespace-nowrap">
+										<input
+											type="checkbox"
+											checked={showPlanTime}
+											onChange={(e) => setShowPlanTime(e.target.checked)}
+											className="w-3 h-3 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+										/>
+										{(t as any).gantt?.showPlanTime ?? "Show Plan Time"}
+									</label>
+									<label className="flex items-center gap-1 text-[11px] text-gray-600 dark:text-gray-300 cursor-pointer select-none whitespace-nowrap">
+										<input
+											type="checkbox"
+											checked={showActualTime}
+											onChange={(e) => setShowActualTime(e.target.checked)}
+											className="w-3 h-3 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700"
+										/>
+										{(t as any).gantt?.showActualTime ?? "Show Actual Time"}
+									</label>
+								</div>
 								<tr className="border-b border-gray-200 dark:border-gray-700" style={{ height: HEADER_HEIGHT }}>
 									{renderSortableHeader((t as any).gantt?.columns?.id ?? "ID", "id", "w-24")}
 									{renderSortableHeader((t as any).gantt?.columns?.title ?? "Title", "title", "")}
-									{renderSortableHeader((t as any).gantt?.columns?.start ?? "Start", "start", "w-20")}
-									{renderSortableHeader((t as any).gantt?.columns?.end ?? "End", "end", "w-20")}
+									{showPlanTime && renderSortableHeader((t as any).gantt?.columns?.plannedStart ?? "Plan Start", "plannedStart", hasCrossYearTasks ? "w-24" : "w-20")}
+									{showPlanTime && renderSortableHeader((t as any).gantt?.columns?.plannedEnd ?? "Plan End", "plannedEnd", hasCrossYearTasks ? "w-24" : "w-20")}
+									{showActualTime && renderSortableHeader((t as any).gantt?.columns?.actualStart ?? "Actual Start", "actualStart", hasCrossYearTasks ? "w-44" : "w-32")}
+									{showActualTime && renderSortableHeader((t as any).gantt?.columns?.actualEnd ?? "Actual End", "actualEnd", hasCrossYearTasks ? "w-44" : "w-32")}
 									<th className="px-2 w-20 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style={{ height: HEADER_HEIGHT }}>
 										<div className="h-full flex items-end pb-2">
 											{(t as any).gantt?.columns?.action ?? "Action"}
@@ -568,16 +710,11 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 									<tr
 										key={task.id}
 										className={`hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer ${
-											selectedTaskId === task.id ? "bg-blue-50 dark:bg-blue-900/20" : ""
+											selectedTaskId === task.id ? "bg-blue-100 dark:bg-blue-900/40" : ""
 										}`}
 										onClick={() => {
 											setSelectedTaskId((prev) => (prev === task.id ? null : task.id));
-											const pos = taskPositions[task.id];
-											if (pos && timelineContainerRef.current) {
-												const container = timelineContainerRef.current;
-												const targetScrollLeft = pos.x + pos.width / 2 - container.clientWidth / 2;
-												container.scrollTo({ left: Math.max(0, targetScrollLeft), behavior: "smooth" });
-											}
+											scrollToTask(task.id);
 										}}
 									>
 										<td className="px-2 h-10 text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap w-24">
@@ -586,16 +723,30 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 										<td className="px-2 h-10 text-sm text-gray-700 dark:text-gray-300 truncate" title={task.title}>
 											{task.title}
 										</td>
-										<td className="px-2 h-10 text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap w-20">
-											{formatDisplayDate(task.start)}
-										</td>
-										<td className="px-2 h-10 text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap w-20">
-											{task.isFallback ? (
-												<span className="text-amber-600 dark:text-amber-400">{formatDisplayDate(task.end)} *</span>
-											) : (
-												formatDisplayDate(task.end)
+										{showPlanTime && (
+											<React.Fragment>
+												<td className={`px-2 h-10 text-sm text-gray-600 dark:text-gray-400 truncate ${hasCrossYearTasks ? "w-24" : "w-20"}`}>
+													{task.plannedStart ? formatDisplayDate(task.plannedStart, false) : "-"}
+												</td>
+												<td className={`px-2 h-10 text-sm text-gray-600 dark:text-gray-400 truncate ${hasCrossYearTasks ? "w-24" : "w-20"}`}>
+													{task.plannedEnd ? formatDisplayDate(task.plannedEnd, false) : "-"}
+												</td>
+											</React.Fragment>
+										)}
+											{showActualTime && (
+												<React.Fragment>
+													<td className={`px-2 h-10 text-sm text-gray-600 dark:text-gray-400 truncate ${hasCrossYearTasks ? "w-44" : "w-32"}`}>
+														{task.raw.actualStart ? formatDisplayDate(task.start) : (
+															<span className="text-amber-600 dark:text-amber-400">{formatDisplayDate(task.start)} *</span>
+														)}
+													</td>
+													<td className={`px-2 h-10 text-sm text-gray-600 dark:text-gray-400 truncate ${hasCrossYearTasks ? "w-44" : "w-32"}`}>
+														{task.raw.actualEnd ? formatDisplayDate(task.end) : (
+															<span className="text-amber-600 dark:text-amber-400">{formatDisplayDate(task.end)} *</span>
+														)}
+													</td>
+												</React.Fragment>
 											)}
-										</td>
 										<td className="px-2 h-10 whitespace-nowrap w-20">
 											<button
 												type="button"
@@ -723,17 +874,18 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 								/>
 							))}
 
-							{/* Task bars */}
+							{/* Actual task bars (bottom layer) */}
 							{sortedTasks.map((task) => {
 								const pos = taskPositions[task.id];
 								if (!pos) return null;
 								const isHighlighted = highlightedIds.has(task.id);
 								const isDimmed = selectedTaskId && !isHighlighted;
 								const isHovered = hoveredTaskId === task.id;
+								const barTop = pos.y + (ROW_HEIGHT - 24) / 2;
 
 								return (
 									<div
-										key={task.id}
+										key={`actual-${task.id}`}
 										data-task-bar
 										className={`absolute h-6 rounded transition-all duration-200 cursor-pointer ${
 											getTaskStatusColor(task.status)
@@ -742,7 +894,7 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 										}`}
 										style={{
 											left: pos.x,
-											top: pos.y + (ROW_HEIGHT - 24) / 2,
+											top: barTop,
 											width: Math.max(pos.width, 2),
 											minWidth: 2,
 										}}
@@ -769,6 +921,41 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 								);
 							})}
 
+							{/* Plan border bars (top layer) */}
+							{sortedTasks.map((task) => {
+								const planPos = planPositions[task.id];
+								if (!planPos) return null;
+								const isHighlighted = highlightedIds.has(task.id);
+								const isDimmed = selectedTaskId && !isHighlighted;
+								const barTop = planPos.y + (ROW_HEIGHT - 24) / 2;
+								const hatch = "repeating-linear-gradient(-60deg, transparent, transparent 4px, rgba(128,128,128,0.18) 4px, rgba(128,128,128,0.18) 5px)";
+
+								return (
+									<div
+										key={`plan-${task.id}`}
+										className={`absolute h-6 rounded-md pointer-events-none border-2 border-white dark:border-gray-500 ${
+											isDimmed ? "opacity-20" : isHighlighted ? "opacity-100" : "opacity-80"
+										}`}
+										style={{
+											left: planPos.x,
+											top: barTop,
+											width: Math.max(planPos.width, 2),
+											minWidth: 2,
+											backgroundImage: hatch,
+											backgroundSize: "6px 6px",
+										}}
+									>
+										<div
+											className="absolute inset-0 rounded-md border border-gray-400 dark:border-white"
+											style={{
+												backgroundImage: hatch,
+												backgroundSize: "6px 6px",
+											}}
+										/>
+									</div>
+								);
+							})}
+
 							{/* Dependency arrows */}
 							<svg
 								className="absolute inset-0 pointer-events-none"
@@ -776,13 +963,32 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 							>
 								{sortedTasks.map((task) =>
 									task.dependencies.map((depId) => {
-										const from = taskPositions[depId];
-										const to = taskPositions[task.id];
-										if (!from || !to) return null;
-										const startX = from.x + from.width;
-										const startY = from.y + ROW_HEIGHT / 2;
-										const endX = to.x;
-										const endY = to.y + ROW_HEIGHT / 2;
+										const fromTask = sortedTasks.find((t) => t.id === depId);
+										const toTask = task;
+										if (!fromTask || !toTask) return null;
+
+										const fromPos = taskPositions[depId];
+										const toPos = taskPositions[task.id];
+										if (!fromPos || !toPos) return null;
+
+										// Resolve arrow start point (from task's end side)
+										let startX: number;
+										if (fromTask.plannedStart && fromTask.end.getTime() < fromTask.plannedStart.getTime()) {
+											startX = fromTask.plannedEnd ? getTimelineX(fromTask.plannedEnd, columns, granularity) : fromPos.x + fromPos.width;
+										} else {
+											startX = fromPos.x + fromPos.width;
+										}
+
+										// Resolve arrow end point (to task's start side)
+										let endX: number;
+										if (toTask.plannedStart && toTask.start.getTime() < toTask.plannedStart.getTime()) {
+											endX = toPos.x;
+										} else {
+											endX = toTask.plannedStart ? getTimelineX(toTask.plannedStart, columns, granularity) : toPos.x;
+										}
+
+										const startY = fromPos.y + ROW_HEIGHT / 2;
+										const endY = toPos.y + ROW_HEIGHT / 2;
 										const HSEG = 6;
 										const ARROW_SIZE = 6;
 										const p0x = startX + HSEG;
@@ -800,10 +1006,10 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 										const isDimmed = selectedTaskId && !isHighlighted;
 										const colorClass = isHighlighted
 											? "stroke-blue-500 dark:stroke-blue-400"
-											: "stroke-gray-800 dark:stroke-white";
+											: "stroke-gray-500 dark:stroke-gray-400";
 										const fillClass = isHighlighted
 											? "fill-blue-500 dark:fill-blue-400"
-											: "fill-gray-800 dark:fill-white";
+											: "fill-gray-500 dark:fill-gray-400";
 										const opacityClass = isDimmed ? "opacity-20" : isHighlighted ? "opacity-100" : "opacity-70";
 
 										return (
@@ -831,15 +1037,15 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 							return (
 								<div className="space-y-0.5">
 									<div className="font-semibold">{task.id} - {task.title}</div>
-									<div>
-										{(t as any).gantt?.tooltip?.start ?? "Start"}: {formatDisplayDate(task.start)}
-										{task.originalStart && ` (${task.originalStart})`}
-									</div>
-									<div>
-										{(t as any).gantt?.tooltip?.end ?? "End"}: {formatDisplayDate(task.end)}
-										{task.originalEnd && ` (${task.originalEnd})`}
-										{task.isFallback && ` [${(t as any).gantt?.tooltip?.fallback ?? "fallback"}]`}
-									</div>
+											{task.plannedStart && task.plannedEnd && (
+												<div className="text-gray-300">
+													{(t as any).gantt?.tooltip?.planned ?? "Planned"}: {formatDisplayDate(task.plannedStart, false)} → {formatDisplayDate(task.plannedEnd, false)}
+												</div>
+											)}
+											<div>
+												{(t as any).gantt?.tooltip?.actual ?? "Actual"}: {formatDisplayDate(task.start)} → {formatDisplayDate(task.end)}
+												{task.isFallback && ` [${(t as any).gantt?.tooltip?.fallback ?? "fallback"}]`}
+											</div>
 								</div>
 							);
 						})()}

--- a/src/web/components/GanttView.tsx
+++ b/src/web/components/GanttView.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Task } from "../../types";
+import { compareTaskIds, groupSubtasksUnderParents } from "../../utils/task-sorting";
 import { useI18n } from "../hooks/useI18n";
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -327,19 +328,8 @@ function getTimelineX(date: Date, columns: TimelineColumn[], granularity: Granul
 	return x;
 }
 
-function extractTaskNumericId(taskId: string): number | null {
-	const match = taskId.trim().match(/(\d+)$/);
-	if (!match?.[1]) return null;
-	return Number.parseInt(match[1], 10);
-}
-
-function compareTaskIds(a: ParsedTask, b: ParsedTask): number {
-	const idA = extractTaskNumericId(a.id);
-	const idB = extractTaskNumericId(b.id);
-	if (idA !== null && idB !== null) return idA - idB;
-	if (idA !== null) return -1;
-	if (idB !== null) return 1;
-	return a.id.localeCompare(b.id, undefined, { sensitivity: "base", numeric: true });
+function compareParsedTaskIds(a: ParsedTask, b: ParsedTask): number {
+	return compareTaskIds(a.id, b.id);
 }
 
 function getTaskStatusColor(status: string): string {
@@ -393,13 +383,24 @@ export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
 	}, [parsedTasks, currentYear]);
 
 	const sortedTasks = useMemo(() => {
+		if (sortColumn === "id") {
+			const list = [...parsedTasks];
+			list.sort((a, b) => {
+				const cmp = compareParsedTaskIds(a, b);
+				return sortDirection === "asc" ? cmp : -cmp;
+			});
+			return groupSubtasksUnderParents(
+				list,
+				compareParsedTaskIds,
+				(p) => p.raw.parentTaskId,
+				sortDirection,
+			);
+		}
+
 		const list = [...parsedTasks];
 		list.sort((a, b) => {
 			let cmp = 0;
 			switch (sortColumn) {
-				case "id":
-					cmp = compareTaskIds(a, b);
-					break;
 				case "title":
 					cmp = a.title.localeCompare(b.title);
 					break;

--- a/src/web/components/GanttView.tsx
+++ b/src/web/components/GanttView.tsx
@@ -1,0 +1,851 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Task } from "../../types";
+import { useI18n } from "../hooks/useI18n";
+
+const DAY = 24 * 60 * 60 * 1000;
+const ROW_HEIGHT = 40;
+const HEADER_HEIGHT = 80;
+const LEFT_PANEL_WIDTH = 480;
+
+export type Granularity = "day" | "week" | "month" | "quarter" | "year";
+
+const GRANULARITY_CONFIG: Record<Granularity, {
+	pxPerDay: number;
+	minWidthPx: number;
+	minDurationDays: number;
+	columnWidth: number;
+}> = {
+	day: { pxPerDay: 90, minWidthPx: (90 / 24) * 4, minDurationDays: 4 / 24, columnWidth: 90 },
+	week: { pxPerDay: 350 / 7, minWidthPx: 350 / 7, minDurationDays: 1, columnWidth: 350 },
+	month: { pxPerDay: 350 / 30, minWidthPx: 350 / 30, minDurationDays: 1, columnWidth: 350 },
+	quarter: { pxPerDay: 350 / 90, minWidthPx: 8, minDurationDays: 0, columnWidth: 350 },
+	year: { pxPerDay: 350 / 365, minWidthPx: 8, minDurationDays: 0, columnWidth: 350 },
+};
+
+type GanttSortColumn = "id" | "title" | "start" | "end";
+type SortDirection = "asc" | "desc";
+
+interface ParsedTask {
+	id: string;
+	title: string;
+	start: Date;
+	end: Date;
+	originalStart?: string;
+	originalEnd?: string;
+	isFallback: boolean;
+	status: string;
+	priority?: "high" | "medium" | "low";
+	dependencies: string[];
+	raw: Task;
+}
+
+interface TimelineColumn {
+	start: Date;
+	end: Date;
+	middleLabel: string;
+	topLabel: string;
+	bottomTicks: Array<{ offsetPx: number; label: string }>;
+}
+
+interface GanttViewProps {
+	tasks: Task[];
+	onEditTask: (task: Task) => void;
+}
+
+function parseDate(dateStr?: string): Date | null {
+	if (!dateStr) return null;
+	const iso = dateStr.includes(" ") ? dateStr.replace(" ", "T") : `${dateStr}T00:00:00`;
+	const d = new Date(iso);
+	return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function parseTasks(tasks: Task[]): ParsedTask[] {
+	return tasks.map((task) => {
+		const plannedStart = parseDate(task.plannedStart);
+		const plannedEnd = parseDate(task.plannedEnd);
+		const created = parseDate(task.createdDate);
+		const updated = parseDate(task.updatedDate);
+
+		let start: Date;
+		let originalStart: string | undefined;
+		if (plannedStart) {
+			start = plannedStart;
+			originalStart = task.plannedStart;
+		} else if (created) {
+			start = created;
+			originalStart = task.createdDate;
+		} else {
+			start = new Date();
+		}
+
+		let end: Date;
+		let originalEnd: string | undefined;
+		let isFallback = false;
+		if (plannedEnd) {
+			end = plannedEnd;
+			originalEnd = task.plannedEnd;
+		} else if (updated) {
+			end = updated;
+			originalEnd = task.updatedDate;
+		} else if (created) {
+			end = new Date(created.getTime() + DAY);
+			isFallback = true;
+			originalEnd = undefined;
+		} else {
+			end = new Date(start.getTime() + DAY);
+			isFallback = true;
+		}
+
+		if (end.getTime() < start.getTime()) {
+			end = new Date(start.getTime() + DAY);
+			isFallback = true;
+		}
+
+		return {
+			id: task.id,
+			title: task.title,
+			start,
+			end,
+			originalStart,
+			originalEnd,
+			isFallback,
+			status: task.status,
+			priority: task.priority,
+			dependencies: task.dependencies ?? [],
+			raw: task,
+		};
+	});
+}
+
+function formatShortDate(date: Date): string {
+	return `${date.getMonth() + 1}/${date.getDate()}`;
+}
+
+function formatDisplayDate(date: Date): string {
+	const y = date.getFullYear();
+	const m = date.getMonth() + 1;
+	const d = date.getDate();
+	const now = new Date();
+	if (y === now.getFullYear()) {
+		return `${m}/${d}`;
+	}
+	return `${y}/${m}/${d}`;
+}
+
+function getWeekStart(date: Date): Date {
+	const d = new Date(date);
+	d.setHours(0, 0, 0, 0);
+	const day = d.getDay();
+	d.setDate(d.getDate() - day);
+	return d;
+}
+
+function getWeekNumber(date: Date): number {
+	const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+	const dayNum = d.getUTCDay() || 7;
+	d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+	const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+	return Math.ceil((((d.getTime() - yearStart.getTime()) / DAY) + 1) / 7);
+}
+
+function getQuarter(date: Date): number {
+	return Math.floor(date.getMonth() / 3) + 1;
+}
+
+function getInitialViewRange(parsedTasks: ParsedTask[], granularity: Granularity): { start: Date; end: Date } {
+	const unitMs: Record<Granularity, number> = {
+		day: DAY,
+		week: 7 * DAY,
+		month: 30 * DAY,
+		quarter: 90 * DAY,
+		year: 365 * DAY,
+	};
+	const expand = 2 * unitMs[granularity];
+	if (parsedTasks.length === 0) {
+		const now = new Date();
+		now.setHours(0, 0, 0, 0);
+		return { start: new Date(now.getTime() - expand), end: new Date(now.getTime() + expand) };
+	}
+	const minStart = new Date(Math.min(...parsedTasks.map((t) => t.start.getTime())));
+	const maxEnd = new Date(Math.max(...parsedTasks.map((t) => t.end.getTime())));
+	return { start: new Date(minStart.getTime() - expand), end: new Date(maxEnd.getTime() + expand) };
+}
+
+function getTimelineColumns(viewStart: Date, viewEnd: Date, granularity: Granularity): TimelineColumn[] {
+	const columns: TimelineColumn[] = [];
+	let current = new Date(viewStart);
+	current.setHours(0, 0, 0, 0);
+
+	switch (granularity) {
+		case "day": {
+			while (current.getTime() < viewEnd.getTime()) {
+				const next = new Date(current.getTime() + DAY);
+				const topLabel = `${current.getFullYear()}年${current.getMonth() + 1}月`;
+				const cw = GRANULARITY_CONFIG.day.columnWidth;
+				columns.push({
+					start: current,
+					end: next,
+					middleLabel: `${current.getMonth() + 1}/${current.getDate()}`,
+					topLabel,
+					bottomTicks: [
+						{ offsetPx: 0, label: "0" },
+						{ offsetPx: cw * 0.25, label: "6" },
+						{ offsetPx: cw * 0.5, label: "12" },
+						{ offsetPx: cw * 0.75, label: "18" },
+					],
+				});
+				current = next;
+			}
+			break;
+		}
+		case "week": {
+			current = getWeekStart(current);
+			while (current.getTime() < viewEnd.getTime()) {
+				const next = new Date(current.getTime() + 7 * DAY);
+				const weekNum = getWeekNumber(current);
+				const startStr = formatShortDate(current);
+				const endStr = formatShortDate(new Date(next.getTime() - DAY));
+				const topLabel = `${current.getFullYear()}年${current.getMonth() + 1}月`;
+				const bottomTicks: Array<{ offsetPx: number; label: string }> = [];
+				for (let i = 0; i < 7; i++) {
+					const d = new Date(current.getTime() + i * DAY);
+					bottomTicks.push({ offsetPx: (i / 7) * GRANULARITY_CONFIG.week.columnWidth, label: `${d.getMonth() + 1}/${d.getDate()}` });
+				}
+				columns.push({
+					start: current,
+					end: next,
+					middleLabel: `${weekNum}周(${startStr}-${endStr})`,
+					topLabel,
+					bottomTicks,
+				});
+				current = next;
+			}
+			break;
+		}
+		case "month": {
+			current.setDate(1);
+			while (current.getTime() < viewEnd.getTime()) {
+				const next = new Date(current.getFullYear(), current.getMonth() + 1, 1);
+				const daysInMonth = (next.getTime() - current.getTime()) / DAY;
+				const topLabel = `${current.getFullYear()}年 第${getQuarter(current)}季度`;
+				const bottomTicks: Array<{ offsetPx: number; label: string }> = [];
+				for (const day of [1, 11, 21]) {
+					if (day <= daysInMonth) {
+						bottomTicks.push({ offsetPx: ((day - 1) / daysInMonth) * GRANULARITY_CONFIG.month.columnWidth, label: `${day}日` });
+					}
+				}
+				columns.push({
+					start: current,
+					end: next,
+					middleLabel: `${current.getMonth() + 1}月`,
+					topLabel,
+					bottomTicks,
+				});
+				current = next;
+			}
+			break;
+		}
+		case "quarter": {
+			current.setDate(1);
+			current.setMonth(Math.floor(current.getMonth() / 3) * 3);
+			while (current.getTime() < viewEnd.getTime()) {
+				const next = new Date(current.getFullYear(), current.getMonth() + 3, 1);
+				const topLabel = `${current.getFullYear()}年`;
+				const bottomTicks: Array<{ offsetPx: number; label: string }> = [];
+				for (let i = 0; i < 3; i++) {
+					const m = current.getMonth() + 1 + i;
+					bottomTicks.push({ offsetPx: (i / 3) * GRANULARITY_CONFIG.quarter.columnWidth, label: `${m}月` });
+				}
+				columns.push({
+					start: current,
+					end: next,
+					middleLabel: `Q${getQuarter(current)}`,
+					topLabel,
+					bottomTicks,
+				});
+				current = next;
+			}
+			break;
+		}
+		case "year": {
+			current = new Date(current.getFullYear(), 0, 1);
+			while (current.getTime() < viewEnd.getTime()) {
+				const next = new Date(current.getFullYear() + 1, 0, 1);
+				const bottomTicks: Array<{ offsetPx: number; label: string }> = [];
+				for (let i = 0; i < 4; i++) {
+					bottomTicks.push({ offsetPx: (i / 4) * GRANULARITY_CONFIG.year.columnWidth, label: `Q${i + 1}` });
+				}
+				columns.push({
+					start: current,
+					end: next,
+					middleLabel: `${current.getFullYear()}年`,
+					topLabel: "",
+					bottomTicks,
+				});
+				current = next;
+			}
+			break;
+		}
+	}
+
+	return columns;
+}
+
+function getTimelineX(date: Date, columns: TimelineColumn[], granularity: Granularity): number {
+	let x = 0;
+	for (const col of columns) {
+		if (date.getTime() >= col.end.getTime()) {
+			x += GRANULARITY_CONFIG[granularity].columnWidth;
+		} else if (date.getTime() >= col.start.getTime()) {
+			const ratio = (date.getTime() - col.start.getTime()) / (col.end.getTime() - col.start.getTime());
+			x += ratio * GRANULARITY_CONFIG[granularity].columnWidth;
+			break;
+		}
+	}
+	return x;
+}
+
+function extractTaskNumericId(taskId: string): number | null {
+	const match = taskId.trim().match(/(\d+)$/);
+	if (!match?.[1]) return null;
+	return Number.parseInt(match[1], 10);
+}
+
+function compareTaskIds(a: ParsedTask, b: ParsedTask): number {
+	const idA = extractTaskNumericId(a.id);
+	const idB = extractTaskNumericId(b.id);
+	if (idA !== null && idB !== null) return idA - idB;
+	if (idA !== null) return -1;
+	if (idB !== null) return 1;
+	return a.id.localeCompare(b.id, undefined, { sensitivity: "base", numeric: true });
+}
+
+function getTaskStatusColor(status: string): string {
+	switch (status?.toLowerCase()) {
+		case "done":
+		case "completed":
+			return "bg-emerald-500";
+		case "in progress":
+			return "bg-blue-500";
+		case "to do":
+			return "bg-gray-400 dark:bg-gray-500";
+		case "blocked":
+			return "bg-red-500";
+		case "cancelled":
+			return "bg-gray-300 dark:bg-gray-600";
+		default:
+			return "bg-blue-400";
+	}
+}
+
+export default function GanttView({ tasks, onEditTask }: GanttViewProps) {
+	const { t } = useI18n();
+	const [granularity, setGranularity] = useState<Granularity>("week");
+	const [sortColumn, setSortColumn] = useState<GanttSortColumn>("id");
+	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+	const [hoveredTaskId, setHoveredTaskId] = useState<string | null>(null);
+	const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+	const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number } | null>(null);
+	const [viewStart, setViewStart] = useState<Date>(new Date());
+	const [viewEnd, setViewEnd] = useState<Date>(new Date());
+	const [isDragging, setIsDragging] = useState(false);
+	const dragStartX = useRef(0);
+	const viewStartAtDrag = useRef<Date>(new Date());
+	const leftScrollRef = useRef<HTMLDivElement>(null);
+	const timelineContainerRef = useRef<HTMLDivElement>(null);
+
+	const parsedTasks = useMemo(() => parseTasks(tasks), [tasks]);
+
+	const sortedTasks = useMemo(() => {
+		const list = [...parsedTasks];
+		list.sort((a, b) => {
+			let cmp = 0;
+			switch (sortColumn) {
+				case "id":
+					cmp = compareTaskIds(a, b);
+					break;
+				case "title":
+					cmp = a.title.localeCompare(b.title);
+					break;
+				case "start":
+					cmp = a.start.getTime() - b.start.getTime();
+					break;
+				case "end":
+					cmp = a.end.getTime() - b.end.getTime();
+					break;
+			}
+			return sortDirection === "asc" ? cmp : -cmp;
+		});
+		return list;
+	}, [parsedTasks, sortColumn, sortDirection]);
+
+	useEffect(() => {
+		const range = getInitialViewRange(sortedTasks, granularity);
+		setViewStart(range.start);
+		setViewEnd(range.end);
+	}, [sortedTasks, granularity]);
+
+	const config = GRANULARITY_CONFIG[granularity];
+	const columns = useMemo(() => getTimelineColumns(viewStart, viewEnd, granularity), [viewStart, viewEnd, granularity]);
+	const timelineWidth = columns.length * config.columnWidth;
+
+	const taskPositions = useMemo(() => {
+		const positions: Record<string, { x: number; y: number; width: number }> = {};
+		sortedTasks.forEach((task) => {
+			const x = getTimelineX(task.start, columns, granularity);
+			const endX = getTimelineX(task.end, columns, granularity);
+			const rawWidth = endX - x;
+			const minWidth = config.minWidthPx;
+			const width = Math.max(rawWidth, minWidth);
+			const y = HEADER_HEIGHT + sortedTasks.indexOf(task) * ROW_HEIGHT;
+			positions[task.id] = { x, y, width };
+		});
+		return positions;
+	}, [sortedTasks, columns, granularity, config]);
+
+	const highlightedIds = useMemo(() => {
+		if (!selectedTaskId) return new Set<string>();
+		const ids = new Set<string>();
+		ids.add(selectedTaskId);
+		const task = sortedTasks.find((t) => t.id === selectedTaskId);
+		if (task) {
+			for (const depId of task.dependencies) ids.add(depId);
+		}
+		for (const t of sortedTasks) {
+			if (t.dependencies.includes(selectedTaskId)) ids.add(t.id);
+		}
+		return ids;
+	}, [selectedTaskId, sortedTasks]);
+
+	const handleSortChange = useCallback((column: GanttSortColumn) => {
+		setSortColumn((prev) => {
+			if (prev === column) {
+				setSortDirection((d) => (d === "asc" ? "desc" : "asc"));
+				return prev;
+			}
+			setSortDirection(column === "id" ? "desc" : "asc");
+			return column;
+		});
+	}, []);
+
+	const getSortAriaValue = useCallback((column: GanttSortColumn): "none" | "ascending" | "descending" => {
+		if (sortColumn !== column) return "none";
+		return sortDirection === "asc" ? "ascending" : "descending";
+	}, [sortColumn, sortDirection]);
+
+	const renderSortIcon = useCallback((column: GanttSortColumn) => {
+		const isActive = sortColumn === column;
+		const isAsc = sortDirection === "asc";
+		return (
+			<span className="inline-flex items-center justify-center w-4 text-xs select-none" aria-hidden="true">
+				<span className={isActive && isAsc ? "text-gray-600 dark:text-gray-300" : "text-gray-300 dark:text-gray-600"}>↑</span>
+				<span className={isActive && !isAsc ? "text-gray-600 dark:text-gray-300" : "text-gray-300 dark:text-gray-600"}>↓</span>
+			</span>
+		);
+	}, [sortColumn, sortDirection]);
+
+	const renderSortableHeader = useCallback((label: string, column: GanttSortColumn, widthClass: string) => (
+		<th className={`px-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider ${widthClass}`} style={{ height: HEADER_HEIGHT }} aria-sort={getSortAriaValue(column)}>
+			<div className="h-full flex items-end pb-2">
+				<button type="button" onClick={() => handleSortChange(column)} className="inline-flex items-center gap-1 hover:text-gray-700 dark:hover:text-gray-100">
+					{label}
+					{renderSortIcon(column)}
+				</button>
+			</div>
+		</th>
+	), [handleSortChange, getSortAriaValue, renderSortIcon]);
+
+	const handleMouseDown = useCallback((e: React.MouseEvent) => {
+		if ((e.target as HTMLElement).closest("[data-task-bar]")) return;
+		setIsDragging(true);
+		dragStartX.current = e.clientX;
+		viewStartAtDrag.current = new Date(viewStart.getTime());
+	}, [viewStart]);
+
+	const handleMouseMove = useCallback((e: React.MouseEvent) => {
+		if (!isDragging) return;
+		const deltaX = e.clientX - dragStartX.current;
+		const pxPerDay = config.pxPerDay;
+		const deltaDays = deltaX / pxPerDay;
+		const newStart = new Date(viewStartAtDrag.current.getTime() - deltaDays * DAY);
+		const rangeMs = viewEnd.getTime() - viewStart.getTime();
+		setViewStart(newStart);
+		setViewEnd(new Date(newStart.getTime() + rangeMs));
+	}, [isDragging, config.pxPerDay, viewEnd, viewStart]);
+
+	const handleMouseUp = useCallback(() => {
+		setIsDragging(false);
+	}, []);
+
+	useEffect(() => {
+		if (!isDragging) return;
+		const handleGlobalMouseUp = () => setIsDragging(false);
+		document.addEventListener("mouseup", handleGlobalMouseUp);
+		return () => document.removeEventListener("mouseup", handleGlobalMouseUp);
+	}, [isDragging]);
+
+	// Sync vertical scroll between left table and right timeline
+	useEffect(() => {
+		const left = leftScrollRef.current;
+		const right = timelineContainerRef.current;
+		if (!left || !right) return;
+
+		const syncFromLeft = () => { right.scrollTop = left.scrollTop; };
+		const syncFromRight = () => { left.scrollTop = right.scrollTop; };
+
+		left.addEventListener("scroll", syncFromLeft);
+		right.addEventListener("scroll", syncFromRight);
+		return () => {
+			left.removeEventListener("scroll", syncFromLeft);
+			right.removeEventListener("scroll", syncFromRight);
+		};
+	}, []);
+
+	const today = new Date();
+	today.setHours(0, 0, 0, 0);
+	const todayX = getTimelineX(today, columns, granularity);
+	const showTodayLine = todayX >= 0 && todayX <= timelineWidth;
+
+	const granularityButtons: { key: Granularity; label: string }[] = [
+		{ key: "day", label: (t as any).gantt?.granularity?.day ?? "日" },
+		{ key: "week", label: (t as any).gantt?.granularity?.week ?? "周" },
+		{ key: "month", label: (t as any).gantt?.granularity?.month ?? "月" },
+		{ key: "quarter", label: (t as any).gantt?.granularity?.quarter ?? "季" },
+		{ key: "year", label: (t as any).gantt?.granularity?.year ?? "年" },
+	];
+
+	return (
+		<>
+			<style>{"\n\t\t\t\t.gantt-hide-scrollbar::-webkit-scrollbar { display: none; }\n\t\t\t"}</style>
+			<div className="flex flex-col h-full bg-white dark:bg-gray-900 transition-colors duration-200">
+				{/* Toolbar */}
+				<div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+					<h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+						{(t as any).gantt?.title ?? "Gantt"}
+					</h2>
+					<div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+						{granularityButtons.map((btn) => (
+							<button
+								key={btn.key}
+								type="button"
+								onClick={() => setGranularity(btn.key)}
+								className={`px-3 py-1 text-sm rounded-md transition-colors ${
+									granularity === btn.key
+										? "bg-white dark:bg-gray-700 text-blue-600 dark:text-blue-400 shadow-sm font-medium"
+										: "text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+								}`}
+							>
+								{btn.label}
+							</button>
+						))}
+					</div>
+				</div>
+
+				{/* Main content */}
+				<div className="flex flex-1 overflow-hidden">
+					{/* Left panel: task list */}
+					<div
+						ref={leftScrollRef}
+						className="flex-shrink-0 border-r border-gray-200 dark:border-gray-700 overflow-y-auto gantt-hide-scrollbar"
+						style={{ width: LEFT_PANEL_WIDTH, scrollbarWidth: "none" }}
+					>
+						<table className="w-full text-left border-collapse table-fixed">
+							<thead className="sticky top-0 bg-gray-50 dark:bg-gray-800 z-10" style={{ height: HEADER_HEIGHT }}>
+								<tr className="border-b border-gray-200 dark:border-gray-700" style={{ height: HEADER_HEIGHT }}>
+									{renderSortableHeader((t as any).gantt?.columns?.id ?? "ID", "id", "w-24")}
+									{renderSortableHeader((t as any).gantt?.columns?.title ?? "Title", "title", "")}
+									{renderSortableHeader((t as any).gantt?.columns?.start ?? "Start", "start", "w-20")}
+									{renderSortableHeader((t as any).gantt?.columns?.end ?? "End", "end", "w-20")}
+									<th className="px-2 w-20 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider" style={{ height: HEADER_HEIGHT }}>
+										<div className="h-full flex items-end pb-2">
+											{(t as any).gantt?.columns?.action ?? "Action"}
+										</div>
+									</th>
+								</tr>
+							</thead>
+							<tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+								{sortedTasks.map((task) => (
+									<tr
+										key={task.id}
+										className={`hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer ${
+											selectedTaskId === task.id ? "bg-blue-50 dark:bg-blue-900/20" : ""
+										}`}
+										onClick={() => {
+											setSelectedTaskId((prev) => (prev === task.id ? null : task.id));
+											const pos = taskPositions[task.id];
+											if (pos && timelineContainerRef.current) {
+												const container = timelineContainerRef.current;
+												const targetScrollLeft = pos.x + pos.width / 2 - container.clientWidth / 2;
+												container.scrollTo({ left: Math.max(0, targetScrollLeft), behavior: "smooth" });
+											}
+										}}
+									>
+										<td className="px-2 h-10 text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap w-24">
+											{task.id}
+										</td>
+										<td className="px-2 h-10 text-sm text-gray-700 dark:text-gray-300 truncate" title={task.title}>
+											{task.title}
+										</td>
+										<td className="px-2 h-10 text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap w-20">
+											{formatDisplayDate(task.start)}
+										</td>
+										<td className="px-2 h-10 text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap w-20">
+											{task.isFallback ? (
+												<span className="text-amber-600 dark:text-amber-400">{formatDisplayDate(task.end)} *</span>
+											) : (
+												formatDisplayDate(task.end)
+											)}
+										</td>
+										<td className="px-2 h-10 whitespace-nowrap w-20">
+											<button
+												type="button"
+												className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium"
+												onClick={(e) => {
+													e.stopPropagation();
+													onEditTask(task.raw);
+												}}
+											>
+												{(t as any).gantt?.action?.detail ?? "Detail"}
+											</button>
+										</td>
+									</tr>
+								))}
+								{sortedTasks.length === 0 && (
+									<tr>
+										<td colSpan={5} className="px-4 h-10 text-center text-gray-500 dark:text-gray-400 text-sm w-full">
+											{(t as any).gantt?.noTasks ?? "No tasks to display"}
+										</td>
+									</tr>
+								)}
+							</tbody>
+						</table>
+					</div>
+
+					{/* Right panel: timeline */}
+					<div
+						ref={timelineContainerRef}
+						className="flex-1 overflow-auto relative select-none"
+						onMouseDown={handleMouseDown}
+						onMouseMove={handleMouseMove}
+						onMouseUp={handleMouseUp}
+						style={{ cursor: isDragging ? "grabbing" : "grab" }}
+					>
+						<div className="relative" style={{ width: timelineWidth, height: HEADER_HEIGHT + Math.max(sortedTasks.length * ROW_HEIGHT, 200) }}>
+							{/* Timeline header - three-level ticks */}
+							<div className="sticky top-0 left-0 bg-gray-50 dark:bg-gray-800 z-20 border-b border-gray-200 dark:border-gray-700 flex flex-col" style={{ height: HEADER_HEIGHT }}>
+								{/* Layer 1: group labels */}
+								<div className="h-[20px] flex relative border-b border-gray-100 dark:border-gray-700/50">
+									{(() => {
+										const groups: Array<{ label: string; start: number; width: number }> = [];
+										let cur: { label: string; start: number; width: number } | null = null;
+										columns.forEach((col, idx) => {
+											const prevTop = idx > 0 ? columns[idx - 1]?.topLabel : null;
+											if (col.topLabel !== prevTop || !cur) {
+												if (cur) groups.push(cur);
+												cur = { label: col.topLabel, start: idx * config.columnWidth, width: config.columnWidth };
+											} else {
+												cur.width += config.columnWidth;
+											}
+										});
+										if (cur) groups.push(cur);
+										return (
+											<>
+												{groups.map((g, i) => (
+													g.label && (
+															<div key={i} className="absolute top-0 bottom-0 flex items-center justify-center text-[10px] text-gray-500 dark:text-gray-400 font-medium text-center truncate px-1" style={{ left: g.start, width: g.width }}>
+																{g.label}
+															</div>
+														)
+													))}
+													{columns.map((col, idx) => {
+														const prevTop = idx > 0 ? columns[idx - 1]?.topLabel : null;
+														const showTop = col.topLabel && col.topLabel !== prevTop;
+														return showTop && idx > 0 ? (
+															<div key={idx} className="absolute top-0 bottom-0 w-px bg-gray-400 dark:bg-gray-500" style={{ left: idx * config.columnWidth }} />
+														) : null;
+													})}
+												</>
+											);
+										})()}
+								</div>
+								{/* Layer 2: column labels */}
+								<div className="h-[30px] flex border-b border-gray-100 dark:border-gray-700/50">
+									{columns.map((col) => (
+										<div
+											key={`m-${col.start.getTime()}`}
+											className="flex-shrink-0 border-r border-gray-200 dark:border-gray-700 flex items-center justify-center text-[11px] text-gray-700 dark:text-gray-300 font-medium text-center truncate px-1"
+											style={{ width: config.columnWidth }}
+										>
+											{col.middleLabel}
+										</div>
+									))}
+								</div>
+								{/* Layer 3: bottom ticks */}
+								<div className="h-[30px] flex">
+									{columns.map((col) => (
+										<div
+											key={`b-${col.start.getTime()}`}
+											className="flex-shrink-0 border-r border-gray-200 dark:border-gray-700 relative"
+											style={{ width: config.columnWidth }}
+										>
+											{col.bottomTicks.map((tick) => (
+												<div
+													key={tick.offsetPx}
+													className="absolute bottom-0 border-l border-gray-300 dark:border-gray-600"
+													style={{ left: tick.offsetPx, height: 6 }}
+												>
+														<span className="absolute -top-3 left-0 text-[9px] text-gray-400 dark:text-gray-500 whitespace-nowrap">
+															{tick.label}
+														</span>
+													</div>
+											))}
+										</div>
+									))}
+								</div>
+							</div>
+							{/* Today line */}
+							{showTodayLine && (
+								<div
+									className="absolute bottom-0 border-l-2 border-red-400 dark:border-red-500 z-10 pointer-events-none"
+										style={{ top: HEADER_HEIGHT, left: todayX }}
+								>
+									<span className="absolute top-0 -translate-x-1/2 text-[10px] text-red-500 dark:text-red-400 bg-white dark:bg-gray-900 px-1">
+										{(t as any).gantt?.today ?? "Today"}
+									</span>
+								</div>
+							)}
+
+							{/* Grid lines */}						{Array.from({ length: sortedTasks.length + 1 }).map((_, i) => (
+								<div
+									key={`grid-${i}`}
+									className="absolute left-0 right-0 border-b border-gray-100 dark:border-gray-800"
+									style={{ top: HEADER_HEIGHT + i * ROW_HEIGHT }}
+								/>
+							))}
+
+							{/* Task bars */}
+							{sortedTasks.map((task) => {
+								const pos = taskPositions[task.id];
+								if (!pos) return null;
+								const isHighlighted = highlightedIds.has(task.id);
+								const isDimmed = selectedTaskId && !isHighlighted;
+								const isHovered = hoveredTaskId === task.id;
+
+								return (
+									<div
+										key={task.id}
+										data-task-bar
+										className={`absolute h-6 rounded transition-all duration-200 cursor-pointer ${
+											getTaskStatusColor(task.status)
+										} ${isDimmed ? "opacity-30" : isHighlighted ? "opacity-100" : "opacity-90"} ${
+											isHovered ? "ring-2 ring-white dark:ring-gray-700 z-20" : ""
+										}`}
+										style={{
+											left: pos.x,
+											top: pos.y + (ROW_HEIGHT - 24) / 2,
+											width: Math.max(pos.width, 2),
+											minWidth: 2,
+										}}
+										onMouseEnter={(e) => {
+											setHoveredTaskId(task.id);
+											const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+											setTooltipPos({ x: rect.left + rect.width / 2, y: rect.top });
+										}}
+										onMouseLeave={() => {
+											setHoveredTaskId(null);
+											setTooltipPos(null);
+										}}
+										onClick={(e) => {
+											e.stopPropagation();
+											setSelectedTaskId((prev) => (prev === task.id ? null : task.id));
+										}}
+									>
+										{pos.width > 60 && (
+											<span className="text-[10px] text-white font-medium truncate px-1.5 leading-6 block">
+												{task.id}
+											</span>
+										)}
+									</div>
+								);
+							})}
+
+							{/* Dependency arrows */}
+							<svg
+								className="absolute inset-0 pointer-events-none"
+								style={{ width: timelineWidth, height: HEADER_HEIGHT + Math.max(sortedTasks.length * ROW_HEIGHT, 200) }}
+							>
+								{sortedTasks.map((task) =>
+									task.dependencies.map((depId) => {
+										const from = taskPositions[depId];
+										const to = taskPositions[task.id];
+										if (!from || !to) return null;
+										const startX = from.x + from.width;
+										const startY = from.y + ROW_HEIGHT / 2;
+										const endX = to.x;
+										const endY = to.y + ROW_HEIGHT / 2;
+										const HSEG = 6;
+										const ARROW_SIZE = 6;
+										const p0x = startX + HSEG;
+										const p3x = endX - HSEG;
+										const segDx = p3x - p0x;
+										const CURVE = Math.max(Math.abs(segDx) * 0.5, HSEG * 6);
+										const cp1x = p0x + CURVE;
+										const cp2x = p3x - CURVE;
+										const pathD = `M ${startX} ${startY} L ${p0x} ${startY} C ${cp1x} ${startY}, ${cp2x} ${endY}, ${p3x} ${endY}`;
+
+										const arrowBaseX = endX - ARROW_SIZE;
+										const arrowPoints = `${endX},${endY} ${arrowBaseX},${endY - 2.5} ${arrowBaseX},${endY + 2.5}`;
+
+										const isHighlighted = selectedTaskId && (selectedTaskId === task.id || selectedTaskId === depId);
+										const isDimmed = selectedTaskId && !isHighlighted;
+										const colorClass = isHighlighted
+											? "stroke-blue-500 dark:stroke-blue-400"
+											: "stroke-gray-800 dark:stroke-white";
+										const fillClass = isHighlighted
+											? "fill-blue-500 dark:fill-blue-400"
+											: "fill-gray-800 dark:fill-white";
+										const opacityClass = isDimmed ? "opacity-20" : isHighlighted ? "opacity-100" : "opacity-70";
+
+										return (
+											<g key={`${depId}-${task.id}`} className={opacityClass}>
+												<path d={pathD} fill="none" className={colorClass} strokeWidth="1.5" />
+												<polygon points={arrowPoints} className={fillClass} />
+											</g>
+										);
+									}),
+								)}
+							</svg>
+						</div>
+					</div>
+				</div>
+
+				{/* Tooltip */}
+				{hoveredTaskId && tooltipPos && (
+					<div
+						className="fixed z-50 bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-lg px-3 py-2 shadow-xl pointer-events-none max-w-xs"
+						style={{ left: tooltipPos.x, top: tooltipPos.y - 8, transform: "translate(-50%, -100%)" }}
+					>
+						{(() => {
+							const task = sortedTasks.find((t) => t.id === hoveredTaskId);
+							if (!task) return null;
+							return (
+								<div className="space-y-0.5">
+									<div className="font-semibold">{task.id} - {task.title}</div>
+									<div>
+										{(t as any).gantt?.tooltip?.start ?? "Start"}: {formatDisplayDate(task.start)}
+										{task.originalStart && ` (${task.originalStart})`}
+									</div>
+									<div>
+										{(t as any).gantt?.tooltip?.end ?? "End"}: {formatDisplayDate(task.end)}
+										{task.originalEnd && ` (${task.originalEnd})`}
+										{task.isFallback && ` [${(t as any).gantt?.tooltip?.fallback ?? "fallback"}]`}
+									</div>
+								</div>
+							);
+						})()}
+					</div>
+				)}
+			</div>
+		</>
+	);
+}

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -6,6 +6,7 @@ import { apiClient } from "../lib/api";
 import { buildMilestoneBuckets, collectArchivedMilestoneKeys, isDoneStatus, milestoneKey } from "../utils/milestones";
 import { storedUtcToDateTimeLocal, dateTimeLocalToStoredUtc, formatStoredUtcDateForDisplay } from "../utils/date-display";
 import { type Milestone, type MilestoneBucket, type Task } from "../../types";
+import { compareTaskIds, groupSubtasksUnderParents } from "../../utils/task-sorting";
 import MilestoneTaskRow from "./MilestoneTaskRow";
 import Modal from "./Modal";
 
@@ -30,19 +31,8 @@ const BUCKET_PRIORITY_RANK: Record<string, number> = {
 	low: 1,
 };
 
-function extractTaskNumericId(taskId: string): number | null {
-	const match = taskId.trim().match(/(\d+)$/);
-	if (!match?.[1]) return null;
-	return Number.parseInt(match[1], 10);
-}
-
 function compareTaskIdsAscending(a: Task, b: Task): number {
-	const idA = extractTaskNumericId(a.id);
-	const idB = extractTaskNumericId(b.id);
-	if (idA !== null && idB !== null) return idA - idB;
-	if (idA !== null) return -1;
-	if (idB !== null) return 1;
-	return a.id.localeCompare(b.id, undefined, { sensitivity: "base", numeric: true });
+	return compareTaskIds(a.id, b.id);
 }
 
 const rebuildFilteredBucket = (
@@ -593,13 +583,14 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		const collator = new Intl.Collator(undefined, { sensitivity: "base", numeric: true });
 		const withDirection = (value: number) => (config.direction === "asc" ? value : -value);
 
+		if (config.column === "id") {
+			const sorted = bucketTasks.slice().sort((a, b) => withDirection(compareTaskIdsAscending(a, b)));
+			return groupSubtasksUnderParents(sorted, compareTaskIdsAscending, undefined, config.direction);
+		}
+
 		return bucketTasks.slice().sort((a, b) => {
 			let result = 0;
 			switch (config.column) {
-				case "id": {
-					result = withDirection(compareTaskIdsAscending(a, b));
-					break;
-				}
 				case "title": {
 					result = withDirection(collator.compare(a.title, b.title));
 					break;

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -4,6 +4,7 @@ import Fuse from "fuse.js";
 import { useI18n } from "../hooks/useI18n";
 import { apiClient } from "../lib/api";
 import { buildMilestoneBuckets, collectArchivedMilestoneKeys, isDoneStatus, milestoneKey } from "../utils/milestones";
+import { storedUtcToDateTimeLocal, dateTimeLocalToStoredUtc, formatStoredUtcDateForDisplay } from "../utils/date-display";
 import { type Milestone, type MilestoneBucket, type Task } from "../../types";
 import MilestoneTaskRow from "./MilestoneTaskRow";
 import Modal from "./Modal";
@@ -107,9 +108,13 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 	const [newMilestoneDueDate, setNewMilestoneDueDate] = useState("");
 	const [newMilestonePlannedStart, setNewMilestonePlannedStart] = useState("");
 	const [newMilestonePlannedEnd, setNewMilestonePlannedEnd] = useState("");
+	const [newMilestoneActualStart, setNewMilestoneActualStart] = useState("");
+	const [newMilestoneActualEnd, setNewMilestoneActualEnd] = useState("");
 	const [editMilestoneDueDate, setEditMilestoneDueDate] = useState("");
 	const [editMilestonePlannedStart, setEditMilestonePlannedStart] = useState("");
 	const [editMilestonePlannedEnd, setEditMilestonePlannedEnd] = useState("");
+	const [editMilestoneActualStart, setEditMilestoneActualStart] = useState("");
+	const [editMilestoneActualEnd, setEditMilestoneActualEnd] = useState("");
 	const [removingBucket, setRemovingBucket] = useState<MilestoneBucket | null>(null);
 	const [removeTaskHandling, setRemoveTaskHandling] = useState<RemoveTaskHandling>("clear");
 	const [removeReassignTo, setRemoveReassignTo] = useState("");
@@ -279,6 +284,8 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		setNewMilestoneDueDate("");
 		setNewMilestonePlannedStart("");
 		setNewMilestonePlannedEnd("");
+		setNewMilestoneActualStart("");
+		setNewMilestoneActualEnd("");
 		setError(null);
 	};
 
@@ -295,7 +302,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		setError(null);
 		setSuccess(null);
 		try {
-			await apiClient.createMilestone(value, undefined, newMilestoneDueDate, newMilestonePlannedStart, newMilestonePlannedEnd);
+			await apiClient.createMilestone(value, undefined, newMilestoneDueDate, newMilestonePlannedStart, newMilestonePlannedEnd, newMilestoneActualStart, newMilestoneActualEnd);
 			closeAddModal();
 			setSuccess(t.milestones.addSuccess(value));
 			if (onRefreshData) {
@@ -357,6 +364,8 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		setEditMilestoneDueDate(entity?.dueDate || "");
 		setEditMilestonePlannedStart(entity?.plannedStart || "");
 		setEditMilestonePlannedEnd(entity?.plannedEnd || "");
+		setEditMilestoneActualStart(entity?.actualStart || "");
+		setEditMilestoneActualEnd(entity?.actualEnd || "");
 		setModalError(null);
 		setError(null);
 		setSuccess(null);
@@ -368,6 +377,8 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		setEditMilestoneDueDate("");
 		setEditMilestonePlannedStart("");
 		setEditMilestonePlannedEnd("");
+		setEditMilestoneActualStart("");
+		setEditMilestoneActualEnd("");
 		setModalError(null);
 	};
 
@@ -401,7 +412,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		setError(null);
 		setSuccess(null);
 		try {
-			await apiClient.updateMilestone(bucket.milestone, value, editMilestoneDueDate, editMilestonePlannedStart, editMilestonePlannedEnd);
+			await apiClient.updateMilestone(bucket.milestone, value, editMilestoneDueDate, editMilestonePlannedStart, editMilestonePlannedEnd, editMilestoneActualStart, editMilestoneActualEnd);
 			closeEditModal();
 			setSuccess(t.milestones.renameSuccess(previousLabel, value));
 			if (onRefreshData) {
@@ -663,7 +674,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 					{/* Milestone dates */}
 					{(() => {
 						const entity = milestoneEntities.find((m) => m.id === bucket.milestone);
-						if (!entity || (!entity.dueDate && !entity.plannedStart && !entity.plannedEnd)) return null;
+						if (!entity || (!entity.dueDate && !entity.plannedStart && !entity.plannedEnd && !entity.actualStart && !entity.actualEnd)) return null;
 						return (
 							<div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
 								{entity.dueDate && (
@@ -674,6 +685,12 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 								)}
 								{entity.plannedEnd && (
 									<span>{t.taskDetails.section.plannedEnd}: {entity.plannedEnd}</span>
+								)}
+								{entity.actualStart && (
+									<span>{t.taskDetails.section.actualStart}: {formatStoredUtcDateForDisplay(entity.actualStart)}</span>
+								)}
+								{entity.actualEnd && (
+									<span>{t.taskDetails.section.actualEnd}: {formatStoredUtcDateForDisplay(entity.actualEnd)}</span>
 								)}
 							</div>
 						);
@@ -1087,6 +1104,24 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:[color-scheme:dark]"
 						/>
 					</div>
+					<div className="space-y-2">
+						<label className="text-sm font-medium text-gray-900 dark:text-gray-100">{t.taskDetails.section.actualStart}</label>
+						<input
+							type="datetime-local"
+							value={storedUtcToDateTimeLocal(newMilestoneActualStart)}
+							onChange={(e) => setNewMilestoneActualStart(dateTimeLocalToStoredUtc(e.target.value))}
+							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:[color-scheme:dark]"
+						/>
+					</div>
+					<div className="space-y-2">
+						<label className="text-sm font-medium text-gray-900 dark:text-gray-100">{t.taskDetails.section.actualEnd}</label>
+						<input
+							type="datetime-local"
+							value={storedUtcToDateTimeLocal(newMilestoneActualEnd)}
+							onChange={(e) => setNewMilestoneActualEnd(dateTimeLocalToStoredUtc(e.target.value))}
+							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:[color-scheme:dark]"
+						/>
+					</div>
 					<div className="flex justify-end gap-2">
 						<button
 							type="button"
@@ -1150,6 +1185,24 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 							type="date"
 							value={editMilestonePlannedEnd}
 							onChange={(e) => setEditMilestonePlannedEnd(e.target.value)}
+							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:[color-scheme:dark]"
+						/>
+					</div>
+					<div className="space-y-2">
+						<label className="text-sm font-medium text-gray-900 dark:text-gray-100">{t.taskDetails.section.actualStart}</label>
+						<input
+							type="datetime-local"
+							value={storedUtcToDateTimeLocal(editMilestoneActualStart)}
+							onChange={(e) => setEditMilestoneActualStart(dateTimeLocalToStoredUtc(e.target.value))}
+							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:[color-scheme:dark]"
+						/>
+					</div>
+					<div className="space-y-2">
+						<label className="text-sm font-medium text-gray-900 dark:text-gray-100">{t.taskDetails.section.actualEnd}</label>
+						<input
+							type="datetime-local"
+							value={storedUtcToDateTimeLocal(editMilestoneActualEnd)}
+							onChange={(e) => setEditMilestoneActualEnd(dateTimeLocalToStoredUtc(e.target.value))}
 							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 dark:[color-scheme:dark]"
 						/>
 					</div>

--- a/src/web/components/SideNavigation.tsx
+++ b/src/web/components/SideNavigation.tsx
@@ -174,6 +174,11 @@ const Icons = {
 			<circle cx="12" cy="12" r="1" strokeWidth={2} />
 		</svg>
 	),
+	Gantt: () => (
+		<svg className="w-5 h-5" fill="currentColor" viewBox="0 0 1024 1024">
+			<path d="M153.6 806.4a44.8 44.8 0 0 1 44.8-44.8h179.2v-44.8a44.8 44.8 0 0 1 44.8-44.8h313.6a44.8 44.8 0 0 1 44.8 44.8V896a44.8 44.8 0 0 1-44.8 44.8H422.4a44.8 44.8 0 0 1-44.8-44.8v-44.736L198.4 851.2a44.8 44.8 0 0 1-44.8-44.8z m313.6-44.8v89.6h224v-89.6H467.2zM243.2 403.2a44.8 44.8 0 0 1 44.8-44.8h582.4a44.8 44.8 0 0 1 44.8 44.8v44.864L960 448a44.8 44.8 0 0 1 0 89.6l-44.8 0.064V582.4a44.8 44.8 0 0 1-44.8 44.8H288a44.8 44.8 0 0 1-44.8-44.8V403.2z m89.6 44.8v89.6h492.8V448H332.8zM19.2 179.2a44.8 44.8 0 0 1 44.8-44.8l134.4 0.064V89.6a44.8 44.8 0 0 1 44.8-44.8h201.6a44.8 44.8 0 0 1 44.8 44.8v44.864L736 134.4a44.8 44.8 0 0 1 0 89.6H489.6v44.8a44.8 44.8 0 0 1-44.8 44.8H243.2a44.8 44.8 0 0 1-44.8-44.8v-44.8H64a44.8 44.8 0 0 1-44.8-44.8z m268.8-44.8v89.6h112V134.4H288z" />
+		</svg>
+	),
 	Plus: () => (
 		<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 			<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
@@ -1272,6 +1277,21 @@ const SideNavigation = memo(function SideNavigation({
 							<span className="ml-3 text-sm font-medium">{t.nav.milestones}</span>
 						</NavLink>
 
+						{/* Gantt Navigation */}
+						<NavLink
+							to="/gantt"
+							className={({ isActive }) =>
+								`flex items-center px-3 py-2 rounded-lg transition-colors duration-200 ${
+									isActive
+										? 'bg-blue-50 dark:bg-blue-600/20 text-blue-600 dark:text-blue-400 font-medium'
+										: 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100'
+									}`
+							}
+						>
+							<Icons.Gantt />
+							<span className="ml-3 text-sm font-medium">{t.nav.gantt}</span>
+						</NavLink>
+
 						{/* Drafts Navigation */}
 						<NavLink
 							to="/drafts"
@@ -1511,6 +1531,23 @@ const SideNavigation = memo(function SideNavigation({
 						>
 							<div className="w-6 h-6 flex items-center justify-center">
 								<Icons.Milestone />
+							</div>
+						</NavLink>
+						{/* Gantt Navigation */}
+						<NavLink
+							to="/gantt"
+							data-tooltip-id="sidebar-tooltip"
+							data-tooltip-content={t.nav.gantt}
+							className={({ isActive }) =>
+								`flex items-center justify-center p-3 rounded-md transition-colors duration-200 ${
+									isActive
+										? 'bg-blue-50 dark:bg-blue-600/20 text-blue-700 dark:text-blue-400'
+										: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100'
+								}`
+							}
+						>
+							<div className="w-6 h-6 flex items-center justify-center">
+								<Icons.Gantt />
 							</div>
 						</NavLink>
 						{/* Statistics Navigation */}

--- a/src/web/components/TaskColumn.tsx
+++ b/src/web/components/TaskColumn.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useI18n } from '../hooks/useI18n';
 import { type Task } from '../../types';
-import { compareTaskIds, sortByPriority } from '../../utils/task-sorting';
+import { compareTaskIds, groupSubtasksUnderParents, sortByPriority } from '../../utils/task-sorting';
 import type { ReorderTaskPayload } from '../lib/api';
 import TaskCard from './TaskCard';
 
@@ -60,13 +60,26 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
 
   const getDisplayTasks = () => {
     if (!columnSort) return tasks;
+
+    if (columnSort.field === "id") {
+      const sorted = [...tasks].sort((a, b) => {
+        const result = compareTaskIds(a.id, b.id);
+        if (result !== 0) {
+          return columnSort.direction === "asc" ? result : -result;
+        }
+        return compareTaskIds(a.id, b.id);
+      });
+      return groupSubtasksUnderParents(
+        sorted,
+        (a, b) => compareTaskIds(a.id, b.id),
+        undefined,
+        columnSort.direction,
+      );
+    }
+
     return [...tasks].sort((a, b) => {
       let result = 0;
       switch (columnSort.field) {
-        case "id": {
-          result = compareTaskIds(a.id, b.id);
-          break;
-        }
         case "title": {
           result = a.title.localeCompare(b.title, undefined, { sensitivity: "base", numeric: true });
           break;

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -10,7 +10,11 @@ import FilePreviewModal from "./FilePreviewModal";
 import ChipInput from "./ChipInput";
 import DependencyInput from "./DependencyInput";
 import { PathAutocomplete } from "./PathAutocomplete";
-import { formatStoredUtcDateForDisplay } from "../utils/date-display";
+import {
+  dateTimeLocalToStoredUtc,
+  formatStoredUtcDateForDisplay,
+  storedUtcToDateTimeLocal,
+} from "../utils/date-display";
 import { useI18n } from "../hooks/useI18n";
 
 interface Props {
@@ -249,6 +253,9 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const [dueDate, setDueDate] = useState<string>(task?.dueDate || "");
   const [plannedStart, setPlannedStart] = useState<string>(task?.plannedStart || "");
   const [plannedEnd, setPlannedEnd] = useState<string>(task?.plannedEnd || "");
+  const [actualStart, setActualStart] = useState<string>(task?.actualStart || "");
+  const [actualEnd, setActualEnd] = useState<string>(task?.actualEnd || "");
+
   const [availableTasks, setAvailableTasks] = useState<Task[]>([]);
   const [previewFilePath, setPreviewFilePath] = useState<string | null>(null);
   const milestoneSelectionValue = resolveMilestoneToId(milestone);
@@ -266,6 +273,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
     dueDate: task?.dueDate || "",
     plannedStart: task?.plannedStart || "",
     plannedEnd: task?.plannedEnd || "",
+    actualStart: task?.actualStart || "",
+    actualEnd: task?.actualEnd || "",
   }), [task, defaultDefinitionOfDone, isCreateMode]);
 
   const isDirty = useMemo(() => {
@@ -279,9 +288,11 @@ export const TaskDetailsModal: React.FC<Props> = ({
       JSON.stringify(definitionOfDone) !== baseline.definitionOfDone ||
       dueDate !== baseline.dueDate ||
       plannedStart !== baseline.plannedStart ||
-      plannedEnd !== baseline.plannedEnd
+      plannedEnd !== baseline.plannedEnd ||
+      actualStart !== baseline.actualStart ||
+      actualEnd !== baseline.actualEnd
     );
-  }, [title, description, plan, notes, finalSummary, criteria, definitionOfDone, dueDate, plannedStart, plannedEnd, baseline]);
+  }, [title, description, plan, notes, finalSummary, criteria, definitionOfDone, dueDate, plannedStart, plannedEnd, actualStart, actualEnd, baseline]);
 
   useEffect(() => {
     modeRef.current = mode;
@@ -360,6 +371,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
     setDueDate(task?.dueDate || "");
     setPlannedStart(task?.plannedStart || "");
     setPlannedEnd(task?.plannedEnd || "");
+    setActualStart(task?.actualStart || "");
+    setActualEnd(task?.actualEnd || "");
     setMode(shouldPreserveEditMode ? "edit" : isCreateMode ? "create" : "preview");
     preserveEditModeAfterCommentRefresh.current = false;
     previousTaskId.current = nextTaskId;
@@ -396,6 +409,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
       setDueDate(task?.dueDate || "");
       setPlannedStart(task?.plannedStart || "");
       setPlannedEnd(task?.plannedEnd || "");
+      setActualStart(task?.actualStart || "");
+      setActualEnd(task?.actualEnd || "");
       setMode("preview");
       refreshAfterCommentChange();
     }
@@ -561,6 +576,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
         dueDate: dueDate.trim().length > 0 ? dueDate.trim() : undefined,
         plannedStart: plannedStart.trim().length > 0 ? plannedStart.trim() : undefined,
         plannedEnd: plannedEnd.trim().length > 0 ? plannedEnd.trim() : undefined,
+        actualStart: actualStart.trim().length > 0 ? actualStart.trim() : undefined,
+        actualEnd: actualEnd.trim().length > 0 ? actualEnd.trim() : undefined,
       };
 
       if (isCreateMode && onSubmit) {
@@ -1411,6 +1428,38 @@ export const TaskDetailsModal: React.FC<Props> = ({
                     setPlannedEnd(value);
                     if (task && !isCreateMode) {
                       handleInlineMetaUpdate({ plannedEnd: value || undefined });
+                    }
+                  }}
+                  disabled={isFromOtherBranch}
+                  className={`w-full h-10 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200 dark:[color-scheme:dark] ${isFromOtherBranch ? 'opacity-60 cursor-not-allowed' : ''}`}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{t.taskDetails.section.actualStart}</label>
+                <input
+                  type="datetime-local"
+                  value={storedUtcToDateTimeLocal(actualStart)}
+                  onChange={(e) => {
+                    const value = dateTimeLocalToStoredUtc(e.target.value);
+                    setActualStart(value);
+                    if (task && !isCreateMode) {
+                      handleInlineMetaUpdate({ actualStart: value || undefined });
+                    }
+                  }}
+                  disabled={isFromOtherBranch}
+                  className={`w-full h-10 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200 dark:[color-scheme:dark] ${isFromOtherBranch ? 'opacity-60 cursor-not-allowed' : ''}`}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{t.taskDetails.section.actualEnd}</label>
+                <input
+                  type="datetime-local"
+                  value={storedUtcToDateTimeLocal(actualEnd)}
+                  onChange={(e) => {
+                    const value = dateTimeLocalToStoredUtc(e.target.value);
+                    setActualEnd(value);
+                    if (task && !isCreateMode) {
+                      handleInlineMetaUpdate({ actualEnd: value || undefined });
                     }
                   }}
                   disabled={isFromOtherBranch}

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -15,6 +15,7 @@ import {
   formatStoredUtcDateForDisplay,
   storedUtcToDateTimeLocal,
 } from "../utils/date-display";
+import { isTypingTarget } from "../utils/keyboard";
 import { useI18n } from "../hooks/useI18n";
 
 interface Props {
@@ -304,6 +305,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
   // Intercept Escape to cancel edit (not close modal) when in edit mode
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      if (isTypingTarget(e)) return;
+
       if (mode === "edit" && (e.key === "Escape")) {
         e.preventDefault();
         e.stopPropagation();

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -15,6 +15,7 @@ import CleanupModal from "./CleanupModal";
 import LabelFilterDropdown from "./LabelFilterDropdown";
 import { SuccessToast } from "./SuccessToast";
 import { useI18n } from "../hooks/useI18n";
+import { compareTaskIds, groupSubtasksUnderParents } from "../../utils/task-sorting";
 
 interface TaskListProps {
 	onEditTask: (task: Task) => void;
@@ -37,22 +38,8 @@ const PRIORITY_RANK: Record<string, number> = {
 	low: 1,
 };
 
-function extractTaskNumericId(taskId: string): number | null {
-	const match = taskId.trim().match(/(\d+)$/);
-	if (!match?.[1]) return null;
-	return Number.parseInt(match[1], 10);
-}
-
 function compareTaskIdsAscending(a: Task, b: Task): number {
-	const idA = extractTaskNumericId(a.id);
-	const idB = extractTaskNumericId(b.id);
-
-	if (idA !== null && idB !== null) {
-		return idA - idB;
-	}
-	if (idA !== null) return -1;
-	if (idB !== null) return 1;
-	return a.id.localeCompare(b.id, undefined, { sensitivity: "base", numeric: true });
+	return compareTaskIds(a.id, b.id);
 }
 
 function sortTasksByIdDescending(list: Task[]): Task[] {
@@ -520,13 +507,14 @@ const TaskList: React.FC<TaskListProps> = ({
 		const compareText = (a: string, b: string) => collator.compare(a, b);
 		const withDirection = (value: number) => (sortDirection === "asc" ? value : -value);
 
+		if (sortColumn === "id") {
+			const sorted = [...displayTasks].sort((a, b) => withDirection(compareTaskIdsAscending(a, b)));
+			return groupSubtasksUnderParents(sorted, compareTaskIdsAscending, undefined, sortDirection);
+		}
+
 		return [...displayTasks].sort((a, b) => {
 			let result = 0;
 			switch (sortColumn) {
-				case "id": {
-					result = withDirection(compareTaskIdsAscending(a, b));
-					break;
-				}
 				case "title": {
 					result = withDirection(compareText(a.title, b.title));
 					break;

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -507,13 +507,15 @@ export class ApiClient {
 		dueDate?: string,
 		plannedStart?: string,
 		plannedEnd?: string,
+		actualStart?: string,
+		actualEnd?: string,
 	): Promise<Milestone> {
 		const response = await fetch(`${API_BASE}/milestones`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ title, description, dueDate, plannedStart, plannedEnd }),
+			body: JSON.stringify({ title, description, dueDate, plannedStart, plannedEnd, actualStart, actualEnd }),
 		});
 		if (!response.ok) {
 			const data = await response.json().catch(() => ({}));
@@ -528,13 +530,15 @@ export class ApiClient {
 		dueDate?: string,
 		plannedStart?: string,
 		plannedEnd?: string,
+		actualStart?: string,
+		actualEnd?: string,
 	): Promise<{ success: boolean; milestone?: Milestone | null; message?: string }> {
 		const response = await fetch(`${API_BASE}/milestones/${encodeURIComponent(id)}`, {
 			method: "PUT",
 			headers: {
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ title, dueDate, plannedStart, plannedEnd }),
+			body: JSON.stringify({ title, dueDate, plannedStart, plannedEnd, actualStart, actualEnd }),
 		});
 		if (!response.ok) {
 			const data = await response.json().catch(() => ({}));

--- a/src/web/locales/en.ts
+++ b/src/web/locales/en.ts
@@ -650,6 +650,8 @@ export const en = {
 	},
 	gantt: {
 		title: "Gantt",
+		showPlanTime: "Show Plan Time",
+		showActualTime: "Show Actual Time",
 		granularity: {
 			day: "Day",
 			week: "Week",
@@ -660,8 +662,10 @@ export const en = {
 		columns: {
 			id: "ID",
 			title: "Title",
-			start: "Start",
-			end: "End",
+			plannedStart: "Plan Start",
+			plannedEnd: "Plan End",
+			actualStart: "Actual Start",
+			actualEnd: "Actual End",
 			action: "Action",
 		},
 		noTasks: "No tasks to display",
@@ -670,9 +674,22 @@ export const en = {
 			detail: "Detail",
 		},
 		tooltip: {
-			start: "Start",
-			end: "End",
+			planned: "Planned",
+			actual: "Actual",
 			fallback: "fallback",
+		},
+		legend: {
+			actual: "Actual",
+			planned: "Planned",
+			dependency: "Dependency",
+			fallback: "Fallback",
+		},
+		statusLabels: {
+			done: "Done",
+			inProgress: "In Progress",
+			toDo: "To Do",
+			blocked: "Blocked",
+			cancelled: "Cancelled",
 		},
 	},
 	wiki: {

--- a/src/web/locales/en.ts
+++ b/src/web/locales/en.ts
@@ -199,6 +199,8 @@ export const en = {
 			dueDate: "Due Date",
 			plannedStart: "Planned Start",
 			plannedEnd: "Planned End",
+			actualStart: "Actual Start",
+			actualEnd: "Actual End",
 		},
 		clickToPreview: "Click to preview",
 		removeReference: "Remove reference",

--- a/src/web/locales/en.ts
+++ b/src/web/locales/en.ts
@@ -76,6 +76,7 @@ export const en = {
 		tasks: "All Tasks",
 		drafts: "Drafts",
 		milestones: "Milestones",
+		gantt: "Gantt",
 		documents: "Documents",
 		decisions: "Decisions",
 		statistics: "Statistics",
@@ -644,6 +645,33 @@ export const en = {
 		label: "Dependencies",
 		placeholderEmpty: "Type task ID or title, then press Enter or comma",
 		placeholderAddMore: "Add more dependencies...",
+	},
+	gantt: {
+		title: "Gantt",
+		granularity: {
+			day: "Day",
+			week: "Week",
+			month: "Month",
+			quarter: "Quarter",
+			year: "Year",
+		},
+		columns: {
+			id: "ID",
+			title: "Title",
+			start: "Start",
+			end: "End",
+			action: "Action",
+		},
+		noTasks: "No tasks to display",
+		today: "Today",
+		action: {
+			detail: "Detail",
+		},
+		tooltip: {
+			start: "Start",
+			end: "End",
+			fallback: "fallback",
+		},
 	},
 	wiki: {
 		failedToLoad: "Failed to load wiki page",

--- a/src/web/locales/ja.ts
+++ b/src/web/locales/ja.ts
@@ -653,6 +653,8 @@ export const ja: TranslationDict = {
 	},
 	gantt: {
 		title: "ガント",
+		showPlanTime: "計画時間を表示",
+		showActualTime: "実際時間を表示",
 		granularity: {
 			day: "日",
 			week: "週",
@@ -663,8 +665,10 @@ export const ja: TranslationDict = {
 		columns: {
 			id: "ID",
 			title: "タイトル",
-			start: "開始",
-			end: "終了",
+			plannedStart: "計画\n開始",
+			plannedEnd: "計画\n終了",
+			actualStart: "実際\n開始",
+			actualEnd: "実際\n終了",
 			action: "アクション",
 		},
 		noTasks: "表示するタスクがありません",
@@ -673,9 +677,22 @@ export const ja: TranslationDict = {
 			detail: "詳細",
 		},
 		tooltip: {
-			start: "開始",
-			end: "終了",
+			planned: "計画",
+			actual: "実際",
 			fallback: "フォールバック",
+		},
+		legend: {
+			actual: "実際",
+			planned: "計画",
+			dependency: "依存関係",
+			fallback: "フォールバック",
+		},
+		statusLabels: {
+			done: "完了",
+			inProgress: "進行中",
+			toDo: "未着手",
+			blocked: "阻塞",
+			cancelled: "取消",
 		},
 	},
 	wiki: {

--- a/src/web/locales/ja.ts
+++ b/src/web/locales/ja.ts
@@ -78,6 +78,7 @@ export const ja: TranslationDict = {
 		tasks: "すべてのタスク",
 		drafts: "ドラフト",
 		milestones: "マイルストーン",
+		gantt: "ガント",
 		documents: "ドキュメント",
 		decisions: "決定事項",
 		statistics: "統計",
@@ -647,6 +648,33 @@ export const ja: TranslationDict = {
 		label: "依存関係",
 		placeholderEmpty: "タスク ID またはタイトルを入力して、Enter またはカンマを押してください",
 		placeholderAddMore: "さらに依存関係を追加...",
+	},
+	gantt: {
+		title: "ガント",
+		granularity: {
+			day: "日",
+			week: "週",
+			month: "月",
+			quarter: "四半期",
+			year: "年",
+		},
+		columns: {
+			id: "ID",
+			title: "タイトル",
+			start: "開始",
+			end: "終了",
+			action: "アクション",
+		},
+		noTasks: "表示するタスクがありません",
+		today: "今日",
+		action: {
+			detail: "詳細",
+		},
+		tooltip: {
+			start: "開始",
+			end: "終了",
+			fallback: "フォールバック",
+		},
 	},
 	wiki: {
 		failedToLoad: "Wiki ページの読み込みに失敗しました",

--- a/src/web/locales/ja.ts
+++ b/src/web/locales/ja.ts
@@ -202,6 +202,8 @@ export const ja: TranslationDict = {
 			dueDate: "期限",
 			plannedStart: "計画開始日",
 			plannedEnd: "計画終了日",
+			actualStart: "実開始日",
+			actualEnd: "実終了日",
 		},
 		clickToPreview: "クリックしてプレビュー",
 		removeReference: "参照を削除",

--- a/src/web/locales/zh-CN.ts
+++ b/src/web/locales/zh-CN.ts
@@ -201,6 +201,8 @@ export const zhCN: TranslationDict = {
 			dueDate: "截止日期",
 			plannedStart: "计划开始",
 			plannedEnd: "计划结束",
+			actualStart: "实际开始",
+			actualEnd: "实际结束",
 		},
 		clickToPreview: "点击预览",
 		removeReference: "移除引用",

--- a/src/web/locales/zh-CN.ts
+++ b/src/web/locales/zh-CN.ts
@@ -648,6 +648,8 @@ export const zhCN: TranslationDict = {
 	},
 	gantt: {
 		title: "甘特图",
+		showPlanTime: "显示计划时间",
+		showActualTime: "显示实际时间",
 		granularity: {
 			day: "日",
 			week: "周",
@@ -658,8 +660,10 @@ export const zhCN: TranslationDict = {
 		columns: {
 			id: "ID",
 			title: "名称",
-			start: "开始",
-			end: "结束",
+			plannedStart: "计划开始",
+			plannedEnd: "计划结束",
+			actualStart: "实际开始",
+			actualEnd: "实际结束",
 			action: "操作",
 		},
 		noTasks: "暂无任务",
@@ -668,9 +672,22 @@ export const zhCN: TranslationDict = {
 			detail: "详情",
 		},
 		tooltip: {
-			start: "开始",
-			end: "结束",
-			fallback: "兜底",
+			planned: "计划",
+			actual: "实际",
+			fallback: "估算",
+		},
+		legend: {
+			actual: "实际任务",
+			planned: "计划时间",
+			dependency: "依赖关系",
+			fallback: "估算时间",
+		},
+		statusLabels: {
+			done: "已完成",
+			inProgress: "进行中",
+			toDo: "待办",
+			blocked: "阻塞",
+			cancelled: "已取消",
 		},
 	},
 	wiki: {

--- a/src/web/locales/zh-CN.ts
+++ b/src/web/locales/zh-CN.ts
@@ -78,6 +78,7 @@ export const zhCN: TranslationDict = {
 		tasks: "所有任务",
 		drafts: "草稿",
 		milestones: "里程碑",
+		gantt: "甘特图",
 		documents: "文档",
 		decisions: "决策",
 		statistics: "统计",
@@ -642,6 +643,33 @@ export const zhCN: TranslationDict = {
 		label: "依赖",
 		placeholderEmpty: "输入任务 ID 或标题，按回车或逗号确认",
 		placeholderAddMore: "添加更多依赖...",
+	},
+	gantt: {
+		title: "甘特图",
+		granularity: {
+			day: "日",
+			week: "周",
+			month: "月",
+			quarter: "季",
+			year: "年",
+		},
+		columns: {
+			id: "ID",
+			title: "名称",
+			start: "开始",
+			end: "结束",
+			action: "操作",
+		},
+		noTasks: "暂无任务",
+		today: "今天",
+		action: {
+			detail: "详情",
+		},
+		tooltip: {
+			start: "开始",
+			end: "结束",
+			fallback: "兜底",
+		},
 	},
 	wiki: {
 		failedToLoad: "Wiki 页面加载失败",

--- a/src/web/locales/zh-TW.ts
+++ b/src/web/locales/zh-TW.ts
@@ -78,6 +78,7 @@ export const zhTW: TranslationDict = {
 		tasks: "所有任務",
 		drafts: "草稿",
 		milestones: "里程碑",
+		gantt: "甘特圖",
 		documents: "文檔",
 		decisions: "決策",
 		statistics: "統計",
@@ -642,6 +643,33 @@ export const zhTW: TranslationDict = {
 		label: "依賴",
 		placeholderEmpty: "輸入任務 ID 或標題，按回車或逗號確認",
 		placeholderAddMore: "添加更多依賴...",
+	},
+	gantt: {
+		title: "甘特圖",
+		granularity: {
+			day: "日",
+			week: "週",
+			month: "月",
+			quarter: "季",
+			year: "年",
+		},
+		columns: {
+			id: "ID",
+			title: "名稱",
+			start: "開始",
+			end: "結束",
+			action: "操作",
+		},
+		noTasks: "暫無任務",
+		today: "今天",
+		action: {
+			detail: "詳情",
+		},
+		tooltip: {
+			start: "開始",
+			end: "結束",
+			fallback: "兜底",
+		},
 	},
 	wiki: {
 		failedToLoad: "Wiki 頁面載入失敗",

--- a/src/web/locales/zh-TW.ts
+++ b/src/web/locales/zh-TW.ts
@@ -201,6 +201,8 @@ export const zhTW: TranslationDict = {
 			dueDate: "截止日期",
 			plannedStart: "計劃開始",
 			plannedEnd: "計劃結束",
+			actualStart: "實際開始",
+			actualEnd: "實際結束",
 		},
 		clickToPreview: "點擊預覽",
 		removeReference: "移除引用",

--- a/src/web/locales/zh-TW.ts
+++ b/src/web/locales/zh-TW.ts
@@ -648,6 +648,8 @@ export const zhTW: TranslationDict = {
 	},
 	gantt: {
 		title: "甘特圖",
+		showPlanTime: "顯示計劃時間",
+		showActualTime: "顯示實際時間",
 		granularity: {
 			day: "日",
 			week: "週",
@@ -658,8 +660,10 @@ export const zhTW: TranslationDict = {
 		columns: {
 			id: "ID",
 			title: "名稱",
-			start: "開始",
-			end: "結束",
+			plannedStart: "計劃開始",
+			plannedEnd: "計劃結束",
+			actualStart: "實際開始",
+			actualEnd: "實際結束",
 			action: "操作",
 		},
 		noTasks: "暫無任務",
@@ -668,9 +672,22 @@ export const zhTW: TranslationDict = {
 			detail: "詳情",
 		},
 		tooltip: {
-			start: "開始",
-			end: "結束",
-			fallback: "兜底",
+			planned: "計劃",
+			actual: "實際",
+			fallback: "估算",
+		},
+		legend: {
+			actual: "實際任務",
+			planned: "計劃時間",
+			dependency: "依賴關係",
+			fallback: "估算時間",
+		},
+		statusLabels: {
+			done: "已完成",
+			inProgress: "進行中",
+			toDo: "待辦",
+			blocked: "阻塞",
+			cancelled: "已取消",
 		},
 	},
 	wiki: {

--- a/src/web/utils/date-display.test.ts
+++ b/src/web/utils/date-display.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import {
+	dateTimeLocalToStoredUtc,
 	formatStoredUtcDateForCompactDisplay,
 	formatStoredUtcDateForDisplay,
 	parseStoredUtcDate,
+	storedUtcToDateTimeLocal,
 } from "./date-display";
 
 describe("parseStoredUtcDate", () => {
@@ -60,5 +62,43 @@ describe("formatStoredUtcDateForCompactDisplay", () => {
 	it("handles missing and invalid values gracefully", () => {
 		expect(formatStoredUtcDateForCompactDisplay("", now)).toBe("—");
 		expect(formatStoredUtcDateForCompactDisplay("not-a-date", now)).toBe("not-a-date");
+	});
+});
+
+describe("storedUtcToDateTimeLocal", () => {
+	it("converts stored UTC datetime to local datetime-local format", () => {
+		const result = storedUtcToDateTimeLocal("2026-02-09 06:01");
+		const [datePart, timePart] = result.split("T");
+		expect(datePart).toBe("2026-02-09");
+		expect(timePart).toBeDefined();
+		const [hours, minutes] = timePart!.split(":");
+		expect(hours).toBeDefined();
+		expect(minutes).toBeDefined();
+		const localDate = new Date(2026, 1, 9, Number.parseInt(hours!, 10), Number.parseInt(minutes!, 10), 0);
+		expect(localDate.toISOString()).toBe("2026-02-09T06:01:00.000Z");
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(storedUtcToDateTimeLocal("")).toBe("");
+	});
+
+	it("falls back to T replacement for invalid input", () => {
+		expect(storedUtcToDateTimeLocal("not-a-date")).toBe("not-a-date");
+	});
+});
+
+describe("dateTimeLocalToStoredUtc", () => {
+	it("converts local datetime-local to stored UTC format", () => {
+		const utcDate = new Date(Date.UTC(2026, 1, 9, 6, 1, 0));
+		const localStr = `${utcDate.getFullYear()}-${String(utcDate.getMonth() + 1).padStart(2, "0")}-${String(utcDate.getDate()).padStart(2, "0")}T${String(utcDate.getHours()).padStart(2, "0")}:${String(utcDate.getMinutes()).padStart(2, "0")}`;
+		expect(dateTimeLocalToStoredUtc(localStr)).toBe("2026-02-09 06:01");
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(dateTimeLocalToStoredUtc("")).toBe("");
+	});
+
+	it("falls back to space replacement for non-datetime-local input", () => {
+		expect(dateTimeLocalToStoredUtc("2026-02-09 06:01")).toBe("2026-02-09 06:01");
 	});
 });

--- a/src/web/utils/date-display.ts
+++ b/src/web/utils/date-display.ts
@@ -72,6 +72,36 @@ export function formatStoredUtcDateForDisplay(dateStr: string): string {
 	return parsed.toLocaleDateString();
 }
 
+export function storedUtcToDateTimeLocal(dateStr: string): string {
+	const parsed = parseStoredUtcDate(dateStr);
+	if (!parsed) return dateStr.replace(" ", "T");
+
+	const year = parsed.getFullYear();
+	const month = String(parsed.getMonth() + 1).padStart(2, "0");
+	const day = String(parsed.getDate()).padStart(2, "0");
+	const hours = String(parsed.getHours()).padStart(2, "0");
+	const minutes = String(parsed.getMinutes()).padStart(2, "0");
+
+	return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+export function dateTimeLocalToStoredUtc(localStr: string): string {
+	const normalized = localStr.trim();
+	if (!normalized) return "";
+
+	const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/);
+	if (!match) return normalized.replace("T", " ");
+
+	const year = parseIntStrict(match[1]!);
+	const month = parseIntStrict(match[2]!) - 1;
+	const day = parseIntStrict(match[3]!);
+	const hours = parseIntStrict(match[4]!);
+	const minutes = parseIntStrict(match[5]!);
+
+	const date = new Date(year, month, day, hours, minutes, 0);
+	return date.toISOString().slice(0, 16).replace("T", " ");
+}
+
 export function formatStoredUtcDateForCompactDisplay(dateStr: string, now: Date = new Date()): string {
 	const normalized = dateStr.trim();
 	if (!normalized) return "—";

--- a/src/web/utils/keyboard.test.ts
+++ b/src/web/utils/keyboard.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { isTypingTarget } from "./keyboard";
+
+function makeEvent(target: unknown): KeyboardEvent {
+	return { target } as KeyboardEvent;
+}
+
+function makeElement(tagName: string, isContentEditable = false): unknown {
+	return { tagName, isContentEditable };
+}
+
+describe("isTypingTarget", () => {
+	it("returns true for INPUT targets", () => {
+		const event = makeEvent(makeElement("INPUT"));
+		expect(isTypingTarget(event)).toBe(true);
+	});
+
+	it("returns true for TEXTAREA targets", () => {
+		const event = makeEvent(makeElement("TEXTAREA"));
+		expect(isTypingTarget(event)).toBe(true);
+	});
+
+	it("returns true for contenteditable elements", () => {
+		const event = makeEvent(makeElement("DIV", true));
+		expect(isTypingTarget(event)).toBe(true);
+	});
+
+	it("returns false for non-input HTMLElement targets", () => {
+		const event = makeEvent(makeElement("DIV"));
+		expect(isTypingTarget(event)).toBe(false);
+	});
+
+	it("returns false when target is not an HTMLElement", () => {
+		const event = makeEvent({ foo: "bar" });
+		expect(isTypingTarget(event)).toBe(false);
+	});
+
+	it("returns false when target is null", () => {
+		const event = makeEvent(null);
+		expect(isTypingTarget(event)).toBe(false);
+	});
+});

--- a/src/web/utils/keyboard.ts
+++ b/src/web/utils/keyboard.ts
@@ -1,0 +1,22 @@
+interface TypableElement {
+	tagName: string;
+	isContentEditable: boolean;
+}
+
+/**
+ * Determine whether a keyboard event originated while the user is typing
+ * into a text-input element (input, textarea, or contenteditable).
+ */
+export function isTypingTarget(event: KeyboardEvent): boolean {
+	const target = event.target as unknown;
+	if (!target || typeof target !== "object") return false;
+
+	const el = target as TypableElement;
+	const tag = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+
+	if (tag === "INPUT" || tag === "TEXTAREA" || el.isContentEditable) {
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
> [!NOTE]
> **Maintainer-split slice 8/9 of #669.** All commits are authored by @kuwork — I only rebased them onto current `main` and resolved conflicts. Merge with **Rebase and merge** to keep the per-task commits and original authorship.

## Stack

Based on `pr669/7-dates-stats` (slice 7). Review only the commits unique to this PR. After the previous slice merges, restack with `git rebase --onto main pr669/7-dates-stats pr669/8-gantt-actuals`.

## Tasks in this slice

### BACK-491 — Smart Gantt view
- `src/web/components/GanttView.tsx`: zoom levels, drag-to-scroll, today marker, dependency arrows, dark mode; `/gantt` route

### BACK-492 / BACK-493 — actualStart and actualEnd for tasks and milestones
- Auto-population on status change (first non-todo → `actualStart`, completion → `actualEnd`)
- CLI / MCP / web support, markdown round-trip

### BACK-494 — Fix modal keyboard shortcuts interfering with title input
- `src/web/utils/keyboard.ts`: `isEditingText()` focus detection guard

### BACK-495 — Tracking Gantt: plan vs actual comparison
- Planned bars vs actual bars, overdue/at-risk color coding

### BACK-496 — Subtask grouping under parent for ID sorting
- `src/utils/task-sorting.ts`: shared sort utility replacing inline sorts across views

## Notes

- Depends on slice 7 (BACK-401 planned dates feed the Gantt; BACK-489 health categories feed tracking colors).
- Task IDs in `backlog/tasks/` were minted on the fork — re-mint before merge if taken.
- Validated at this tip: `bun install --frozen-lockfile`, `bunx tsc --noEmit`.

Original combined PR: #669.

**Full stack:** #675 editor/paste → #676 wiki → #677 i18n → #678 doc editing → #679 search/sidebar → #680 fixes → #681 dates/stats → #682 Gantt → #683 timezone/polish — split from #669, all commits authored by @kuwork.
