### PR TITLE
BACK-518 - Preserve updated_date for ordinal-only task reorders

### DIFF
--- a/backlog/tasks/back-518 - Preserve-updated_date-for-ordinal-only-task-reorders.md
+++ b/backlog/tasks/back-518 - Preserve-updated_date-for-ordinal-only-task-reorders.md
@@ -1,0 +1,51 @@
+---
+id: BACK-518
+title: Preserve updated_date for ordinal-only task reorders
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-02 20:39'
+updated_date: '2026-07-02 20:46'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/684'
+priority: high
+ordinal: 113000
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Editing only a task ordinal preserves the existing updated_date value
+- [x] #2 Editing only a task ordinal does not add updated_date when it was absent
+- [x] #3 Saving ordinal changes together with any non-order task field updates updated_date normally
+- [x] #4 Board reorder and sort bulk flows preserve updated_date for ordinal-only changes
+- [x] #5 Focused regression tests cover direct and bulk reorder behavior
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Centralize updated_date stamping in Core.updateTask so ordinal-only saves restore the prior updatedDate instead of stamping now.
+2. Add focused regression coverage for direct ordinal edits, direct ordinal plus content edits, updateTasksBulk ordinal-only saves, and reorderTask same-column reorders.
+3. Run targeted tests, typecheck, and Biome checks for touched files; update Backlog task status/acceptance criteria before commit/PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented timestamp preservation in Core.updateTask by comparing persisted task fields excluding ordinal and updatedDate. Validation passed: bun test src/test/reorder-utils.test.ts; bunx tsc --noEmit; bun run check .; bun test (1379 pass, 2 skip).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Preserved updated_date for ordinal-only task saves across direct edits, bulk updates, and same-column reorder flows while keeping normal updated_date stamping for ordinal plus content/metadata edits. Added focused regression coverage and verified with targeted tests, typecheck, Biome, and the full test suite.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -113,6 +113,46 @@ export interface TuiTaskEditResult {
 	reason?: TuiTaskEditFailureReason;
 }
 
+function buildUpdatedDateComparableTask(task: Task): Record<string, unknown> {
+	return {
+		id: task.id,
+		title: task.title,
+		status: task.status,
+		assignee: task.assignee ?? [],
+		reporter: task.reporter,
+		createdDate: task.createdDate,
+		labels: task.labels ?? [],
+		milestone: task.milestone,
+		dependencies: task.dependencies ?? [],
+		references: task.references ?? [],
+		documentation: task.documentation ?? [],
+		modifiedFiles: task.modifiedFiles ?? [],
+		rawContent: task.rawContent ?? "",
+		description: task.description,
+		implementationPlan: task.implementationPlan,
+		implementationNotes: task.implementationNotes,
+		comments: task.comments ?? [],
+		finalSummary: task.finalSummary,
+		acceptanceCriteriaItems: task.acceptanceCriteriaItems ?? [],
+		definitionOfDoneItems: task.definitionOfDoneItems ?? [],
+		parentTaskId: task.parentTaskId,
+		subtasks: task.subtasks ?? [],
+		priority: task.priority,
+		onStatusChange: task.onStatusChange,
+	};
+}
+
+function hasUpdatedDateRelevantChanges(originalTask: Task | null, nextTask: Task): boolean {
+	if (!originalTask) {
+		return true;
+	}
+
+	return (
+		JSON.stringify(buildUpdatedDateComparableTask(originalTask)) !==
+		JSON.stringify(buildUpdatedDateComparableTask(nextTask))
+	);
+}
+
 function buildLatestStateMap(
 	stateEntries: BranchTaskStateEntry[] = [],
 	localTasks: Array<Task & { lastModified?: Date; updatedDate?: string }> = [],
@@ -1184,8 +1224,13 @@ export class Core {
 		const newStatus = task.status ?? "";
 		const statusChanged = oldStatus !== newStatus;
 
-		// Always set updatedDate when updating a task
-		task.updatedDate = new Date().toISOString().slice(0, 16).replace("T", " ");
+		if (hasUpdatedDateRelevantChanges(originalTask, task)) {
+			task.updatedDate = new Date().toISOString().slice(0, 16).replace("T", " ");
+		} else if (originalTask?.updatedDate) {
+			task.updatedDate = originalTask.updatedDate;
+		} else {
+			delete task.updatedDate;
+		}
 
 		await this.fs.saveTask(task);
 		// Keep any in-process ContentStore in sync for immediate UI/search freshness.

--- a/src/test/reorder-utils.test.ts
+++ b/src/test/reorder-utils.test.ts
@@ -15,7 +15,7 @@ let core: Core;
 
 const FIXED_DATE = "2025-01-01 00:00";
 
-const buildTask = (id: string, status: string, ordinal?: number): Task => ({
+const buildTask = (id: string, status: string, ordinal?: number, overrides: Partial<Task> = {}): Task => ({
 	id,
 	title: `Task ${id}`,
 	status,
@@ -24,6 +24,7 @@ const buildTask = (id: string, status: string, ordinal?: number): Task => ({
 	labels: [],
 	dependencies: [],
 	...(ordinal !== undefined ? { ordinal } : {}),
+	...overrides,
 });
 
 beforeEach(async () => {
@@ -105,17 +106,104 @@ describe("resolveOrdinalConflicts", () => {
 });
 
 describe("Core.reorderTask", () => {
-	const createTasks = async (tasks: Array<[string, string, number?]>) => {
-		for (const [id, status, ordinal] of tasks) {
-			await core.createTask(buildTask(id, status, ordinal), false);
+	const createTasks = async (tasks: Array<[string, string, number?, Partial<Task>?]>) => {
+		for (const [id, status, ordinal, overrides] of tasks) {
+			await core.createTask(buildTask(id, status, ordinal, overrides), false);
 		}
 	};
+
+	it("preserves updatedDate when editing only ordinal", async () => {
+		await core.createTask(
+			buildTask("task-1", "To Do", 1000, {
+				updatedDate: "2025-01-02 12:00",
+			}),
+			false,
+		);
+
+		await core.updateTaskFromInput("task-1", { ordinal: 2000 }, false);
+
+		const updatedTask = await core.filesystem.loadTask("task-1");
+		expect(updatedTask?.ordinal).toBe(2000);
+		expect(updatedTask?.updatedDate).toBe("2025-01-02 12:00");
+	});
+
+	it("does not add updatedDate when editing only ordinal on a task without one", async () => {
+		await core.createTask(buildTask("task-1", "To Do", 1000), false);
+
+		await core.updateTaskFromInput("task-1", { ordinal: 2000 }, false);
+
+		const updatedTask = await core.filesystem.loadTask("task-1");
+		expect(updatedTask?.ordinal).toBe(2000);
+		expect(updatedTask?.updatedDate).toBeUndefined();
+	});
+
+	it("updates updatedDate when ordinal changes with another task field", async () => {
+		await core.createTask(
+			buildTask("task-1", "To Do", 1000, {
+				updatedDate: "2025-01-02 12:00",
+			}),
+			false,
+		);
+
+		await core.updateTaskFromInput("task-1", { ordinal: 2000, title: "Updated Task" }, false);
+
+		const updatedTask = await core.filesystem.loadTask("task-1");
+		const now = new Date().toISOString().slice(0, 16).replace("T", " ");
+		expect(updatedTask?.title).toBe("Updated Task");
+		expect(updatedTask?.ordinal).toBe(2000);
+		expect(updatedTask?.updatedDate).toBe(now);
+	});
+
+	it("preserves updatedDate for ordinal-only bulk updates", async () => {
+		await createTasks([
+			[
+				"task-1",
+				"To Do",
+				1000,
+				{
+					updatedDate: "2025-01-02 12:00",
+				},
+			],
+			["task-2", "To Do", 2000],
+		]);
+
+		const task1 = await core.filesystem.loadTask("task-1");
+		const task2 = await core.filesystem.loadTask("task-2");
+		expect(task1).not.toBeNull();
+		expect(task2).not.toBeNull();
+		if (!task1 || !task2) {
+			throw new Error("Expected tasks to exist");
+		}
+
+		await core.updateTasksBulk(
+			[
+				{ ...task1, ordinal: 3000 },
+				{ ...task2, ordinal: 4000 },
+			],
+			"Sort To Do",
+			false,
+		);
+
+		const updatedTask1 = await core.filesystem.loadTask("task-1");
+		const updatedTask2 = await core.filesystem.loadTask("task-2");
+		expect(updatedTask1?.ordinal).toBe(3000);
+		expect(updatedTask1?.updatedDate).toBe("2025-01-02 12:00");
+		expect(updatedTask2?.ordinal).toBe(4000);
+		expect(updatedTask2?.updatedDate).toBeUndefined();
+	});
 
 	it("reorders within a column without touching unaffected tasks", async () => {
 		await createTasks([
 			["task-1", "To Do", 1000],
 			["task-2", "To Do", 2000],
-			["task-3", "To Do", 3000],
+			[
+				"task-3",
+				"To Do",
+				3000,
+				{
+					updatedDate: "2025-01-02 12:00",
+				},
+			],
 		]);
 
 		const result = await core.reorderTask({
@@ -130,7 +218,9 @@ describe("Core.reorderTask", () => {
 		expect(result.changedTasks.map((task) => task.id)).toEqual(["TASK-3"]);
 
 		const task2 = await core.filesystem.loadTask("task-2");
+		const task3 = await core.filesystem.loadTask("task-3");
 		expect(task2?.ordinal).toBe(2000);
+		expect(task3?.updatedDate).toBe("2025-01-02 12:00");
 	});
 
 	it("rebalances ordinals when collisions exist", async () => {


### PR DESCRIPTION
Alex's Agent: This PR keeps `updated_date` focused on meaningful task edits by preserving the existing value when only `ordinal` changes.

Fixes #684.

Summary:
- Centralizes the timestamp decision in `Core.updateTask` by comparing persisted task fields while ignoring `ordinal` and `updatedDate`.
- Preserves existing `updated_date`, including absence, for direct ordinal edits, bulk ordinal updates, and same-column reorder flows.
- Keeps normal timestamp updates when ordinal changes are saved with content or metadata edits.

Validation:
- `bun test src/test/reorder-utils.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test` (1379 pass, 2 skip)
