### PR TITLE
BACK-513 - Refresh committed worktree branch task caches

### DIFF
--- a/backlog/tasks/back-511 - Investigate-stale-worktree-branch-discovery.md
+++ b/backlog/tasks/back-511 - Investigate-stale-worktree-branch-discovery.md
@@ -1,0 +1,63 @@
+---
+id: BACK-511
+title: Investigate stale worktree branch discovery
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-01 17:57'
+updated_date: '2026-07-01 18:10'
+labels:
+  - bug
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/689'
+modified_files:
+  - src/core/backlog.ts
+  - src/core/content-store.ts
+  - src/test/worktree-refresh.test.ts
+priority: medium
+ordinal: 110000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Issue #689 reports that Backlog sees active branches/worktrees only at startup and does not refresh later when check_active_branches is true. Investigate whether the local branch/worktree task scanner caches state incorrectly, reproduce if feasible, and make the smallest safe fix.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 With check_active_branches: true, task search/listing reflects newly committed task changes in another worktree after Backlog has already started
+- [x] #2 Focused tests cover refreshing branch/worktree state without broad feature expansion
+- [x] #3 If no safe fix is clear, leave a precise diagnostic or GitHub comment explaining the observed behavior
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the stale long-lived process path with a real git worktree: initialize a watcher-backed Core, query once, commit a task on a second worktree branch, then query again with check_active_branches enabled.
+2. Reuse ContentStore's existing cross-branch loader refresh instead of adding a new scanner or watcher layer.
+3. Refresh tasks before watcher-backed cross-branch reads/searches after initial startup, preserving CLI one-shot behavior and check_active_branches=false behavior.
+4. Run focused tests plus type/check validation as needed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the fix in the existing ContentStore/Core path. Diagnosis: direct branch scans were fresh, but watcher-backed long-lived Core instances served list/search results from the initialized ContentStore until a current-worktree filesystem event happened. Reused the loader-backed task refresh before watcher-backed cross-branch reads, and guarded no-op refreshes so unchanged snapshots do not notify clients.
+
+Validation: bun test src/test/worktree-refresh.test.ts; bun test src/test/content-store.test.ts src/test/search-service.test.ts; bun test src/test/find-task-in-branches.test.ts src/test/worktree-refresh.test.ts; bunx tsc --noEmit; bun run check . Full bun test run had 1341 pass / 2 skip / 1 timeout in CLI Priority Filtering > case insensitive priority filtering; rerunning that single test passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed stale long-lived task reads for worktree branch changes by refreshing the existing loader-backed ContentStore before watcher-backed cross-branch list/search queries. Added a git-worktree regression that starts on main, initializes list/search caches, commits a task in another worktree branch, and verifies the original Core sees it without restart. Verified with focused tests, typecheck, Biome, and reran the only full-suite timeout successfully.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-513 - Investigate-stale-worktree-branch-discovery.md
+++ b/backlog/tasks/back-513 - Investigate-stale-worktree-branch-discovery.md
@@ -1,5 +1,5 @@
 ---
-id: BACK-511
+id: BACK-513
 title: Investigate stale worktree branch discovery
 status: Done
 assignee:

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -240,6 +240,19 @@ export class Core {
 		return this.searchService;
 	}
 
+	private async refreshCachedTasksForCrossBranchRead(includeCrossBranch: boolean): Promise<void> {
+		if (!this.enableWatchers || !includeCrossBranch || !this.contentStore) {
+			return;
+		}
+
+		const config = await this.fs.loadConfig();
+		if (config?.checkActiveBranches === false) {
+			return;
+		}
+
+		await this.contentStore.refreshTasks();
+	}
+
 	private applyTaskFilters(
 		tasks: Task[],
 		filters?: TaskListFilter,
@@ -384,10 +397,13 @@ export class Core {
 
 		if (!trimmedQuery) {
 			const store = await this.getContentStore();
+			await this.refreshCachedTasksForCrossBranchRead(includeCrossBranch);
 			const tasks = store.getTasks();
 			return await applyFiltersAndLimit(tasks);
 		}
 
+		await this.getContentStore();
+		await this.refreshCachedTasksForCrossBranchRead(includeCrossBranch);
 		const searchService = await this.getSearchService();
 		const searchFilters: SearchFilters = {};
 		if (filters?.status) {

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -94,6 +94,14 @@ export class ContentStore {
 		return this.getSnapshot();
 	}
 
+	async refreshTasks(): Promise<void> {
+		if (!this.initialized) {
+			await this.ensureInitialized();
+			return;
+		}
+		await this.refreshTasksFromDisk();
+	}
+
 	getTasks(filter?: TaskListFilter): Task[] {
 		if (!this.initialized) {
 			throw new Error("ContentStore not initialized. Call ensureInitialized() first.");
@@ -662,6 +670,18 @@ export class ContentStore {
 		return JSON.stringify(previous) !== JSON.stringify(next);
 	}
 
+	private hasTaskCollectionChanged(nextTasks: Task[]): boolean {
+		const nextCachedTasks = sortByTaskId(nextTasks);
+		if (this.cachedTasks.length !== nextCachedTasks.length) {
+			return true;
+		}
+
+		return nextCachedTasks.some((task, index) => {
+			const previous = this.cachedTasks[index];
+			return !previous || this.hasTaskChanged(previous, task);
+		});
+	}
+
 	private async refreshTasksFromDisk(expectedId?: string, previous?: Task): Promise<void> {
 		const tasks = await this.retryRead(
 			async () => this.loadTasksWithLoader(),
@@ -680,6 +700,9 @@ export class ContentStore {
 			},
 		);
 		if (!tasks) {
+			return;
+		}
+		if (!this.hasTaskCollectionChanged(tasks)) {
 			return;
 		}
 		this.replaceTasks(tasks);

--- a/src/test/worktree-refresh.test.ts
+++ b/src/test/worktree-refresh.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let WORKTREE_DIR: string;
+let mainCore: Core | undefined;
+
+describe("worktree task refresh", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-worktree-refresh");
+		WORKTREE_DIR = `${TEST_DIR}-feature`;
+		await mkdir(TEST_DIR, { recursive: true });
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+	});
+
+	afterEach(async () => {
+		mainCore?.disposeContentStore();
+		mainCore = undefined;
+		try {
+			await safeCleanup(WORKTREE_DIR);
+			await safeCleanup(TEST_DIR);
+		} catch {
+			// Ignore cleanup errors - unique directory names prevent conflicts.
+		}
+	});
+
+	it("refreshes tasks committed in another worktree after startup when active branch checks are enabled", async () => {
+		const setupCore = new Core(TEST_DIR);
+		await initializeTestProject(setupCore, "Worktree Refresh", true);
+		const config = await setupCore.filesystem.loadConfig();
+		if (!config) {
+			throw new Error("Expected initialized config");
+		}
+		await setupCore.filesystem.saveConfig({
+			...config,
+			checkActiveBranches: true,
+			remoteOperations: false,
+		});
+		await $`git add backlog/config.yml`.cwd(TEST_DIR).quiet();
+		await $`git commit -m "Configure active branch scanning"`.cwd(TEST_DIR).quiet();
+
+		mainCore = new Core(TEST_DIR, { enableWatchers: true });
+		expect(await mainCore.queryTasks()).toEqual([]);
+		expect(await mainCore.queryTasks({ query: "Created elsewhere" })).toEqual([]);
+
+		await $`git worktree add ${WORKTREE_DIR} -b feature`.cwd(TEST_DIR).quiet();
+		const featureCore = new Core(WORKTREE_DIR);
+		const worktreeTask: Task = {
+			id: "task-1",
+			title: "Created elsewhere",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-07-01",
+			labels: [],
+			dependencies: [],
+			rawContent: "## Description\nCreated after the main Core initialized.",
+		};
+		await featureCore.createTask(worktreeTask, true);
+
+		const searchResults = await mainCore.queryTasks({ query: "Created elsewhere" });
+		expect(searchResults.map((task) => task.id)).toContain("TASK-1");
+
+		const listedTasks = await mainCore.queryTasks();
+		expect(listedTasks.map((task) => task.id)).toContain("TASK-1");
+	});
+});


### PR DESCRIPTION
Alex's Agent:

Backlog task: BACK-513
Linked issue: #689

## Summary
- Refresh watcher-backed task caches through the existing cross-branch loader before committed cross-branch Core reads.
- Avoid notifying clients when a refresh produces the same task snapshot.
- Add a git-worktree regression that initializes a long-lived Core on main, commits a task in another worktree branch, and verifies the long-lived read sees it without restart.

## Scope
This fixes stale committed sibling-worktree visibility for long-lived Core/browser listing paths that use cross-branch reads. It does not change uncommitted sibling-worktree listing/search visibility, and it is separate from the task-ID allocation fix merged in #710.

## Root Cause
Direct branch scans were fresh, but long-lived Core instances served task results from the initialized ContentStore until a filesystem event occurred in the current worktree. Changes committed in another worktree branch did not trigger that local watcher.

## Validation
- bun test src/test/worktree-refresh.test.ts
- bun test src/test/content-store.test.ts src/test/search-service.test.ts
- bun test src/test/find-task-in-branches.test.ts src/test/worktree-refresh.test.ts
- bunx tsc --noEmit
- bun run check .
- bun test: 1341 pass / 2 skip / 1 timeout in CLI Priority Filtering > case insensitive priority filtering; reran that single test and it passed.

GitHub CI is green across lint/unit, compile/smoke, and CodeQL.
