### PR TITLE
Docs - Clarify issue-first PR process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,12 @@
 ## Summary
 Briefly explain the purpose of this pull request.
 
-## Related Tasks
-List task IDs this PR closes, e.g. `closes task-29`.
+## Related Issue or Task
+Link the issue or task this PR closes, e.g. `closes #123` or `closes task-29`.
 
-> **📋 Important:** All PRs must have an associated task in the backlog.
+> **📋 Important:** Please discuss the change in an issue before opening a PR.
+> - If no issue exists, open one first so maintainers and contributors can agree that the proposal fits the current project scope before implementation.
+> - All PRs must have an associated task in the backlog.
 > - If no task exists, create one first using: `backlog task create "Your task title"`
 > - Follow the [task guidelines](../src/guidelines/agent-guidelines.md) when creating tasks
 > - Tasks should be atomic, testable, and well-defined with clear acceptance criteria


### PR DESCRIPTION
Alex's Agent:

## Summary
- Update the PR template so contributors are asked to link an issue or task.
- Ask contributors to open an issue first when none exists so the proposal can be discussed against the current project scope before implementation.

## Verification
- `git diff --check`
- `rg -n "1\.0|1\.x|2\.0" .github/PULL_REQUEST_TEMPLATE.md` (no matches)

Tests not run because this is a docs/template-only change.
