### PR TITLE
BACK-429 - Preserve unsaved Web drafts across file refreshes

### DIFF
--- a/backlog/tasks/back-429 - Preserve-unsaved-Web-drafts-across-file-refreshes.md
+++ b/backlog/tasks/back-429 - Preserve-unsaved-Web-drafts-across-file-refreshes.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-04-25 12:14'
-updated_date: '2026-07-01 18:10'
+updated_date: '2026-07-01 18:58'
 labels:
   - web-ui
   - state
@@ -44,13 +44,15 @@ Track GitHub issue #578: unsaved Web UI form state should not reset when task fi
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented a same-open modal refresh merge: refreshed task data updates untouched fields while preserving locally edited create/edit fields across filesystem-triggered UI refreshes. Added regression coverage for dirty edit fields, clean external updates, and unsaved create fields during refreshed props. Validation passed: bun test src/test/web-task-details-modal-final-summary.test.tsx src/test/web-task-details-modal-documentation.test.tsx src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx src/test/web-milestones-page-search.test.tsx; bun test src/test/cli-priority-filtering.test.ts; bunx tsc --noEmit; bun run check . Full bun test was attempted but stopped after stale pre-fix modal failures and unrelated priority CLI timeouts; the affected suites passed on rerun.
+Implemented a same-open modal refresh merge: refreshed task data updates untouched fields while preserving locally edited create/edit fields across filesystem-triggered UI refreshes. Added regression coverage for dirty edit fields, clean external updates, and unsaved create fields during refreshed props.
+
+PR #705 follow-up: stabilized the JSDOM regression harness so controlled create/edit inputs update React state before simulating refreshed props. Validation passed: bun test src/test/web-task-details-modal-final-summary.test.tsx; bun test src/test/web-task-details-modal-final-summary.test.tsx src/test/web-task-details-modal-documentation.test.tsx src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx src/test/web-milestones-page-search.test.tsx; bunx tsc --noEmit; bun run check .; bun test (1343 pass, 2 skip, 0 fail).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed Web task modal refresh handling so background file updates no longer wipe unsaved create/edit fields, while untouched fields still receive refreshed task data. Verified with focused Web regression tests, the previously timed-out priority CLI file, TypeScript, and Biome.
+Fixed Web task modal refresh handling so background file updates no longer wipe unsaved create/edit fields, while untouched fields still receive refreshed task data. Stabilized the regression harness and verified with focused Web tests, TypeScript, Biome, and the full Bun test suite.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-429 - Preserve-unsaved-Web-drafts-across-file-refreshes.md
+++ b/backlog/tasks/back-429 - Preserve-unsaved-Web-drafts-across-file-refreshes.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-429
 title: Preserve unsaved Web drafts across file refreshes
-status: To Do
+status: Done
 assignee:
-  - '@alex-agent'
+  - '@codex'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-07-01 18:10'
 labels:
   - web-ui
   - state
@@ -12,6 +13,9 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/578'
+modified_files:
+  - src/web/components/TaskDetailsModal.tsx
+  - src/test/web-task-details-modal-final-summary.test.tsx
 priority: high
 ---
 
@@ -23,14 +27,35 @@ Track GitHub issue #578: unsaved Web UI form state should not reset when task fi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Unsaved task create/edit fields survive external task file refreshes.
-- [ ] #2 Saved external changes still appear after refresh when they do not conflict with local unsaved form state.
-- [ ] #3 A regression test or browser automation covers unsaved edits plus an external file watcher update.
+- [x] #1 Unsaved task create/edit fields survive external task file refreshes.
+- [x] #2 Saved external changes still appear after refresh when they do not conflict with local unsaved form state.
+- [x] #3 A regression test or browser automation covers unsaved edits plus an external file watcher update.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the reset at component level by rerendering an open task/create modal with refreshed props.
+2. Update TaskDetailsModal reset handling so same-open refreshes preserve dirty local fields and update untouched fields from refreshed data.
+3. Add focused regression tests for unsaved edit/create fields and non-conflicting external updates.
+4. Run scoped tests, typecheck, and lint/check as appropriate.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a same-open modal refresh merge: refreshed task data updates untouched fields while preserving locally edited create/edit fields across filesystem-triggered UI refreshes. Added regression coverage for dirty edit fields, clean external updates, and unsaved create fields during refreshed props. Validation passed: bun test src/test/web-task-details-modal-final-summary.test.tsx src/test/web-task-details-modal-documentation.test.tsx src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx src/test/web-milestones-page-search.test.tsx; bun test src/test/cli-priority-filtering.test.ts; bunx tsc --noEmit; bun run check . Full bun test was attempted but stopped after stale pre-fix modal failures and unrelated priority CLI timeouts; the affected suites passed on rerun.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed Web task modal refresh handling so background file updates no longer wipe unsaved create/edit fields, while untouched fields still receive refreshed task data. Verified with focused Web regression tests, the previously timed-out priority CLI file, TypeScript, and Biome.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/test/web-task-details-modal-final-summary.test.tsx
+++ b/src/test/web-task-details-modal-final-summary.test.tsx
@@ -11,11 +11,28 @@ import { apiClient } from "../web/lib/api.ts";
 let activeRoot: Root | null = null;
 
 const setFormValue = (element: HTMLInputElement | HTMLTextAreaElement, value: string) => {
+	const ownerWindow = element.ownerDocument.defaultView ?? window;
+	globalThis.HTMLElement = ownerWindow.HTMLElement;
+	globalThis.HTMLTextAreaElement = ownerWindow.HTMLTextAreaElement;
 	const valueSetter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), "value")?.set;
 	valueSetter?.call(element, value);
-	element.dispatchEvent(new window.Event("input", { bubbles: true }));
-	element.dispatchEvent(new window.Event("change", { bubbles: true }));
+	element.dispatchEvent(new ownerWindow.Event("input", { bubbles: true }));
+	element.dispatchEvent(new ownerWindow.Event("change", { bubbles: true }));
 };
+
+const clickElement = (element: Element) => {
+	const ownerWindow = element.ownerDocument.defaultView ?? window;
+	element.dispatchEvent(new ownerWindow.MouseEvent("click", { bubbles: true }));
+};
+
+const findButton = (container: HTMLElement, text: string): HTMLButtonElement | undefined =>
+	Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes(text));
+
+const findInputByValue = (container: HTMLElement, value: string): HTMLInputElement | undefined =>
+	Array.from(container.querySelectorAll("input")).find((input) => input.value === value);
+
+const findTextareaByValue = (container: HTMLElement, value: string): HTMLTextAreaElement | undefined =>
+	Array.from(container.querySelectorAll("textarea")).find((textarea) => textarea.value === value);
 
 const setupDom = () => {
 	const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { url: "http://localhost" });
@@ -24,6 +41,8 @@ const setupDom = () => {
 	globalThis.document = dom.window.document as Document;
 	globalThis.navigator = dom.window.navigator as Navigator;
 	globalThis.localStorage = dom.window.localStorage;
+	globalThis.HTMLElement = dom.window.HTMLElement;
+	globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
 	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(callback, 0);
 	globalThis.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
 
@@ -203,7 +222,7 @@ describe("Web task popup Final Summary display", () => {
 		);
 		expect(editButton).toBeTruthy();
 		await act(async () => {
-			editButton?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+			clickElement(editButton as HTMLButtonElement);
 			await Promise.resolve();
 		});
 
@@ -258,7 +277,7 @@ describe("Web task popup Final Summary display", () => {
 			);
 			expect(editButton).toBeTruthy();
 			await act(async () => {
-				editButton?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+				clickElement(editButton as HTMLButtonElement);
 				await Promise.resolve();
 			});
 
@@ -279,7 +298,7 @@ describe("Web task popup Final Summary display", () => {
 			);
 			expect(addButton).toBeTruthy();
 			await act(async () => {
-				addButton?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+				clickElement(addButton as HTMLButtonElement);
 				await Promise.resolve();
 			});
 
@@ -298,6 +317,133 @@ describe("Web task popup Final Summary display", () => {
 		} finally {
 			apiClient.updateTask = originalUpdateTask;
 		}
+	});
+
+	it("preserves dirty edit fields and applies clean refreshed fields while the modal stays open", async () => {
+		setupDom();
+
+		const task: Task = {
+			id: "TASK-13",
+			title: "Original title",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2025-01-01",
+			labels: [],
+			dependencies: [],
+			description: "Original description",
+			implementationPlan: "Original plan",
+			implementationNotes: "Original notes",
+			finalSummary: "Original final summary",
+		};
+		const refreshedTask: Task = {
+			...task,
+			title: "External title",
+			description: "External description",
+			implementationPlan: "External plan",
+			implementationNotes: "External notes",
+			finalSummary: "External final summary",
+		};
+		const container = document.getElementById("root");
+		expect(container).toBeTruthy();
+		activeRoot = createRoot(container as HTMLElement);
+
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal task={task} isOpen={true} onClose={() => {}} />
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+
+		const editButton = findButton(container as HTMLElement, "Edit");
+		expect(editButton).toBeTruthy();
+		await act(async () => {
+			clickElement(editButton as HTMLButtonElement);
+			await Promise.resolve();
+		});
+
+		const titleInput = findInputByValue(container as HTMLElement, "Original title");
+		const descriptionTextarea = findTextareaByValue(container as HTMLElement, "Original description");
+		expect(titleInput).toBeTruthy();
+		expect(descriptionTextarea).toBeTruthy();
+		await act(async () => {
+			setFormValue(titleInput!, "Local title");
+			setFormValue(descriptionTextarea!, "Local description");
+			await Promise.resolve();
+		});
+
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal task={refreshedTask} isOpen={true} onClose={() => {}} />
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+
+		expect(findInputByValue(container as HTMLElement, "Local title")).toBeTruthy();
+		expect(findTextareaByValue(container as HTMLElement, "Local description")).toBeTruthy();
+		expect(findTextareaByValue(container as HTMLElement, "External plan")).toBeTruthy();
+		expect(findTextareaByValue(container as HTMLElement, "External notes")).toBeTruthy();
+		expect(container?.textContent).toContain("Save");
+	});
+
+	it("preserves unsaved create fields when refreshed props change while the modal stays open", async () => {
+		setupDom();
+
+		const container = document.getElementById("root");
+		expect(container).toBeTruthy();
+		activeRoot = createRoot(container as HTMLElement);
+
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal
+						isOpen={true}
+						onClose={() => {}}
+						availableStatuses={["To Do", "In Progress", "Done"]}
+						definitionOfDoneDefaults={["Initial default"]}
+					/>
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+
+		const titleInput = (container as HTMLElement).querySelector(
+			"input[placeholder='Enter task title']",
+		) as HTMLInputElement | null;
+		const descriptionTextarea = (container as HTMLElement).querySelector("textarea") as HTMLTextAreaElement | null;
+		expect(titleInput).toBeTruthy();
+		expect(descriptionTextarea).toBeTruthy();
+		await act(async () => {
+			setFormValue(titleInput!, "Local draft title");
+			setFormValue(descriptionTextarea!, "Local draft description");
+			await Promise.resolve();
+		});
+
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal
+						isOpen={true}
+						onClose={() => {}}
+						availableStatuses={["Backlog", "To Do", "In Progress", "Done"]}
+						definitionOfDoneDefaults={["Refreshed default"]}
+					/>
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+
+		expect((container as HTMLElement).querySelector("input[placeholder='Enter task title']")).toHaveProperty(
+			"value",
+			"Local draft title",
+		);
+		expect((container as HTMLElement).querySelector("textarea")).toHaveProperty(
+			"value",
+			"Local draft description",
+		);
 	});
 
 	it("hides Final Summary section in preview when empty", () => {

--- a/src/test/web-task-details-modal-final-summary.test.tsx
+++ b/src/test/web-task-details-modal-final-summary.test.tsx
@@ -10,14 +10,25 @@ import { apiClient } from "../web/lib/api.ts";
 
 let activeRoot: Root | null = null;
 
+type ControlledFormElement = HTMLInputElement | HTMLTextAreaElement;
+type MountedReactProps = {
+	onChange?: (event: { target: ControlledFormElement; currentTarget: ControlledFormElement }) => void;
+};
+
 const setFormValue = (element: HTMLInputElement | HTMLTextAreaElement, value: string) => {
 	const ownerWindow = element.ownerDocument.defaultView ?? window;
 	globalThis.HTMLElement = ownerWindow.HTMLElement;
+	globalThis.HTMLInputElement = ownerWindow.HTMLInputElement;
 	globalThis.HTMLTextAreaElement = ownerWindow.HTMLTextAreaElement;
 	const valueSetter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), "value")?.set;
+	element.focus();
 	valueSetter?.call(element, value);
-	element.dispatchEvent(new ownerWindow.Event("input", { bubbles: true }));
+	element.dispatchEvent(new ownerWindow.InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
 	element.dispatchEvent(new ownerWindow.Event("change", { bubbles: true }));
+	const reactPropsKey = Object.keys(element).find((key) => key.startsWith("__reactProps$"));
+	if (!reactPropsKey) return;
+	const reactProps = (element as unknown as Record<string, MountedReactProps>)[reactPropsKey];
+	reactProps?.onChange?.({ target: element, currentTarget: element });
 };
 
 const clickElement = (element: Element) => {
@@ -34,6 +45,22 @@ const findInputByValue = (container: HTMLElement, value: string): HTMLInputEleme
 const findTextareaByValue = (container: HTMLElement, value: string): HTMLTextAreaElement | undefined =>
 	Array.from(container.querySelectorAll("textarea")).find((textarea) => textarea.value === value);
 
+const waitFor = async (predicate: () => boolean) => {
+	for (let attempt = 0; attempt < 10; attempt += 1) {
+		if (predicate()) return;
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+	}
+};
+
+const flushReact = async () => {
+	await act(async () => {
+		await Promise.resolve();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+};
+
 const setupDom = () => {
 	const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { url: "http://localhost" });
 	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -42,6 +69,7 @@ const setupDom = () => {
 	globalThis.navigator = dom.window.navigator as Navigator;
 	globalThis.localStorage = dom.window.localStorage;
 	globalThis.HTMLElement = dom.window.HTMLElement;
+	globalThis.HTMLInputElement = dom.window.HTMLInputElement;
 	globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
 	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(callback, 0);
 	globalThis.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
@@ -355,6 +383,8 @@ describe("Web task popup Final Summary display", () => {
 			);
 			await Promise.resolve();
 		});
+		await flushReact();
+		await waitFor(() => Boolean(findInputByValue(container as HTMLElement, "Original title")));
 
 		const editButton = findButton(container as HTMLElement, "Edit");
 		expect(editButton).toBeTruthy();
@@ -362,6 +392,7 @@ describe("Web task popup Final Summary display", () => {
 			clickElement(editButton as HTMLButtonElement);
 			await Promise.resolve();
 		});
+		await flushReact();
 
 		const titleInput = findInputByValue(container as HTMLElement, "Original title");
 		const descriptionTextarea = findTextareaByValue(container as HTMLElement, "Original description");
@@ -372,6 +403,9 @@ describe("Web task popup Final Summary display", () => {
 			setFormValue(descriptionTextarea!, "Local description");
 			await Promise.resolve();
 		});
+		await flushReact();
+		await waitFor(() => Boolean(findInputByValue(container as HTMLElement, "Local title")));
+		await waitFor(() => Boolean(findTextareaByValue(container as HTMLElement, "Local description")));
 
 		await act(async () => {
 			activeRoot?.render(
@@ -409,6 +443,8 @@ describe("Web task popup Final Summary display", () => {
 			);
 			await Promise.resolve();
 		});
+		await flushReact();
+		await waitFor(() => Boolean((container as HTMLElement).querySelector("input[placeholder='Enter task title']")));
 
 		const titleInput = (container as HTMLElement).querySelector(
 			"input[placeholder='Enter task title']",
@@ -421,6 +457,13 @@ describe("Web task popup Final Summary display", () => {
 			setFormValue(descriptionTextarea!, "Local draft description");
 			await Promise.resolve();
 		});
+		await flushReact();
+		await waitFor(
+			() =>
+				((container as HTMLElement).querySelector("input[placeholder='Enter task title']") as HTMLInputElement | null)
+					?.value === "Local draft title",
+		);
+		await waitFor(() => ((container as HTMLElement).querySelector("textarea") as HTMLTextAreaElement | null)?.value === "Local draft description");
 
 		await act(async () => {
 			activeRoot?.render(

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -41,7 +41,64 @@ type InlineMetaUpdatePayload = Omit<Partial<Task>, "milestone"> & {
   milestone?: string | null;
 };
 
+type TaskDetailsFormState = {
+  title: string;
+  description: string;
+  plan: string;
+  notes: string;
+  displayComments: TaskComment[];
+  finalSummary: string;
+  criteria: AcceptanceCriterion[];
+  definitionOfDone: AcceptanceCriterion[];
+  status: string;
+  assignee: string[];
+  labels: string[];
+  priority: string;
+  dependencies: string[];
+  references: string[];
+  milestone: string;
+};
+
 const containsCommentDelimiterLine = (value: string): boolean => /^\s*---\s*$/m.test(value.replace(/\r\n/g, "\n"));
+
+const areJsonEqual = (first: unknown, second: unknown): boolean => JSON.stringify(first) === JSON.stringify(second);
+
+const preserveDirtyRefreshValue = <T,>(
+  current: T,
+  previous: T,
+  next: T,
+  isEqual: (first: T, second: T) => boolean = Object.is,
+): T => (isEqual(current, previous) ? next : current);
+
+const buildTaskDetailsFormState = ({
+  task,
+  isCreateMode,
+  isDraftMode,
+  availableStatuses,
+  defaultDefinitionOfDone,
+}: {
+  task?: Task;
+  isCreateMode: boolean;
+  isDraftMode?: boolean;
+  availableStatuses?: string[];
+  defaultDefinitionOfDone: AcceptanceCriterion[];
+}): TaskDetailsFormState => ({
+  title: task?.title || "",
+  description: task?.description || "",
+  plan: task?.implementationPlan || "",
+  notes: task?.implementationNotes || "",
+  displayComments: task?.comments ?? [],
+  finalSummary: task?.finalSummary || "",
+  criteria: task?.acceptanceCriteriaItems || [],
+  definitionOfDone: task?.definitionOfDoneItems || (isCreateMode ? defaultDefinitionOfDone : []),
+  status: task?.status || (isDraftMode ? "Draft" : (availableStatuses?.[0] || "To Do")),
+  assignee: task?.assignee || [],
+  labels: task?.labels || [],
+  priority: task?.priority || "",
+  dependencies: task?.dependencies || [],
+  references: task?.references || [],
+  milestone: task?.milestone || "",
+});
 
 const SectionHeader: React.FC<{ title: string; right?: React.ReactNode }> = ({ title, right }) => (
   <div className="flex items-center justify-between mb-3">
@@ -73,6 +130,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const modeRef = useRef(mode);
   const previousTaskId = useRef(task?.id ?? "");
   const previousIsOpen = useRef(isOpen);
+  const formBaselineRef = useRef<TaskDetailsFormState | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -301,35 +359,96 @@ export const TaskDetailsModal: React.FC<Props> = ({
   // Reset local state when task changes or modal opens
   useEffect(() => {
     const nextTaskId = task?.id ?? "";
-    const sameOpenTaskRefresh = isOpen && previousIsOpen.current && nextTaskId.length > 0 && previousTaskId.current === nextTaskId;
+    const nextFormState = buildTaskDetailsFormState({
+      task,
+      isCreateMode,
+      isDraftMode,
+      availableStatuses,
+      defaultDefinitionOfDone,
+    });
+    const previousFormState = formBaselineRef.current;
+    const sameOpenModalRefresh =
+      Boolean(previousFormState) && isOpen && previousIsOpen.current && previousTaskId.current === nextTaskId;
     const shouldPreserveEditMode =
       !isCreateMode &&
-      sameOpenTaskRefresh &&
+      sameOpenModalRefresh &&
       (modeRef.current === "edit" || preserveEditModeAfterCommentRefresh.current);
 
-    setTitle(task?.title || "");
-    setDescription(task?.description || "");
-    setPlan(task?.implementationPlan || "");
-    setNotes(task?.implementationNotes || "");
-    setDisplayComments(task?.comments ?? []);
+    if (sameOpenModalRefresh && previousFormState) {
+      setTitle((current) => preserveDirtyRefreshValue(current, previousFormState.title, nextFormState.title));
+      setDescription((current) =>
+        preserveDirtyRefreshValue(current, previousFormState.description, nextFormState.description),
+      );
+      setPlan((current) => preserveDirtyRefreshValue(current, previousFormState.plan, nextFormState.plan));
+      setNotes((current) => preserveDirtyRefreshValue(current, previousFormState.notes, nextFormState.notes));
+      setDisplayComments(nextFormState.displayComments);
+      setCommentSaving(false);
+      setCommentsChanged(false);
+      setFinalSummary((current) =>
+        preserveDirtyRefreshValue(current, previousFormState.finalSummary, nextFormState.finalSummary),
+      );
+      setCriteria((current) =>
+        preserveDirtyRefreshValue(current, previousFormState.criteria, nextFormState.criteria, areJsonEqual),
+      );
+      setDefinitionOfDone((current) =>
+        preserveDirtyRefreshValue(
+          current,
+          previousFormState.definitionOfDone,
+          nextFormState.definitionOfDone,
+          areJsonEqual,
+        ),
+      );
+      setStatus((current) => preserveDirtyRefreshValue(current, previousFormState.status, nextFormState.status));
+      setAssignee((current) =>
+        preserveDirtyRefreshValue(current, previousFormState.assignee, nextFormState.assignee, areJsonEqual),
+      );
+      setLabels((current) =>
+        preserveDirtyRefreshValue(current, previousFormState.labels, nextFormState.labels, areJsonEqual),
+      );
+      setPriority((current) => preserveDirtyRefreshValue(current, previousFormState.priority, nextFormState.priority));
+      setDependencies((current) =>
+        preserveDirtyRefreshValue(current, previousFormState.dependencies, nextFormState.dependencies, areJsonEqual),
+      );
+      setReferences((current) =>
+        preserveDirtyRefreshValue(current, previousFormState.references, nextFormState.references, areJsonEqual),
+      );
+      setMilestone((current) =>
+        preserveDirtyRefreshValue(current, previousFormState.milestone, nextFormState.milestone),
+      );
+      setMode(shouldPreserveEditMode ? "edit" : isCreateMode ? "create" : modeRef.current);
+      preserveEditModeAfterCommentRefresh.current = false;
+      previousTaskId.current = nextTaskId;
+      previousIsOpen.current = isOpen;
+      formBaselineRef.current = nextFormState;
+      setError(null);
+      apiClient.fetchTasks().then(setAvailableTasks).catch(() => setAvailableTasks([]));
+      return;
+    }
+
+    setTitle(nextFormState.title);
+    setDescription(nextFormState.description);
+    setPlan(nextFormState.plan);
+    setNotes(nextFormState.notes);
+    setDisplayComments(nextFormState.displayComments);
     setCommentBody("");
     setCommentAuthor("");
     setCommentSaving(false);
     setCommentsChanged(false);
-    setFinalSummary(task?.finalSummary || "");
-    setCriteria(task?.acceptanceCriteriaItems || []);
-    setDefinitionOfDone(task?.definitionOfDoneItems || (isCreateMode ? defaultDefinitionOfDone : []));
-    setStatus(task?.status || (isDraftMode ? "Draft" : (availableStatuses?.[0] || "To Do")));
-    setAssignee(task?.assignee || []);
-    setLabels(task?.labels || []);
-    setPriority(task?.priority || "");
-    setDependencies(task?.dependencies || []);
-    setReferences(task?.references || []);
-    setMilestone(task?.milestone || "");
-    setMode(shouldPreserveEditMode ? "edit" : isCreateMode ? "create" : "preview");
+    setFinalSummary(nextFormState.finalSummary);
+    setCriteria(nextFormState.criteria);
+    setDefinitionOfDone(nextFormState.definitionOfDone);
+    setStatus(nextFormState.status);
+    setAssignee(nextFormState.assignee);
+    setLabels(nextFormState.labels);
+    setPriority(nextFormState.priority);
+    setDependencies(nextFormState.dependencies);
+    setReferences(nextFormState.references);
+    setMilestone(nextFormState.milestone);
+    setMode(isCreateMode ? "create" : "preview");
     preserveEditModeAfterCommentRefresh.current = false;
     previousTaskId.current = nextTaskId;
     previousIsOpen.current = isOpen;
+    formBaselineRef.current = nextFormState;
     setError(null);
     // Preload tasks for dependency picker
     apiClient.fetchTasks().then(setAvailableTasks).catch(() => setAvailableTasks([]));


### PR DESCRIPTION
Alex's Agent: Fixes #578.

## Summary
- Preserve local create/edit modal fields when task data refreshes while the modal remains open.
- Merge refreshed task data into untouched fields so non-conflicting external changes still appear.
- Stabilize the JSDOM regression harness so dirty create/edit fields are applied before refreshed props are simulated.

## Validation
- bun test src/test/web-task-details-modal-final-summary.test.tsx
- bun test src/test/web-task-details-modal-final-summary.test.tsx src/test/web-task-details-modal-documentation.test.tsx src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx src/test/web-milestones-page-search.test.tsx
- bunx tsc --noEmit
- bun run check .
- bun test
