### PR TITLE
BACK-270 - Document shell quoting for literal backticks in task creation inputs

### DIFF
--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -125,6 +125,19 @@ The same shape works for `--plan`, `--notes`, `--comment`, `--final-summary`, an
   backlog task create "Feature" --desc "Line1`nLine2`n`nFinal paragraph"
   ```
 
+### Literal backticks in task text
+
+When task text includes Markdown code spans, quote it so the shell passes the backticks literally. Unescaped backticks in double-quoted or unquoted arguments are command substitution in many shells, and Backlog.md cannot recover the original text after the shell has already executed it.
+
+Use single-quoted CLI arguments for values that contain literal backticks:
+
+```bash
+backlog task create 'Document `backlog init` setup' \
+  --ac 'Instructions mention `backlog init --defaults` literally'
+```
+
+If single quotes are not practical in your shell, escape each literal backtick before running the command. Do not rely on Backlog.md to sanitize accidental command output after substitution.
+
 ## Milestone Management
 
 Milestones are managed through milestone files. Use CLI commands instead of editing milestone markdown directly so IDs, filenames, task references, and archive state stay consistent.

--- a/backlog/tasks/back-270 - Prevent-command-substitution-in-task-creation-inputs.md
+++ b/backlog/tasks/back-270 - Prevent-command-substitution-in-task-creation-inputs.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-270
 title: Prevent command substitution in task creation inputs
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2025-09-17 21:20'
+updated_date: '2026-07-01 18:04'
 labels: []
 dependencies: []
 ---
@@ -17,7 +18,29 @@ When creating tasks via the CLI we attempted to reference `backlog init` inside 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Document safe quoting patterns for including literal backticks in CLI task commands.
-- [ ] #2 Evaluate updating CLI helpers so they escape backticks before submission or offer a flag to bypass shell parsing.
-- [ ] #3 Verify existing tasks are not affected by stray `backlog init` prompt text and repair any impacted files.
+- [x] #1 Document safe quoting patterns for including literal backticks in CLI task commands.
+- [x] #2 Evaluate updating CLI helpers so they escape backticks before submission or offer a flag to bypass shell parsing.
+- [x] #3 Verify existing tasks are not affected by stray `backlog init` prompt text and repair any impacted files.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect PR #361 patch, checks, comments, and conflicts against current main.
+2. Verify whether current public CLI/MCP/instruction surfaces already cover literal backtick safety.
+3. Replace the stale sanitizer approach with narrow current guidance for safe shell quoting where needed.
+4. Add regression assertions for the shipped instruction surfaces.
+5. Search backlog files for prompt-output corruption, run targeted checks, then close/update PRs accordingly.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Inspected PR #361: it is open, conflicts with current main, has stale CI from September 2025, and uses a lossy post-substitution sanitizer. Decided not to merge that branch because Backlog.md cannot reconstruct literal backticks after the shell has already executed command substitution. Added shell-quoting guidance to the shipped CLI task-creation guide, generated agent guidelines, and CLI reference instead, with regression tests. Verified existing backlog task files do not contain stray backlog-init prompt output requiring repair.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added literal-backtick shell quoting guidance to the CLI task-creation workflow guide, generated agent guidelines, and CLI reference. Added regression coverage for the shipped CLI and agent instruction surfaces. Evaluated PR #361 and rejected its post-substitution sanitizer approach as lossy because the shell executes backticks before Backlog.md receives arguments. Verified no existing backlog task files needed repair.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -602,6 +602,19 @@ Prefer forms **1** and **2** when running under Claude Code, Codex, or any agent
 
 Do not expect the literal sequence `\n` inside double quotes to become a newline. The CLI stores the backslash and `n` as written.
 
+### Literal Backticks in CLI Task Text
+
+When a task title, description, acceptance criterion, note, comment, or summary needs Markdown code spans, quote the value so the shell passes the backticks literally. Unescaped backticks in double-quoted or unquoted arguments are command substitution in many shells, and Backlog.md cannot recover the original text after the shell has already executed it.
+
+Prefer single-quoted CLI arguments for values that contain literal backticks:
+
+```bash
+backlog task create 'Document `backlog init` setup' \
+  --ac 'Instructions mention `backlog init --defaults` literally'
+```
+
+If single quotes are not practical in your shell, escape each literal backtick before running the command. Do not rely on Backlog.md to sanitize accidental command output after substitution.
+
 ### Implementation Notes Formatting
 
 - Keep implementation notes concise and time-ordered; focus on progress, decisions, and blockers.

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -77,6 +77,19 @@ backlog task create "Add settings docs" \
   --ref https://example.com/spec
 ```
 
+### Shell Quoting for Literal Backticks
+
+When task text includes Markdown code spans, quote it so the shell passes the backticks literally. Unescaped backticks in double-quoted or unquoted arguments are command substitution in many shells, and Backlog.md cannot recover the original text after the shell has already executed it.
+
+Use single-quoted CLI arguments for values that contain literal backticks:
+
+```bash
+backlog task create 'Document `backlog init` setup' \
+  --ac 'Instructions mention `backlog init --defaults` literally'
+```
+
+If single quotes are not practical in your shell, escape each literal backtick before running the command. Do not rely on Backlog.md to sanitize accidental command output after substitution.
+
 ### Acceptance Criteria
 
 Acceptance criteria define the expected behavior, not implementation steps.

--- a/src/test/agent-instructions.test.ts
+++ b/src/test/agent-instructions.test.ts
@@ -229,6 +229,17 @@ describe("addAgentInstructions", () => {
 		expect(ansiCIdx).toBeGreaterThan(appendIdx);
 	});
 
+	it("agent guidelines document literal backtick shell quoting (BACK-270)", async () => {
+		const guideline = await _loadAgentGuideline(AGENT_GUIDELINES);
+		const sectionMatch = guideline.match(/### Literal Backticks in CLI Task Text[\s\S]*?(?=\n### |\n## |$)/);
+		expect(sectionMatch).not.toBeNull();
+		const section = sectionMatch?.[0] ?? "";
+
+		expect(section).toContain("single-quoted CLI arguments");
+		expect(section).toContain("backlog task create 'Document `backlog init` setup'");
+		expect(section).toContain("Backlog.md cannot recover the original text after the shell has already executed it");
+	});
+
 	// BACK-431 / issue #595: option help text must not advertise shell forms that AI
 	// agent sandboxes reject. Help text is what `--help` surfaces and what agents echo
 	// when reasoning about how to call the CLI.

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -144,6 +144,11 @@ describe("CLI Integration", () => {
 			expect(taskFinalization).not.toContain("backlog task edit BACK-123 -s Done");
 			expect(taskCreation).not.toContain("task_create");
 			expect(taskCreation).not.toContain("task_search");
+			expect(taskCreation).toContain("### Shell Quoting for Literal Backticks");
+			expect(taskCreation).toContain("backlog task create 'Document `backlog init` setup'");
+			expect(taskCreation).toContain(
+				"Backlog.md cannot recover the original text after the shell has already executed it",
+			);
 			expect(initRequired).toContain("This directory does not have Backlog.md initialized.");
 			expect(initRequired).toContain("backlog init --defaults");
 		}, 15_000);


### PR DESCRIPTION
Alex's Agent:

## Summary
- Add literal-backtick shell quoting guidance to the CLI task-creation workflow guide, generated agent guidelines, and CLI reference.
- Document why Backlog.md cannot recover original text after shell command substitution has already run.
- Add regression assertions for the shipped CLI and agent instruction surfaces.
- Close BACK-270 after verifying existing backlog task files did not need repair.

This is a minimal current replacement for stale PR #361. It keeps the current project scope narrow by avoiding lossy post-substitution sanitization.

## Tests
- bun test src/test/cli.test.ts src/test/agent-instructions.test.ts
- bunx biome check --files-ignore-unknown=true CLI-INSTRUCTIONS.md src/guidelines/agent-guidelines.md src/guidelines/cli-instructions/task-creation.md src/test/agent-instructions.test.ts src/test/cli.test.ts 'backlog/tasks/back-270 - Prevent-command-substitution-in-task-creation-inputs.md'
- bunx tsc --noEmit
