### PR TITLE
Fix task ID allocation across git worktrees

### DIFF
--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1,7 +1,7 @@
-import { rename as moveFile, unlink } from "node:fs/promises";
-import { join } from "node:path";
-import { DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
-import { FileSystem } from "../file-system/operations.ts";
+import { rename as moveFile, stat, unlink } from "node:fs/promises";
+import { isAbsolute, join, relative } from "node:path";
+import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
+import { FileSystem, isCreateLockError } from "../file-system/operations.ts";
 import { GitOperations } from "../git/operations.ts";
 import {
 	type AcceptanceCriterion,
@@ -36,7 +36,13 @@ import {
 	normalizeMilestoneFilterValue,
 	resolveClosestMilestoneFilterValue,
 } from "../utils/milestone-filter.ts";
-import { buildIdRegex, extractAnyPrefix, getPrefixForType, normalizeId } from "../utils/prefix-config.ts";
+import {
+	buildGlobPattern,
+	buildIdRegex,
+	extractAnyPrefix,
+	getPrefixForType,
+	normalizeId,
+} from "../utils/prefix-config.ts";
 import {
 	getCanonicalStatus as resolveCanonicalStatus,
 	getValidStatuses as resolveValidStatuses,
@@ -850,8 +856,71 @@ export class Core {
 	 *
 	 * This is used for ID generation to determine the next available ID.
 	 */
+	private async loadWorktreeTaskStateEntries(taskPrefix: string): Promise<BranchTaskStateEntry[]> {
+		const [repoRoot, worktreeRoots] = await Promise.all([this.git.getRepositoryRoot(), this.git.listWorktreePaths()]);
+		if (!repoRoot || worktreeRoots.length === 0) {
+			return [];
+		}
+
+		const projectRelativePath = relative(repoRoot, this.fs.rootDir);
+		if (projectRelativePath.startsWith("..") || isAbsolute(projectRelativePath)) {
+			return [];
+		}
+
+		const backlogDir = await this.getBacklogDirectoryName();
+		const entries: BranchTaskStateEntry[] = [];
+		for (const worktreeRoot of worktreeRoots) {
+			const projectRoot = projectRelativePath ? join(worktreeRoot, projectRelativePath) : worktreeRoot;
+			entries.push(...(await this.loadTaskStateEntriesFromWorktree(projectRoot, backlogDir, taskPrefix, worktreeRoot)));
+		}
+
+		return entries;
+	}
+
+	private async loadTaskStateEntriesFromWorktree(
+		projectRoot: string,
+		backlogDir: string,
+		taskPrefix: string,
+		worktreeRoot: string,
+	): Promise<BranchTaskStateEntry[]> {
+		const idRegex = buildIdRegex(taskPrefix);
+		const globPattern = buildGlobPattern(taskPrefix.toLowerCase());
+		const directories: Array<{ path: string; type: "task" | "completed" }> = [
+			{ path: join(projectRoot, backlogDir, DEFAULT_DIRECTORIES.TASKS), type: "task" },
+			{ path: join(projectRoot, backlogDir, DEFAULT_DIRECTORIES.COMPLETED), type: "completed" },
+		];
+		const entries: BranchTaskStateEntry[] = [];
+
+		for (const { path, type } of directories) {
+			let files: string[];
+			try {
+				files = await Array.fromAsync(new Bun.Glob(globPattern).scan({ cwd: path, followSymlinks: true }));
+			} catch {
+				continue;
+			}
+
+			for (const file of files) {
+				const match = file.match(idRegex);
+				if (!match?.[1]) continue;
+
+				const filePath = join(path, file);
+				const stats = await stat(filePath).catch(() => null);
+				entries.push({
+					id: normalizeId(match[1], taskPrefix),
+					type,
+					branch: `worktree:${worktreeRoot}`,
+					path: filePath,
+					lastModified: stats?.mtime ?? new Date(0),
+				});
+			}
+		}
+
+		return entries;
+	}
+
 	private async getActiveAndCompletedTaskIds(): Promise<string[]> {
 		const config = await this.fs.loadConfig();
+		const taskPrefix = config?.prefixes?.task ?? "task";
 
 		// Load local active and completed tasks
 		const localTasks = await this.listTasksWithMetadata();
@@ -885,6 +954,10 @@ export class Core {
 				lastModified,
 			});
 		}
+
+		// Same-repository worktrees share the task ID namespace even before their
+		// task files are committed, so include their filesystem state for allocation.
+		stateEntries.push(...(await this.loadWorktreeTaskStateEntries(taskPrefix)));
 
 		// If cross-branch checking is enabled, scan other branches for task states
 		if (config?.checkActiveBranches !== false) {
@@ -2244,7 +2317,43 @@ export class Core {
 	}
 
 	async promoteDraft(draftId: string, autoCommit?: boolean): Promise<boolean> {
-		const success = await this.fs.promoteDraft(draftId);
+		let success = false;
+		try {
+			success = await this.withCreateLock(async () => {
+				const draft = await this.fs.loadDraft(draftId);
+				if (!draft?.filePath) return false;
+
+				const config = await this.fs.loadConfig();
+				const newTaskId = await this.generateNextId(EntityType.Task, draft.parentTaskId);
+				const promotedStatus =
+					!draft.status || draft.status.trim().toLowerCase() === "draft"
+						? config?.defaultStatus || FALLBACK_STATUS
+						: draft.status;
+
+				const promotedTask: Task = {
+					...draft,
+					id: newTaskId,
+					status: promotedStatus,
+					filePath: undefined,
+				};
+
+				normalizeAssignee(promotedTask);
+				await this.fs.saveTask(promotedTask);
+				await unlink(draft.filePath);
+
+				const savedTask = await this.fs.loadTask(promotedTask.id);
+				if (this.contentStore && savedTask) {
+					this.contentStore.upsertTask(savedTask);
+				}
+
+				return true;
+			});
+		} catch (error) {
+			if (isCreateLockError(error)) {
+				throw error;
+			}
+			return false;
+		}
 
 		if (success && (await this.shouldAutoCommit(autoCommit))) {
 			const backlogDir = await this.getBacklogDirectoryName();

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1,5 +1,5 @@
 import { mkdir, rename, stat, unlink } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import matter from "gray-matter";
 import lockfile from "proper-lockfile";
 import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
@@ -31,6 +31,11 @@ interface CreateLockOptions {
 	timeoutMs?: number;
 	retryDelayMs?: number;
 	staleMs?: number;
+}
+
+interface CreateLockTarget {
+	targetPath: string;
+	locksDir: string;
 }
 
 const DEFAULT_CREATE_LOCK_TIMEOUT_MS = 30_000;
@@ -236,6 +241,50 @@ export class FileSystem {
 		return error instanceof Error ? error : new Error(String(error));
 	}
 
+	private async getGitCommonDir(): Promise<string | null> {
+		try {
+			const config = await this.loadConfig();
+			if (config?.filesystemOnly) {
+				return null;
+			}
+		} catch {
+			// If config cannot be read, still try git and fall back to the backlog directory on failure.
+		}
+
+		try {
+			const subprocess = Bun.spawn(["git", "rev-parse", "--git-common-dir"], {
+				cwd: this.projectRoot,
+				stdin: "ignore",
+				stdout: "pipe",
+				stderr: "ignore",
+				env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" } as Record<string, string>,
+			});
+			const stdoutPromise = subprocess.stdout ? new Response(subprocess.stdout).text() : Promise.resolve("");
+			const [exitCode, stdout] = await Promise.all([subprocess.exited, stdoutPromise]);
+			if (exitCode !== 0) return null;
+			const commonDir = stdout.trim();
+			if (!commonDir) return null;
+			return isAbsolute(commonDir) ? commonDir : resolve(this.projectRoot, commonDir);
+		} catch {
+			return null;
+		}
+	}
+
+	private async getCreateLockTarget(backlogDir: string): Promise<CreateLockTarget> {
+		const commonGitDir = await this.getGitCommonDir();
+		if (commonGitDir) {
+			return {
+				targetPath: commonGitDir,
+				locksDir: join(commonGitDir, "backlog.md", "locks"),
+			};
+		}
+
+		return {
+			targetPath: backlogDir,
+			locksDir: join(backlogDir, ".locks"),
+		};
+	}
+
 	// Uses a maintained lockfile with stale-lock recovery; USE_GLOBAL_TASK_ID_LOCK=false restores legacy behavior.
 	async withCreateLock<T>(fn: () => Promise<T>, options: CreateLockOptions = {}): Promise<T> {
 		if (process.env.USE_GLOBAL_TASK_ID_LOCK?.toLowerCase() === "false") {
@@ -243,7 +292,8 @@ export class FileSystem {
 		}
 
 		const backlogDir = await this.getBacklogDir();
-		const locksDir = join(backlogDir, ".locks");
+		const lockTarget = await this.getCreateLockTarget(backlogDir);
+		const locksDir = lockTarget.locksDir;
 		const lockDir = join(locksDir, "create");
 		const timeoutMs = options.timeoutMs ?? DEFAULT_CREATE_LOCK_TIMEOUT_MS;
 		const retryDelayMs = options.retryDelayMs ?? DEFAULT_CREATE_LOCK_RETRY_DELAY_MS;
@@ -254,7 +304,7 @@ export class FileSystem {
 
 		let release: (() => Promise<void>) | undefined;
 		try {
-			release = await lockfile.lock(backlogDir, {
+			release = await lockfile.lock(lockTarget.targetPath, {
 				lockfilePath: lockDir,
 				realpath: true,
 				stale: staleMs,

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -232,6 +232,28 @@ export class GitOperations {
 		const { stdout } = await this.execGit(["branch", "--show-current"], { readOnly: true });
 		return stdout.trim();
 	}
+
+	async getRepositoryRoot(cwd = this.projectRoot): Promise<string | null> {
+		return await this.resolveRepoRoot(cwd);
+	}
+
+	async listWorktreePaths(): Promise<string[]> {
+		if (!(await this.isRepository())) {
+			return [];
+		}
+		try {
+			const { stdout } = await this.execGit(["worktree", "list", "--porcelain"], { readOnly: true });
+			return stdout
+				.split("\n")
+				.map((line) => line.trimEnd())
+				.filter((line) => line.startsWith("worktree "))
+				.map((line) => line.slice("worktree ".length))
+				.filter(Boolean);
+		} catch {
+			return [];
+		}
+	}
+
 	async hasUncommittedChanges(): Promise<boolean> {
 		const status = await this.getStatus();
 		return status.trim() !== "";

--- a/src/test/worktree-task-id-allocation.test.ts
+++ b/src/test/worktree-task-id-allocation.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+	reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+async function createRepository(testDir: string, projectName: string): Promise<string> {
+	const mainRepo = join(testDir, "repo");
+	await mkdir(mainRepo, { recursive: true });
+	await $`git init -b main`.cwd(mainRepo).quiet();
+	await $`git config user.name "Test User"`.cwd(mainRepo).quiet();
+	await $`git config user.email test@example.com`.cwd(mainRepo).quiet();
+
+	const core = new Core(mainRepo);
+	await initializeTestProject(core, projectName, true);
+	return mainRepo;
+}
+
+async function addWorktree(mainRepo: string, testDir: string, branch: string): Promise<string> {
+	const worktree = join(testDir, "worktrees", branch);
+	await $`git worktree add ${worktree} -b ${branch}`.cwd(mainRepo).quiet();
+	return worktree;
+}
+
+describe("task ID allocation across git worktrees", () => {
+	let testDir: string;
+
+	afterEach(async () => {
+		if (testDir) {
+			await safeCleanup(testDir);
+		}
+	});
+
+	it("allocates after an uncommitted task in a sibling worktree", async () => {
+		testDir = createUniqueTestDir("worktree-task-id");
+		const mainRepo = await createRepository(testDir, "Worktree Task ID Test");
+		const sibling = await addWorktree(mainRepo, testDir, "feature-task");
+
+		const siblingCore = new Core(sibling);
+		const siblingTask = await siblingCore.createTaskFromInput({ title: "Sibling task" }, false);
+		expect(siblingTask.task.id).toBe("TASK-1");
+
+		const mainCore = new Core(mainRepo);
+		const mainTask = await mainCore.createTaskFromInput({ title: "Main task" }, false);
+
+		expect(mainTask.task.id).toBe("TASK-2");
+		expect(await mainCore.fs.loadTask("task-2")).not.toBeNull();
+	});
+
+	it("allocates promoted draft task IDs after uncommitted sibling worktree tasks", async () => {
+		testDir = createUniqueTestDir("worktree-promote-id");
+		const mainRepo = await createRepository(testDir, "Worktree Promote ID Test");
+		const sibling = await addWorktree(mainRepo, testDir, "feature-promote");
+
+		const siblingCore = new Core(sibling);
+		await siblingCore.createTaskFromInput({ title: "Sibling task" }, false);
+
+		const mainCore = new Core(mainRepo);
+		await mainCore.createTaskFromInput({ title: "Draft to promote", status: "Draft" }, false);
+		const promoted = await mainCore.promoteDraft("draft-1", false);
+
+		expect(promoted).toBe(true);
+		const promotedTask = await mainCore.fs.loadTask("task-2");
+		expect(promotedTask?.title).toBe("Draft to promote");
+	});
+
+	it("uses the same create lock for concurrent task creation in sibling worktrees", async () => {
+		testDir = createUniqueTestDir("worktree-create-lock");
+		const mainRepo = await createRepository(testDir, "Worktree Create Lock Test");
+		const sibling = await addWorktree(mainRepo, testDir, "feature-lock");
+
+		const first = new Core(mainRepo);
+		const second = new Core(sibling);
+		const firstEnteredSave = createDeferred<void>();
+		const releaseFirstSave = createDeferred<void>();
+		let saveEntries = 0;
+
+		const patchSaveTask = (core: Core) => {
+			const original = core.fs.saveTask.bind(core.fs);
+			core.fs.saveTask = (async (task: Task): Promise<string> => {
+				saveEntries += 1;
+				if (task.title === "Alpha") {
+					firstEnteredSave.resolve();
+					await releaseFirstSave.promise;
+				}
+				return await original(task);
+			}) as typeof core.fs.saveTask;
+		};
+
+		patchSaveTask(first);
+		patchSaveTask(second);
+
+		const firstCreate = first.createTaskFromInput({ title: "Alpha" }, false);
+		await firstEnteredSave.promise;
+
+		const secondCreate = second.createTaskFromInput({ title: "Beta" }, false);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(saveEntries).toBe(1);
+
+		releaseFirstSave.resolve();
+		const [createdA, createdB] = await Promise.all([firstCreate, secondCreate]);
+
+		expect(new Set([createdA.task.id, createdB.task.id]).size).toBe(2);
+		expect([createdA.task.id, createdB.task.id].sort()).toEqual(["TASK-1", "TASK-2"]);
+	});
+
+	it("preserves custom task prefixes when scanning sibling worktrees", async () => {
+		testDir = createUniqueTestDir("worktree-prefix-id");
+		const mainRepo = await createRepository(testDir, "Worktree Prefix ID Test");
+		const mainCore = new Core(mainRepo);
+		const config = await mainCore.fs.loadConfig();
+		if (!config) throw new Error("Expected initialized config");
+		config.prefixes = { task: "OPS" };
+		await mainCore.fs.saveConfig(config);
+		const repoRoot = await mainCore.gitOps.stageBacklogDirectory(mainCore.filesystem.backlogDirName);
+		await mainCore.gitOps.commitChanges("test: set custom task prefix", repoRoot);
+
+		const sibling = await addWorktree(mainRepo, testDir, "feature-prefix");
+		const siblingCore = new Core(sibling);
+		const siblingTask = await siblingCore.createTaskFromInput({ title: "Sibling task" }, false);
+		expect(siblingTask.task.id).toBe("OPS-1");
+
+		const mainTask = await mainCore.createTaskFromInput({ title: "Main task" }, false);
+		expect(mainTask.task.id).toBe("OPS-2");
+	});
+});


### PR DESCRIPTION
Alex's Agent: This PR addresses the create/allocation side of #689 by preventing duplicate task IDs across same-repository git worktrees.

## What changed
- Include active and completed task files from sibling git worktrees when generating the next task ID, including uncommitted files.
- Move the create/promote/demote lock to the git common directory when available so linked worktrees share the same create lock.
- Route Core draft promotion through the same task ID allocator used by task creation.
- Add integration coverage for uncommitted sibling worktree tasks, concurrent creates across worktrees, draft promotion, and custom task prefixes.

## Validation
- `bun run check .`
- `bunx tsc --noEmit`
- `bun test src/test/worktree-task-id-allocation.test.ts src/test/atomic-task-create.test.ts src/test/remote-id-conflict.test.ts`
- `bun test` (1356 pass, 2 skip, 0 fail)

## Notes
This does not change task listing/search behavior; it only protects create-time ID allocation. Branch and remote scanning still follow the existing configuration, while same-repository worktree files are treated as part of the creation namespace for integrity.