### PR TITLE
feat: authenticated multi-user hosting — per-user commit attribution (web) + Streamable HTTP MCP transport

### DIFF
--- a/AUTHENTICATED-HOSTING.md
+++ b/AUTHENTICATED-HOSTING.md
@@ -1,0 +1,192 @@
+# Authenticated multi-user hosting
+
+This guide shows how to host Backlog.md as a shared service for a team — the **web UI**
+and the **MCP server** — behind a single OpenID Connect (OIDC) provider, so that every
+commit is attributed to the authenticated end-user.
+
+It uses [Keycloak](https://www.keycloak.org/) as the example identity provider and
+[oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) as the authenticating
+reverse proxy, but any OIDC provider / proxy that forwards identity headers works.
+
+> Backlog.md never talks to the identity provider itself. It trusts the identity that
+> the proxy forwards as request headers, and turns it into the **git commit author**.
+> The git **committer** always stays the server's own identity.
+
+## Architecture
+
+```
+                       ┌──────────────┐
+                       │   Keycloak   │  (OIDC provider)
+                       └──────┬───────┘
+                              │ OIDC
+                   ┌──────────┴───────────┐
+                   │     oauth2-proxy     │  forwards X-Forwarded-Email /
+                   └───┬──────────────┬───┘  X-Forwarded-Preferred-Username
+                       │              │
+              ┌────────┴───┐   ┌──────┴───────────────┐
+              │ backlog    │   │ backlog mcp start    │
+              │ browser    │   │ --http               │
+              │ (web UI)   │   │ (Streamable HTTP)    │
+              └────────┬───┘   └──────┬───────────────┘
+                       └───────┬──────┘
+                        ┌──────┴───────┐
+                        │  Backlog.md  │  auto_pull / auto_push
+                        │  git repo    │  + push deploy key
+                        └──────┬───────┘
+                               │ push / pull
+                        ┌──────┴───────┐
+                        │ git remote   │
+                        └──────────────┘
+```
+
+Two consumers, **one identity model**: whether a change comes from the web UI or an AI
+agent over MCP, the commit author is the authenticated user from the proxy headers.
+
+## Relevant configuration
+
+```yml
+# backlog/config.yml
+remote_operations: true
+
+# Keep the shared checkout in sync with the remote automatically
+auto_pull: true            # pull --rebase before each operation (CLI/web/MCP)
+auto_push: true            # push after each commit
+
+# Attribute commits to the proxied end-user (web UI and MCP HTTP both use this)
+commit_author_from_proxy_headers: true
+# Header names are configurable; these are the oauth2-proxy defaults:
+proxy_author_email_header: x-forwarded-email
+proxy_author_name_header: x-forwarded-preferred-username
+```
+
+The server git identity (used as the committer) is the ambient git config of the user
+running the server:
+
+```bash
+git config user.name  "Backlog Server"
+git config user.email "backlog@example.com"
+```
+
+Give that server a **deploy key** with push access to the remote so `auto_push` works.
+
+## 1. Keycloak
+
+Create a realm (e.g. `backlog`) and two clients:
+
+1. **Web UI** — a *confidential* client, standard authorization-code flow.
+   - Valid redirect URI: `https://backlog.example.com/oauth2/callback`
+   - Note the client ID and secret.
+2. **Agents (MCP)** — depends on the UX you want (see §3):
+   - *Service account* client (`Client authentication: On`, `Service accounts roles: On`)
+     for headless agents using a Bearer token, **or**
+   - a *public* client for interactive OAuth from a desktop MCP client.
+
+Map `email` and `preferred_username` into the tokens (default Keycloak mappers already do).
+
+## 2. Web UI behind oauth2-proxy (browser login)
+
+Run the web UI bound to localhost and put oauth2-proxy in front:
+
+```bash
+backlog browser --port 6420 --no-open
+```
+
+```bash
+oauth2-proxy \
+  --provider=keycloak-oidc \
+  --oidc-issuer-url=https://keycloak.example.com/realms/backlog \
+  --client-id=backlog-web --client-secret=$WEB_CLIENT_SECRET \
+  --redirect-url=https://backlog.example.com/oauth2/callback \
+  --upstream=http://127.0.0.1:6420 \
+  --email-domain='*' \
+  --pass-user-headers=true \
+  --cookie-secret=$COOKIE_SECRET \
+  --http-address=0.0.0.0:443
+```
+
+`--pass-user-headers=true` forwards `X-Forwarded-Email` and
+`X-Forwarded-Preferred-Username` to the upstream — which is exactly what
+`commit_author_from_proxy_headers` reads. A human just sees a Keycloak login screen.
+
+## 3. MCP over HTTP
+
+Start the MCP server with the HTTP transport (single shared process, stateless):
+
+```bash
+backlog mcp start --http --port 6421 --host 127.0.0.1
+```
+
+Put it behind oauth2-proxy as well. **An MCP client is not a browser**, so there are two
+authentication UX options.
+
+### Option A — Bearer token (no interaction; best for agents)
+
+The MCP client sends an `Authorization: Bearer <token>` header. Configure oauth2-proxy to
+accept and validate JWT bearer tokens (in addition to, or instead of, the cookie flow):
+
+```bash
+oauth2-proxy \
+  --provider=keycloak-oidc \
+  --oidc-issuer-url=https://keycloak.example.com/realms/backlog \
+  --client-id=backlog-web --client-secret=$WEB_CLIENT_SECRET \
+  --upstream=http://127.0.0.1:6421 \
+  --skip-jwt-bearer-tokens=true \
+  --pass-user-headers=true \
+  --email-domain='*' \
+  --cookie-secret=$COOKIE_SECRET \
+  --http-address=0.0.0.0:8443
+```
+
+Obtain a token from Keycloak (e.g. a service-account client-credentials grant for an
+agent), then point the MCP client at the URL with the header. Example client entry:
+
+```json
+{
+  "mcpServers": {
+    "backlog": {
+      "type": "http",
+      "url": "https://backlog-mcp.example.com/mcp",
+      "headers": { "Authorization": "Bearer <ACCESS_TOKEN>" }
+    }
+  }
+}
+```
+
+No link to click, no code to paste — ideal for automation and CI. The commit author will
+be the identity carried by the token (e.g. the service account, or the user the token was
+issued for).
+
+### Option B — interactive OAuth (browser login once; for humans)
+
+Some desktop MCP clients can perform the OAuth authorization-code flow against a remote
+MCP server: the client opens a browser **once**, the user logs in to Keycloak, and the
+client then stores and refreshes the access token automatically. If your client does not
+implement remote OAuth directly, the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote)
+bridge can handle the flow for it:
+
+```json
+{
+  "mcpServers": {
+    "backlog": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://backlog-mcp.example.com/mcp"]
+    }
+  }
+}
+```
+
+This is the "click a link, sign in" experience — convenient for a human, but unnecessary
+for an unattended agent (use Option A there).
+
+## Security notes
+
+- Bind `backlog browser` and `backlog mcp start --http` to `127.0.0.1` (or a private
+  interface) so they are only reachable **through** the proxy.
+- The HTTP MCP transport is **stateless**: a fresh, watcher-free server is built per
+  request, so requests are isolated and the deployment scales horizontally.
+- The proxy is the trust boundary. Backlog.md attributes the **author** from the
+  forwarded headers but never changes the **committer**, so the server identity remains
+  auditable.
+- With multiple users committing through one server, `auto_pull` (pull-before) plus
+  Backlog.md's task-id locking minimise non-fast-forward pushes; `auto_push` shares each
+  commit immediately.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Backlog.md merges the following layers (highest → lowest):
 Run `backlog config` with no arguments to launch the full interactive wizard. This is the same experience triggered from `backlog init` when you opt into advanced settings, and it walks through the complete configuration surface:
 - Cross-branch accuracy: `checkActiveBranches`, `remoteOperations`, and `activeBranchDays`.
 - Git workflow: `autoCommit` and `bypassGitHooks`.
+- Hosted/web attribution: `commitAuthorFromProxyHeaders` (opt-in, default off) — the web server sets each commit's **author** from the identity forwarded by an auth proxy; the committer stays the server identity. Header names are configurable via `proxyAuthorEmailHeader` (default `x-forwarded-email`) and `proxyAuthorNameHeader` (default `x-forwarded-preferred-username`), matching oauth2-proxy. Only enable behind a proxy you control.
 - ID formatting: enable or size `zeroPaddedIds`.
 - Editor integration: pick a `defaultEditor` with availability checks.
 - Definition of Done defaults: interactively add/remove/reorder/clear project-level `definition_of_done` checklist items.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,26 @@ To keep the Web UI running as an auto-starting local service, see [Running Backl
 CLI instructions are the default AI setup. MCP remains supported for AI coding assistants like Claude Code, Codex, Gemini CLI and Kiro when you explicitly prefer an MCP connector.
 You can run `backlog init` (even if you already initialized Backlog.md) and choose MCP integration, or follow the manual steps below.
 
+### Transports: stdio (default) and Streamable HTTP
+
+`backlog mcp start` serves over **stdio** by default — one process per local client.
+
+For a **shared, hosted** MCP server (a single long-lived process for a team), use the
+Streamable HTTP transport:
+
+```bash
+backlog mcp start --http --port 6421 --host 127.0.0.1
+```
+
+Run it **behind an authenticating reverse proxy** (e.g. oauth2-proxy). When the proxy
+forwards the end-user identity headers and `commit_author_from_proxy_headers` is enabled,
+each request's commit is attributed to that user (committer stays the server identity) —
+the same model as the web UI. The transport is stateless, so no per-client process is
+spawned.
+
+See **[Authenticated multi-user hosting](AUTHENTICATED-HOSTING.md)** for an end-to-end
+setup (Keycloak + oauth2-proxy, web + MCP, and the two MCP client auth options).
+
 ### Client guides
 
 <details>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3993,6 +3993,15 @@ addHelpSchema(configCmd.command("get <key>"), {
 				case "autoCommit":
 					console.log(config.autoCommit?.toString() || "");
 					break;
+				case "commitAuthorFromProxyHeaders":
+					console.log(config.commitAuthorFromProxyHeaders?.toString() || "false");
+					break;
+				case "proxyAuthorEmailHeader":
+					console.log(config.proxyAuthorEmailHeader || "");
+					break;
+				case "proxyAuthorNameHeader":
+					console.log(config.proxyAuthorNameHeader || "");
+					break;
 				case "filesystemOnly":
 					console.log(config.filesystemOnly?.toString() || "false");
 					break;
@@ -4120,6 +4129,24 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 					}
 					break;
 				}
+				case "commitAuthorFromProxyHeaders": {
+					const boolValue = value.toLowerCase();
+					if (boolValue === "true" || boolValue === "1" || boolValue === "yes") {
+						config.commitAuthorFromProxyHeaders = true;
+					} else if (boolValue === "false" || boolValue === "0" || boolValue === "no") {
+						config.commitAuthorFromProxyHeaders = false;
+					} else {
+						console.error("commitAuthorFromProxyHeaders must be true or false");
+						process.exit(1);
+					}
+					break;
+				}
+				case "proxyAuthorEmailHeader":
+					config.proxyAuthorEmailHeader = value;
+					break;
+				case "proxyAuthorNameHeader":
+					config.proxyAuthorNameHeader = value;
+					break;
 				case "filesystemOnly": {
 					const boolValue = value.toLowerCase();
 					if (boolValue === "true" || boolValue === "1" || boolValue === "yes") {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,11 +1,13 @@
 /**
  * MCP Command Group - Model Context Protocol CLI commands.
  *
- * This simplified command set focuses on the stdio transport, which is the
- * only supported transport for Backlog.md's local MCP integration.
+ * `mcp start` serves over stdio by default (local editor integration). With
+ * `--http` it serves over Streamable HTTP as a single shared server, intended to
+ * run behind an authenticating reverse proxy that forwards the end-user identity.
  */
 
 import type { Command } from "commander";
+import { startHttpMcpServer } from "../mcp/http-server.ts";
 import { createMcpServer } from "../mcp/server.ts";
 import { findBacklogRoot } from "../utils/find-backlog-root.ts";
 import { resolveRuntimeCwd } from "../utils/runtime-cwd.ts";
@@ -13,6 +15,9 @@ import { resolveRuntimeCwd } from "../utils/runtime-cwd.ts";
 type StartOptions = {
 	debug?: boolean;
 	cwd?: string;
+	http?: boolean;
+	port?: string;
+	host?: string;
 };
 
 /**
@@ -26,18 +31,45 @@ export function registerMcpCommand(program: Command): void {
 }
 
 /**
- * Register 'mcp start' command for stdio transport.
+ * Register 'mcp start' command (stdio by default, Streamable HTTP with --http).
  */
 function registerStartCommand(mcpCmd: Command): void {
 	mcpCmd
 		.command("start")
-		.description("Start the MCP server using stdio transport")
+		.description("Start the MCP server (stdio by default, or Streamable HTTP with --http)")
 		.option("-d, --debug", "Enable debug logging", false)
 		.option("--cwd <path>", "Directory to resolve Backlog root from (overrides BACKLOG_CWD)")
+		.option(
+			"--http",
+			"Serve over Streamable HTTP instead of stdio (single shared server behind a reverse proxy)",
+			false,
+		)
+		.option("--port <port>", "HTTP port (with --http)", "6421")
+		.option("--host <host>", "HTTP bind address (with --http)", "127.0.0.1")
 		.action(async (options: StartOptions) => {
 			try {
 				const runtimeCwd = await resolveRuntimeCwd({ cwd: options.cwd });
 				const projectRoot = (await findBacklogRoot(runtimeCwd.cwd)) ?? runtimeCwd.cwd;
+
+				// HTTP transport: a single long-lived server; identity comes per-request
+				// from auth-proxy headers (see commit_author_from_proxy_headers).
+				if (options.http) {
+					const port = Number.parseInt(options.port ?? "6421", 10);
+					if (!Number.isFinite(port) || port <= 0) {
+						console.error(`Invalid --port value: ${options.port}`);
+						process.exit(1);
+					}
+					startHttpMcpServer(projectRoot, { port, host: options.host, debug: options.debug });
+					console.error(`Backlog.md MCP server (Streamable HTTP) running on http://${options.host}:${port}/mcp`);
+					const shutdownHttp = (signal: string) => {
+						if (options.debug) console.error(`Received ${signal}, shutting down MCP HTTP server...`);
+						process.exit(0);
+					};
+					process.once("SIGINT", () => shutdownHttp("SIGINT"));
+					process.once("SIGTERM", () => shutdownHttp("SIGTERM"));
+					return;
+				}
+
 				// An explicit --cwd/BACKLOG_CWD pins the root; an inferred process.cwd()
 				// lets the server follow the client's workspace roots instead.
 				const pinned = runtimeCwd.source !== "process";

--- a/src/core/config-migration.ts
+++ b/src/core/config-migration.ts
@@ -16,6 +16,9 @@ export function migrateConfig(config: Partial<BacklogConfig>): BacklogConfig {
 		defaultPort: 6420,
 		remoteOperations: true,
 		autoCommit: false,
+		commitAuthorFromProxyHeaders: false,
+		proxyAuthorEmailHeader: "x-forwarded-email",
+		proxyAuthorNameHeader: "x-forwarded-preferred-username",
 		bypassGitHooks: false,
 		checkActiveBranches: true,
 		activeBranchDays: 30,
@@ -50,6 +53,9 @@ export function needsMigration(config: Partial<BacklogConfig>): boolean {
 		{ field: "autoOpenBrowser", hasDefault: true },
 		{ field: "remoteOperations", hasDefault: true },
 		{ field: "autoCommit", hasDefault: true },
+		{ field: "commitAuthorFromProxyHeaders", hasDefault: true },
+		{ field: "proxyAuthorEmailHeader", hasDefault: true },
+		{ field: "proxyAuthorNameHeader", hasDefault: true },
 	];
 
 	return expectedFieldsWithDefaults.some(({ field }) => {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1398,6 +1398,15 @@ ${description || `Milestone: ${title}`}`,
 				case "auto_commit":
 					config.autoCommit = value.toLowerCase() === "true";
 					break;
+				case "commit_author_from_proxy_headers":
+					config.commitAuthorFromProxyHeaders = value.toLowerCase() === "true";
+					break;
+				case "proxy_author_email_header":
+					config.proxyAuthorEmailHeader = value;
+					break;
+				case "proxy_author_name_header":
+					config.proxyAuthorNameHeader = value;
+					break;
 				case "filesystem_only":
 				case "filesystemOnly":
 					config.filesystemOnly = value.toLowerCase() === "true";
@@ -1444,6 +1453,9 @@ ${description || `Milestone: ${title}`}`,
 			defaultPort: config.defaultPort,
 			remoteOperations: config.remoteOperations,
 			autoCommit: config.autoCommit,
+			commitAuthorFromProxyHeaders: config.commitAuthorFromProxyHeaders,
+			proxyAuthorEmailHeader: config.proxyAuthorEmailHeader,
+			proxyAuthorNameHeader: config.proxyAuthorNameHeader,
 			filesystemOnly: config.filesystemOnly,
 			zeroPaddedIds: config.zeroPaddedIds,
 			bypassGitHooks: config.bypassGitHooks,
@@ -1474,6 +1486,11 @@ ${description || `Milestone: ${title}`}`,
 			...(config.defaultPort ? [`default_port: ${config.defaultPort}`] : []),
 			...(typeof config.remoteOperations === "boolean" ? [`remote_operations: ${config.remoteOperations}`] : []),
 			...(typeof config.autoCommit === "boolean" ? [`auto_commit: ${config.autoCommit}`] : []),
+			...(typeof config.commitAuthorFromProxyHeaders === "boolean"
+				? [`commit_author_from_proxy_headers: ${config.commitAuthorFromProxyHeaders}`]
+				: []),
+			...(config.proxyAuthorEmailHeader ? [`proxy_author_email_header: ${config.proxyAuthorEmailHeader}`] : []),
+			...(config.proxyAuthorNameHeader ? [`proxy_author_name_header: ${config.proxyAuthorNameHeader}`] : []),
 			...(typeof config.filesystemOnly === "boolean" ? [`filesystem_only: ${config.filesystemOnly}`] : []),
 			...(typeof config.zeroPaddedIds === "number" ? [`zero_padded_ids: ${config.zeroPaddedIds}`] : []),
 			...(typeof config.bypassGitHooks === "boolean" ? [`bypass_git_hooks: ${config.bypassGitHooks}`] : []),

--- a/src/git/commit-context.ts
+++ b/src/git/commit-context.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Per-request commit context. Lets the web server attribute a commit to the
+ * authenticated end-user (e.g. forwarded by oauth2-proxy) without threading an
+ * author argument through every core method. Backed by AsyncLocalStorage, so it
+ * is isolated per async context (concurrency-safe across simultaneous requests).
+ */
+export interface CommitContext {
+	/** Git author string, e.g. `Jane Doe <jane@example.com>`. */
+	author?: string;
+}
+
+export const commitContext = new AsyncLocalStorage<CommitContext>();
+
+/** Run `fn` with the given commit author bound to the current async context. */
+export function runWithCommitAuthor<T>(author: string | undefined, fn: () => T): T {
+	return author ? commitContext.run({ author }, fn) : fn();
+}
+
+/** Extra `git commit` args (`--author`) for the current context, or none. */
+export function commitAuthorArgs(): string[] {
+	const author = commitContext.getStore()?.author;
+	return author ? ["--author", author] : [];
+}

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -2,6 +2,7 @@ import { realpath, stat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative } from "node:path";
 import { $ } from "bun";
 import type { BacklogConfig } from "../types/index.ts";
+import { commitAuthorArgs } from "./commit-context.ts";
 
 type GitPathContext = {
 	repoRoot: string;
@@ -74,6 +75,7 @@ export class GitOperations {
 		if (this.config?.bypassGitHooks) {
 			args.push("--no-verify");
 		}
+		args.push(...commitAuthorArgs());
 		const repoRoot = filePath ? (await this.getPathContext(filePath))?.repoRoot : undefined;
 		if (!(await this.isRepository(repoRoot ?? this.projectRoot))) {
 			return;
@@ -89,6 +91,7 @@ export class GitOperations {
 		if (this.config?.bypassGitHooks) {
 			args.push("--no-verify");
 		}
+		args.push(...commitAuthorArgs());
 		await this.execGit(args, { cwd: repoRoot ?? undefined });
 	}
 
@@ -128,6 +131,7 @@ export class GitOperations {
 		if (this.config?.bypassGitHooks) {
 			args.push("--no-verify");
 		}
+		args.push(...commitAuthorArgs());
 		args.push("--", ...uniqueRelativePaths);
 		await this.execGit(args, { cwd: resolvedRepoRoot });
 	}
@@ -180,6 +184,7 @@ export class GitOperations {
 		if (this.config?.bypassGitHooks) {
 			args.push("--no-verify");
 		}
+		args.push(...commitAuthorArgs());
 		await this.execGit(args, { cwd: repoRoot ?? undefined });
 	}
 

--- a/src/git/proxy-identity.ts
+++ b/src/git/proxy-identity.ts
@@ -1,0 +1,27 @@
+import type { BacklogConfig } from "../types/index.ts";
+
+/** Minimal header accessor shared by the web server (Request) and the MCP HTTP transport. */
+export interface HeaderGetter {
+	get(name: string): string | null;
+}
+
+/**
+ * Build a git author string (`Name <email>`) from auth-proxy identity headers
+ * (e.g. forwarded by oauth2-proxy). Returns undefined unless
+ * `commitAuthorFromProxyHeaders` is enabled and at least one configured header
+ * is present. Header names are configurable and default to the oauth2-proxy
+ * conventions (`x-forwarded-email` / `x-forwarded-preferred-username`).
+ *
+ * Shared by the web server and the MCP Streamable-HTTP transport so both attribute
+ * commits to the authenticated end-user the same way.
+ */
+export function authorFromProxyHeaders(headers: HeaderGetter, config: BacklogConfig | null): string | undefined {
+	if (!config?.commitAuthorFromProxyHeaders) return undefined;
+	const emailHeader = config.proxyAuthorEmailHeader || "x-forwarded-email";
+	const nameHeader = config.proxyAuthorNameHeader || "x-forwarded-preferred-username";
+	const get = (name: string) => headers.get(name)?.trim() || undefined;
+	const email = get(emailHeader);
+	const name = get(nameHeader) || email;
+	if (!email && !name) return undefined;
+	return `${name ?? email} <${email ?? "unknown@localhost"}>`;
+}

--- a/src/mcp/http-server.ts
+++ b/src/mcp/http-server.ts
@@ -1,0 +1,79 @@
+/**
+ * MCP server over Streamable HTTP (Web Standard transport).
+ *
+ * Runs the Backlog.md MCP server as a single long-lived HTTP service instead of a
+ * per-client stdio process. Designed to sit behind an authenticating reverse proxy
+ * (e.g. oauth2-proxy): the proxy forwards the end-user identity as headers, and each
+ * request's resulting git commit is attributed to that user — the same
+ * `commit_author_from_proxy_headers` model as the web UI.
+ *
+ * Stateless mode: a fresh transport + MCP server is built per request, so requests
+ * are independent and horizontally scalable. The per-request server is constructed
+ * with filesystem watchers disabled.
+ */
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { runWithCommitAuthor } from "../git/commit-context.ts";
+import { authorFromProxyHeaders } from "../git/proxy-identity.ts";
+import { createMcpServer } from "./server.ts";
+
+export interface HttpMcpOptions {
+	port: number;
+	host?: string;
+	debug?: boolean;
+	/** MCP endpoint path (default `/mcp`). */
+	path?: string;
+}
+
+/**
+ * Start the MCP Streamable-HTTP server. Returns the Bun server handle.
+ */
+export function startHttpMcpServer(projectRoot: string, options: HttpMcpOptions) {
+	const host = options.host ?? "127.0.0.1";
+	const mcpPath = options.path ?? "/mcp";
+
+	const server = Bun.serve({
+		port: options.port,
+		hostname: host,
+		idleTimeout: 0,
+		fetch: async (req: Request): Promise<Response> => {
+			const url = new URL(req.url);
+
+			if (url.pathname === "/health") {
+				return Response.json({ status: "ok" });
+			}
+
+			if (url.pathname !== mcpPath) {
+				return new Response("Not Found", { status: 404 });
+			}
+
+			// Build a request-scoped MCP server (no watchers) and a stateless transport.
+			const mcp = await createMcpServer(projectRoot, {
+				debug: options.debug,
+				pinned: true,
+				enableWatchers: false,
+			});
+			const config = await mcp.filesystem.loadConfig();
+			const author = authorFromProxyHeaders(req.headers, config);
+
+			const transport = new WebStandardStreamableHTTPServerTransport({
+				// Stateless: no session id generator.
+				sessionIdGenerator: undefined,
+				// Plain JSON responses (no SSE) — simplest behind a proxy.
+				enableJsonResponse: true,
+			});
+			await mcp.getServer().connect(transport);
+
+			// Attribute any commit produced by this request to the proxied end-user.
+			return runWithCommitAuthor(author, () => transport.handleRequest(req));
+		},
+		error(error: Error) {
+			return new Response(`Internal Server Error: ${error?.message ?? "unknown"}`, { status: 500 });
+		},
+	});
+
+	if (options.debug) {
+		console.error(`Backlog.md MCP server (Streamable HTTP) listening on http://${host}:${options.port}${mcpPath}`);
+	}
+
+	return server;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -59,6 +59,8 @@ type ServerInitOptions = {
 	debug?: boolean;
 	/** When true (from --cwd/BACKLOG_CWD), the root is fixed and client roots are never consulted. */
 	pinned?: boolean;
+	/** Disable filesystem watchers (used by the stateless HTTP transport that builds a server per request). */
+	enableWatchers?: boolean;
 };
 
 type ServerRequestExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
@@ -90,8 +92,8 @@ export class McpServer extends Core {
 	private readonly resources = new Map<string, McpResourceHandler>();
 	private readonly prompts = new Map<string, McpPromptHandler>();
 
-	constructor(projectRoot: string, instructions: string) {
-		super(projectRoot, { enableWatchers: true });
+	constructor(projectRoot: string, instructions: string, options?: { enableWatchers?: boolean }) {
+		super(projectRoot, { enableWatchers: options?.enableWatchers ?? true });
 		this.initialProjectRoot = projectRoot;
 
 		this.server = new Server(
@@ -512,7 +514,7 @@ export async function createMcpServer(projectRoot: string, options: ServerInitOp
 	await tempCore.ensureConfigLoaded();
 	const config = await tempCore.filesystem.loadConfig();
 
-	const server = new McpServer(projectRoot, INSTRUCTIONS);
+	const server = new McpServer(projectRoot, INSTRUCTIONS, { enableWatchers: options.enableWatchers });
 
 	// Graceful fallback: if config doesn't exist, provide init-required resource
 	// and enable roots discovery so the server can find the project via MCP roots

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import type { SearchService } from "../core/search-service.ts";
 import { getTaskStatistics } from "../core/statistics.ts";
 import { isCreateLockError } from "../file-system/operations.ts";
 import { runWithCommitAuthor } from "../git/commit-context.ts";
+import { authorFromProxyHeaders } from "../git/proxy-identity.ts";
 import { BacklogToolError } from "../mcp/errors/mcp-errors.ts";
 import { MilestoneHandlers } from "../mcp/tools/milestones/handlers.ts";
 import {
@@ -809,17 +810,10 @@ export class BacklogServer {
 		return runWithCommitAuthor(author, fn);
 	}
 
-	/** Build a git author from auth-proxy identity headers (gated by config.commitAuthorFromProxyHeaders; header names configurable, oauth2-proxy defaults). */
+	/** Build a git author from auth-proxy identity headers (shared with the MCP HTTP transport). */
 	private async getProxyCommitAuthor(req: Request): Promise<string | undefined> {
 		const config = await this.core.filesystem.loadConfig();
-		if (!config?.commitAuthorFromProxyHeaders) return undefined;
-		const emailHeader = config.proxyAuthorEmailHeader || "x-forwarded-email";
-		const nameHeader = config.proxyAuthorNameHeader || "x-forwarded-preferred-username";
-		const get = (name: string) => req.headers.get(name)?.trim() || undefined;
-		const email = get(emailHeader);
-		const name = get(nameHeader) || email;
-		if (!email && !name) return undefined;
-		return `${name ?? email} <${email ?? "unknown@localhost"}>`;
+		return authorFromProxyHeaders(req.headers, config);
 	}
 
 	private async handleCreateTask(req: Request): Promise<Response> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,7 @@ import { initializeProject } from "../core/init.ts";
 import type { SearchService } from "../core/search-service.ts";
 import { getTaskStatistics } from "../core/statistics.ts";
 import { isCreateLockError } from "../file-system/operations.ts";
+import { runWithCommitAuthor } from "../git/commit-context.ts";
 import { BacklogToolError } from "../mcp/errors/mcp-errors.ts";
 import { MilestoneHandlers } from "../mcp/tools/milestones/handlers.ts";
 import {
@@ -315,18 +316,21 @@ export class BacklogServer {
 					// API Routes using Bun's native route syntax
 					"/api/tasks": {
 						GET: async (req: Request) => await this.handleListTasks(req),
-						POST: async (req: Request) => await this.handleCreateTask(req),
+						POST: async (req: Request) => await this.withCommitContext(req, () => this.handleCreateTask(req)),
 					},
 					"/api/task/:id": {
 						GET: async (req: Request & { params: { id: string } }) => await this.handleGetTask(req.params.id),
 					},
 					"/api/tasks/:id": {
 						GET: async (req: Request & { params: { id: string } }) => await this.handleGetTask(req.params.id),
-						PUT: async (req: Request & { params: { id: string } }) => await this.handleUpdateTask(req, req.params.id),
-						DELETE: async (req: Request & { params: { id: string } }) => await this.handleDeleteTask(req.params.id),
+						PUT: async (req: Request & { params: { id: string } }) =>
+							await this.withCommitContext(req, () => this.handleUpdateTask(req, req.params.id)),
+						DELETE: async (req: Request & { params: { id: string } }) =>
+							await this.withCommitContext(req, () => this.handleDeleteTask(req.params.id)),
 					},
 					"/api/tasks/:id/complete": {
-						POST: async (req: Request & { params: { id: string } }) => await this.handleCompleteTask(req.params.id),
+						POST: async (req: Request & { params: { id: string } }) =>
+							await this.withCommitContext(req, () => this.handleCompleteTask(req.params.id)),
 					},
 					"/api/statuses": {
 						GET: async () => await this.handleGetStatuses(),
@@ -337,18 +341,19 @@ export class BacklogServer {
 					},
 					"/api/docs": {
 						GET: async () => await this.handleListDocs(),
-						POST: async (req: Request) => await this.handleCreateDoc(req),
+						POST: async (req: Request) => await this.withCommitContext(req, () => this.handleCreateDoc(req)),
 					},
 					"/api/doc/:id": {
 						GET: async (req: Request & { params: { id: string } }) => await this.handleGetDoc(req.params.id),
 					},
 					"/api/docs/:id": {
 						GET: async (req: Request & { params: { id: string } }) => await this.handleGetDoc(req.params.id),
-						PUT: async (req: Request & { params: { id: string } }) => await this.handleUpdateDoc(req, req.params.id),
+						PUT: async (req: Request & { params: { id: string } }) =>
+							await this.withCommitContext(req, () => this.handleUpdateDoc(req, req.params.id)),
 					},
 					"/api/decisions": {
 						GET: async () => await this.handleListDecisions(),
-						POST: async (req: Request) => await this.handleCreateDecision(req),
+						POST: async (req: Request) => await this.withCommitContext(req, () => this.handleCreateDecision(req)),
 					},
 					"/api/decision/:id": {
 						GET: async (req: Request & { params: { id: string } }) => await this.handleGetDecision(req.params.id),
@@ -356,17 +361,18 @@ export class BacklogServer {
 					"/api/decisions/:id": {
 						GET: async (req: Request & { params: { id: string } }) => await this.handleGetDecision(req.params.id),
 						PUT: async (req: Request & { params: { id: string } }) =>
-							await this.handleUpdateDecision(req, req.params.id),
+							await this.withCommitContext(req, () => this.handleUpdateDecision(req, req.params.id)),
 					},
 					"/api/drafts": {
 						GET: async () => await this.handleListDrafts(),
 					},
 					"/api/drafts/:id/promote": {
-						POST: async (req: Request & { params: { id: string } }) => await this.handlePromoteDraft(req.params.id),
+						POST: async (req: Request & { params: { id: string } }) =>
+							await this.withCommitContext(req, () => this.handlePromoteDraft(req.params.id)),
 					},
 					"/api/milestones": {
 						GET: async () => await this.handleListMilestones(),
-						POST: async (req: Request) => await this.handleCreateMilestone(req),
+						POST: async (req: Request) => await this.withCommitContext(req, () => this.handleCreateMilestone(req)),
 					},
 					"/api/milestones/archived": {
 						GET: async () => await this.handleListArchivedMilestones(),
@@ -374,15 +380,16 @@ export class BacklogServer {
 					"/api/milestones/:id": {
 						GET: async (req: Request & { params: { id: string } }) => await this.handleGetMilestone(req.params.id),
 						PUT: async (req: Request & { params: { id: string } }) =>
-							await this.handleUpdateMilestone(req, req.params.id),
+							await this.withCommitContext(req, () => this.handleUpdateMilestone(req, req.params.id)),
 						DELETE: async (req: Request & { params: { id: string } }) =>
-							await this.handleRemoveMilestone(req, req.params.id),
+							await this.withCommitContext(req, () => this.handleRemoveMilestone(req, req.params.id)),
 					},
 					"/api/milestones/:id/archive": {
-						POST: async (req: Request & { params: { id: string } }) => await this.handleArchiveMilestone(req.params.id),
+						POST: async (req: Request & { params: { id: string } }) =>
+							await this.withCommitContext(req, () => this.handleArchiveMilestone(req.params.id)),
 					},
 					"/api/tasks/reorder": {
-						POST: async (req: Request) => await this.handleReorderTask(req),
+						POST: async (req: Request) => await this.withCommitContext(req, () => this.handleReorderTask(req)),
 					},
 					"/api/tasks/cleanup": {
 						GET: async (req: Request) => await this.handleCleanupPreview(req),
@@ -409,13 +416,13 @@ export class BacklogServer {
 						GET: async () => await this.handleGetSequences(),
 					},
 					"/sequences/move": {
-						POST: async (req: Request) => await this.handleMoveSequence(req),
+						POST: async (req: Request) => await this.withCommitContext(req, () => this.handleMoveSequence(req)),
 					},
 					"/api/sequences": {
 						GET: async () => await this.handleGetSequences(),
 					},
 					"/api/sequences/move": {
-						POST: async (req: Request) => await this.handleMoveSequence(req),
+						POST: async (req: Request) => await this.withCommitContext(req, () => this.handleMoveSequence(req)),
 					},
 					// Serve files placed under backlog/assets at /assets/<relative-path>
 					"/assets/*": {
@@ -795,6 +802,24 @@ export class BacklogServer {
 			console.error("Error performing search:", error);
 			return Response.json({ error: "Search failed" }, { status: 500 });
 		}
+	}
+
+	private async withCommitContext<T>(req: Request, fn: () => Promise<T>): Promise<T> {
+		const author = await this.getProxyCommitAuthor(req);
+		return runWithCommitAuthor(author, fn);
+	}
+
+	/** Build a git author from auth-proxy identity headers (gated by config.commitAuthorFromProxyHeaders; header names configurable, oauth2-proxy defaults). */
+	private async getProxyCommitAuthor(req: Request): Promise<string | undefined> {
+		const config = await this.core.filesystem.loadConfig();
+		if (!config?.commitAuthorFromProxyHeaders) return undefined;
+		const emailHeader = config.proxyAuthorEmailHeader || "x-forwarded-email";
+		const nameHeader = config.proxyAuthorNameHeader || "x-forwarded-preferred-username";
+		const get = (name: string) => req.headers.get(name)?.trim() || undefined;
+		const email = get(emailHeader);
+		const name = get(nameHeader) || email;
+		if (!email && !name) return undefined;
+		return `${name ?? email} <${email ?? "unknown@localhost"}>`;
 	}
 
 	private async handleCreateTask(req: Request): Promise<Response> {

--- a/src/test/commit-author.test.ts
+++ b/src/test/commit-author.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { runWithCommitAuthor } from "../git/commit-context.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+describe("Commit author from request context", () => {
+	let core: Core;
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-commit-author");
+		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
+		await mkdir(TEST_DIR, { recursive: true });
+		await $`git init`.cwd(TEST_DIR).quiet();
+		await $`git config user.email robot@host`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Backlog Robot"`.cwd(TEST_DIR).quiet();
+		core = new Core(TEST_DIR);
+		await initializeTestProject(core, "Commit Author Project", true);
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("sets the commit author from runWithCommitAuthor while keeping the committer", async () => {
+		await runWithCommitAuthor("Jane Doe <jane@example.com>", async () => {
+			await core.createTaskFromInput({ title: "Authored by Jane" }, true);
+		});
+
+		const { stdout } = await $`git log -1 --format=%an%x09%ae%x09%cn%x09%ce`.cwd(TEST_DIR).quiet();
+		const [authorName, authorEmail, committerName, committerEmail] = stdout.toString().trim().split("\t");
+		expect(authorName).toBe("Jane Doe");
+		expect(authorEmail).toBe("jane@example.com");
+		// committer stays the server/git identity
+		expect(committerName).toBe("Backlog Robot");
+		expect(committerEmail).toBe("robot@host");
+	});
+
+	it("falls back to the git identity when no author context is set", async () => {
+		await core.createTaskFromInput({ title: "No context" }, true);
+
+		const { stdout } = await $`git log -1 --format=%an%x09%ae`.cwd(TEST_DIR).quiet();
+		const [authorName, authorEmail] = stdout.toString().trim().split("\t");
+		expect(authorName).toBe("Backlog Robot");
+		expect(authorEmail).toBe("robot@host");
+	});
+});

--- a/src/test/mcp-http-transport.test.ts
+++ b/src/test/mcp-http-transport.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { startHttpMcpServer } from "../mcp/http-server.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let httpServer: ReturnType<typeof startHttpMcpServer> | null = null;
+
+async function lastAuthor(dir: string) {
+	const { stdout } = await $`git log -1 --format=%an%x09%ae%x09%cn`.cwd(dir).quiet();
+	const [authorName, authorEmail, committerName] = stdout.toString().trim().split("\t");
+	return { authorName, authorEmail, committerName };
+}
+
+async function callCreateTask(port: number, headers: Record<string, string>, title: string) {
+	const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+		requestInit: { headers },
+	});
+	const client = new Client({ name: "test-client", version: "1.0.0" });
+	await client.connect(transport);
+	try {
+		await client.callTool({ name: "task_create", arguments: { title } });
+	} finally {
+		await client.close();
+	}
+}
+
+describe("MCP Streamable-HTTP transport", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("mcp-http");
+		await mkdir(TEST_DIR, { recursive: true });
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.email robot@host`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Backlog Robot"`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await initializeTestProject(core, "MCP HTTP Project", true);
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("no config");
+		config.autoCommit = true;
+		config.commitAuthorFromProxyHeaders = true;
+		await core.filesystem.saveConfig(config);
+
+		httpServer = startHttpMcpServer(TEST_DIR, { port: 0 });
+	});
+
+	afterEach(async () => {
+		httpServer?.stop(true);
+		httpServer = null;
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("attributes the commit to the proxied user from forwarded headers", async () => {
+		const port = httpServer?.port ?? 0;
+		expect(port).toBeGreaterThan(0);
+
+		await callCreateTask(
+			port,
+			{ "x-forwarded-email": "alice@example.com", "x-forwarded-preferred-username": "Alice Dupont" },
+			"Created over HTTP by Alice",
+		);
+
+		const id = await lastAuthor(TEST_DIR);
+		expect(id.authorName).toBe("Alice Dupont");
+		expect(id.authorEmail).toBe("alice@example.com");
+		// committer stays the server git identity
+		expect(id.committerName).toBe("Backlog Robot");
+	});
+
+	it("falls back to the git identity when no identity headers are present", async () => {
+		const port = httpServer?.port ?? 0;
+		await callCreateTask(port, {}, "Created over HTTP anonymously");
+
+		const id = await lastAuthor(TEST_DIR);
+		expect(id.authorName).toBe("Backlog Robot");
+		expect(id.authorEmail).toBe("robot@host");
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -311,6 +311,12 @@ export interface BacklogConfig {
 	defaultPort?: number;
 	remoteOperations?: boolean;
 	autoCommit?: boolean;
+	/** Web server: derive each git commit author from auth-proxy identity headers (opt-in). */
+	commitAuthorFromProxyHeaders?: boolean;
+	/** Header carrying the user email (default oauth2-proxy `x-forwarded-email`). */
+	proxyAuthorEmailHeader?: string;
+	/** Header carrying the user display name (default oauth2-proxy `x-forwarded-preferred-username`). */
+	proxyAuthorNameHeader?: string;
 	/** Disable all Git integration for filesystem-only projects. */
 	filesystemOnly?: boolean;
 	zeroPaddedIds?: number;


### PR DESCRIPTION
# feat: authenticated multi-user hosting — per-user commit attribution (web) + Streamable HTTP MCP transport

## Summary
Two complementary changes that let Backlog.md be hosted for a team behind a single OIDC
provider, with every commit attributed to the authenticated end-user:

1. **Web — commit author from auth-proxy headers.** When the web server runs behind an
   authenticating reverse proxy (e.g. oauth2-proxy), the commit **author** is derived
   from the forwarded identity headers; the **committer** stays the server identity.
   Opt-in, header names configurable (oauth2-proxy defaults).
2. **MCP — Streamable HTTP transport.** `backlog mcp start --http` serves the MCP server
   over HTTP as a single long-lived process (no per-client stdio process), behind the
   same proxy, reusing the **same** per-request identity → commit-author mechanism.

This PR contains two reviewable commits (web first, then the MCP transport that builds on
it). They are submitted together because the MCP transport reuses the web commit's new
`commit-context.ts` and the shared `authorFromProxyHeaders()` helper, so they share config
plumbing and cannot be opened as independent cross-fork PRs.

## Commit 1 — web commits attributed to the auth-proxy user
- New opt-in config `commit_author_from_proxy_headers` (default off) with configurable
  header names `proxy_author_email_header` / `proxy_author_name_header`
  (defaults `x-forwarded-email` / `x-forwarded-preferred-username`).
- A small `AsyncLocalStorage`-backed `commit-context.ts` binds a per-request git author;
  the commit builders append `--author` when one is set. Concurrency-safe, no signature
  threading through `Core`.
- The web server wraps mutating routes so each commit is authored by the proxied user.

## Commit 2 — Streamable HTTP transport for MCP
- `backlog mcp start --http [--port 6421] [--host 127.0.0.1]`; stdio stays the default.
- Uses the SDK's `WebStandardStreamableHTTPServerTransport` (no new dependency), stateless
  (fresh transport + watchers-disabled server per request) → no per-client process spawned.
- Per-request author resolution is shared with the web server via `authorFromProxyHeaders()`
  (extracted from the web server, which now reuses it); request handling is wrapped in
  `runWithCommitAuthor()`.
- `AUTHENTICATED-HOSTING.md`: end-to-end guide (Keycloak + oauth2-proxy, web + MCP, and the
  two MCP client auth options — Bearer token for agents, interactive OAuth for humans).

## Behavior & safety
- Both behaviours are **opt-in** and default off — no change for existing users.
- The git **committer** always stays the server identity; only the **author** is overridden,
  so history remains auditable.
- The config field is intentionally **not** added to `needsMigration` (no forced config
  rewrite on existing projects).

## Testing
- `bunx tsc --noEmit` → clean. `npx biome check .` (changed files) → clean.
- `bun test`:
  - `commit-author.test.ts` — author from the request context, committer preserved, fallback
    to git identity.
  - `mcp-http-transport.test.ts` — end-to-end via the MCP SDK client over HTTP: a tool call
    with forwarded identity headers produces a commit authored by the proxied user (committer
    preserved), and falls back to the git identity without headers.
  - `config-commands.test.ts` — config serialize/parse roundtrip.

## Related Tasks
> Happy to create/associate a backlog task per the PR template, and to split the two commits
> into separate PRs if preferred once the first lands.
