### PR TITLE
BACK-428 - Document npx backlog.md usage

### DIFF
--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -2,7 +2,7 @@
 
 Full command reference for Backlog.md. For getting started, see [README.md](README.md).
 
-All examples use the `backlog` command, which is available after a global install (`npm i -g backlog.md`). To run one-off commands without installing, use `npx` with the full package name — `npx backlog.md <command>`, e.g. `npx backlog.md board` (`npx backlog` fails because the npm package is named `backlog.md`).
+All examples use the `backlog` command, available after installing the `backlog.md` package globally (`npm i -g backlog.md`) or as a project dependency. For one-off runs without installing, use the full package name — `npx backlog.md <command>`, e.g. `npx backlog.md board`; without an install, `npx backlog` resolves to an unrelated third-party npm package, not this tool.
 
 ## Project Setup
 

--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -2,6 +2,8 @@
 
 Full command reference for Backlog.md. For getting started, see [README.md](README.md).
 
+All examples use the `backlog` command, which is available after a global install (`npm i -g backlog.md`). To run one-off commands without installing, use `npx` with the full package name — `npx backlog.md <command>`, e.g. `npx backlog.md board` (`npx backlog` fails because the npm package is named `backlog.md`).
+
 ## Project Setup
 
 | Action      | Example                                              |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ backlog init "My Awesome Project"
 backlog init "Personal Planning" --no-git
 ```
 
+> [!TIP]
+> **Running one-off with `npx`?** Use the full package name: `npx backlog.md init "My Project"`, `npx backlog.md board`.
+> `npx backlog <command>` fails with "could not determine executable to run" because the npm package is `backlog.md`;
+> the short `backlog` command is available after a global install.
+
 The init wizard will ask how you want to connect AI tools:
 - **CLI instructions** (recommended): creates a short instruction file that tells agents to run `backlog instructions overview`.
 - **MCP connector**: optionally auto-configures Claude Code, Codex, Gemini CLI, Kiro or Cursor for teams that prefer MCP.

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ backlog init "Personal Planning" --no-git
 ```
 
 > [!TIP]
-> **Running one-off with `npx`?** Use the full package name: `npx backlog.md init "My Project"`, `npx backlog.md board`.
-> `npx backlog <command>` fails with "could not determine executable to run" because the npm package is `backlog.md`;
-> the short `backlog` command is available after a global install.
+> **Running one-off with `npx`?** This tool's npm package is named `backlog.md`, so use the full name: `npx backlog.md init "My Project"`, `npx backlog.md board`.
+> Without an install, `npx backlog` resolves to an unrelated third-party npm package — not this tool.
+> (With `backlog.md` installed as a project dependency, `npx backlog` runs the local binary as usual.)
 
 The init wizard will ask how you want to connect AI tools:
 - **CLI instructions** (recommended): creates a short instruction file that tells agents to run `backlog instructions overview`.

--- a/backlog/tasks/back-428 - Document-npx-backlog.md-usage.md
+++ b/backlog/tasks/back-428 - Document-npx-backlog.md-usage.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-04-25 12:14'
-updated_date: '2026-07-04 13:51'
+updated_date: '2026-07-04 17:49'
 labels:
   - documentation
   - cli
@@ -38,6 +38,8 @@ Track GitHub issue #566: clarify that one-off npm execution uses the backlog.md 
 
 <!-- SECTION:NOTES:BEGIN -->
 README Getting started now has a GitHub TIP callout right after the install block explaining one-off npx usage requires the full package name (npx backlog.md init/board) and why bare npx backlog fails; global install examples untouched and clearly separated. CLI-INSTRUCTIONS.md intro now states all examples assume global install and shows npx backlog.md <command> for one-off runs. Grep verification: no 'npx backlog' (without .md) examples exist in user-facing docs; only historical completed-task records mention it, left untouched. Validation: bunx tsc --noEmit clean; biome check on src/scripts/*.json clean (305 files; note: 'bun run check .' scans 0 files inside .claude worktree paths due to gitignore-based VCS ignore, ran with explicit paths instead); scoped bun test documentation.test.ts 10/10 pass (doc-only change).
+
+Review correction: the earlier claim that bare 'npx backlog' fails with 'could not determine executable to run' was outdated — an unrelated npm package named 'backlog' (an AI-agent orchestrator) now ships a 'backlog' bin, so a no-install 'npx backlog' silently runs a different tool. Both callouts reworded: state the package is named backlog.md so one-off runs must use 'npx backlog.md <command>', warn that no-install 'npx backlog' resolves to an unrelated third-party package, and scope the warning to one-off/no-install usage (with backlog.md installed as a local project dependency, 'npx backlog' resolving node_modules/.bin remains a supported flow per BACK-252/BACK-385). Verified via 'npm view backlog': name=backlog, bin=backlog, description=AI coding agent orchestrator.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-428 - Document-npx-backlog.md-usage.md
+++ b/backlog/tasks/back-428 - Document-npx-backlog.md-usage.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-428
 title: Document npx backlog.md usage
-status: To Do
+status: Done
 assignee:
-  - '@alex-agent'
+  - '@claude'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-07-04 13:51'
 labels:
   - documentation
   - cli
@@ -22,14 +23,32 @@ Track GitHub issue #566: clarify that one-off npm execution uses the backlog.md 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 README examples show the correct npx backlog.md command form where one-off execution is documented.
-- [ ] #2 Global install and direct backlog command examples remain clearly separated.
-- [ ] #3 Documentation checks or grep verification confirm no misleading npx backlog examples remain.
+- [x] #1 README examples show the correct npx backlog.md command form where one-off execution is documented.
+- [x] #2 Global install and direct backlog command examples remain clearly separated.
+- [x] #3 Documentation checks or grep verification confirm no misleading npx backlog examples remain.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add npx one-off usage (npx backlog.md <command>) to README Getting started install section, kept separate from global-install examples. 2. Add a short npx note to CLI-INSTRUCTIONS.md. 3. Grep repo to confirm no misleading 'npx backlog' (without .md) examples remain.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+README Getting started now has a GitHub TIP callout right after the install block explaining one-off npx usage requires the full package name (npx backlog.md init/board) and why bare npx backlog fails; global install examples untouched and clearly separated. CLI-INSTRUCTIONS.md intro now states all examples assume global install and shows npx backlog.md <command> for one-off runs. Grep verification: no 'npx backlog' (without .md) examples exist in user-facing docs; only historical completed-task records mention it, left untouched. Validation: bunx tsc --noEmit clean; biome check on src/scripts/*.json clean (305 files; note: 'bun run check .' scans 0 files inside .claude worktree paths due to gitignore-based VCS ignore, ran with explicit paths instead); scoped bun test documentation.test.ts 10/10 pass (doc-only change).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Documented one-off npx usage: README Getting started gains a TIP callout showing npx backlog.md <command> (full package name) and explaining that npx backlog fails because the npm package is backlog.md; CLI-INSTRUCTIONS.md intro notes examples assume a global install and gives the npx backlog.md form. Verified via grep that no misleading npx backlog examples remain in user docs. Doc-only change; tsc + biome clean, scoped test pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->


### PR DESCRIPTION
Closes #566

## Summary
- README "Getting started": added a TIP callout right after the install block explaining that this tool's npm package is named `backlog.md`, so one-off execution must use the full name (`npx backlog.md init "My Project"`, `npx backlog.md board`). It warns that without an install, `npx backlog` resolves to an unrelated third-party npm package (an AI-agent orchestrator that ships its own `backlog` bin) — not this tool — and notes that with `backlog.md` installed as a project dependency, the local `npx backlog` binary works as usual (the supported local-dependency flow is unchanged). Global-install examples remain clearly separated.
- CLI-INSTRUCTIONS.md: intro now states all examples assume the `backlog.md` package installed globally or as a project dependency, gives the `npx backlog.md <command>` one-off form, and carries the same scoped warning about no-install `npx backlog`.
- Grep verification: no misleading `npx backlog` (without `.md`) examples remain in user-facing docs; the only mentions are historical completed-task records, left untouched.

## Verification
- `npm view backlog` confirms the unrelated package (`bin: backlog`, "Orchestrator for AI coding agents")
- `bunx tsc --noEmit` clean
- Biome check clean (ran `bunx biome check src scripts package.json biome.json` — `bun run check .` scans 0 files from inside a `.claude` worktree path due to VCS-ignore integration)
- Doc-only change; scoped `bun test src/test/documentation.test.ts` 10/10 pass