### PR TITLE
BACK-510 - Fix repeated task edit label flags

### DIFF
--- a/backlog/tasks/back-510 - Fix-repeated-task-edit-label-flags.md
+++ b/backlog/tasks/back-510 - Fix-repeated-task-edit-label-flags.md
@@ -1,0 +1,61 @@
+---
+id: BACK-510
+title: Fix repeated task edit label flags
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-06-18 16:47'
+updated_date: '2026-06-18 16:57'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/692'
+priority: medium
+ordinal: 109000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make task edit label flags consistent and explicit. Repeated --add-label should collect all values, repeated --label should collect a full replacement label set, and mixed replacement/mutation modes should avoid silent data loss. Update agent-facing help/schema so the behavior is clear to external agents using only the public CLI surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 task edit --add-label accepts repeated flags and comma-separated values, adding every requested label without replacing existing labels
+- [x] #2 task edit --label accepts repeated flags and comma-separated values, replacing the full label set with every requested label
+- [x] #3 Combining --label with --add-label or --remove-label fails with a clear error instead of silently applying precedence
+- [x] #4 task edit --help input schema and option descriptions document label replacement, additive/removal behavior, repeatability, and comma-separated values
+- [x] #5 Tests cover repeated label flags, mixed-mode rejection, and relevant help/schema text
+- [x] #6 task edit --clear-labels intentionally clears all labels and rejects combination with other label flags
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Register task edit --label, --add-label, and --remove-label with the existing repeatable option accumulator so parseDelimitedStringList receives every flag occurrence.
+2. Add --clear-labels as an explicit replacement mode for intentionally empty labels.
+3. Reject mixed label replacement/clear/mutation modes with direct error messages before any task update is built.
+4. Update task edit help schema and option text to describe replacement, add/remove, clear, repeatability, comma-separated values, and conflict behavior for agents.
+5. Add CLI-level tests for repeated label replacement, addition/removal, clear-labels, mixed-mode rejection, and help/schema text.
+6. Run focused CLI tests plus full validation before finalizing BACK-510.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented repeatable task edit label parsing for --label, --add-label, and --remove-label using the existing accumulator and parser. Added --clear-labels as an explicit empty replacement mode, preserved empty label replacements through buildTaskUpdateInput, and rejected mixed replacement/clear/mutation label modes before mutation. Validation passed: bun test src/test/cli.test.ts; bunx tsc --noEmit; bun run check .; bun run build; git diff --check; full bun test (1340 pass, 2 skip, 0 fail).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented repeatable task edit label flags and explicit label clearing. The CLI now collects repeated --label/--add-label/--remove-label values, supports --clear-labels, rejects ambiguous mixed label modes, and documents these semantics in task edit help/schema. Added CLI integration coverage and verified with focused tests, typecheck, Biome, build, diff check, and full bun test.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-510 - Fix-repeated-task-edit-label-flags.md
+++ b/backlog/tasks/back-510 - Fix-repeated-task-edit-label-flags.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-06-18 16:47'
-updated_date: '2026-06-18 16:57'
+updated_date: '2026-06-18 17:26'
 labels: []
 dependencies: []
 references:
@@ -45,12 +45,16 @@ Make task edit label flags consistent and explicit. Repeated --add-label should 
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented repeatable task edit label parsing for --label, --add-label, and --remove-label using the existing accumulator and parser. Added --clear-labels as an explicit empty replacement mode, preserved empty label replacements through buildTaskUpdateInput, and rejected mixed replacement/clear/mutation label modes before mutation. Validation passed: bun test src/test/cli.test.ts; bunx tsc --noEmit; bun run check .; bun run build; git diff --check; full bun test (1340 pass, 2 skip, 0 fail).
+
+Reopened to address PR #693 review feedback: blank-only label arrays must not be interpreted as explicit label clearing; clearing remains reserved for explicit empty arrays / --clear-labels.
+
+Addressed PR #693 review thread PRRT_kwDOO2LIE86Kn8VH by preserving labels on blank-only task_edit label arrays while retaining explicit labels: [] clearing. Validation passed: bun test src/test/mcp-tasks.test.ts; bun test src/test/cli.test.ts; bunx tsc --noEmit; bun run check .; bun run build; git diff --check. Local full bun test hit an unrelated existing timeout in CLI Priority Filtering > case insensitive priority filtering at 5s; the targeted behavior passed with bun test --timeout 15000 src/test/cli-priority-filtering.test.ts -t 'case insensitive priority filtering'.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented repeatable task edit label flags and explicit label clearing. The CLI now collects repeated --label/--add-label/--remove-label values, supports --clear-labels, rejects ambiguous mixed label modes, and documents these semantics in task edit help/schema. Added CLI integration coverage and verified with focused tests, typecheck, Biome, build, diff check, and full bun test.
+Implemented repeatable task edit label flags, explicit label clearing, agent-facing help/schema updates, and the PR review fix ensuring blank-only label arrays do not clear labels. Verified with focused MCP/CLI tests, typecheck, Biome, build, diff check, and a targeted timeout-adjusted rerun of the unrelated priority-filter case.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -331,6 +331,7 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.ordinal !== undefined ||
 			options.milestone !== undefined ||
 			options.clearMilestone ||
+			options.clearLabels ||
 			options.plain ||
 			options.addLabel !== undefined ||
 			options.removeLabel !== undefined ||
@@ -2348,6 +2349,26 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		{ name: "title", type: "String", description: "Replacement task title" },
 		{ name: "description", type: "Markdown", description: "Replacement description" },
 		{ name: "status", type: statusType, description: "Project task status; case-insensitive" },
+		{
+			name: "label",
+			type: "Comma-separated strings",
+			description: "Replace all labels; repeat --label or use label1,label2",
+		},
+		{
+			name: "add-label",
+			type: "Comma-separated strings",
+			description: "Add labels; repeat --add-label or use label1,label2",
+		},
+		{
+			name: "remove-label",
+			type: "Comma-separated strings",
+			description: "Remove labels; repeat --remove-label or use label1,label2",
+		},
+		{
+			name: "clear-labels",
+			type: "Boolean",
+			description: "Remove all labels; cannot combine with other label flags",
+		},
 		{ name: "plan", type: "Markdown", description: "Replacement implementation plan" },
 		{ name: "notes", type: "Markdown", description: "Replacement implementation notes" },
 		{ name: "comment", type: "Markdown", description: "Append a discussion comment" },
@@ -2367,14 +2388,27 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 	.option("--desc <text>", "alias for --description")
 	.option("-a, --assignee <assignee>")
 	.option("-s, --status <status>")
-	.option("-l, --label <labels>")
+	.option(
+		"-l, --label <labels>",
+		"replace all task labels (comma-separated or repeatable; cannot combine with --add-label/--remove-label)",
+		createMultiValueAccumulator(),
+	)
 	.option("--priority <priority>", "set task priority (high, medium, low)")
 	.option("--ordinal <number>", "set task ordinal for custom ordering")
 	.option("-m, --milestone <milestone>", "assign task to milestone by ID or title")
 	.option("--clear-milestone", "clear task milestone assignment")
 	.option("--plain", "use plain text output after editing")
-	.option("--add-label <label>")
-	.option("--remove-label <label>")
+	.option(
+		"--add-label <labels>",
+		"add task labels without replacing existing labels (comma-separated or repeatable)",
+		createMultiValueAccumulator(),
+	)
+	.option(
+		"--remove-label <labels>",
+		"remove task labels without replacing others (comma-separated or repeatable)",
+		createMultiValueAccumulator(),
+	)
+	.option("--clear-labels", "remove all task labels (cannot combine with --label/--add-label/--remove-label)")
 	.option("--ac <criteria>", "add acceptance criteria (can be used multiple times)", createMultiValueAccumulator())
 	.option("--dod <item>", "add Definition of Done item (can be used multiple times)", createMultiValueAccumulator())
 	.option(
@@ -2606,6 +2640,25 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			return;
 		}
 
+		if (
+			options.clearLabels &&
+			(options.label !== undefined || options.addLabel !== undefined || options.removeLabel !== undefined)
+		) {
+			console.error(
+				"Cannot combine --clear-labels with --label, --add-label, or --remove-label. Use --clear-labels by itself, or --label a,b for the final full label set.",
+			);
+			process.exitCode = 1;
+			return;
+		}
+
+		if (options.label !== undefined && (options.addLabel !== undefined || options.removeLabel !== undefined)) {
+			console.error(
+				"Cannot combine --label with --add-label or --remove-label. Use --label a,b for the final full label set, or use add/remove flags without --label.",
+			);
+			process.exitCode = 1;
+			return;
+		}
+
 		const labelValues = parseDelimitedStringList(options.label) ?? [];
 		const addLabelValues = parseDelimitedStringList(options.addLabel) ?? [];
 		const removeLabelValues = parseDelimitedStringList(options.removeLabel) ?? [];
@@ -2648,6 +2701,8 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		}
 		if (labelValues.length > 0) {
 			editArgs.labels = labelValues;
+		} else if (options.clearLabels) {
+			editArgs.labels = [];
 		}
 		if (addLabelValues.length > 0) {
 			editArgs.addLabels = addLabelValues;

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -257,6 +257,7 @@ describe("CLI Integration", () => {
 			const createHelp = await $`bun ${CLI_PATH} task create --help`.cwd(TEST_DIR).text();
 			const listHelp = await $`bun ${CLI_PATH} task list --help`.cwd(TEST_DIR).text();
 			const editHelp = await $`bun ${CLI_PATH} task edit --help`.cwd(TEST_DIR).text();
+			const editHelpCompact = editHelp.replace(/\s+/g, " ");
 			const completeHelp = await $`bun ${CLI_PATH} task complete --help`.cwd(TEST_DIR).text();
 
 			expect(createHelp).toContain("title: String");
@@ -275,6 +276,20 @@ describe("CLI Integration", () => {
 			expect(editHelp).toContain("taskId: Task ID");
 			expect(editHelp).toContain("status: one of configured statuses: To Do, In Progress, Done");
 			expect(editHelp).not.toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
+			expect(editHelp).toContain(
+				"label: Comma-separated strings - Replace all labels; repeat --label or use label1,label2",
+			);
+			expect(editHelp).toContain(
+				"add-label: Comma-separated strings - Add labels; repeat --add-label or use label1,label2",
+			);
+			expect(editHelp).toContain(
+				"remove-label: Comma-separated strings - Remove labels; repeat --remove-label or use label1,label2",
+			);
+			expect(editHelp).toContain("clear-labels: Boolean - Remove all labels; cannot combine with other label flags");
+			expect(editHelpCompact).toContain("replace all task labels");
+			expect(editHelpCompact).toContain("add task labels without replacing existing labels");
+			expect(editHelpCompact).toContain("remove task labels without replacing others");
+			expect(editHelpCompact).toContain("remove all task labels");
 			expect(editHelp).toContain("plan: Markdown");
 			expect(editHelp).toContain("Writes:");
 			expect(completeHelp).toContain("cleanup procedure");
@@ -1560,6 +1575,142 @@ describe("CLI Integration", () => {
 			// Verify label was removed
 			const updatedTask = await core.filesystem.loadTask("task-5");
 			expect(updatedTask?.labels).toEqual(["keep1", "keep2"]);
+		});
+
+		it("should replace labels from repeated CLI label flags", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-6",
+					title: "Repeated Label Replace Test",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: ["old1", "old2"],
+					dependencies: [],
+					rawContent: "Testing repeated label replacement",
+				},
+				false,
+			);
+
+			await $`bun ${CLI_PATH} task edit task-6 --label new1 --label new2,new3 --plain`.cwd(TEST_DIR).quiet();
+
+			const updatedTask = await core.filesystem.loadTask("task-6");
+			expect(updatedTask?.labels).toEqual(["new1", "new2", "new3"]);
+		});
+
+		it("should add labels from repeated CLI add-label flags", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-7",
+					title: "Repeated Label Add Test",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: ["existing"],
+					dependencies: [],
+					rawContent: "Testing repeated label additions",
+				},
+				false,
+			);
+
+			await $`bun ${CLI_PATH} task edit task-7 --add-label video --add-label test,bug --plain`.cwd(TEST_DIR).quiet();
+
+			const updatedTask = await core.filesystem.loadTask("task-7");
+			expect(updatedTask?.labels).toEqual(["existing", "video", "test", "bug"]);
+		});
+
+		it("should remove labels from repeated CLI remove-label flags", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-8",
+					title: "Repeated Label Remove Test",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: ["keep", "drop1", "drop2", "drop3"],
+					dependencies: [],
+					rawContent: "Testing repeated label removals",
+				},
+				false,
+			);
+
+			await $`bun ${CLI_PATH} task edit task-8 --remove-label drop1 --remove-label drop2,drop3 --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			const updatedTask = await core.filesystem.loadTask("task-8");
+			expect(updatedTask?.labels).toEqual(["keep"]);
+		});
+
+		it("should clear labels from CLI clear-labels flag", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-9",
+					title: "Clear Labels Test",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: ["old1", "old2"],
+					dependencies: [],
+					rawContent: "Testing label clearing",
+				},
+				false,
+			);
+
+			await $`bun ${CLI_PATH} task edit task-9 --clear-labels --plain`.cwd(TEST_DIR).quiet();
+
+			const updatedTask = await core.filesystem.loadTask("task-9");
+			expect(updatedTask?.labels).toEqual([]);
+		});
+
+		it("should reject mixing CLI label replacement with label mutations", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-10",
+					title: "Mixed Label Mode Test",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: ["old"],
+					dependencies: [],
+					rawContent: "Testing mixed label mode rejection",
+				},
+				false,
+			);
+
+			const addResult = await $`bun ${CLI_PATH} task edit task-10 --label replacement --add-label extra --plain`
+				.cwd(TEST_DIR)
+				.nothrow()
+				.quiet();
+			const removeResult = await $`bun ${CLI_PATH} task edit task-10 --label replacement --remove-label old --plain`
+				.cwd(TEST_DIR)
+				.nothrow()
+				.quiet();
+			const clearResult = await $`bun ${CLI_PATH} task edit task-10 --clear-labels --add-label extra --plain`
+				.cwd(TEST_DIR)
+				.nothrow()
+				.quiet();
+
+			for (const result of [addResult, removeResult]) {
+				expect(result.exitCode).toBe(1);
+				expect(result.stderr.toString()).toContain("Cannot combine --label with --add-label or --remove-label");
+			}
+			expect(clearResult.exitCode).toBe(1);
+			expect(clearResult.stderr.toString()).toContain(
+				"Cannot combine --clear-labels with --label, --add-label, or --remove-label",
+			);
+			const updatedTask = await core.filesystem.loadTask("task-10");
+			expect(updatedTask?.labels).toEqual(["old"]);
 		});
 
 		it("should handle non-existent task gracefully", async () => {

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -555,6 +555,44 @@ describe("MCP task tools (MVP)", () => {
 		expect(criteriaText).toContain("- [ ] #2 Agents can follow instructions end-to-end");
 	});
 
+	it("does not clear labels from blank-only task_edit label arrays", async () => {
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Label blank input",
+					labels: ["docs", "workflow"],
+				},
+			},
+		});
+
+		const blankEdit = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					labels: ["", "   "],
+				},
+			},
+		});
+
+		expect(getText(blankEdit.content)).toContain("Labels: docs, workflow");
+		expect((await mcpServer.getTask("task-1"))?.labels).toEqual(["docs", "workflow"]);
+
+		const clearEdit = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					labels: [],
+				},
+			},
+		});
+
+		expect(getText(clearEdit.content)).not.toContain("Labels:");
+		expect((await mcpServer.getTask("task-1"))?.labels).toEqual([]);
+	});
+
 	it("creates, edits, lists, and views tasks with ordinal", async () => {
 		const createdA = await mcpServer.testInterface.callTool({
 			params: {

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -56,8 +56,8 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	}
 
 	const labels = normalizeStringList(args.labels);
-	if (labels) {
-		updateInput.labels = labels;
+	if (labels || args.labels !== undefined) {
+		updateInput.labels = labels ?? [];
 	}
 
 	const addLabels = normalizeStringList(args.addLabels);

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -55,9 +55,13 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		updateInput.ordinal = args.ordinal;
 	}
 
-	const labels = normalizeStringList(args.labels);
-	if (labels || args.labels !== undefined) {
-		updateInput.labels = labels ?? [];
+	if (args.labels !== undefined) {
+		const labels = normalizeStringList(args.labels);
+		if (labels) {
+			updateInput.labels = labels;
+		} else if (args.labels.length === 0) {
+			updateInput.labels = [];
+		}
 	}
 
 	const addLabels = normalizeStringList(args.addLabels);


### PR DESCRIPTION
## Summary

Fixes task edit label handling so the CLI matches the expected set-style behavior:

- `--label` replaces the full label set and now accepts repeated flags plus comma-separated values.
- `--add-label` and `--remove-label` now collect repeated flags plus comma-separated values.
- `--clear-labels` explicitly clears all labels.
- Ambiguous mixed modes now fail clearly instead of silently applying partial behavior.
- `task edit --help` now exposes the label semantics in the agent-facing input schema and option descriptions.

Closes #692

## Validation

- `bun test src/test/cli.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- `git diff --check`
- `bun test` (1340 pass, 2 skip, 0 fail)
