### PR TITLE
BACK-515 - Fix TUI completion status update

### DIFF
--- a/backlog/tasks/back-511 - Fix-TUI-completion-status-update.md
+++ b/backlog/tasks/back-511 - Fix-TUI-completion-status-update.md
@@ -1,0 +1,67 @@
+---
+id: BACK-511
+title: Fix TUI completion status update
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-07-01 17:57'
+updated_date: '2026-07-01 18:11'
+labels:
+  - bug
+  - tui
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/697'
+modified_files:
+  - src/ui/task-lifecycle.ts
+  - src/ui/board.ts
+  - src/ui/task-viewer-with-search.ts
+  - src/test/tui-task-lifecycle.test.ts
+priority: medium
+ordinal: 110000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Investigate GitHub Issue #697: TUI Mark as completed reportedly moves a task into completed/ without setting the task status to Done. If current, implement the smallest current-project-scope fix and focused regression tests for completion/archive behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 TUI Mark as completed does not move non-terminal tasks into completed/.
+- [x] #2 TUI Mark as completed still moves terminal-status tasks into completed/.
+- [x] #3 Related archive/completion behavior is checked for regressions without broad temporal-model changes.
+- [x] #4 Focused tests cover the fixed behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read GitHub Issue #697 and identify reported repro.
+2. Trace TUI completion and archive paths plus nearest tests.
+3. Reproduce locally with the smallest CLI/TUI-callable path.
+4. If current, apply a narrow fix and focused regression tests.
+5. Run targeted tests plus type/check as appropriate, update task, and open a PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced Issue #697 by calling the same low-level complete path previously used by the TUI: a To Do task was removed from active tasks and appeared in completed/ with status still To Do.
+Implemented a TUI-only guard so completion requires the configured terminal status before moving the task. Left the lower-level completion move intact for cleanup and already-terminal callers.
+Validation: bun test src/test/cleanup.test.ts src/test/mcp-task-complete.test.ts src/test/tui-task-lifecycle.test.ts; bunx tsc --noEmit; bunx biome check touched files. Full bun run check . currently fails only on unrelated untracked onionskin.config.json formatting. Full bun test had unrelated failures in cli-priority-filtering 5s timeout and mcp-documents timestamp expectation; mcp-documents passed in isolation, and cli-priority-filtering passed with --timeout 10000.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a shared TUI completion guard and wired both board and task-list completion shortcuts through it. Non-terminal tasks now stay active with an explanatory message; terminal-status tasks still move to completed/. Added focused regression coverage for default and custom terminal statuses.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-515 - Fix-TUI-completion-status-update.md
+++ b/backlog/tasks/back-515 - Fix-TUI-completion-status-update.md
@@ -1,5 +1,5 @@
 ---
-id: BACK-511
+id: BACK-515
 title: Fix TUI completion status update
 status: In Progress
 assignee:

--- a/src/test/tui-task-lifecycle.test.ts
+++ b/src/test/tui-task-lifecycle.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import type { Task } from "../types/index.ts";
+import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "../ui/task-lifecycle.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let core: Core;
+
+const createTask = async (task: Pick<Task, "id" | "title" | "status">) => {
+	await core.createTask(
+		{
+			...task,
+			assignee: [],
+			createdDate: "2026-07-01",
+			labels: [],
+			dependencies: [],
+			rawContent: "Test task",
+		},
+		false,
+	);
+};
+
+describe("TUI task lifecycle", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("tui-task-lifecycle");
+		await mkdir(TEST_DIR, { recursive: true });
+
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		core = new Core(TEST_DIR);
+		await initializeTestProject(core, "TUI Task Lifecycle Test");
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("does not move non-terminal tasks to completed", async () => {
+		await createTask({ id: "task-1", title: "Open task", status: "To Do" });
+		const task = await core.filesystem.loadTask("task-1");
+		expect(task).not.toBeNull();
+
+		const result = await completeTaskFromTui(core, task as Task);
+
+		expect(result).toEqual({ success: false, reason: "not-terminal", terminalStatus: "Done" });
+		expect(formatTaskCompletionBlockedMessage("TASK-1", "Done")).toBe(
+			'Task TASK-1 is not Done. Set status to "Done" before completing it.',
+		);
+		expect((await core.filesystem.loadTask("task-1"))?.status).toBe("To Do");
+		expect(await core.filesystem.listCompletedTasks()).toHaveLength(0);
+	});
+
+	it("moves terminal tasks to completed", async () => {
+		await createTask({ id: "task-1", title: "Done task", status: "Done" });
+		const task = await core.filesystem.loadTask("task-1");
+		expect(task).not.toBeNull();
+
+		const result = await completeTaskFromTui(core, task as Task);
+
+		expect(result).toEqual({ success: true });
+		expect(await core.filesystem.loadTask("task-1")).toBeNull();
+		const completedTasks = await core.filesystem.listCompletedTasks();
+		expect(completedTasks).toHaveLength(1);
+		expect(completedTasks[0]?.status).toBe("Done");
+	});
+
+	it("uses the configured terminal status", async () => {
+		const config = await core.filesystem.loadConfig();
+		if (!config) {
+			throw new Error("Expected test project config to exist");
+		}
+		await core.filesystem.saveConfig({
+			...config,
+			statuses: ["To Do", "Review", "Closed"],
+			defaultStatus: "To Do",
+		});
+
+		await createTask({ id: "task-1", title: "Review task", status: "Review" });
+		const reviewTask = await core.filesystem.loadTask("task-1");
+		expect(reviewTask).not.toBeNull();
+		expect(await completeTaskFromTui(core, reviewTask as Task)).toEqual({
+			success: false,
+			reason: "not-terminal",
+			terminalStatus: "Closed",
+		});
+
+		await createTask({ id: "task-2", title: "Closed task", status: "Closed" });
+		const closedTask = await core.filesystem.loadTask("task-2");
+		expect(closedTask).not.toBeNull();
+		expect(await completeTaskFromTui(core, closedTask as Task)).toEqual({ success: true });
+		expect((await core.filesystem.listCompletedTasks()).map((task) => task.id)).toEqual(["TASK-2"]);
+	});
+});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -19,6 +19,7 @@ import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./compo
 import { openHelpPopup } from "./components/help-popup.ts";
 import { formatFooterContent } from "./footer-content.ts";
 import { getStatusIcon } from "./status-icon.ts";
+import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-lifecycle.ts";
 import {
 	createTaskPopup,
 	resolveSearchExitTargetIndex,
@@ -1159,15 +1160,16 @@ export async function renderBoardTui(
 				if (confirmed) {
 					try {
 						const core = new Core(process.cwd(), { enableWatchers: true });
-						const config = await core.fs.loadConfig();
-						const success = await core.completeTask(task.id, config?.autoCommit ?? false);
+						const result = await completeTaskFromTui(core, task);
 
-						if (success) {
+						if (result.success) {
 							currentTasks = currentTasks.filter((t) => t.id !== task.id);
 							showTransientFooter(` {green-fg}Completed ${task.id}{/}`);
 							close();
 							popupOpen = false;
 							renderView();
+						} else if (result.reason === "not-terminal") {
+							showTransientFooter(` {red-fg}${formatTaskCompletionBlockedMessage(task.id, result.terminalStatus)}{/}`);
 						} else {
 							showTransientFooter(` {red-fg}Failed to complete ${task.id}{/}`);
 						}
@@ -1403,13 +1405,14 @@ export async function renderBoardTui(
 			if (confirmed) {
 				try {
 					const core = new Core(process.cwd(), { enableWatchers: true });
-					const config = await core.fs.loadConfig();
-					const success = await core.completeTask(task.id, config?.autoCommit ?? false);
+					const result = await completeTaskFromTui(core, task);
 
-					if (success) {
+					if (result.success) {
 						currentTasks = currentTasks.filter((t) => t.id !== task.id);
 						showTransientFooter(` {green-fg}Completed ${task.id}{/}`);
 						renderView();
+					} else if (result.reason === "not-terminal") {
+						showTransientFooter(` {red-fg}${formatTaskCompletionBlockedMessage(task.id, result.terminalStatus)}{/}`);
 					} else {
 						showTransientFooter(` {red-fg}Failed to complete ${task.id}{/}`);
 					}

--- a/src/ui/task-lifecycle.ts
+++ b/src/ui/task-lifecycle.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_STATUSES } from "../constants/index.ts";
+import type { Core } from "../core/backlog.ts";
+import type { Task } from "../types/index.ts";
+import { getTerminalStatus, isTerminalStatus } from "../utils/terminal-status.ts";
+
+export type CompleteTaskFromTuiResult =
+	| { success: true }
+	| { success: false; reason: "not-terminal"; terminalStatus: string }
+	| { success: false; reason: "failed" };
+
+export function formatTaskCompletionBlockedMessage(taskId: string, terminalStatus: string): string {
+	return `Task ${taskId} is not ${terminalStatus}. Set status to "${terminalStatus}" before completing it.`;
+}
+
+export async function completeTaskFromTui(core: Core, task: Task): Promise<CompleteTaskFromTuiResult> {
+	const config = await core.filesystem.loadConfig();
+	const statuses = config?.statuses ?? [...DEFAULT_STATUSES];
+	const terminalStatus = getTerminalStatus(statuses) ?? "Done";
+
+	if (!isTerminalStatus(task.status, statuses)) {
+		return { success: false, reason: "not-terminal", terminalStatus };
+	}
+
+	const success = await core.completeTask(task.id, config?.autoCommit ?? false);
+	return success ? { success: true } : { success: false, reason: "failed" };
+}

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -33,6 +33,7 @@ import { formatFooterContent } from "./footer-content.ts";
 import { formatHeading } from "./heading.ts";
 import { createLoadingScreen } from "./loading.ts";
 import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-icon.ts";
+import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-lifecycle.ts";
 import { addScrollKeys, createScreen } from "./tui.ts";
 
 function getPriorityDisplay(priority?: "high" | "medium" | "low"): string {
@@ -1158,16 +1159,21 @@ export async function viewTaskEnhanced(
 		}
 
 		try {
-			const config = await core.fs.loadConfig();
-			const success =
+			const config = action === "archive" ? await core.fs.loadConfig() : null;
+			const result =
 				action === "complete"
-					? await core.completeTask(task.id, config?.autoCommit ?? false)
-					: await core.archiveTask(task.id, config?.autoCommit ?? false);
+					? await completeTaskFromTui(core, task)
+					: {
+							success: await core.archiveTask(task.id, config?.autoCommit ?? false),
+							reason: "failed" as const,
+						};
 
-			if (success) {
+			if (result.success) {
 				removeTaskFromCurrentView(task.id);
 				const label = action === "complete" ? "Completed" : "Archived";
 				showTransientHelp(` {green-fg}${label} ${task.id}{/}`);
+			} else if (action === "complete" && result.reason === "not-terminal") {
+				showTransientHelp(` {red-fg}${formatTaskCompletionBlockedMessage(task.id, result.terminalStatus)}{/}`);
 			} else {
 				const verb = action === "complete" ? "complete" : "archive";
 				showTransientHelp(` {red-fg}Failed to ${verb} ${task.id}{/}`);


### PR DESCRIPTION
Alex's Agent:

Backlog task: BACK-515

Fixes #697

## Summary
- Add a shared TUI completion guard that requires the configured terminal status before moving a task to completed/.
- Wire both board and task-list completion shortcuts through that guard.
- Add focused regression tests for non-terminal tasks, terminal tasks, and custom terminal statuses.

## Root Cause
The TUI shortcuts called the low-level complete move directly. That move only relocates the task file and intentionally does not edit task status, so a non-terminal task could land in completed/.

## Validation
- bun test src/test/cleanup.test.ts src/test/mcp-task-complete.test.ts src/test/tui-task-lifecycle.test.ts
- bunx tsc --noEmit
- bunx biome check src/ui/task-lifecycle.ts src/ui/board.ts src/ui/task-viewer-with-search.ts src/test/tui-task-lifecycle.test.ts

GitHub CI is green across lint/unit, compile/smoke, and CodeQL.
