### PR TITLE
BACK-259 BACK-415 BACK-416 - Close already-implemented tasks with evidence

### DIFF
--- a/backlog/tasks/back-259 - Add-task-list-filters-for-Status-and-Priority.md
+++ b/backlog/tasks/back-259 - Add-task-list-filters-for-Status-and-Priority.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-259
 title: Add task list filters for Status and Priority
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2025-09-06 23:39'
+updated_date: '2026-07-04 14:11'
 labels:
   - tui
   - filters
@@ -14,19 +16,33 @@ priority: medium
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Add two filter selectors in the Task List view:
 
 - Status filter: choose from configured statuses (To Do, In Progress, Done or custom)
 - Priority filter: choose from high, medium, low
 
 The filters should be accessible from the task list pane and update the list immediately. Keep controls minimal to match the simplified footer.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Status filter is available in the task list and lists statuses from backlog/config.yml
-- [ ] #2 Priority filter is available in the task list and lists: high, medium, low
-- [ ] #3 Applying a filter updates the task list immediately and can be cleared to show all tasks
-- [ ] #4 Filters persist during the current TUI session and reset on exit
-- [ ] #5 Works alongside existing navigation; minimal footer remains uncluttered
-- [ ] #6 Tests cover filtering logic for status and priority; type-check and lint pass
+- [x] #1 Status filter is available in the task list and lists statuses from backlog/config.yml
+- [x] #2 Priority filter is available in the task list and lists: high, medium, low
+- [x] #3 Applying a filter updates the task list immediately and can be cleared to show all tasks
+- [x] #4 Filters persist during the current TUI session and reset on exit
+- [x] #5 Works alongside existing navigation; minimal footer remains uncluttered
+- [x] #6 Tests cover filtering logic for status and priority; type-check and lint pass
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Already implemented on main as of commit d0f3cff; closing with evidence instead of re-implementing. Evidence: src/ui/components/filter-header.ts provides the TUI filter header with status and priority controls (FilterControlId includes status/priority; buttons show 'All' when cleared). src/ui/task-viewer-with-search.ts wires it into the task list: statuses come from config (statuses = config?.statuses || defaults, ~line 217), priority choices are high/medium/low (~line 368), selections call applyFilters() immediately, and the 'All' choice (empty value) clears a filter; filter state is in-memory TUI session state so it resets on exit and coexists with existing navigation. Tests: src/test/filter-header-navigation.test.ts (filter header navigation), src/test/unified-view-filters.test.ts (status/priority filtering logic via createUnifiedViewFilters/applyTaskFilters), src/test/cli-priority-filtering.test.ts. Type-check and lint pass on main.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+No code change needed: TUI task list already ships status and priority filters (config-driven statuses, high/medium/low priorities, instant apply, clearable via 'All', session-scoped state) with test coverage. Closed as already implemented on main (d0f3cff).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-415 - Add-CLI-milestone-create-command.md
+++ b/backlog/tasks/back-415 - Add-CLI-milestone-create-command.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-415
 title: Add CLI milestone create command
-status: To Do
+status: Done
 assignee:
-  - '@alex-agent'
+  - '@claude'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-07-04 14:11'
 labels:
   - cli
   - milestones
@@ -23,15 +24,27 @@ Track GitHub issue #232: provide a public CLI path for creating milestones, usin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A CLI milestone create command creates a milestone using the current milestone storage model.
-- [ ] #2 Duplicate milestone names or IDs are rejected with a clear error.
-- [ ] #3 Created milestones appear in milestone list and existing milestone-aware views.
-- [ ] #4 Tests cover successful creation and duplicate validation.
+- [x] #1 A CLI milestone create command creates a milestone using the current milestone storage model.
+- [x] #2 Duplicate milestone names or IDs are rejected with a clear error.
+- [x] #3 Created milestones appear in milestone list and existing milestone-aware views.
+- [x] #4 Tests cover successful creation and duplicate validation.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Already implemented on main as of commit d0f3cff; closing with evidence instead of re-implementing. Evidence: 'backlog milestone add <name>' with -d/--description exists in src/cli.ts (~line 3261, with help schema and examples) and creates a milestone markdown file in the active milestones directory via the shared MilestoneHandlers.addMilestone (src/mcp/tools/milestones/handlers.ts ~line 343), which rejects duplicate names/alias conflicts with a clear error ('Milestone alias conflict: ...', ~line 358). Created milestones use the current milestone file storage model and appear in 'backlog milestone list' and milestone-aware views. Documented in CLI-INSTRUCTIONS.md milestone table. Tests: src/test/cli-milestone-management.test.ts covers 'adds milestone files with descriptions and rejects duplicate aliases', auto-commit behavior, and CLI/MCP handler parity. DoD: no code touched for this closure; tsc/biome/tests verified passing on main during triage.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+No code change needed: 'backlog milestone add' already exists with duplicate/alias validation, milestone-file storage, list integration, and test coverage. Closed as already implemented on main (d0f3cff). Tracks GitHub issue #232.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/backlog/tasks/back-416 - Add-full-content-task-view-output-mode.md
+++ b/backlog/tasks/back-416 - Add-full-content-task-view-output-mode.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-04-25 12:14'
-updated_date: '2026-07-04 14:11'
+updated_date: '2026-07-04 17:52'
 labels:
   - cli
   - task-view
@@ -33,6 +33,8 @@ Track GitHub issue #289: add an output mode for viewing full task content when -
 
 <!-- SECTION:NOTES:BEGIN -->
 Already implemented on main as of commit d0f3cff; closing with evidence instead of re-implementing. Evidence: 'backlog task view <id> --plain' outputs all structured sections in full with no truncation via formatTaskPlainText (src/formatters/task-plain-text.ts): metadata header, description, acceptance criteria, Definition of Done, implementation plan, implementation notes, comments, and final summary. Markdown headings inside section content are preserved because structured-section extraction (src/markdown/structured-sections.ts) only stops at known structured section headers, so custom '## ...'/'### ...' headings stay inside their section. Tests covering markdown headings inside content sections: src/test/update-task-description.test.ts ('### Subsection' preserved in implementation notes while editing description), src/test/implementation-notes.test.ts ('preserves nested H2 headings when migrating legacy implementation notes'), src/test/acceptance-criteria.test.ts ('preserves markdown headings inside acceptance criteria when updating'). Plain output shape is asserted stable in src/test/cli.test.ts. DoD: no code touched for this closure; tsc/biome/tests verified passing on main during triage.
+
+Citation correction (review): plain output shape stability is asserted in src/test/cli-plain-output.test.ts (CLI plain output for AI agents, incl. 'task view --plain'), not src/test/cli.test.ts as previously written.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-416 - Add-full-content-task-view-output-mode.md
+++ b/backlog/tasks/back-416 - Add-full-content-task-view-output-mode.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-416
 title: Add full-content task view output mode
-status: To Do
+status: Done
 assignee:
-  - '@alex-agent'
+  - '@claude'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-07-04 14:11'
 labels:
   - cli
   - task-view
@@ -23,14 +24,26 @@ Track GitHub issue #289: add an output mode for viewing full task content when -
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A task view option outputs the full markdown content or all structured sections without truncation.
-- [ ] #2 Existing plain output remains stable unless explicitly documented otherwise.
-- [ ] #3 Tests cover tasks containing markdown headings inside content sections.
+- [x] #1 A task view option outputs the full markdown content or all structured sections without truncation.
+- [x] #2 Existing plain output remains stable unless explicitly documented otherwise.
+- [x] #3 Tests cover tasks containing markdown headings inside content sections.
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Already implemented on main as of commit d0f3cff; closing with evidence instead of re-implementing. Evidence: 'backlog task view <id> --plain' outputs all structured sections in full with no truncation via formatTaskPlainText (src/formatters/task-plain-text.ts): metadata header, description, acceptance criteria, Definition of Done, implementation plan, implementation notes, comments, and final summary. Markdown headings inside section content are preserved because structured-section extraction (src/markdown/structured-sections.ts) only stops at known structured section headers, so custom '## ...'/'### ...' headings stay inside their section. Tests covering markdown headings inside content sections: src/test/update-task-description.test.ts ('### Subsection' preserved in implementation notes while editing description), src/test/implementation-notes.test.ts ('preserves nested H2 headings when migrating legacy implementation notes'), src/test/acceptance-criteria.test.ts ('preserves markdown headings inside acceptance criteria when updating'). Plain output shape is asserted stable in src/test/cli.test.ts. DoD: no code touched for this closure; tsc/biome/tests verified passing on main during triage.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+No code change needed: --plain already emits the full task content (all structured sections, untruncated, headings preserved) with test coverage, satisfying the full-content output mode request. Closed as already implemented on main (d0f3cff). Tracks GitHub issue #289.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->


### PR DESCRIPTION
Task hygiene: these tasks were triaged as already implemented on main. Each cited evidence path was re-verified before closing; all metadata edits were made via the backlog CLI (ACs/DoD checked, implementation notes citing evidence files, final summary, status Done).

## Closed (verified already implemented on main as of d0f3cff)

**BACK-259 — TUI task list filters for Status and Priority**
`src/ui/components/filter-header.ts` (status/priority filter controls) wired into the task list by `src/ui/task-viewer-with-search.ts`: statuses come from config (`config?.statuses`, ~line 217), priorities are high/medium/low (~line 368), selections apply instantly, "All" clears, state is session-scoped. Tests: `src/test/filter-header-navigation.test.ts`, `src/test/unified-view-filters.test.ts`, `src/test/cli-priority-filtering.test.ts`.

**BACK-415 — `backlog milestone add`**
Exists in `src/cli.ts` (~line 3261) with `-d/--description`, backed by `MilestoneHandlers.addMilestone` (`src/mcp/tools/milestones/handlers.ts` ~line 343) which rejects duplicate/alias conflicts with a clear error; created milestones use the milestone-file storage model and appear in `milestone list`. Tests: `src/test/cli-milestone-management.test.ts` (creation + duplicate rejection + CLI/MCP parity). Tracks issue #232.

**BACK-416 — full-content `task view --plain` output**
`src/formatters/task-plain-text.ts` emits every structured section untruncated (description, AC, DoD, plan, notes, comments, final summary); `src/markdown/structured-sections.ts` extraction only stops at known section headers, so custom markdown headings stay inside their sections. Heading-in-content tests: `src/test/update-task-description.test.ts`, `src/test/implementation-notes.test.ts`, `src/test/acceptance-criteria.test.ts`. Tracks issue #289.

## Not closed

**BACK-260 — Web All Tasks filters** was also triaged as done, but verification failed on AC #3: the All Tasks view (`src/web/components/TaskList.tsx`) has status/priority/label/milestone filters with URL-param persistence and a Clear control, but no text-search filter on the page (text search exists only as the global sidebar search, without URL persistence). Left untouched per honest-closure policy.

## Verification
- `bunx tsc --noEmit` clean; Biome clean (`bunx biome check src scripts package.json biome.json`, 305 files — `bun run check .` scans 0 files from inside a `.claude` worktree path due to VCS-ignore integration)
- Scoped tests over the cited evidence suites: 65/65 pass (filter-header-navigation, unified-view-filters, cli-milestone-management, update-task-description, implementation-notes, acceptance-criteria)
- Task-metadata-only change (no source code touched)