### PR TITLE
BACK-506 - Fix Codex MCP connection failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can run `backlog init` (even if you already initialized Backlog.md) to set u
   <summary><strong>Codex</strong></summary>
 
   ```bash
-  codex mcp add backlog backlog mcp start
+  codex mcp add backlog -- backlog mcp start
   ```
 
 </details>

--- a/backlog/tasks/back-506 - Fix-Codex-MCP-connection-failure.md
+++ b/backlog/tasks/back-506 - Fix-Codex-MCP-connection-failure.md
@@ -1,0 +1,84 @@
+---
+id: BACK-506
+title: Fix Codex MCP connection failure
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-06-13 14:01'
+updated_date: '2026-06-13 14:09'
+labels:
+  - mcp
+  - codex
+dependencies: []
+documentation:
+  - 'https://developers.openai.com/codex/mcp'
+  - 'https://www.npmjs.com/package/@modelcontextprotocol/sdk'
+modified_files:
+  - README.md
+  - src/cli.ts
+  - src/core/init.ts
+  - src/utils/mcp-client-setup.ts
+  - src/test/build.test.ts
+  - src/test/mcp-client-setup.test.ts
+priority: high
+ordinal: 31000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate why current Codex cannot connect to the Backlog.md MCP server, determine whether Backlog is relying on non-standard MCP behavior or needs an SDK/server compatibility update, and ship the smallest fix on the public CLI/MCP surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Codex-compatible MCP startup is reproduced with an SDK/client-level test or local smoke harness.
+- [x] #2 Backlog MCP startup does not depend on non-standard stdout/stderr behavior or obsolete SDK assumptions.
+- [x] #3 If an SDK update is needed, dependency changes are minimal and justified; otherwise no dependency churn is introduced.
+- [x] #4 Targeted MCP tests pass and cover the regression path.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect existing Codex/MCP setup docs, prior tasks, and current SDK usage.
+2. Reproduce the connection failure through a local MCP client or Codex-equivalent stdio handshake.
+3. Identify whether failure is startup output, transport lifecycle, roots discovery, schema compatibility, or dependency drift.
+4. Apply the smallest server/CLI/dependency fix and add regression coverage.
+5. Run targeted MCP validation and simplify the final implementation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Investigation found that the SDK itself is already current at @modelcontextprotocol/sdk 1.29.0, so no dependency bump is needed. The source MCP path (`bun src/cli.ts mcp start --debug`) initialized correctly and exposed tools/resources through the SDK client. The reproduced failure was on the packaged command path Codex launches: the local `backlog` command resolved to a stale/broken `dist/backlog` binary that closed during MCP initialization. Rebuilding fixed the local binary, and the code now adds compiled-binary MCP smoke coverage so this path is tested.
+
+Implementation simplified MCP client setup into one shared helper used by CLI and core init. Codex setup now emits the current stdio separator form (`codex mcp add backlog -- backlog mcp start`), and setup commands now fail on non-zero exit instead of printing success. README manual setup was updated to match.
+
+Validation passed: `bun test src/test/mcp-client-setup.test.ts src/test/build.test.ts src/test/mcp-stdio-exit.test.ts`, `bunx tsc --noEmit`, `bun run check .`.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Summary:
+- Added a shared MCP client setup helper for Claude, Codex, Gemini, and Kiro setup commands.
+- Updated Codex setup to the current `--` stdio command separator and README docs.
+- Fixed setup command execution so non-zero client setup exits are reported instead of treated as success.
+- Added a compiled executable MCP stdio smoke test to cover the binary path Codex launches.
+
+Root cause:
+- Backlog MCP source startup was standards-compliant and did not require an SDK bump; the local failure reproduced through a stale/broken compiled `dist/backlog` binary, while source startup succeeded. The missing regression coverage was that compiled binaries were smoke-tested for `--help`/`--version`, but not MCP stdio initialization.
+
+Validation:
+- bun test src/test/mcp-client-setup.test.ts src/test/build.test.ts src/test/mcp-stdio-exit.test.ts
+- bunx tsc --noEmit
+- bun run check .
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { basename, join } from "node:path";
 import { stdin as input } from "node:process";
 import { createInterface } from "node:readline/promises";
 import * as clack from "@clack/prompts";
-import { $, spawn } from "bun";
+import { $ } from "bun";
 import { Command } from "commander";
 import { runAdvancedConfigWizard } from "./commands/advanced-config-wizard.ts";
 import { type CompletionInstallResult, installCompletion, registerCompletionCommand } from "./commands/completion.ts";
@@ -52,6 +52,13 @@ import { scrollableViewer } from "./ui/tui.ts";
 import { type AgentSelectionValue, processAgentSelection } from "./utils/agent-selection.ts";
 import { normalizeProjectBacklogDirectory } from "./utils/backlog-directory.ts";
 import { findBacklogRoot } from "./utils/find-backlog-root.ts";
+import {
+	formatMcpClientSetupCommand,
+	getMcpClientSetupCommand,
+	isMcpClientSetupKey,
+	type McpClientSetupKey,
+	runMcpClientSetupCommand,
+} from "./utils/mcp-client-setup.ts";
 import { createMilestoneFilterValueResolver, resolveClosestMilestoneFilterValue } from "./utils/milestone-filter.ts";
 import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
 import { hasAnyPrefix } from "./utils/prefix-config.ts";
@@ -135,21 +142,17 @@ async function openUrlInBrowser(url: string): Promise<void> {
 	}
 }
 
-async function runMcpClientCommand(label: string, command: string, args: string[]): Promise<string> {
+async function runMcpClientCommand(client: McpClientSetupKey, serverName = MCP_SERVER_NAME): Promise<string> {
+	const { label, command, args } = getMcpClientSetupCommand(client, serverName);
 	console.log(`    Configuring ${label}...`);
 	try {
-		const child = spawn({
-			cmd: [command, ...args],
-			stdout: "inherit",
-			stderr: "inherit",
-		});
-		await child.exited;
+		await runMcpClientSetupCommand(command, args, { stdout: "inherit", stderr: "inherit" });
 		console.log(`    ✓ Added Backlog MCP server to ${label}`);
 		return label;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		console.warn(`    ⚠️ Unable to configure ${label} automatically (${message}).`);
-		console.warn(`       Run manually: ${command} ${args.join(" ")}`);
+		console.warn(`       Run manually: ${formatMcpClientSetupCommand(command, args)}`);
 		return `${label} (manual setup required)`;
 	}
 }
@@ -973,63 +976,8 @@ program
 							const uniq = (values: string[]) => [...new Set(values)];
 
 							for (const client of selectedClients) {
-								if (client === "claude") {
-									const result = await runMcpClientCommand("Claude Code", "claude", [
-										"mcp",
-										"add",
-										"-s",
-										"user",
-										mcpServerName,
-										"--",
-										"backlog",
-										"mcp",
-										"start",
-									]);
-									results.push(result);
-									await recordGuidelinesForClient(client);
-									continue;
-								}
-								if (client === "codex") {
-									const result = await runMcpClientCommand("OpenAI Codex", "codex", [
-										"mcp",
-										"add",
-										mcpServerName,
-										"backlog",
-										"mcp",
-										"start",
-									]);
-									results.push(result);
-									await recordGuidelinesForClient(client);
-									continue;
-								}
-								if (client === "gemini") {
-									const result = await runMcpClientCommand("Gemini CLI", "gemini", [
-										"mcp",
-										"add",
-										"-s",
-										"user",
-										mcpServerName,
-										"backlog",
-										"mcp",
-										"start",
-									]);
-									results.push(result);
-									await recordGuidelinesForClient(client);
-									continue;
-								}
-								if (client === "kiro") {
-									const result = await runMcpClientCommand("Kiro", "kiro-cli", [
-										"mcp",
-										"add",
-										"--scope",
-										"global",
-										"--name",
-										mcpServerName,
-										"--command",
-										"backlog",
-										"--args",
-										"mcp,start",
-									]);
+								if (isMcpClientSetupKey(client)) {
+									const result = await runMcpClientCommand(client, mcpServerName);
 									results.push(result);
 									await recordGuidelinesForClient(client);
 									continue;

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -1,4 +1,3 @@
-import { spawn } from "bun";
 import {
 	type AgentInstructionFile,
 	addAgentInstructions,
@@ -8,6 +7,13 @@ import {
 import { DEFAULT_INIT_CONFIG } from "../constants/index.ts";
 import type { BacklogConfig } from "../types/index.ts";
 import { normalizeProjectBacklogDirectory } from "../utils/backlog-directory.ts";
+import {
+	formatMcpClientSetupCommand,
+	getMcpClientSetupCommand,
+	isMcpClientSetupKey,
+	type McpClientSetupKey,
+	runMcpClientSetupCommand,
+} from "../utils/mcp-client-setup.ts";
 import type { Core } from "./backlog.ts";
 
 export const MCP_SERVER_NAME = "backlog";
@@ -15,6 +21,13 @@ export const MCP_GUIDE_URL = "https://github.com/MrLesk/Backlog.md#-mcp-integrat
 
 export type IntegrationMode = "mcp" | "cli" | "none";
 export type McpClient = "claude" | "codex" | "gemini" | "kiro" | "guide";
+
+const MCP_CLIENT_INSTRUCTION_MAP: Record<McpClientSetupKey, AgentInstructionFile> = {
+	claude: "CLAUDE.md",
+	codex: "AGENTS.md",
+	gemini: "GEMINI.md",
+	kiro: "AGENTS.md",
+};
 
 export interface InitializeProjectOptions {
 	projectName: string;
@@ -52,22 +65,15 @@ export interface InitializeProjectResult {
 	mcpResults?: Record<string, string>;
 }
 
-async function runMcpClientCommand(label: string, command: string, args: string[]): Promise<string> {
+async function runMcpClientCommand(client: McpClientSetupKey): Promise<string> {
+	const { label, command, args } = getMcpClientSetupCommand(client, MCP_SERVER_NAME);
 	try {
-		const child = spawn({
-			cmd: [command, ...args],
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-		const exitCode = await child.exited;
-		if (exitCode !== 0) {
-			throw new Error(`Command exited with code ${exitCode}`);
-		}
+		await runMcpClientSetupCommand(command, args);
 		return `Added Backlog MCP server to ${label}`;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw new Error(
-			`Unable to configure ${label} automatically (${message}). Run manually: ${command} ${args.join(" ")}`,
+			`Unable to configure ${label} automatically (${message}). Run manually: ${formatMcpClientSetupCommand(command, args)}`,
 		);
 	}
 }
@@ -226,62 +232,16 @@ export async function initializeProject(
 	if (integrationMode === "mcp" && mcpClients.length > 0) {
 		for (const client of mcpClients) {
 			try {
-				if (client === "claude") {
-					const result = await runMcpClientCommand("Claude Code", "claude", [
-						"mcp",
-						"add",
-						"-s",
-						"user",
-						MCP_SERVER_NAME,
-						"--",
-						"backlog",
-						"mcp",
-						"start",
-					]);
-					mcpResults.claude = result;
-					await ensureMcpGuidelines(projectRoot, "CLAUDE.md");
-				} else if (client === "codex") {
-					const result = await runMcpClientCommand("OpenAI Codex", "codex", [
-						"mcp",
-						"add",
-						MCP_SERVER_NAME,
-						"backlog",
-						"mcp",
-						"start",
-					]);
-					mcpResults.codex = result;
-					await ensureMcpGuidelines(projectRoot, "AGENTS.md");
-				} else if (client === "gemini") {
-					const result = await runMcpClientCommand("Gemini CLI", "gemini", [
-						"mcp",
-						"add",
-						"-s",
-						"user",
-						MCP_SERVER_NAME,
-						"backlog",
-						"mcp",
-						"start",
-					]);
-					mcpResults.gemini = result;
-					await ensureMcpGuidelines(projectRoot, "GEMINI.md");
-				} else if (client === "kiro") {
-					const result = await runMcpClientCommand("Kiro", "kiro-cli", [
-						"mcp",
-						"add",
-						"--scope",
-						"global",
-						"--name",
-						MCP_SERVER_NAME,
-						"--command",
-						"backlog",
-						"--args",
-						"mcp,start",
-					]);
-					mcpResults.kiro = result;
-					await ensureMcpGuidelines(projectRoot, "AGENTS.md");
-				} else if (client === "guide") {
+				if (client === "guide") {
 					mcpResults.guide = `Setup guide: ${MCP_GUIDE_URL}`;
+					continue;
 				}
+				if (!isMcpClientSetupKey(client)) {
+					continue;
+				}
+
+				mcpResults[client] = await runMcpClientCommand(client);
+				await ensureMcpGuidelines(projectRoot, MCP_CLIENT_INSTRUCTION_MAP[client]);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				mcpResults[client] = `Failed: ${message}`;

--- a/src/test/build.test.ts
+++ b/src/test/build.test.ts
@@ -2,12 +2,33 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
 import { platform } from "node:os";
 import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { $ } from "bun";
-import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
+import { createUniqueTestDir, getPlatformTimeout, safeCleanup } from "./test-utils.ts";
 
 let TEST_DIR: string;
 const isWindows = platform() === "win32";
 const executableName = isWindows ? "backlog.exe" : "backlog";
+
+function withTimeout<T>(operation: Promise<T>, label: string, timeoutMs: number, details: () => string): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			reject(new Error(`${label} timed out after ${timeoutMs}ms.${details()}`));
+		}, timeoutMs);
+
+		operation.then(
+			(value) => {
+				clearTimeout(timer);
+				resolve(value);
+			},
+			(error: unknown) => {
+				clearTimeout(timer);
+				reject(error);
+			},
+		);
+	});
+}
 
 describe("CLI packaging", () => {
 	beforeEach(async () => {
@@ -32,7 +53,7 @@ describe("CLI packaging", () => {
 		const version = packageJson.version;
 
 		try {
-			await $`bun build src/cli.ts --compile --define __EMBEDDED_VERSION__="\"${version}\"" --outfile ${OUTFILE}`.quiet();
+			await $`bun build src/cli.ts --compile --minify --define __EMBEDDED_VERSION__="\"${version}\"" --outfile ${OUTFILE}`.quiet();
 		} catch (error: unknown) {
 			// Skip test if build fails due to cross-filesystem issues (e.g., virtiofs)
 			// This is environment-specific and doesn't indicate a code problem
@@ -53,5 +74,35 @@ describe("CLI packaging", () => {
 		const versionResult = await $`${OUTFILE} --version`.quiet();
 		const versionOutput = versionResult.stdout.toString().trim();
 		expect(versionOutput).toBe(version);
+
+		const timeout = getPlatformTimeout(8000);
+		let stderr = "";
+		const transport = new StdioClientTransport({
+			command: OUTFILE,
+			args: ["mcp", "start", "--cwd", process.cwd(), "--debug"],
+			cwd: process.cwd(),
+			stderr: "pipe",
+		});
+		transport.stderr?.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		const client = new Client({ name: "Compiled MCP Smoke Test", version: "1.0.0" }, { capabilities: {} });
+		try {
+			await withTimeout(client.connect(transport), "connect", timeout, () => ` stderr:\n${stderr}`);
+
+			const tools = await withTimeout(client.listTools(), "listTools", timeout, () => ` stderr:\n${stderr}`);
+			expect(tools.tools.map((tool) => tool.name)).toContain("task_list");
+
+			const resources = await withTimeout(
+				client.listResources(),
+				"listResources",
+				timeout,
+				() => ` stderr:\n${stderr}`,
+			);
+			expect(resources.resources.map((resource) => resource.uri)).toContain("backlog://workflow/overview");
+		} finally {
+			await client.close().catch(() => {});
+		}
 	});
 });

--- a/src/test/mcp-client-setup.test.ts
+++ b/src/test/mcp-client-setup.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import {
+	formatMcpClientSetupCommand,
+	getMcpClientSetupCommand,
+	runMcpClientSetupCommand,
+} from "../utils/mcp-client-setup.ts";
+
+describe("MCP client setup commands", () => {
+	it("uses Codex's stdio command separator", () => {
+		const setup = getMcpClientSetupCommand("codex", "backlog");
+
+		expect(setup).toEqual({
+			label: "OpenAI Codex",
+			command: "codex",
+			args: ["mcp", "add", "backlog", "--", "backlog", "mcp", "start"],
+		});
+		expect(formatMcpClientSetupCommand(setup.command, setup.args)).toBe("codex mcp add backlog -- backlog mcp start");
+	});
+
+	it("fails when a setup command exits non-zero", async () => {
+		await expect(
+			runMcpClientSetupCommand("bun", ["-e", "console.error('setup failed'); process.exit(42)"]),
+		).rejects.toThrow("Command exited with code 42: setup failed");
+	});
+});

--- a/src/utils/mcp-client-setup.ts
+++ b/src/utils/mcp-client-setup.ts
@@ -1,0 +1,71 @@
+import { spawn } from "bun";
+
+export type McpClientSetupKey = "claude" | "codex" | "gemini" | "kiro";
+
+export type McpClientSetupCommand = {
+	label: string;
+	command: string;
+	args: string[];
+};
+
+export type McpClientSetupStdio = "inherit" | "pipe";
+
+export function isMcpClientSetupKey(client: string): client is McpClientSetupKey {
+	return client === "claude" || client === "codex" || client === "gemini" || client === "kiro";
+}
+
+export function getMcpClientSetupCommand(client: McpClientSetupKey, serverName: string): McpClientSetupCommand {
+	switch (client) {
+		case "claude":
+			return {
+				label: "Claude Code",
+				command: "claude",
+				args: ["mcp", "add", "-s", "user", serverName, "--", "backlog", "mcp", "start"],
+			};
+		case "codex":
+			return {
+				label: "OpenAI Codex",
+				command: "codex",
+				args: ["mcp", "add", serverName, "--", "backlog", "mcp", "start"],
+			};
+		case "gemini":
+			return {
+				label: "Gemini CLI",
+				command: "gemini",
+				args: ["mcp", "add", "-s", "user", serverName, "backlog", "mcp", "start"],
+			};
+		case "kiro":
+			return {
+				label: "Kiro",
+				command: "kiro-cli",
+				args: ["mcp", "add", "--scope", "global", "--name", serverName, "--command", "backlog", "--args", "mcp,start"],
+			};
+	}
+}
+
+export function formatMcpClientSetupCommand(command: string, args: string[]): string {
+	return [command, ...args].join(" ");
+}
+
+export async function runMcpClientSetupCommand(
+	command: string,
+	args: string[],
+	options: { stdout?: McpClientSetupStdio; stderr?: McpClientSetupStdio } = {},
+): Promise<void> {
+	const stdout = options.stdout ?? "pipe";
+	const stderr = options.stderr ?? "pipe";
+	const child = spawn({
+		cmd: [command, ...args],
+		stdout,
+		stderr,
+	});
+
+	const stdoutText = stdout === "pipe" && child.stdout ? new Response(child.stdout).text() : Promise.resolve("");
+	const stderrText = stderr === "pipe" && child.stderr ? new Response(child.stderr).text() : Promise.resolve("");
+	const [exitCode, capturedStdout, capturedStderr] = await Promise.all([child.exited, stdoutText, stderrText]);
+
+	if (exitCode !== 0) {
+		const details = [capturedStderr.trim(), capturedStdout.trim()].filter(Boolean).join("\n");
+		throw new Error(`Command exited with code ${exitCode}${details ? `: ${details}` : ""}`);
+	}
+}


### PR DESCRIPTION
## Summary
- Add a shared MCP client setup helper used by CLI and core init.
- Update Codex setup docs/commands to `codex mcp add backlog -- backlog mcp start`.
- Treat non-zero MCP client setup exits as failures instead of reporting success.
- Add compiled executable MCP stdio smoke coverage so the binary path Codex launches is tested.

## Root Cause
Backlog's source MCP server path initializes cleanly with the current MCP SDK, and `@modelcontextprotocol/sdk` is already at the current `1.29.0` release. The reproduced local failure was the packaged command path: `backlog` resolved to a stale/broken compiled `dist/backlog` binary that closed during MCP initialization. Existing compiled-binary coverage only checked `--help` and `--version`, so MCP stdio startup could regress unnoticed.

## Backlog
- `BACK-506` is tracked in `backlog/tasks/back-506 - Fix-Codex-MCP-connection-failure.md` and marked Done with AC/DoD checked.

## Validation
- `bun test src/test/mcp-client-setup.test.ts src/test/build.test.ts src/test/mcp-stdio-exit.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`