### PR TITLE
BACK-355.01 - Core: Add type field to task domain model and persistence

### DIFF
--- a/backlog/tasks/back-355 - Add-task-type-field-bug-feature-enhancement-etc..md
+++ b/backlog/tasks/back-355 - Add-task-type-field-bug-feature-enhancement-etc..md
@@ -4,6 +4,7 @@ title: 'Add task type field (bug, feature, enhancement, etc.)'
 status: To Do
 assignee: []
 created_date: '2026-01-01 23:37'
+updated_date: '2026-07-04 17:50'
 labels:
   - enhancement
   - core
@@ -22,14 +23,14 @@ Add a mutually exclusive 'type' field to tasks that categorizes them semanticall
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Task domain model includes optional type field with values: bug, feature, enhancement, task (default), chore, docs, spike
-- [ ] #2 Task types are configurable per-project in config.yml with sensible defaults
-- [ ] #3 CLI task create and task edit commands support --type flag
-- [ ] #4 MCP task_create and task_edit tools include type parameter
-- [ ] #5 TUI board displays task type with visual distinction (icon or badge)
-- [ ] #6 Web UI displays task type in task cards and detail view
-- [ ] #7 Task list and search support type-based filtering (--type flag)
-- [ ] #8 Existing tasks without type field default to 'task' type
-- [ ] #9 Type validation ensures value is one of the configured types
-- [ ] #10 Type field persists in task markdown YAML frontmatter
+- [ ] #1 Task types are configurable per-project in config.yml with sensible defaults
+- [ ] #2 CLI task create and task edit commands support --type flag
+- [ ] #3 MCP task_create and task_edit tools include type parameter
+- [ ] #4 TUI board displays task type with visual distinction (icon or badge)
+- [ ] #5 Web UI displays task type in task cards and detail view
+- [ ] #6 Task list and search support type-based filtering (--type flag)
+- [ ] #7 Type validation ensures value is one of the configured types
+- [ ] #8 Type field persists in task markdown YAML frontmatter
+- [ ] #9 Task domain model includes an optional 'type' field; default allowed set: bug, feature, enhancement, task, chore, docs, spike (project-overridable via the 'types' config key)
+- [ ] #10 Existing tasks without a 'type' field stay untyped: the parser leaves type undefined, display surfaces show no type badge/value for them, and there is no retroactive defaulting or migration
 <!-- AC:END -->

--- a/backlog/tasks/back-355.01 - Core-Add-type-field-to-task-domain-model-and-persistence.md
+++ b/backlog/tasks/back-355.01 - Core-Add-type-field-to-task-domain-model-and-persistence.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-355.01
 title: 'Core: Add type field to task domain model and persistence'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@alex-agent'
 created_date: '2026-01-01 23:37'
+updated_date: '2026-07-04 14:05'
 labels:
   - core
 dependencies: []
@@ -19,11 +21,39 @@ Add the foundational type field to the Task interface and implement persistence 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Task interface includes optional 'type' field with union type: 'bug' | 'feature' | 'enhancement' | 'task' | 'chore' | 'docs' | 'spike'
-- [ ] #2 TaskCreateInput and TaskUpdateInput interfaces include type field
-- [ ] #3 Task parser reads type from YAML frontmatter (defaults to 'task' if missing)
-- [ ] #4 Task writer persists type to YAML frontmatter
-- [ ] #5 BacklogConfig interface includes 'types' array for project-level customization
-- [ ] #6 Default types array is defined in config defaults
-- [ ] #7 Unit tests verify type field CRUD operations
+- [x] #1 Task interface includes optional 'type' field with union type: 'bug' | 'feature' | 'enhancement' | 'task' | 'chore' | 'docs' | 'spike'
+- [x] #2 TaskCreateInput and TaskUpdateInput interfaces include type field
+- [x] #3 Task parser reads type from YAML frontmatter (defaults to 'task' if missing)
+- [x] #4 Task writer persists type to YAML frontmatter
+- [x] #5 BacklogConfig interface includes 'types' array for project-level customization
+- [x] #6 Default types array is defined in config defaults
+- [x] #7 Unit tests verify type field CRUD operations
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add optional type?: string to Task, TaskCreateInput, TaskUpdateInput (string, not closed union, because the allowed set is config-overridable; mirrors TaskStatus).
+2. Add DEFAULT_TASK_TYPES constant (bug, feature, enhancement, task, chore, docs, spike) next to DEFAULT_STATUSES.
+3. Add optional types?: string[] to BacklogConfig; parse/serialize 'types: [...]' in config.yml mirroring the statuses key (absent key = defaults, no config migration).
+4. Parser: read frontmatter 'type' as optional string (absent stays undefined - untyped, per approved design; no 'task' default injection).
+5. Serializer: emit 'type' in frontmatter next to priority, omitted when unset.
+6. Core validation on write: normalizeTaskType helper (mirrors normalizePriority + canonical-casing match like statuses) used by createTaskFromInput and applyTaskUpdateInput; clear error listing allowed values; empty string clears the field. Include type in updated_date relevance comparison.
+7. Tests: CRUD round-trip, validation failure, config override, absent-field back-compat, config round-trip.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Core implementation complete: Task/TaskCreateInput/TaskUpdateInput.type (optional string), DEFAULT_TASK_TYPES constant, BacklogConfig.types + config.yml 'types' key (parse/serialize), frontmatter 'type' parse/serialize next to priority, normalizeTaskType write validation (canonical casing, clear error listing allowed values, empty string clears), type included in updated_date relevance check. 12 unit tests in src/test/task-type.test.ts covering CRUD round-trip, validation failure, config override, and absent-field back-compat.
+<!-- SECTION:NOTES:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @alex-agent
+created: 2026-07-04 14:05
+---
+Implementation note on ACs 1 and 3, per the approved BACK-355 design review: the allowed type set is project-configurable (config key 'types'), so Task.type is an optional string validated on write against the configured set (DEFAULT_TASK_TYPES fallback: bug, feature, enhancement, task, chore, docs, spike) rather than a closed TS union; and a missing 'type' key stays undefined (untyped) instead of defaulting to 'task' - no migration of existing tasks. Frontmatter key: 'type'.
+---
+<!-- COMMENTS:END -->

--- a/backlog/tasks/back-355.01 - Core-Add-type-field-to-task-domain-model-and-persistence.md
+++ b/backlog/tasks/back-355.01 - Core-Add-type-field-to-task-domain-model-and-persistence.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-01-01 23:37'
-updated_date: '2026-07-04 14:15'
+updated_date: '2026-07-04 17:49'
 labels:
   - core
 dependencies: []
@@ -21,13 +21,13 @@ Add the foundational type field to the Task interface and implement persistence 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 Task interface includes optional 'type' field with union type: 'bug' | 'feature' | 'enhancement' | 'task' | 'chore' | 'docs' | 'spike'
-- [x] #2 TaskCreateInput and TaskUpdateInput interfaces include type field
-- [x] #3 Task parser reads type from YAML frontmatter (defaults to 'task' if missing)
-- [x] #4 Task writer persists type to YAML frontmatter
-- [x] #5 BacklogConfig interface includes 'types' array for project-level customization
-- [x] #6 Default types array is defined in config defaults
-- [x] #7 Unit tests verify type field CRUD operations
+- [x] #1 TaskCreateInput and TaskUpdateInput interfaces include type field
+- [x] #2 Task writer persists type to YAML frontmatter
+- [x] #3 BacklogConfig interface includes 'types' array for project-level customization
+- [x] #4 Default types array is defined in config defaults
+- [x] #5 Unit tests verify type field CRUD operations
+- [x] #6 Task interface includes optional 'type' field as a string validated on write against the configured allowed set (default DEFAULT_TASK_TYPES: bug, feature, enhancement, task, chore, docs, spike)
+- [x] #7 Task parser reads 'type' from YAML frontmatter; an absent key stays undefined (untyped) - no default injection and no migration of existing tasks
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -48,6 +48,8 @@ Add the foundational type field to the Task interface and implement persistence 
 Core implementation complete: Task/TaskCreateInput/TaskUpdateInput.type (optional string), DEFAULT_TASK_TYPES constant, BacklogConfig.types + config.yml 'types' key (parse/serialize), frontmatter 'type' parse/serialize next to priority, normalizeTaskType write validation (canonical casing, clear error listing allowed values, empty string clears), type included in updated_date relevance check. 12 unit tests in src/test/task-type.test.ts covering CRUD round-trip, validation failure, config override, and absent-field back-compat.
 
 Validation: bunx tsc --noEmit clean; biome check clean; full bun test 1390 pass / 1 fail - the single failure (CLI Priority Filtering > case insensitive priority filtering, 5s timeout) reproduces identically on a pristine origin/main worktree, so it is a pre-existing flake unrelated to this change. End-to-end sanity check against a real scratch project confirmed create/edit/reject and config.yml 'types' override behavior.
+
+Config edge-case note: an empty 'types: []' in config.yml behaves as 'use DEFAULT_TASK_TYPES' (validation falls back to defaults and serializeConfig omits the empty key), unlike 'statuses: []' which is preserved as configured. Intentional: an empty allowed-type set would make every typed write invalid. AC texts for #1/#3 (now #6/#7 after amendment) were updated to match the approved design (validated string + absent-stays-untyped) instead of the original closed-union/default-to-task wording.
 <!-- SECTION:NOTES:END -->
 
 ## Comments

--- a/backlog/tasks/back-355.01 - Core-Add-type-field-to-task-domain-model-and-persistence.md
+++ b/backlog/tasks/back-355.01 - Core-Add-type-field-to-task-domain-model-and-persistence.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-355.01
 title: 'Core: Add type field to task domain model and persistence'
-status: In Progress
+status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-01-01 23:37'
-updated_date: '2026-07-04 14:05'
+updated_date: '2026-07-04 14:15'
 labels:
   - core
 dependencies: []
@@ -46,6 +46,8 @@ Add the foundational type field to the Task interface and implement persistence 
 
 <!-- SECTION:NOTES:BEGIN -->
 Core implementation complete: Task/TaskCreateInput/TaskUpdateInput.type (optional string), DEFAULT_TASK_TYPES constant, BacklogConfig.types + config.yml 'types' key (parse/serialize), frontmatter 'type' parse/serialize next to priority, normalizeTaskType write validation (canonical casing, clear error listing allowed values, empty string clears), type included in updated_date relevance check. 12 unit tests in src/test/task-type.test.ts covering CRUD round-trip, validation failure, config override, and absent-field back-compat.
+
+Validation: bunx tsc --noEmit clean; biome check clean; full bun test 1390 pass / 1 fail - the single failure (CLI Priority Filtering > case insensitive priority filtering, 5s timeout) reproduces identically on a pristine origin/main worktree, so it is a pre-existing flake unrelated to this change. End-to-end sanity check against a real scratch project confirmed create/edit/reject and config.yml 'types' override behavior.
 <!-- SECTION:NOTES:END -->
 
 ## Comments
@@ -57,3 +59,9 @@ created: 2026-07-04 14:05
 Implementation note on ACs 1 and 3, per the approved BACK-355 design review: the allowed type set is project-configurable (config key 'types'), so Task.type is an optional string validated on write against the configured set (DEFAULT_TASK_TYPES fallback: bug, feature, enhancement, task, chore, docs, spike) rather than a closed TS union; and a missing 'type' key stays undefined (untyped) instead of defaulting to 'task' - no migration of existing tasks. Frontmatter key: 'type'.
 ---
 <!-- COMMENTS:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added optional 'type' to the task domain model with frontmatter persistence and write-time validation. Task/TaskCreateInput/TaskUpdateInput gained type (string; the allowed set is config-overridable so no closed union), DEFAULT_TASK_TYPES (bug, feature, enhancement, task, chore, docs, spike) added to constants, BacklogConfig.types + config.yml 'types' key parse/serialize mirroring statuses, frontmatter 'type' parsed/serialized next to priority (absent stays untyped, no migration), normalizeTaskType validates create/edit input with canonical casing and a clear error listing allowed values (empty string clears), and type participates in updated_date change detection. Verified with 12 new unit tests (CRUD round-trip, validation failure, config override, back-compat) plus tsc/biome/full suite.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -51,6 +51,11 @@ export const DEFAULT_STATUSES = ["To Do", "In Progress", "Done"] as const;
 export const FALLBACK_STATUS = "To Do";
 
 /**
+ * Default task types, used when no `types` are configured
+ */
+export const DEFAULT_TASK_TYPES = ["bug", "feature", "enhancement", "task", "chore", "docs", "spike"] as const;
+
+/**
  * Maximum width for wrapped text lines in UI components
  */
 export const WRAP_LIMIT = 72;

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1,6 +1,6 @@
 import { rename as moveFile, stat, unlink } from "node:fs/promises";
 import { isAbsolute, join, relative } from "node:path";
-import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
+import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, DEFAULT_TASK_TYPES, FALLBACK_STATUS } from "../constants/index.ts";
 import { FileSystem, isCreateLockError } from "../file-system/operations.ts";
 import { GitOperations } from "../git/operations.ts";
 import {
@@ -138,6 +138,7 @@ function buildUpdatedDateComparableTask(task: Task): Record<string, unknown> {
 		parentTaskId: task.parentTaskId,
 		subtasks: task.subtasks ?? [],
 		priority: task.priority,
+		type: task.type,
 		onStatusChange: task.onStatusChange,
 	};
 }
@@ -372,6 +373,20 @@ export class Core {
 			throw new Error(`Invalid priority: ${value}. Valid values are: high, medium, low`);
 		}
 		return normalized as "high" | "medium" | "low";
+	}
+
+	private async normalizeTaskType(value: string | undefined): Promise<string | undefined> {
+		if (value === undefined || value === "") {
+			return undefined;
+		}
+		const config = await this.fs.loadConfig();
+		const allowed = config?.types?.length ? config.types : [...DEFAULT_TASK_TYPES];
+		const normalized = value.trim().toLowerCase();
+		const canonical = allowed.find((type) => type.toLowerCase() === normalized);
+		if (!canonical) {
+			throw new Error(`Invalid type: ${value}. Valid types are: ${allowed.join(", ")}`);
+		}
+		return canonical;
 	}
 
 	private isExactTaskReference(reference: string, taskId: string): boolean {
@@ -1140,6 +1155,7 @@ export class Core {
 		}
 
 		const priority = this.normalizePriority(input.priority);
+		const type = await this.normalizeTaskType(input.type);
 		const createdDate = new Date().toISOString().slice(0, 16).replace("T", " ");
 		if (
 			input.ordinal !== undefined &&
@@ -1182,6 +1198,7 @@ export class Core {
 				createdDate,
 				...(input.parentTaskId && { parentTaskId: input.parentTaskId }),
 				...(priority && { priority }),
+				...(type && { type }),
 				...(typeof ordinal === "number" && { ordinal }),
 				...(typeof input.milestone === "string" &&
 					input.milestone.trim().length > 0 && {
@@ -1302,6 +1319,14 @@ export class Core {
 			const normalizedPriority = this.normalizePriority(String(input.priority));
 			if (task.priority !== normalizedPriority) {
 				task.priority = normalizedPriority;
+				mutated = true;
+			}
+		}
+
+		if (input.type !== undefined) {
+			const normalizedType = await this.normalizeTaskType(String(input.type));
+			if (task.type !== normalizedType) {
+				task.type = normalizedType;
 				mutated = true;
 			}
 		}

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1419,6 +1419,7 @@ ${description || `Milestone: ${title}`}`,
 					break;
 				case "statuses":
 				case "labels":
+				case "types":
 					if (value.startsWith("[") && value.endsWith("]")) {
 						const arrayContent = value.slice(1, -1);
 						config[key] = arrayContent
@@ -1493,6 +1494,7 @@ ${description || `Milestone: ${title}`}`,
 			defaultReporter: config.defaultReporter,
 			statuses: config.statuses || [...DEFAULT_STATUSES],
 			labels: config.labels || [],
+			types: config.types,
 			definitionOfDone: config.definitionOfDone,
 			defaultStatus: config.defaultStatus,
 			dateFormat: config.dateFormat || "yyyy-mm-dd",
@@ -1523,6 +1525,7 @@ ${description || `Milestone: ${title}`}`,
 			...(config.defaultStatus ? [`default_status: "${config.defaultStatus}"`] : []),
 			`statuses: [${config.statuses.map((s) => `"${s}"`).join(", ")}]`,
 			`labels: [${config.labels.map((l) => `"${l}"`).join(", ")}]`,
+			...(config.types && config.types.length > 0 ? [`types: [${config.types.map((t) => `"${t}"`).join(", ")}]`] : []),
 			...(Array.isArray(normalizedDefinitionOfDone)
 				? [`definition_of_done: [${normalizedDefinitionOfDone.map((item) => JSON.stringify(item)).join(", ")}]`]
 				: []),

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -193,6 +193,7 @@ export function parseTask(content: string): Task {
 		parentTaskId: frontmatter.parent_task_id ? String(frontmatter.parent_task_id) : undefined,
 		subtasks: Array.isArray(frontmatter.subtasks) ? frontmatter.subtasks.map(String) : undefined,
 		priority: validatedPriority,
+		type: frontmatter.type ? String(frontmatter.type) : undefined,
 		ordinal: frontmatter.ordinal !== undefined ? Number(frontmatter.ordinal) : undefined,
 		onStatusChange: frontmatter.onStatusChange ? String(frontmatter.onStatusChange) : undefined,
 	};

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -65,6 +65,7 @@ export function serializeTask(task: Task): string {
 		...(task.parentTaskId && { parent_task_id: task.parentTaskId }),
 		...(task.subtasks && task.subtasks.length > 0 && { subtasks: task.subtasks }),
 		...(task.priority && { priority: task.priority }),
+		...(task.type && { type: task.type }),
 		...(task.ordinal !== undefined && { ordinal: task.ordinal }),
 		...(task.onStatusChange && { onStatusChange: task.onStatusChange }),
 	};

--- a/src/test/task-type.test.ts
+++ b/src/test/task-type.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { $ } from "bun";
+import { DEFAULT_TASK_TYPES } from "../constants/index.ts";
+import { Core } from "../core/backlog.ts";
+import { parseTask } from "../markdown/parser.ts";
+import { serializeTask } from "../markdown/serializer.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+describe("task type field", () => {
+	let core: Core;
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-task-type");
+		core = new Core(TEST_DIR);
+		await core.filesystem.ensureBacklogStructure();
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+		await initializeTestProject(core, "Type Test Project");
+	});
+
+	afterEach(async () => {
+		try {
+			await safeCleanup(TEST_DIR);
+		} catch {
+			// Ignore cleanup errors - the unique directory names prevent conflicts
+		}
+	});
+
+	describe("persistence round-trip", () => {
+		it("should persist type on create and read it back", async () => {
+			const { task } = await core.createTaskFromInput({ title: "Typed task", type: "feature" }, false);
+			expect(task.type).toBe("feature");
+
+			const loaded = await core.filesystem.loadTask(task.id);
+			expect(loaded?.type).toBe("feature");
+		});
+
+		it("should update and clear type through edit input", async () => {
+			const { task } = await core.createTaskFromInput({ title: "Typed task", type: "feature" }, false);
+
+			await core.updateTaskFromInput(task.id, { type: "bug" }, false);
+			let loaded = await core.filesystem.loadTask(task.id);
+			expect(loaded?.type).toBe("bug");
+			expect(loaded?.updatedDate).toBeDefined();
+
+			await core.updateTaskFromInput(task.id, { type: "" }, false);
+			loaded = await core.filesystem.loadTask(task.id);
+			expect(loaded?.type).toBeUndefined();
+		});
+
+		it("should normalize type casing against the allowed set", async () => {
+			const { task } = await core.createTaskFromInput({ title: "Typed task", type: "BUG" }, false);
+			expect(task.type).toBe("bug");
+		});
+
+		it("should serialize type to frontmatter and parse it back", () => {
+			const task: Task = {
+				id: "task-1",
+				title: "Round trip",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2026-01-01",
+				labels: [],
+				dependencies: [],
+				type: "chore",
+			};
+
+			const serialized = serializeTask(task);
+			expect(serialized).toContain("type: chore");
+			expect(parseTask(serialized).type).toBe("chore");
+		});
+	});
+
+	describe("validation", () => {
+		it("should reject unknown type on create with allowed values in the error", async () => {
+			await expect(core.createTaskFromInput({ title: "Bad type", type: "banana" }, false)).rejects.toThrow(
+				`Invalid type: banana. Valid types are: ${DEFAULT_TASK_TYPES.join(", ")}`,
+			);
+		});
+
+		it("should reject unknown type on edit", async () => {
+			const { task } = await core.createTaskFromInput({ title: "Typed task" }, false);
+			await expect(core.updateTaskFromInput(task.id, { type: "banana" }, false)).rejects.toThrow(
+				"Invalid type: banana",
+			);
+		});
+	});
+
+	describe("config override", () => {
+		it("should validate against configured types and preserve configured casing", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) throw new Error("Config not found");
+			config.types = ["Bug", "Epic"];
+			await core.filesystem.saveConfig(config);
+
+			const { task } = await core.createTaskFromInput({ title: "Custom type", type: "epic" }, false);
+			expect(task.type).toBe("Epic");
+
+			await expect(core.createTaskFromInput({ title: "Default type", type: "feature" }, false)).rejects.toThrow(
+				"Invalid type: feature. Valid types are: Bug, Epic",
+			);
+		});
+
+		it("should round-trip the types config key", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) throw new Error("Config not found");
+			config.types = ["bug", "epic"];
+			await core.filesystem.saveConfig(config);
+
+			const reloaded = await new Core(TEST_DIR).filesystem.loadConfig();
+			expect(reloaded?.types).toEqual(["bug", "epic"]);
+		});
+
+		it("should leave types undefined when the config key is absent", async () => {
+			const config = await core.filesystem.loadConfig();
+			expect(config?.types).toBeUndefined();
+		});
+	});
+
+	describe("back-compat for untyped tasks", () => {
+		it("should keep tasks without type untyped", async () => {
+			const { task } = await core.createTaskFromInput({ title: "Untyped task" }, false);
+			const loaded = await core.filesystem.loadTask(task.id);
+			expect(loaded?.type).toBeUndefined();
+		});
+
+		it("should parse legacy frontmatter without a type key", () => {
+			const legacy = [
+				"---",
+				"id: task-1",
+				"title: Legacy",
+				"status: To Do",
+				"created_date: 2026-01-01",
+				"---",
+				"",
+			].join("\n");
+			expect(parseTask(legacy).type).toBeUndefined();
+		});
+
+		it("should not write a type key for untyped tasks", async () => {
+			const { task } = await core.createTaskFromInput({ title: "Untyped task" }, false);
+			await core.updateTaskFromInput(task.id, { title: "Still untyped" }, false);
+
+			const loaded = await core.filesystem.loadTask(task.id);
+			if (!loaded) throw new Error("Task not found");
+			expect(loaded.type).toBeUndefined();
+			expect(serializeTask(loaded)).not.toContain("type:");
+		});
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,8 @@ export interface Task {
 	subtasks?: string[];
 	subtaskSummaries?: Array<{ id: string; title: string }>;
 	priority?: "high" | "medium" | "low";
+	/** Semantic task type (e.g. bug, feature). Allowed values come from config `types` (defaults to DEFAULT_TASK_TYPES); absent means untyped. */
+	type?: string;
 	branch?: string;
 	ordinal?: number;
 	filePath?: string;
@@ -105,6 +107,7 @@ export interface TaskCreateInput {
 	description?: string;
 	status?: TaskStatus;
 	priority?: "high" | "medium" | "low";
+	type?: string;
 	ordinal?: number;
 	milestone?: string;
 	labels?: string[];
@@ -128,6 +131,7 @@ export interface TaskUpdateInput {
 	description?: string;
 	status?: TaskStatus;
 	priority?: "high" | "medium" | "low";
+	type?: string;
 	milestone?: string | null;
 	labels?: string[];
 	addLabels?: string[];
@@ -299,6 +303,8 @@ export interface BacklogConfig {
 	defaultReporter?: string;
 	statuses: string[];
 	labels: string[];
+	/** Allowed task types. Defaults to DEFAULT_TASK_TYPES when not configured. */
+	types?: string[];
 	/** @deprecated Milestones are sourced from milestone files, not config. */
 	milestones?: string[];
 	definitionOfDone?: string[];


### PR DESCRIPTION
## Summary

Foundation for the BACK-355 task-type family: adds an optional, mutually exclusive `type` field to the task domain model with YAML frontmatter persistence and write-time validation. Core-only — CLI flags, MCP schemas, TUI, and Web UI are covered by sibling subtasks.

- `Task`, `TaskCreateInput`, and `TaskUpdateInput` gain an optional `type` field (string, since the allowed set is project-configurable — mirrors how statuses work)
- Frontmatter key `type` is parsed and serialized next to `priority`; absent key stays absent (untyped) — no migration of existing tasks
- Default allowed set `DEFAULT_TASK_TYPES`: `bug`, `feature`, `enhancement`, `task`, `chore`, `docs`, `spike`
- Projects can override the allowed set via the `types` config key in `config.yml` (e.g. `types: ["bug", "epic"]`), mirroring the `statuses` key; key absent → defaults apply, empty → defaults apply
- Validation on write (`createTaskFromInput` / task edit input) with canonical-casing match against the configured set and a clear error listing allowed values (`Invalid type: banana. Valid types are: bug, feature, ...`); empty string clears the field
- Changing `type` counts as an edit for `updated_date` purposes

Per the approved design review: absent `type` means untyped (no `task` default injected at parse time), and `Task.type` is a validated string rather than a closed TS union because the set is config-overridable.

Keys sibling subtasks should use:
- Frontmatter key: `type`
- Config key: `types` (string array, `BacklogConfig.types`)
- Defaults constant: `DEFAULT_TASK_TYPES` in `src/constants/index.ts`

## Testing

- 12 new unit tests in `src/test/task-type.test.ts`: CRUD round-trip, casing normalization, serialize/parse round-trip, validation failures on create and edit, config override + configured-casing preservation, config key round-trip, and absent-field back-compat
- `bunx tsc --noEmit` clean
- `bunx biome check src` clean
- Full `bun test`: 1390 pass / 2 skip / 1 fail — the single failure (`CLI Priority Filtering > case insensitive priority filtering`, 5s timeout) is a pre-existing flake that reproduces identically on a pristine origin/main worktree; unrelated to this change

Note: the AC texts on BACK-355.01 (and the two affected parent BACK-355 ACs) were amended via the backlog CLI to record the approved semantics — validated string against the configured set, absent = untyped, no default injection, no migration — replacing the original closed-union/default-to-`task` wording.

Closes BACK-355.01
