### PR TITLE
BACK-426 - Fix in-document markdown hash links

### DIFF
--- a/backlog/tasks/back-426 - Fix-in-document-markdown-hash-links.md
+++ b/backlog/tasks/back-426 - Fix-in-document-markdown-hash-links.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-426
 title: Fix in-document markdown hash links
-status: To Do
+status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-07-02 18:26'
 labels:
   - web-ui
   - markdown
@@ -12,6 +13,9 @@ labels:
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/529'
+modified_files:
+  - src/web/components/MermaidMarkdown.tsx
+  - src/test/mermaid-markdown.test.tsx
 priority: medium
 ---
 
@@ -23,14 +27,37 @@ Track GitHub issue #529: make links to headings within rendered documents/tasks 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Rendered markdown headings receive stable deterministic IDs.
-- [ ] #2 Links using #anchor navigate within the rendered document without leaving the current document context unexpectedly.
-- [ ] #3 Tests or browser verification cover a document with multiple heading links.
+- [x] #1 Rendered markdown headings receive stable deterministic IDs.
+- [x] #2 Links using #anchor navigate within the rendered document without leaving the current document context unexpectedly.
+- [x] #3 Tests or browser verification cover a document with multiple heading links.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inspect the shared web markdown renderer and nearby tests for existing heading/link behavior.
+2. Keep same-page hash links inside the current markdown route/context despite the document base URL.
+3. Add focused regression coverage for hash-only markdown links.
+4. Run targeted tests plus relevant type/lint checks for the touched area.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented hash-only markdown link handling in the shared MermaidMarkdown renderer by resolving href="#..." values against the current route and query string in the browser. This keeps generated heading anchors and authored heading links in the current task/document/decision route despite the app-level <base href="/">.
+
+Validation: bun test src/test/mermaid-markdown.test.tsx passed; bunx tsc --noEmit passed; bun test passed (1373 pass, 2 skip); git ls-files scoped Biome check passed for tracked configured files. Global bun run check . was also attempted but is blocked by unrelated untracked onionskin.config.json formatting outside this task.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hash-only markdown links now resolve to the current route plus hash in the web markdown renderer, so in-document heading links stay in the current rendered markdown context. Added a regression test with multiple heading links and a simulated <base href="/"> document. Verified with focused renderer tests, TypeScript, full tests, and tracked-file Biome checks; global bun run check . is blocked by unrelated untracked onionskin.config.json.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
 - [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/test/mermaid-markdown.test.tsx
+++ b/src/test/mermaid-markdown.test.tsx
@@ -1,6 +1,13 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
 import { renderToString } from "react-dom/server";
 import MermaidMarkdown from "../web/components/MermaidMarkdown.tsx";
+
+afterEach(() => {
+	delete (globalThis as { window?: Window & typeof globalThis }).window;
+	delete (globalThis as { document?: Document }).document;
+	delete (globalThis as { navigator?: Navigator }).navigator;
+});
 
 describe("MermaidMarkdown", () => {
 	it("renders angle-bracket type strings without throwing", () => {
@@ -27,5 +34,26 @@ describe("MermaidMarkdown", () => {
 
 		expect(html).toContain('href="ftp://example.com/file"');
 		expect(html).toContain('href="mailto:foo@example.com"');
+	});
+
+	it("keeps hash-only markdown links on the current route when a base href is present", () => {
+		const dom = new JSDOM("<!doctype html><html><head><base href='/'></head><body></body></html>", {
+			url: "http://localhost/tasks/BACK-426?view=detail",
+		});
+		globalThis.window = dom.window as unknown as Window & typeof globalThis;
+		globalThis.document = dom.window.document as Document;
+		globalThis.navigator = dom.window.navigator as Navigator;
+
+		const source = "# First Heading\n\n[First](#first-heading) [Second](#second-heading)\n\n## Second Heading";
+		const html = renderToString(<MermaidMarkdown source={source} />);
+		const renderedDocument = new JSDOM(html).window.document;
+		const links = Array.from(renderedDocument.querySelectorAll("p a")).map((link) => link.getAttribute("href"));
+
+		expect(renderedDocument.querySelector("#first-heading")).toBeTruthy();
+		expect(renderedDocument.querySelector("#second-heading")).toBeTruthy();
+		expect(links).toEqual([
+			"/tasks/BACK-426?view=detail#first-heading",
+			"/tasks/BACK-426?view=detail#second-heading",
+		]);
 	});
 });

--- a/src/web/components/MermaidMarkdown.tsx
+++ b/src/web/components/MermaidMarkdown.tsx
@@ -19,6 +19,14 @@ function sanitizeMarkdownSource(source: string): string {
 	});
 }
 
+function keepHashLinksInCurrentRoute(url: string, key: string): string {
+	if (key !== "href" || !url.startsWith("#") || typeof window === "undefined") {
+		return url;
+	}
+
+	return `${window.location.pathname}${window.location.search}${url}`;
+}
+
 export default function MermaidMarkdown({ source }: Props) {
 	const ref = useRef<HTMLDivElement | null>(null);
 	const safeSource = sanitizeMarkdownSource(source);
@@ -39,7 +47,7 @@ export default function MermaidMarkdown({ source }: Props) {
 
 	return (
 		<div ref={ref} className="wmde-markdown">
-			<MDEditor.Markdown source={safeSource} />
+			<MDEditor.Markdown source={safeSource} urlTransform={keepHashLinksInCurrentRoute} />
 		</div>
 	);
 }


### PR DESCRIPTION
Alex's Agent: Fixes #529.

## Summary
- Resolve hash-only markdown links against the current web route before rendering, so `<base href="/">` no longer sends in-document heading links to the app root.
- Add focused renderer coverage for multiple heading links with a simulated base href document.
- Mark BACK-426 complete with validation notes.

## Validation
- `bun test src/test/mermaid-markdown.test.tsx`
- `bunx tsc --noEmit`
- `bun test` (1373 pass, 2 skip)
- `git ls-files -z '*.json' 'src/**/*.ts' 'scripts/**/*.cjs' | xargs -0 bunx biome check`

`bun run check .` was attempted but is blocked in this worktree by unrelated untracked `onionskin.config.json` formatting outside this task.