### PR TITLE
BACK-427 - Support unassigned task filtering in CLI and MCP

### DIFF
--- a/backlog/tasks/back-427 - Support-unassigned-task-filtering-in-CLI-and-MCP.md
+++ b/backlog/tasks/back-427 - Support-unassigned-task-filtering-in-CLI-and-MCP.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-427
 title: Support unassigned task filtering in CLI and MCP
-status: To Do
+status: In Progress
 assignee:
   - '@alex-agent'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-07-04 13:50'
 labels:
   - cli
   - mcp
@@ -28,6 +29,16 @@ Track GitHub issue #557: allow users and agents to list tasks with no assignee.
 - [ ] #2 MCP task_list exposes an equivalent unassigned filter without overloading a real assignee value ambiguously.
 - [ ] #3 Help text, schemas, and tests cover the new filter.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add unassigned?: boolean to TaskListFilter (src/types/index.ts)
+2. Implement the filter once in Core.applyTaskFilters (src/core/backlog.ts) so both the plain-list and search paths of queryTasks share it (covers CLI plain, CLI interactive, MCP)
+3. CLI: add --unassigned flag to task list, mutually exclusive with --assignee (clear error), update help schema and interactive filter title
+4. MCP: add unassigned boolean to taskListSchema with description, validate assignee+unassigned conflict in TaskHandlers.listTasks, support draft status path, clarify task_list tool description
+5. Tests: cli.test.ts (--unassigned filtering + conflict error), mcp-tasks.test.ts (unassigned filtering incl. drafts + conflict rejection)
+<!-- SECTION:PLAN:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/back-427 - Support-unassigned-task-filtering-in-CLI-and-MCP.md
+++ b/backlog/tasks/back-427 - Support-unassigned-task-filtering-in-CLI-and-MCP.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-427
 title: Support unassigned task filtering in CLI and MCP
-status: In Progress
+status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-04-25 12:14'
-updated_date: '2026-07-04 13:50'
+updated_date: '2026-07-04 17:47'
 labels:
   - cli
   - mcp
@@ -25,9 +25,9 @@ Track GitHub issue #557: allow users and agents to list tasks with no assignee.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 CLI task list can filter for tasks with no assignee.
-- [ ] #2 MCP task_list exposes an equivalent unassigned filter without overloading a real assignee value ambiguously.
-- [ ] #3 Help text, schemas, and tests cover the new filter.
+- [x] #1 CLI task list can filter for tasks with no assignee.
+- [x] #2 MCP task_list exposes an equivalent unassigned filter without overloading a real assignee value ambiguously.
+- [x] #3 Help text, schemas, and tests cover the new filter.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -40,9 +40,23 @@ Track GitHub issue #557: allow users and agents to list tasks with no assignee.
 5. Tests: cli.test.ts (--unassigned filtering + conflict error), mcp-tasks.test.ts (unassigned filtering incl. drafts + conflict rejection)
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented unassigned filtering: TaskListFilter.unassigned flows through Core.applyTaskFilters (single shared implementation covering plain, interactive, and search paths). CLI gained --unassigned on task list with a mutual-exclusion error against --assignee; MCP task_list gained an unassigned boolean with schema description, handler validation, and draft-path support. Tool description clarified. Tests added in cli.test.ts and mcp-tasks.test.ts; targeted runs green, full suite running.
+
+Validation: bunx tsc --noEmit clean; biome check clean; full bun test run 1382 pass / 2 skip / 1 fail — the one failure (cli-priority-filtering case-insensitive 5s timeout) reproduces identically on pristine origin/main (d0f3cff) and is a pre-existing flake unrelated to this change. Earlier full-run failures were caused by a stale worktree node_modules missing @tailwindcss/cli, fixed with bun i.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added unassigned task filtering to CLI and MCP (issue #557). TaskListFilter gained an unassigned flag implemented once in Core.applyTaskFilters, shared by CLI plain output, CLI interactive view, and MCP task_list. CLI: new --unassigned flag on backlog task list, mutually exclusive with --assignee (clear error), documented in help schema. MCP: task_list accepts unassigned: true (boolean schema with description), rejects combining it with assignee, and applies the filter in the Draft status path too; tool description now enumerates filters. Shipped instruction guides mention the new filter. Verified with new tests in cli.test.ts and mcp-tasks.test.ts plus full suite (1382 pass; single failure is a pre-existing cli-priority-filtering timeout flake reproduced on pristine main).
+<!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2014,6 +2014,11 @@ addHelpSchema(taskCmd.command("list"), {
 	optional: [
 		{ name: "status", type: statusType, description: "Filter by task status; case-insensitive" },
 		{ name: "assignee", type: "Assignee", description: "Filter by @name" },
+		{
+			name: "unassigned",
+			type: "Boolean",
+			description: "Only tasks without an assignee; cannot be combined with --assignee",
+		},
 		{ name: "milestone", type: "Milestone ID or title", description: "Closest case-insensitive match" },
 		{ name: "parent", type: "Task ID", description: "Show subtasks of a parent task" },
 		{ name: "priority", type: choiceType(["high", "medium", "low"]), description: "Filter by task priority" },
@@ -2036,6 +2041,7 @@ addHelpSchema(taskCmd.command("list"), {
 	.description("list tasks grouped by status")
 	.option("-s, --status <status>", "filter tasks by status (case-insensitive)")
 	.option("-a, --assignee <assignee>", "filter tasks by assignee")
+	.option("--unassigned", "filter tasks without an assignee (cannot be combined with --assignee)")
 	.option("-m, --milestone <milestone>", "filter tasks by milestone (closest match, case-insensitive)")
 	.option("-p, --parent <taskId>", "filter tasks by parent task ID")
 	.option("--priority <priority>", "filter tasks by priority (high, medium, low)")
@@ -2055,12 +2061,21 @@ addHelpSchema(taskCmd.command("list"), {
 			core.disposeSearchService();
 			core.disposeContentStore();
 		};
+		if (options.assignee && options.unassigned) {
+			console.error("--unassigned cannot be combined with --assignee.");
+			process.exitCode = 1;
+			cleanup();
+			return;
+		}
 		const baseFilters: TaskListFilter = {};
 		if (options.status) {
 			baseFilters.status = options.status;
 		}
 		if (options.assignee) {
 			baseFilters.assignee = options.assignee;
+		}
+		if (options.unassigned) {
+			baseFilters.unassigned = true;
 		}
 		if (options.milestone) {
 			baseFilters.milestone = options.milestone;
@@ -2214,6 +2229,7 @@ addHelpSchema(taskCmd.command("list"), {
 		const activeFilters: string[] = [];
 		if (options.status) activeFilters.push(`Status: ${options.status}`);
 		if (options.assignee) activeFilters.push(`Assignee: ${options.assignee}`);
+		if (options.unassigned) activeFilters.push("Unassigned");
 		if (options.parent) {
 			activeFilters.push(`Parent: ${normalizeTaskId(String(options.parent))}`);
 		}
@@ -2262,6 +2278,9 @@ addHelpSchema(taskCmd.command("list"), {
 		const interactiveLoaderFilters: TaskListFilter = {};
 		if (options.assignee) {
 			interactiveLoaderFilters.assignee = options.assignee;
+		}
+		if (options.unassigned) {
+			interactiveLoaderFilters.unassigned = true;
 		}
 		if (parentId) {
 			interactiveLoaderFilters.parentTaskId = parentId;

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -316,6 +316,9 @@ export class Core {
 			const assigneeLower = filters.assignee.toLowerCase();
 			result = result.filter((task) => (task.assignee ?? []).some((value) => value.toLowerCase() === assigneeLower));
 		}
+		if (filters.unassigned) {
+			result = result.filter((task) => !(task.assignee ?? []).some((value) => value.trim().length > 0));
+		}
 		if (filters.priority) {
 			const priorityLower = String(filters.priority).toLowerCase();
 			result = result.filter((task) => (task.priority ?? "").toLowerCase() === priorityLower);

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -13,7 +13,7 @@ Recommended CLI commands:
 - `backlog task list --status "<active status>" --plain`
 - `backlog task list --search "desktop app" --labels frontend,bug --limit 20 --plain`
 
-Avoid broad unfiltered listing when the project may have many tasks. Use `--status`, `--assignee`, `--parent`, `--priority`, `--labels`, `--search`, or `--limit` where applicable.
+Avoid broad unfiltered listing when the project may have many tasks. Use `--status`, `--assignee`, `--unassigned`, `--parent`, `--priority`, `--labels`, `--search`, or `--limit` where applicable.
 
 Use `backlog task view {{TASK_ID:123}} --plain` to read full context for likely matches.
 

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -54,7 +54,7 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 
 **Note:** "Done" tasks stay in the Done column until periodic cleanup moves them to the completed folder. Don't use `task_complete` immediately after finishing—it's for batch cleanup, not per-task workflow.
 
-- `task_list` — list tasks with optional filtering by status, assignee, milestone, labels, search, or limit
+- `task_list` — list tasks with optional filtering by status, assignee (or `unassigned: true`), milestone, labels, search, or limit
 - `task_search` — search tasks by title and description, or use `modifiedFiles` to filter by project-root-relative modified file path substrings
 - `task_view` — read full task context (description, plan, notes, comments, final summary, acceptance criteria, Definition of Done)
 - `definition_of_done_defaults_get` — read project-level Definition of Done defaults from config

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -47,6 +47,7 @@ export type TaskCreateArgs = {
 export type TaskListArgs = {
 	status?: string;
 	assignee?: string;
+	unassigned?: boolean;
 	milestone?: string;
 	labels?: string[];
 	search?: string;
@@ -145,6 +146,9 @@ export class TaskHandlers {
 	}
 
 	async listTasks(args: TaskListArgs = {}): Promise<CallToolResult> {
+		if (args.assignee && args.unassigned) {
+			throw new BacklogToolError("unassigned cannot be combined with assignee.", "VALIDATION_ERROR");
+		}
 		if (this.isDraftStatus(args.status)) {
 			let drafts = await this.core.filesystem.listDrafts();
 			if (args.search) {
@@ -154,6 +158,9 @@ export class TaskHandlers {
 
 			if (args.assignee) {
 				drafts = drafts.filter((draft) => (draft.assignee ?? []).includes(args.assignee ?? ""));
+			}
+			if (args.unassigned) {
+				drafts = drafts.filter((draft) => !(draft.assignee ?? []).some((value) => value.trim().length > 0));
 			}
 			if (args.milestone) {
 				const [activeMilestones, archivedMilestones] = await Promise.all([
@@ -218,6 +225,9 @@ export class TaskHandlers {
 		}
 		if (args.assignee) {
 			filters.assignee = args.assignee;
+		}
+		if (args.unassigned) {
+			filters.unassigned = true;
 		}
 		if (args.milestone) {
 			filters.milestone = args.milestone;

--- a/src/mcp/tools/tasks/index.ts
+++ b/src/mcp/tools/tasks/index.ts
@@ -27,7 +27,8 @@ export function registerTaskTools(server: McpServer, config: BacklogConfig): voi
 	const listTaskTool: McpToolHandler = createSimpleValidatedTool(
 		{
 			name: "task_list",
-			description: "List Backlog.md tasks from with optional filtering",
+			description:
+				"List Backlog.md tasks with optional filtering by status, assignee (or unassigned: true for tasks with no assignee), milestone, labels, and search",
 			inputSchema: taskListSchema,
 			annotations: { title: "List Tasks", readOnlyHint: true, destructiveHint: false },
 		},

--- a/src/mcp/tools/tasks/schemas.ts
+++ b/src/mcp/tools/tasks/schemas.ts
@@ -11,6 +11,10 @@ export const taskListSchema: JsonSchema = {
 			type: "string",
 			maxLength: 100,
 		},
+		unassigned: {
+			type: "boolean",
+			description: "When true, only return tasks with no assignee. Cannot be combined with assignee.",
+		},
 		milestone: {
 			type: "string",
 			maxLength: 100,

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1070,6 +1070,51 @@ describe("CLI Integration", () => {
 			expect(out).not.toContain("TASK-2 - Unassigned Task");
 		});
 
+		it("should filter tasks without an assignee using --unassigned", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-1",
+					title: "Assigned Task",
+					status: "To Do",
+					assignee: ["alice"],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					rawContent: "Assigned task",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-2",
+					title: "Unassigned Task",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					rawContent: "Other task",
+				},
+				false,
+			);
+
+			const result = await $`bun ${CLI_PATH} task list --plain --unassigned`.cwd(TEST_DIR).quiet();
+			const out = result.stdout.toString();
+			expect(out).toContain("TASK-2 - Unassigned Task");
+			expect(out).not.toContain("TASK-1 - Assigned Task");
+		});
+
+		it("should reject combining --unassigned with --assignee", async () => {
+			const result = await $`bun ${CLI_PATH} task list --plain --assignee alice --unassigned`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr.toString()).toContain("--unassigned cannot be combined with --assignee");
+		});
+
 		it("should filter tasks by labels requiring every requested label", async () => {
 			const core = new Core(TEST_DIR);
 

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -327,6 +327,68 @@ describe("MCP task tools (MVP)", () => {
 		expect(draftText).not.toContain("DRAFT-2 - Draft Milestone Two");
 	});
 
+	it("filters task_list to unassigned tasks and rejects combining with assignee", async () => {
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Assigned Task",
+					assignee: ["alice"],
+				},
+			},
+		});
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Unassigned Task",
+				},
+			},
+		});
+
+		const unassignedResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_list", arguments: { unassigned: true } },
+		});
+		const unassignedText = getText(unassignedResult.content);
+		expect(unassignedText).toContain("TASK-2 - Unassigned Task");
+		expect(unassignedText).not.toContain("TASK-1 - Assigned Task");
+
+		const conflictResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_list", arguments: { assignee: "alice", unassigned: true } },
+		});
+		expect(conflictResult.isError).toBe(true);
+		expect(getText(conflictResult.content)).toContain("unassigned cannot be combined with assignee");
+	});
+
+	it("applies unassigned filtering in task_list draft status path", async () => {
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Assigned Draft",
+					status: "Draft",
+					assignee: ["alice"],
+				},
+			},
+		});
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Unassigned Draft",
+					status: "Draft",
+				},
+			},
+		});
+
+		const draftResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_list", arguments: { status: "Draft", unassigned: true } },
+		});
+		const draftText = getText(draftResult.content);
+		expect(draftText).toContain("DRAFT-2 - Unassigned Draft");
+		expect(draftText).not.toContain("DRAFT-1 - Assigned Draft");
+	});
+
 	it("includes completed tasks in task_search results and excludes archived tasks", async () => {
 		await mcpServer.testInterface.callTool({
 			params: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -169,6 +169,7 @@ export interface TaskUpdateInput {
 export interface TaskListFilter {
 	status?: string;
 	assignee?: string;
+	unassigned?: boolean;
 	priority?: "high" | "medium" | "low";
 	milestone?: string;
 	parentTaskId?: string;


### PR DESCRIPTION
Closes #557

## What

Adds a way to list tasks that have no assignee, in both the CLI and the MCP `task_list` tool.

- **CLI**: new `--unassigned` flag on `backlog task list`. Mutually exclusive with `--assignee` — combining them exits 1 with `--unassigned cannot be combined with --assignee.` Works with `--plain`, the interactive view, and alongside `--search`/other filters. Documented in the command help schema.
- **MCP**: `task_list` accepts `unassigned: true` (boolean schema property with description). Combining it with `assignee` returns a validation error, so a real assignee value is never overloaded as a sentinel. The Draft status path applies the filter too. Tool description now enumerates the available filters.
- **Core**: `TaskListFilter.unassigned` is implemented once in `Core.applyTaskFilters`, which both the plain-list and search paths of `queryTasks` share — CLI plain, CLI interactive, and MCP all use the same implementation. A task counts as unassigned when it has no non-blank assignee entry.
- **Docs**: shipped instruction guides (`cli-instructions/task-creation.md`, `mcp/overview.md`) mention the new filter.

## Tests

- `cli.test.ts`: `--unassigned` returns only unassigned tasks; `--assignee` + `--unassigned` rejected with exit 1.
- `mcp-tasks.test.ts`: `unassigned: true` filtering, conflict rejection with `assignee`, and Draft status path filtering.

## Verification

- `bunx tsc --noEmit` clean, Biome clean.
- Full `bun test`: 1382 pass / 2 skip / 1 fail — the single failure (`cli-priority-filtering` case-insensitive test, 5s timeout) reproduces identically on pristine `origin/main` (d0f3cff) and is a pre-existing flake unrelated to this change.