### PR TITLE
BACK-310 - Strengthen Backlog workflow overview emphasis on reading detailed guides

### DIFF
--- a/backlog/tasks/back-310 - Strengthen-Backlog-workflow-overview-emphasis-on-reading-detailed-guides.md
+++ b/backlog/tasks/back-310 - Strengthen-Backlog-workflow-overview-emphasis-on-reading-detailed-guides.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-310
 title: Strengthen Backlog workflow overview emphasis on reading detailed guides
-status: To Do
+status: In Progress
 assignee:
-  - '@codex'
+  - '@claude'
 created_date: '2025-10-27 21:37'
+updated_date: '2026-07-04 14:08'
 labels: []
 dependencies: []
 ---
@@ -26,7 +27,19 @@ Make the overview instructions more forceful and prominent about reading the sup
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The workflow overview document highlights (via formatting or callout) that contributors must read the detailed task guides before proceeding.
-- [ ] #2 The updated language adds a brief explanation of why reviewing the detailed guides is required.
-- [ ] #3 No conflicting or redundant instructions remain after the update.
+- [x] #1 The workflow overview document highlights (via formatting or callout) that contributors must read the detailed task guides before proceeding.
+- [x] #2 The updated language adds a brief explanation of why reviewing the detailed guides is required.
+- [x] #3 No conflicting or redundant instructions remain after the update.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Strengthen 'Detailed Guides' section in src/guidelines/cli-instructions/overview.md with a bold required-reading statement plus one-line rationale. 2. Mirror the emphasis in the MCP twin src/guidelines/mcp/overview.md (Detailed Guidance section) and add a matching bold line to src/guidelines/mcp/overview-tools.md; drop now-redundant trailing sentence. 3. Update the exact-string assertion in src/test/cli.test.ts. 4. Leave version-marker mechanics untouched (none present in these files). 5. Run tsc, biome, and scoped cli tests.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+CLI overview (src/guidelines/cli-instructions/overview.md): 'Detailed Guides' section now opens with a bold Required statement (read the matching guide before creating/executing/finalizing; do not rely on the overview alone) plus a one-line rationale (overview says when, guides define the required procedure; skipping them produces inconsistent tasks and metadata). MCP twin (src/guidelines/mcp/overview.md): same emphasis in 'Detailed Guidance (Required)'; dropped the now-redundant trailing sentence 'These guides contain critical workflows...'. Tools-only variant (src/guidelines/mcp/overview-tools.md): added the matching bold requirement after the get_backlog_instructions explanation. Updated the exact-string assertion in src/test/cli.test.ts. No version-marker mechanics exist in these files; none touched.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-310 - Strengthen-Backlog-workflow-overview-emphasis-on-reading-detailed-guides.md
+++ b/backlog/tasks/back-310 - Strengthen-Backlog-workflow-overview-emphasis-on-reading-detailed-guides.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-310
 title: Strengthen Backlog workflow overview emphasis on reading detailed guides
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2025-10-27 21:37'
-updated_date: '2026-07-04 14:08'
+updated_date: '2026-07-04 17:50'
 labels: []
 dependencies: []
 ---
@@ -42,4 +42,14 @@ Make the overview instructions more forceful and prominent about reading the sup
 
 <!-- SECTION:NOTES:BEGIN -->
 CLI overview (src/guidelines/cli-instructions/overview.md): 'Detailed Guides' section now opens with a bold Required statement (read the matching guide before creating/executing/finalizing; do not rely on the overview alone) plus a one-line rationale (overview says when, guides define the required procedure; skipping them produces inconsistent tasks and metadata). MCP twin (src/guidelines/mcp/overview.md): same emphasis in 'Detailed Guidance (Required)'; dropped the now-redundant trailing sentence 'These guides contain critical workflows...'. Tools-only variant (src/guidelines/mcp/overview-tools.md): added the matching bold requirement after the get_backlog_instructions explanation. Updated the exact-string assertion in src/test/cli.test.ts. No version-marker mechanics exist in these files; none touched.
+
+Validation: bunx tsc --noEmit clean; biome check clean (explicit paths, 305 files; 'bun run check .' scans 0 files from inside a .claude worktree path due to VCS-ignore integration); bun test src/test/cli.test.ts 95/95; MCP + build tests 18/18; full bun test 1363 pass with only pre-existing flaky failures unrelated to this diff (cli-priority-filtering timeout flake passes in isolation 11/11).
+
+Review follow-up: dropped an accidentally committed regenerated src/web/styles/style.css (test runs rebuild web assets; churn removed from the branch, css untouched now). Trimmed the now-redundant sentence 'The detailed guides contain the procedure for creating, executing, and finalizing tasks.' from Start Every Request Here since the Detailed Guides callout carries that message, and extended the cli.test.ts assertion to cover the full Required statement including the rationale sentence plus a negative assertion that the trimmed sentence is gone.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made the read-the-detailed-guides requirement impossible to miss in the workflow overview: bold Required callout plus one-line rationale in the CLI overview's Detailed Guides section, mirrored in the MCP overview's Detailed Guidance section and the MCP tools-only overview; removed the now-redundant trailing sentence in the MCP overview. Updated the matching exact-string assertion in src/test/cli.test.ts. No version-marker mechanics touched (none exist in these files). Verified with tsc, biome, cli/MCP/build test suites.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/guidelines/cli-instructions/overview.md
+++ b/src/guidelines/cli-instructions/overview.md
@@ -27,7 +27,7 @@ Search and read before changing anything:
 
 ### Detailed Guides
 
-Always read the relevant guide before that part of the workflow. Do not rely on this overview alone for these actions:
+**Required: read the matching guide below before creating, executing, or finalizing tasks. Do not rely on this overview alone for these actions.** The overview only tells you when to act; the guides define the required procedure, and skipping them produces inconsistent tasks and metadata.
 
 - `backlog instructions task-creation`
   -> Read before creating tasks: how to search, scope, and create tasks

--- a/src/guidelines/cli-instructions/overview.md
+++ b/src/guidelines/cli-instructions/overview.md
@@ -15,7 +15,7 @@ Create tasks for work like bug fixes that need investigation, feature work, API 
 
 ### Start Every Request Here
 
-Use this overview to decide what to read or run next. The detailed guides contain the procedure for creating, executing, and finalizing tasks.
+Use this overview to decide what to read or run next.
 
 Search and read before changing anything:
 

--- a/src/guidelines/mcp/overview-tools.md
+++ b/src/guidelines/mcp/overview-tools.md
@@ -29,6 +29,8 @@ Use this tool to retrieve the required Backlog.md guidance in markdown form:
 
 The tool returns the same content that resource-capable clients read via `backlog://workflow/...` URIs. The overview response is tool-oriented when `instruction` is omitted or set to `overview`.
 
+**Required: fetch and read the matching guide (`task-creation`, `task-execution`, `task-finalization`) before creating, executing, or finalizing tasks — do not act from this overview alone.** The guides define the required procedure; skipping them produces inconsistent tasks and metadata.
+
 ### Typical Workflow (Tools)
 
 1. **Search first:** call `task_search` or `task_list` with filters to find existing work

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -36,13 +36,11 @@ Searching first avoids duplicate tasks and helps you understand existing context
 
 ### Detailed Guidance (Required)
 
-Read these resources to get essential instructions when:
+**Read the matching resource below before creating, executing, or finalizing tasks — do not act from this overview alone.** The overview only tells you when to act; these resources define the required procedure, and skipping them produces inconsistent tasks and metadata.
 
 - **Creating tasks** → `backlog://workflow/task-creation` - Scope assessment, acceptance criteria, parent/subtasks structure
 - **Planning & executing work** → `backlog://workflow/task-execution` - Planning workflow, implementation discipline, scope changes
 - **Finalizing tasks** → `backlog://workflow/task-finalization` - Definition of Done, finalization checklist, next steps
-
-These guides contain critical workflows you need to follow for proper task management.
 
 ### Core Principle
 

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -105,7 +105,7 @@ describe("CLI Integration", () => {
 			expect(overview).toContain('backlog task list --search "login" --labels frontend,bug --limit 20 --plain');
 			expect(overview).toContain("backlog task view BACK-123 --plain");
 			expect(overview).toContain(
-				"Always read the relevant guide before that part of the workflow. Do not rely on this overview alone for these actions:",
+				"**Required: read the matching guide below before creating, executing, or finalizing tasks. Do not rely on this overview alone for these actions.**",
 			);
 			expect(overview).toContain(
 				"`backlog instructions task-creation`\n  -> Read before creating tasks: how to search, scope, and create tasks",

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -98,14 +98,13 @@ describe("CLI Integration", () => {
 
 			expect(overview).toContain("## Backlog.md Overview (CLI)");
 			expect(overview).toContain("### Start Every Request Here");
-			expect(overview).toContain(
-				"Use this overview to decide what to read or run next. The detailed guides contain the procedure for creating, executing, and finalizing tasks.",
-			);
+			expect(overview).toContain("Use this overview to decide what to read or run next.");
+			expect(overview).not.toContain("The detailed guides contain the procedure");
 			expect(overview).toContain('backlog search "query" --plain');
 			expect(overview).toContain('backlog task list --search "login" --labels frontend,bug --limit 20 --plain');
 			expect(overview).toContain("backlog task view BACK-123 --plain");
 			expect(overview).toContain(
-				"**Required: read the matching guide below before creating, executing, or finalizing tasks. Do not rely on this overview alone for these actions.**",
+				"**Required: read the matching guide below before creating, executing, or finalizing tasks. Do not rely on this overview alone for these actions.** The overview only tells you when to act; the guides define the required procedure, and skipping them produces inconsistent tasks and metadata.",
 			);
 			expect(overview).toContain(
 				"`backlog instructions task-creation`\n  -> Read before creating tasks: how to search, scope, and create tasks",


### PR DESCRIPTION
## Summary
Makes the "read the detailed guide before creating/executing/finalizing tasks" requirement prominent in all three workflow overviews, with a one-line rationale:

- `src/guidelines/cli-instructions/overview.md` — the "Detailed Guides" section now opens with a bold **Required** statement (read the matching guide first; do not rely on this overview alone) plus the rationale: the overview only says *when* to act, the guides define the required procedure, and skipping them produces inconsistent tasks and metadata. The now-redundant sentence in "Start Every Request Here" ("The detailed guides contain the procedure…") is trimmed so the message lives in one place.
- `src/guidelines/mcp/overview.md` — same emphasis applied to "Detailed Guidance (Required)"; dropped the now-redundant trailing sentence ("These guides contain critical workflows…").
- `src/guidelines/mcp/overview-tools.md` — matching bold requirement added after the `get_backlog_instructions` explanation for tools-only clients.
- `src/test/cli.test.ts` — assertions updated in sync: the full Required statement including the rationale sentence is asserted, plus a negative assertion that the trimmed sentence is gone.

Wording only — no version-marker mechanics exist in these files and none were introduced. An accidentally committed regenerated `src/web/styles/style.css` (build-test churn) was removed from the branch; the diff is now only the instruction/test files plus the Backlog task metadata.

## Verification
- `bunx tsc --noEmit` clean
- Biome clean (`bunx biome check src scripts package.json biome.json` — `bun run check .` scans 0 files from inside a `.claude` worktree path due to VCS-ignore integration)
- `bun test src/test/cli.test.ts` 95/95 after rebase onto current main; MCP/build suites 18/18
- Full `bun test`: 1363 pass; only pre-existing flaky failures unrelated to this diff (e.g. `cli-priority-filtering` 5s-timeout flake, passes 11/11 in isolation)