### PR TITLE
Issue #684 investigation prototype (closed pending owner decision)

### DIFF
--- a/backlog/tasks/back-511 - Investigate-issue-684-updated_date-bump-on-ordinal-only-edits.md
+++ b/backlog/tasks/back-511 - Investigate-issue-684-updated_date-bump-on-ordinal-only-edits.md
@@ -1,0 +1,62 @@
+---
+id: BACK-511
+title: 'Investigate issue #684 updated_date bump on ordinal-only edits'
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-01 17:57'
+updated_date: '2026-07-01 18:11'
+labels:
+  - bug
+  - github
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/684'
+modified_files:
+  - src/core/backlog.ts
+  - src/test/core.test.ts
+  - src/test/reorder-utils.test.ts
+  - src/test/cli-plain-create-edit.test.ts
+priority: medium
+ordinal: 110000
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Determine whether ordinal-only updated_date changes are a bug under shipped CLI/MCP behavior or require owner product input.
+- [x] #2 If a narrow fix preserves current temporal fields, implement it with focused tests.
+- [x] #3 If no narrow fix is appropriate, document the tradeoff on issue #684 and leave follow-up state clear.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Treat issue #684 as a narrow bug: public CLI/MCP describe ordinal as ordering metadata, and no shipped docs promise ordinal edits refresh updated_date.
+2. Add an internal save option so existing update paths keep the default updated_date stamp, but callers can preserve it for ordinal-only writes.
+3. Detect ordinal-only changes by comparing the original task to the candidate task while ignoring ordinal, updatedDate, and filePath.
+4. Apply preservation in task edit and board reorder paths; keep status/milestone/content edits stamping updated_date.
+5. Add focused core and reorder tests, then run targeted tests plus type/check as appropriate.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Discovery: updateTaskFromInput detects mutation, but updateTask always overwrites updatedDate. reorderTask filters ordinal/status/milestone changes, then saves via updateTasksBulk -> updateTask. Public CLI/MCP only describe ordinal as ordering metadata. Narrow fix can preserve updatedDate for ordinal-only writes without adding temporal fields.
+
+Validation: bun test src/test/core.test.ts src/test/reorder-utils.test.ts passed; bunx tsc --noEmit passed; bun run check . passed. Full bun test completed with three unrelated CLI timeout failures under full-suite load; reran src/test/cli-priority-filtering.test.ts and the timed-out cli.test case in isolation and both passed.
+
+Added a CLI-level regression for the public issue repro: task edit --ordinal on a fresh task keeps updated_date absent and omits Updated from --plain output.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Classified issue #684 as a narrow current-behavior bug: ordinal is public ordering metadata, not a task content timestamp signal. Added internal save options so ordinal-only task edits and board reorders preserve existing updated_date or leave it absent, while mixed content/status/milestone edits still refresh updated_date. Added core, reorder, and CLI regression tests.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-514 - Investigate-issue-684-updated_date-bump-on-ordinal-only-edits.md
+++ b/backlog/tasks/back-514 - Investigate-issue-684-updated_date-bump-on-ordinal-only-edits.md
@@ -1,5 +1,5 @@
 ---
-id: BACK-511
+id: BACK-514
 title: 'Investigate issue #684 updated_date bump on ordinal-only edits'
 status: Done
 assignee:

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -99,6 +99,14 @@ interface TaskQueryOptions {
 	includeCrossBranch?: boolean;
 }
 
+interface TaskSaveOptions {
+	touchUpdatedDate?: boolean;
+}
+
+interface BulkTaskSaveOptions {
+	touchUpdatedDate?: boolean | ((task: Task) => boolean);
+}
+
 export type TuiTaskEditFailureReason = "not_found" | "read_only" | "editor_failed";
 
 export interface TuiTaskEditResult {
@@ -180,6 +188,40 @@ function formatAvailableIndexHint(items: AcceptanceCriterion[], emptyMessage: st
 	const last = indexes[indexes.length - 1] ?? first;
 	const range = first === last ? `#${first}` : `#${first}-#${last}`;
 	return `Available indexes: ${range}.`;
+}
+
+function snapshotTaskWithoutOrderingDate(task: Task): string {
+	const {
+		ordinal: _ordinal,
+		updatedDate: _updatedDate,
+		filePath: _filePath,
+		lastModified: _lastModified,
+		source: _source,
+		branch: _branch,
+		parentTaskTitle: _parentTaskTitle,
+		subtaskSummaries: _subtaskSummaries,
+		...comparable
+	} = task;
+
+	return JSON.stringify(comparable);
+}
+
+function isOrdinalOnlyTaskChange(original: Task, updated: Task): boolean {
+	return (
+		(original.ordinal ?? null) !== (updated.ordinal ?? null) &&
+		snapshotTaskWithoutOrderingDate(original) === snapshotTaskWithoutOrderingDate(updated)
+	);
+}
+
+function isOrdinalOnlyTaskChangeFromSnapshot(
+	originalSnapshot: string,
+	originalOrdinal: number | undefined,
+	updated: Task,
+): boolean {
+	return (
+		(originalOrdinal ?? null) !== (updated.ordinal ?? null) &&
+		originalSnapshot === snapshotTaskWithoutOrderingDate(updated)
+	);
 }
 
 export class Core {
@@ -1086,7 +1128,7 @@ export class Core {
 		return filepath;
 	}
 
-	async updateTask(task: Task, autoCommit?: boolean): Promise<void> {
+	async updateTask(task: Task, autoCommit?: boolean, options: TaskSaveOptions = {}): Promise<void> {
 		normalizeAssignee(task);
 
 		// Load original task to detect status changes for callbacks
@@ -1095,8 +1137,9 @@ export class Core {
 		const newStatus = task.status ?? "";
 		const statusChanged = oldStatus !== newStatus;
 
-		// Always set updatedDate when updating a task
-		task.updatedDate = new Date().toISOString().slice(0, 16).replace("T", " ");
+		if (options.touchUpdatedDate !== false) {
+			task.updatedDate = new Date().toISOString().slice(0, 16).replace("T", " ");
+		}
 
 		await this.fs.saveTask(task);
 		// Keep any in-process ContentStore in sync for immediate UI/search freshness.
@@ -1687,6 +1730,8 @@ export class Core {
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
 		}
+		const originalSnapshot = snapshotTaskWithoutOrderingDate(task);
+		const originalOrdinal = task.ordinal;
 
 		const requestedStatus = input.status?.trim().toLowerCase();
 		if (requestedStatus === "draft") {
@@ -1701,7 +1746,9 @@ export class Core {
 			return task;
 		}
 
-		await this.updateTask(task, autoCommit);
+		await this.updateTask(task, autoCommit, {
+			touchUpdatedDate: !isOrdinalOnlyTaskChangeFromSnapshot(originalSnapshot, originalOrdinal, task),
+		});
 		const refreshed = await this.fs.loadTask(taskId);
 		return refreshed ?? task;
 	}
@@ -1902,10 +1949,17 @@ export class Core {
 		return await this.updateTaskFromInput(taskId, input, autoCommit);
 	}
 
-	async updateTasksBulk(tasks: Task[], commitMessage?: string, autoCommit?: boolean): Promise<void> {
+	async updateTasksBulk(
+		tasks: Task[],
+		commitMessage?: string,
+		autoCommit?: boolean,
+		options: BulkTaskSaveOptions = {},
+	): Promise<void> {
 		// Update all tasks without committing individually
 		for (const task of tasks) {
-			await this.updateTask(task, false); // Don't auto-commit each one
+			const touchUpdatedDate =
+				typeof options.touchUpdatedDate === "function" ? options.touchUpdatedDate(task) : options.touchUpdatedDate;
+			await this.updateTask(task, false, { touchUpdatedDate }); // Don't auto-commit each one
 		}
 
 		// Commit all changes at once if auto-commit is enabled
@@ -2032,6 +2086,12 @@ export class Core {
 				changedTasks,
 				params.commitMessage ?? `Reorder tasks in ${targetStatus}`,
 				params.autoCommit,
+				{
+					touchUpdatedDate: (task) => {
+						const original = originalMap.get(task.id);
+						return original ? !isOrdinalOnlyTaskChange(original, task) : true;
+					},
+				},
 			);
 		}
 

--- a/src/test/cli-plain-create-edit.test.ts
+++ b/src/test/cli-plain-create-edit.test.ts
@@ -83,6 +83,23 @@ describe("CLI --plain for task create/edit", () => {
 		expect(result.stderr.toString()).toContain("Invalid ordinal: Infinity. Must be a non-negative number.");
 	});
 
+	it("does not add updated_date when CLI edit only changes ordinal", async () => {
+		await $`bun ${cliPath} task create "Ordinal-only edit" --plain`.cwd(TEST_DIR).quiet();
+
+		const result = await $`bun ${cliPath} task edit 1 --ordinal 500 --plain`.cwd(TEST_DIR).quiet();
+
+		const out = result.stdout.toString();
+		expect(result.exitCode).toBe(0);
+		expect(out).toContain("Task TASK-1 - Ordinal-only edit");
+		expect(out).toContain("Ordinal: 500");
+		expect(out).not.toContain("Updated:");
+
+		const core = new Core(TEST_DIR);
+		const task = await core.filesystem.loadTask("task-1");
+		expect(task?.ordinal).toBe(500);
+		expect(task?.updatedDate).toBeUndefined();
+	});
+
 	it("prints plain details after task edit --plain", async () => {
 		// Create base task first (without plain)
 		await $`bun ${cliPath} task create "Edit Me" --desc "First"`.cwd(TEST_DIR).quiet();

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -272,6 +272,59 @@ describe("Core", () => {
 			);
 		});
 
+		it("preserves updated_date when update input only changes ordinal", async () => {
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-30",
+					title: "Ordinal-only without updated date",
+					ordinal: 1000,
+				},
+				false,
+			);
+			await core.updateTaskFromInput("task-30", { ordinal: 500 }, false);
+
+			const freshTask = await core.filesystem.loadTask("task-30");
+			expect(freshTask?.ordinal).toBe(500);
+			expect(freshTask?.updatedDate).toBeUndefined();
+
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-31",
+					title: "Ordinal-only with updated date",
+					updatedDate: "2025-06-08 09:30",
+					ordinal: 1000,
+				},
+				false,
+			);
+			await core.updateTaskFromInput("task-31", { ordinal: 500 }, false);
+
+			const datedTask = await core.filesystem.loadTask("task-31");
+			expect(datedTask?.ordinal).toBe(500);
+			expect(datedTask?.updatedDate).toBe("2025-06-08 09:30");
+		});
+
+		it("sets updated_date when an ordinal edit also changes task content", async () => {
+			await core.createTask(
+				{
+					...sampleTask,
+					id: "task-32",
+					title: "Ordinal plus content",
+					ordinal: 1000,
+				},
+				false,
+			);
+
+			await core.updateTaskFromInput("task-32", { title: "Updated ordinal plus content", ordinal: 500 }, false);
+
+			const updatedTask = await core.filesystem.loadTask("task-32");
+			const today = new Date().toISOString().slice(0, 16).replace("T", " ");
+			expect(updatedTask?.title).toBe("Updated ordinal plus content");
+			expect(updatedTask?.ordinal).toBe(500);
+			expect(updatedTask?.updatedDate).toBe(today);
+		});
+
 		it("should NOT match numeric ID with typos when using custom prefix (BACK-364)", async () => {
 			// Configure custom prefix
 			const config = await core.filesystem.loadConfig();

--- a/src/test/reorder-utils.test.ts
+++ b/src/test/reorder-utils.test.ts
@@ -15,7 +15,7 @@ let core: Core;
 
 const FIXED_DATE = "2025-01-01 00:00";
 
-const buildTask = (id: string, status: string, ordinal?: number): Task => ({
+const buildTask = (id: string, status: string, ordinal?: number, updatedDate?: string): Task => ({
 	id,
 	title: `Task ${id}`,
 	status,
@@ -24,6 +24,7 @@ const buildTask = (id: string, status: string, ordinal?: number): Task => ({
 	labels: [],
 	dependencies: [],
 	...(ordinal !== undefined ? { ordinal } : {}),
+	...(updatedDate !== undefined ? { updatedDate } : {}),
 });
 
 beforeEach(async () => {
@@ -105,9 +106,9 @@ describe("resolveOrdinalConflicts", () => {
 });
 
 describe("Core.reorderTask", () => {
-	const createTasks = async (tasks: Array<[string, string, number?]>) => {
-		for (const [id, status, ordinal] of tasks) {
-			await core.createTask(buildTask(id, status, ordinal), false);
+	const createTasks = async (tasks: Array<[string, string, number?, string?]>) => {
+		for (const [id, status, ordinal, updatedDate] of tasks) {
+			await core.createTask(buildTask(id, status, ordinal, updatedDate), false);
 		}
 	};
 
@@ -154,6 +155,29 @@ describe("Core.reorderTask", () => {
 		expect(task1?.ordinal).toBe(1000);
 		expect(task2?.ordinal).toBe(3000);
 		expect(task3?.ordinal).toBe(2000);
+	});
+
+	it("preserves updatedDate when reorder only changes ordinals", async () => {
+		await createTasks([
+			["task-1", "To Do", 1000, "2025-01-02 10:00"],
+			["task-2", "To Do", 1000, "2025-01-03 10:00"],
+			["task-3", "To Do", 1000, "2025-01-04 10:00"],
+		]);
+
+		const result = await core.reorderTask({
+			taskId: "task-3",
+			targetStatus: "To Do",
+			orderedTaskIds: ["task-1", "task-3", "task-2"],
+		});
+
+		expect(result.changedTasks.map((task) => task.id).sort()).toEqual(["TASK-2", "TASK-3"]);
+
+		const task2 = await core.filesystem.loadTask("task-2");
+		const task3 = await core.filesystem.loadTask("task-3");
+		expect(task2?.ordinal).toBe(3000);
+		expect(task2?.updatedDate).toBe("2025-01-03 10:00");
+		expect(task3?.ordinal).toBe(2000);
+		expect(task3?.updatedDate).toBe("2025-01-04 10:00");
 	});
 
 	it("updates status and ordinal when moving across columns", async () => {


### PR DESCRIPTION
Alex's Agent:

Correction: this PR is not an accepted fix. It was opened during investigation of #684, but the product semantic needs an owner decision before any implementation should advance.

Prototype summary:
- Preserves existing updated_date, or leaves it absent, when task edit or board reorder changes only ordinal.
- Keeps updated_date refreshes for mixed edits that also change content, status, or milestone.
- Adds no new temporal fields.

Validation from the prototype branch:
- bun test src/test/core.test.ts src/test/reorder-utils.test.ts src/test/cli-plain-create-edit.test.ts
- bunx tsc --noEmit
- bun run check .
- bun test src/test/cli-priority-filtering.test.ts
- bun test src/test/cli.test.ts --test-name-pattern "should filter tasks by status case-insensitively"

This PR should remain closed/not for merge unless the owner explicitly accepts this semantic.