### PR TITLE
BACK-267 - Add agent instruction version metadata

### DIFF
--- a/backlog/tasks/back-267 - Add-agent-instruction-version-metadata.md
+++ b/backlog/tasks/back-267 - Add-agent-instruction-version-metadata.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-267
 title: Add agent instruction version metadata
-status: To Do
+status: Done
 assignee:
-  - '@codex'
+  - '@alex-agent'
 created_date: '2025-09-17 19:19'
+updated_date: '2026-07-04 17:50'
 labels: []
 dependencies: []
 ---
@@ -17,16 +18,30 @@ Embed a manually maintained version identifier in each agent instruction file th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Version header or comment exists in every bundled agent instruction file
-- [ ] #2 Backlog init writes the version marker when generating agent instruction files
-- [ ] #3 backlog agents --update-instructions preserves/updates the version marker
+- [x] #1 Version header or comment exists in every bundled agent instruction file
+- [x] #2 Backlog init writes the version marker when generating agent instruction files
+- [x] #3 backlog agents --update-instructions preserves/updates the version marker
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Decide version marker format (e.g., YAML frontmatter, HTML comment, or heading).
-2. Update source instruction files under src/guidelines to include the marker.
-3. Adjust embedding/append logic so the marker is written when generating user files.
-4. Ensure unit tests cover init/update flows with new metadata.
+1. Inject a machine-readable HTML comment marker (<!-- backlog.md-instructions-version: X.Y.Z -->) into every managed instruction block at write time in src/agent-instructions.ts (wrapWithMarkers), deriving the version from getVersion() (build-time embedded version in binaries, package.json in dev) instead of hardcoding versions in src/guidelines files.
+2. Apply the marker to CLI nudge blocks (addAgentInstructions), MCP nudge blocks (ensureMcpGuidelines), and the installed .claude/agents/project-manager-backlog.md (installClaudeAgent).
+3. Markers live inside the managed START/END blocks so the existing strip-and-reinsert update flow refreshes them automatically.
+4. Tests: marker present after install, version matches package.json, update flow refreshes marker, idempotency preserved.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Chose write-time injection over manually maintained per-file versions: versionMarkerLine() in src/agent-instructions.ts emits '<!-- backlog.md-instructions-version: X.Y.Z -->' derived from getVersion() (build-time __EMBEDDED_VERSION__ in compiled binaries, package.json in dev). Marker is written as the first line inside every managed CLI/MCP guideline block and appended to the installed .claude/agents/project-manager-backlog.md. Because it lives inside the START/END block, the existing strip-and-reinsert flow (init re-run, agents --update-instructions, CLI/MCP mode switch) refreshes it automatically; same-version re-runs stay 'unchanged'. This avoids any release-time maintenance and cannot drift from the binary that wrote it. BACK-268 can compare via regex /<!-- backlog\.md-instructions-version: (\S+) -->/ against getVersion().
+
+Validation: bunx tsc --noEmit clean; bunx biome check src scripts package.json biome.json clean; full test-file coverage run in chunks (162 files): 1326 pass, 2 skip, 0 new failures. Only failures are 11 in cli-priority-filtering.test.ts, reproduced identically on clean origin/main (pre-existing environment flake, unrelated).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a machine-readable version marker ('<!-- backlog.md-instructions-version: X.Y.Z -->') to every agent instruction surface Backlog.md installs into user projects: first line inside the managed CLI and MCP guideline blocks (addAgentInstructions/ensureMcpGuidelines) and appended to the installed .claude/agents/project-manager-backlog.md (installClaudeAgent). Version is injected at install/update time from getVersion() (build-time embedded version in compiled binaries, package.json in dev) rather than hardcoded in src/guidelines sources, so it can never drift from the binary and needs no release-time maintenance. Because the marker lives inside the START/END block, backlog init re-runs and 'backlog agents --update-instructions' refresh it automatically via the existing strip-and-reinsert flow; same-version re-runs remain 'unchanged'. Verified with new unit tests (marker present after install, version matches package.json, stale marker refreshed on update, MCP block covered, Claude agent file covered) plus tsc/biome/test gates.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -4,6 +4,7 @@ import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CLAUDE_AGENT_CONTENT, CLI_AGENT_NUDGE, MCP_AGENT_NUDGE, README_GUIDELINES } from "./constants/index.ts";
 import type { GitOperations } from "./git/operations.ts";
+import { getVersion } from "./utils/version.ts";
 
 export type AgentInstructionFile =
 	| "AGENTS.md"
@@ -62,11 +63,30 @@ function hasBacklogGuidelines(content: string, fileName: string): boolean {
 }
 
 /**
+ * Builds the machine-readable version marker line embedded in every installed
+ * instruction block. Written at install/update time from the running binary's
+ * version so local instructions can later be compared against the bundled ones.
+ */
+function versionMarkerLine(fileName: string, version: string): string {
+	const marker = `backlog.md-instructions-version: ${version}`;
+	if (fileName === ".cursorrules") {
+		// .cursorrules doesn't support HTML comments, use markdown-style comments
+		return `# ${marker}`;
+	}
+	return `<!-- ${marker} -->`;
+}
+
+/**
  * Wraps the Backlog.md guidelines with appropriate markers
  */
-function wrapWithMarkers(content: string, fileName: string, kind: GuidelineMarkerKind = "default"): string {
+function wrapWithMarkers(
+	content: string,
+	fileName: string,
+	version: string,
+	kind: GuidelineMarkerKind = "default",
+): string {
 	const { start, end } = getMarkers(fileName, kind);
-	return `\n${start}\n${content}\n${end}\n`;
+	return `\n${start}\n${versionMarkerLine(fileName, version)}\n${content}\n${end}\n`;
 }
 
 function stripGuidelineSection(
@@ -135,6 +155,7 @@ export async function addAgentInstructions(
 		"README.md": README_GUIDELINES,
 	};
 
+	const version = await getVersion();
 	const paths: string[] = [];
 	const results: AgentInstructionWriteResult[] = [];
 	for (const name of files) {
@@ -166,7 +187,7 @@ export async function addAgentInstructions(
 					const insertAt = defaultStripped.firstIndex ?? defaultStripped.content.length;
 					finalContent =
 						defaultStripped.content.slice(0, insertAt) +
-						wrapWithMarkers(content, name) +
+						wrapWithMarkers(content, name, version) +
 						defaultStripped.content.slice(insertAt);
 				} else if (hasBacklogGuidelines(existing, name)) {
 					// Guidelines already exist but could not be parsed, skip this file.
@@ -175,7 +196,7 @@ export async function addAgentInstructions(
 				} else {
 					// Append Backlog.md guidelines with markers
 					if (!existing.endsWith("\n")) existing += "\n";
-					finalContent = existing + wrapWithMarkers(content, name);
+					finalContent = existing + wrapWithMarkers(content, name, version);
 				}
 
 				if (finalContent === originalExisting) {
@@ -185,11 +206,11 @@ export async function addAgentInstructions(
 			} catch (error) {
 				console.error(`Error reading existing file ${filePath}:`, error);
 				// If we can't read it, just use the new content with markers
-				finalContent = wrapWithMarkers(content, name);
+				finalContent = wrapWithMarkers(content, name, version);
 			}
 		} else {
 			// File doesn't exist, create with markers
-			finalContent = wrapWithMarkers(content, name);
+			finalContent = wrapWithMarkers(content, name, version);
 		}
 
 		await mkdir(dirname(filePath), { recursive: true });
@@ -252,7 +273,7 @@ export async function ensureMcpGuidelines(
 		}
 	}
 
-	const nudgeBlock = wrapWithMarkers(MCP_AGENT_NUDGE, fileName, "mcp");
+	const nudgeBlock = wrapWithMarkers(MCP_AGENT_NUDGE, fileName, await getVersion(), "mcp");
 	let nextContent: string;
 	if (insertIndex !== null) {
 		const normalizedIndex = Math.max(0, Math.min(insertIndex, existing.length));
@@ -286,6 +307,7 @@ export async function installClaudeAgent(projectRoot: string): Promise<void> {
 	// Create the directory if it doesn't exist
 	await mkdir(agentDir, { recursive: true });
 
-	// Write the agent content
-	await Bun.write(agentPath, CLAUDE_AGENT_CONTENT);
+	// Write the agent content with the version marker appended
+	const versionLine = versionMarkerLine("project-manager-backlog.md", await getVersion());
+	await Bun.write(agentPath, `${CLAUDE_AGENT_CONTENT.trimEnd()}\n\n${versionLine}\n`);
 }

--- a/src/test/agent-instructions.test.ts
+++ b/src/test/agent-instructions.test.ts
@@ -254,6 +254,59 @@ describe("addAgentInstructions", () => {
 		}
 	});
 
+	// BACK-267: every installed instruction block carries a machine-readable version
+	// marker derived from the running binary/package version, so tooling can compare
+	// a project's local instructions against the bundled ones.
+	it("writes a version marker matching package.json inside the guidelines block (BACK-267)", async () => {
+		const { version } = await Bun.file(join(__dirname, "../../package.json")).json();
+		const versionMarker = `<!-- backlog.md-instructions-version: ${version} -->`;
+
+		await addAgentInstructions(TEST_DIR);
+		for (const fileName of ["AGENTS.md", "CLAUDE.md", "GEMINI.md", ".github/copilot-instructions.md"]) {
+			const content = await Bun.file(join(TEST_DIR, fileName)).text();
+			expect(content).toContain(versionMarker);
+			// Marker lives inside the managed block, right after the start marker
+			expect(content.indexOf(versionMarker)).toBeGreaterThan(content.indexOf("<!-- BACKLOG.MD GUIDELINES START -->"));
+			expect(content.indexOf(versionMarker)).toBeLessThan(content.indexOf("<!-- BACKLOG.MD GUIDELINES END -->"));
+			expect((content.match(/<!-- backlog\.md-instructions-version: /g) || []).length).toBe(1);
+		}
+	});
+
+	it("refreshes a stale version marker when updating an existing block (BACK-267)", async () => {
+		const { version } = await Bun.file(join(__dirname, "../../package.json")).json();
+		const agentsPath = join(TEST_DIR, "AGENTS.md");
+		await Bun.write(
+			agentsPath,
+			[
+				"Existing header",
+				"<!-- BACKLOG.MD GUIDELINES START -->",
+				"<!-- backlog.md-instructions-version: 0.0.1 -->",
+				"Old generated Backlog guidance",
+				"<!-- BACKLOG.MD GUIDELINES END -->",
+				"",
+			].join("\n"),
+		);
+
+		await addAgentInstructions(TEST_DIR, undefined, ["AGENTS.md"]);
+		const agents = await Bun.file(agentsPath).text();
+
+		expect(agents).not.toContain("backlog.md-instructions-version: 0.0.1");
+		expect(agents).toContain(`<!-- backlog.md-instructions-version: ${version} -->`);
+		expect(agents).toContain("Existing header");
+	});
+
+	it("writes the version marker in MCP guideline blocks (BACK-267)", async () => {
+		const { version } = await Bun.file(join(__dirname, "../../package.json")).json();
+
+		await ensureMcpGuidelines(TEST_DIR, "AGENTS.md");
+		const content = await Bun.file(join(TEST_DIR, "AGENTS.md")).text();
+		const versionMarker = `<!-- backlog.md-instructions-version: ${version} -->`;
+
+		expect(content).toContain(versionMarker);
+		expect(content.indexOf(versionMarker)).toBeGreaterThan(content.indexOf("<!-- BACKLOG.MD MCP GUIDELINES START -->"));
+		expect(content.indexOf(versionMarker)).toBeLessThan(content.indexOf("<!-- BACKLOG.MD MCP GUIDELINES END -->"));
+	});
+
 	it("replaces MCP nudge with CLI guidelines when switching modes", async () => {
 		const agentsPath = join(TEST_DIR, "AGENTS.md");
 		const mcpBlock = [

--- a/src/test/claude-agent-install.test.ts
+++ b/src/test/claude-agent-install.test.ts
@@ -32,11 +32,21 @@ describe("installClaudeAgent", () => {
 		const agentPath = join(TEST_PROJECT, ".claude", "agents", "project-manager-backlog.md");
 		const content = await Bun.file(agentPath).text();
 
-		expect(content).toBe(CLAUDE_AGENT_CONTENT);
+		expect(content).toContain(CLAUDE_AGENT_CONTENT.trimEnd());
 		expect(content).toContain("name: project-manager-backlog");
 		expect(content).toContain(
 			"You are an expert project manager specializing in the backlog.md task management system",
 		);
+	});
+
+	it("appends a version marker matching package.json (BACK-267)", async () => {
+		await installClaudeAgent(TEST_PROJECT);
+
+		const agentPath = join(TEST_PROJECT, ".claude", "agents", "project-manager-backlog.md");
+		const content = await Bun.file(agentPath).text();
+		const { version } = await Bun.file(join(__dirname, "../../package.json")).json();
+
+		expect(content.trimEnd().endsWith(`<!-- backlog.md-instructions-version: ${version} -->`)).toBe(true);
 	});
 
 	it("overwrites existing agent file", async () => {
@@ -49,7 +59,7 @@ describe("installClaudeAgent", () => {
 		await installClaudeAgent(TEST_PROJECT);
 
 		const content = await Bun.file(agentPath).text();
-		expect(content).toBe(CLAUDE_AGENT_CONTENT);
+		expect(content).toContain(CLAUDE_AGENT_CONTENT.trimEnd());
 		expect(content).not.toContain("Old content");
 	});
 


### PR DESCRIPTION
Implements BACK-267: every agent instruction surface that Backlog.md installs into user projects now carries a machine-readable version marker, so tooling (BACK-268 follow-up) can trivially compare a project's local instructions against the ones bundled with the running binary.

## Marker format

```
<!-- backlog.md-instructions-version: 1.47.1 -->
```

- Written as the first line inside each managed block, right after `<!-- BACKLOG.MD GUIDELINES START -->` / `<!-- BACKLOG.MD MCP GUIDELINES START -->`, and appended at the end of the installed `.claude/agents/project-manager-backlog.md`.
- Invisible when the markdown is rendered.
- Trivial to parse for the BACK-268 comparison: `/<!-- backlog\.md-instructions-version: (\S+) -->/` against `getVersion()`.

## Mechanism choice

The version is injected at install/update time in `src/agent-instructions.ts` (`wrapWithMarkers`), derived from the existing `getVersion()` helper (`__EMBEDDED_VERSION__` in compiled binaries, `package.json` in dev) — not hardcoded in the `src/guidelines/*.md` sources.

Why this over a manually maintained header in each guideline file:

- Zero release-time maintenance: no per-file version bumps, no release automation changes, and the marker can never drift from the binary that wrote it.
- It reuses the codebase's established version pattern (`src/utils/version.ts` build-time embedding) instead of introducing a second, manually synced version source.
- Because the marker lives inside the managed START/END block, the existing strip-and-reinsert update flow (`backlog init` re-run, `backlog agents --update-instructions`, CLI/MCP mode switches) refreshes it automatically — stale markers are removed together with the stale block.

Idempotency is preserved: re-running install/update on the same version still reports `unchanged`; after a version bump the block is rewritten with the new marker.

## Changes

- `src/agent-instructions.ts`: new internal `versionMarkerLine()` helper; `wrapWithMarkers()` takes the version and emits the marker line; `addAgentInstructions`, `ensureMcpGuidelines`, and `installClaudeAgent` resolve the version via `getVersion()` at write time.
- `src/test/agent-instructions.test.ts`: marker present in every generated CLI nudge file and MCP block, version matches `package.json`, marker placed inside the managed block exactly once, stale `0.0.1` marker refreshed on update.
- `src/test/claude-agent-install.test.ts`: installed Claude agent file ends with the version marker; exact-content assertions relaxed to account for the appended marker.

## Testing

- `bunx tsc --noEmit` clean
- `bunx biome check src scripts package.json biome.json` clean
- Full test suite (all 162 test files, run in chunks): 1326 pass, 2 skip, 0 failures related to this change. The only failing suite, `cli-priority-filtering.test.ts` (11 tests), fails identically on a clean `origin/main` checkout in this environment (pre-existing flake, unrelated).
