### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@
 
 ```bash
 # Install
+
+[![Listed on TakoAPI](https://takoapi.com/api/badge/mrlesk-backlog-md)](https://takoapi.com/agents/mrlesk-backlog-md)
+
 bun i -g backlog.md
 # or: npm i -g backlog.md
 # or: brew install backlog-md


### PR DESCRIPTION
Hi! 👋 **Backlog.md** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/mrlesk-backlog-md

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building Backlog.md! 🙏