### PR TITLE
BACK-355.03 - MCP: Add type parameter to task_create and task_edit tools

### DIFF
--- a/backlog/tasks/back-355.03 - MCP-Add-type-parameter-to-task_create-and-task_edit-tools.md
+++ b/backlog/tasks/back-355.03 - MCP-Add-type-parameter-to-task_create-and-task_edit-tools.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-355.03
 title: 'MCP: Add type parameter to task_create and task_edit tools'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@alex-agent'
 created_date: '2026-01-01 23:37'
+updated_date: '2026-07-04 18:15'
 labels:
   - mcp
 dependencies:
@@ -20,10 +22,36 @@ Update MCP tool schemas to support the type field, enabling AI agents to categor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 task_create tool schema includes optional 'type' parameter with enum validation
-- [ ] #2 task_edit tool schema includes optional 'type' parameter
-- [ ] #3 task_view output includes type field
-- [ ] #4 task_list output includes type for each task
-- [ ] #5 MCP tool descriptions document the type field and valid values
-- [ ] #6 Integration tests verify type handling in MCP tools
+- [x] #1 task_create tool schema includes optional 'type' parameter with enum validation
+- [x] #2 task_edit tool schema includes optional 'type' parameter
+- [x] #3 task_view output includes type field
+- [x] #4 task_list output includes type for each task
+- [x] #5 MCP tool descriptions document the type field and valid values
+- [x] #6 Integration tests verify type handling in MCP tools
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add generateTypeFieldSchema(config) in src/mcp/utils/schema-generators.ts mirroring the status pattern: dynamic enum from config.types (fallback DEFAULT_TASK_TYPES), enumCaseInsensitive, description listing valid values, no default (absent = untyped). Wire into generateTaskCreateSchema and generateTaskEditSchema next to priority.
+2. Add type?: string to TaskCreateArgs (src/mcp/tools/tasks/handlers.ts) and pass through createTaskFromInput; add type?: string to TaskEditArgs (src/types/task-edit-args.ts) and map in buildTaskUpdateInput (src/utils/task-edit-builder.ts) so core normalization/validation applies.
+3. Surface type in outputs: Type line in formatTaskPlainText (shared by MCP task_view) next to Priority, and [type] indicator in formatTaskSummaryLine for task_list/task_search summaries.
+4. Minimal tool description update in src/mcp/tools/tasks/index.ts (task_edit metadata list mentions type).
+5. Tests in src/test/mcp-tasks.test.ts: create/edit with type incl. case-insensitive canonicalization, invalid type error surfaced through MCP, type in view/list output, untyped tasks show no type, schema exposes config-driven enum.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Schema approach: mirrored the status pattern (dynamic enum generated from config at tool registration) rather than priority's static enum, because allowed types are config-dependent. New generateTypeFieldSchema(config) in src/mcp/utils/schema-generators.ts builds enum from config.types (fallback DEFAULT_TASK_TYPES) with enumCaseInsensitive: true and no default (absent = untyped). Invalid types are rejected at the MCP boundary with the standard enum validation error listing valid values, exactly like status; core normalizeTaskType still guards the CLI path with 'Invalid type: ...'.
+
+Edit path reuses the shared buildTaskUpdateInput (type added to TaskEditArgs), so CLI (BACK-355.02) gets the same mapping for free. Outputs: 'Type: <type>' line added to shared formatTaskPlainText (task_view, CLI --plain) next to Priority, and '[<type>]' indicator added to the MCP task list/search summary line next to '[PRIORITY]'. Untyped tasks render no type anywhere. Clearing a type via MCP is not supported (enum blocks empty string), same as status; clearing remains a CLI/core capability via empty string.
+
+Validation: bunx tsc --noEmit clean; bunx biome check clean; bun test src/test/mcp-tasks.test.ts 23/23 pass; full bun test 1401 pass with only the documented pre-existing flakes (cli-priority-filtering timeout, server-search-endpoint milestone timeouts — both fail identically on clean origin/main).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added optional 'type' parameter to MCP task_create and task_edit. Schemas expose a config-driven enum (config.types, fallback bug/feature/enhancement/task/chore/docs/spike) with case-insensitive matching canonicalized to configured casing and no default, mirroring the existing dynamic status enum pattern. Type flows through createTaskFromInput and the shared buildTaskUpdateInput so core validation applies. task_view (shared plain-text formatter) now prints 'Type: <type>' next to Priority, and task_list/task_search summaries show '[<type>]' next to the priority indicator; untyped tasks show no type. task_edit tool description mentions type; the type field description lists valid values. Verified with 3 new integration tests in src/test/mcp-tasks.test.ts (create/edit incl. case-insensitivity, invalid-type errors on create and edit, view/list output, untyped rendering, config-driven enum with custom types) plus tsc, biome, and the full suite.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/formatters/task-plain-text.ts
+++ b/src/formatters/task-plain-text.ts
@@ -91,6 +91,9 @@ export function formatTaskPlainText(task: Task, options: TaskPlainTextOptions = 
 	if (priorityLabel) {
 		lines.push(`Priority: ${priorityLabel}`);
 	}
+	if (task.type) {
+		lines.push(`Type: ${task.type}`);
+	}
 	if (task.ordinal !== undefined) {
 		lines.push(`Ordinal: ${task.ordinal}`);
 	}

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -30,6 +30,7 @@ export type TaskCreateArgs = {
 	labels?: string[];
 	assignee?: string[];
 	priority?: "high" | "medium" | "low";
+	type?: string;
 	ordinal?: number;
 	status?: string;
 	milestone?: string;
@@ -83,9 +84,10 @@ export class TaskHandlers {
 
 	private formatTaskSummaryLine(task: Task, options: { includeStatus?: boolean } = {}): string {
 		const priorityIndicator = task.priority ? `[${task.priority.toUpperCase()}] ` : "";
+		const typeIndicator = task.type ? `[${task.type}] ` : "";
 		const status = task.status || (task.source === "completed" ? "Done" : "");
 		const statusText = options.includeStatus && status ? ` (${status})` : "";
-		return `  ${priorityIndicator}${task.id} - ${task.title}${statusText}`;
+		return `  ${priorityIndicator}${typeIndicator}${task.id} - ${task.title}${statusText}`;
 	}
 
 	private async loadTaskOrThrow(id: string): Promise<Task> {
@@ -117,6 +119,7 @@ export class TaskHandlers {
 				description: args.description,
 				status: args.status,
 				priority: args.priority,
+				type: args.type,
 				...(typeof rawOrdinal === "number" ? { ordinal: rawOrdinal } : {}),
 				milestone,
 				labels: args.labels,

--- a/src/mcp/tools/tasks/index.ts
+++ b/src/mcp/tools/tasks/index.ts
@@ -50,7 +50,7 @@ export function registerTaskTools(server: McpServer, config: BacklogConfig): voi
 		{
 			name: "task_edit",
 			description:
-				"Edit a Backlog.md task, including metadata, implementation plan/notes, dependencies, acceptance criteria, and task-specific Definition of Done items",
+				"Edit a Backlog.md task, including metadata (status, priority, type), implementation plan/notes, dependencies, acceptance criteria, and task-specific Definition of Done items",
 			inputSchema: taskEditSchema,
 			annotations: { title: "Edit Task", destructiveHint: false },
 		},

--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_STATUSES } from "../../constants/index.ts";
+import { DEFAULT_STATUSES, DEFAULT_TASK_TYPES } from "../../constants/index.ts";
 import type { BacklogConfig } from "../../types/index.ts";
 import type { JsonSchema } from "../validation/validators.ts";
 
@@ -35,6 +35,22 @@ export function generateStatusFieldSchema(config: BacklogConfig): JsonSchema {
 }
 
 /**
+ * Generates a task type field schema with dynamic enum values sourced from config.
+ * No default is set: tasks without a type stay untyped.
+ */
+function generateTypeFieldSchema(config: BacklogConfig): JsonSchema {
+	const types = config.types?.length ? config.types.map((type) => type.trim()) : [...DEFAULT_TASK_TYPES];
+
+	return {
+		type: "string",
+		maxLength: 50,
+		enum: types,
+		enumCaseInsensitive: true,
+		description: `Optional task type (case-insensitive). Valid values: ${types.join(", ")}`,
+	};
+}
+
+/**
  * Generates the task_create input schema with dynamic status enum
  */
 export function generateTaskCreateSchema(config: BacklogConfig): JsonSchema {
@@ -55,6 +71,7 @@ export function generateTaskCreateSchema(config: BacklogConfig): JsonSchema {
 				type: "string",
 				enum: ["high", "medium", "low"],
 			},
+			type: generateTypeFieldSchema(config),
 			ordinal: {
 				type: "number",
 				minimum: 0,
@@ -173,6 +190,7 @@ export function generateTaskEditSchema(config: BacklogConfig): JsonSchema {
 				type: "string",
 				enum: ["high", "medium", "low"],
 			},
+			type: generateTypeFieldSchema(config),
 			ordinal: {
 				type: "number",
 				minimum: 0,

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { $ } from "bun";
-import { DEFAULT_STATUSES } from "../constants/index.ts";
+import { DEFAULT_STATUSES, DEFAULT_TASK_TYPES } from "../constants/index.ts";
 import { McpServer } from "../mcp/server.ts";
 import { registerTaskTools } from "../mcp/tools/tasks/index.ts";
 import type { JsonSchema } from "../mcp/validation/validators.ts";
@@ -903,5 +903,151 @@ describe("MCP task tools (MVP)", () => {
 		const standaloneText = getText(standaloneView.content);
 		expect(standaloneText).not.toContain("Subtasks (");
 		expect(standaloneText).not.toContain("Subtasks:");
+	});
+
+	it("creates and edits tasks with a semantic type and shows it in view and list output", async () => {
+		const createResult = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Typed task",
+					type: "BUG",
+					priority: "high",
+				},
+			},
+		});
+		expect(getText(createResult.content)).toContain("Type: bug");
+
+		const createdTask = await mcpServer.getTask("task-1");
+		expect(createdTask?.type).toBe("bug");
+
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Untyped task",
+				},
+			},
+		});
+
+		const listResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_list", arguments: {} },
+		});
+		const listText = (listResult.content ?? []).map((entry) => ("text" in entry ? entry.text : "")).join("\n\n");
+		expect(listText).toContain("[HIGH] [bug] TASK-1 - Typed task");
+		expect(listText).toContain("  TASK-2 - Untyped task");
+
+		const editResult = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					type: "Feature",
+				},
+			},
+		});
+		expect(getText(editResult.content)).toContain("Type: feature");
+
+		const editedTask = await mcpServer.getTask("task-1");
+		expect(editedTask?.type).toBe("feature");
+
+		const untypedView = await mcpServer.testInterface.callTool({
+			params: { name: "task_view", arguments: { id: "task-2" } },
+		});
+		expect(getText(untypedView.content)).not.toContain("Type:");
+	});
+
+	it("rejects invalid task types through task_create and task_edit", async () => {
+		const createResult = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Invalid type task",
+					type: "banana",
+				},
+			},
+		});
+		expect(createResult.isError).toBe(true);
+		expect(getText(createResult.content)).toContain(`must be one of: ${DEFAULT_TASK_TYPES.join(", ")}`);
+
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Valid task",
+				},
+			},
+		});
+
+		const editResult = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					type: "banana",
+				},
+			},
+		});
+		expect(editResult.isError).toBe(true);
+		expect(getText(editResult.content)).toContain(`must be one of: ${DEFAULT_TASK_TYPES.join(", ")}`);
+
+		const task = await mcpServer.getTask("task-1");
+		expect(task?.type).toBeUndefined();
+	});
+
+	it("exposes task type enums from configuration without a default", async () => {
+		const tools = await mcpServer.testInterface.listTools();
+		const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+		const createTypeSchema = (toolByName.get("task_create")?.inputSchema as JsonSchema | undefined)?.properties?.type;
+		const editTypeSchema = (toolByName.get("task_edit")?.inputSchema as JsonSchema | undefined)?.properties?.type;
+
+		expect(createTypeSchema?.enum).toEqual([...DEFAULT_TASK_TYPES]);
+		expect(createTypeSchema?.enumCaseInsensitive).toBe(true);
+		expect(createTypeSchema?.default).toBeUndefined();
+		expect(createTypeSchema?.description).toContain(`Valid values: ${DEFAULT_TASK_TYPES.join(", ")}`);
+
+		expect(editTypeSchema?.enum).toEqual([...DEFAULT_TASK_TYPES]);
+		expect(editTypeSchema?.enumCaseInsensitive).toBe(true);
+		expect(editTypeSchema?.default).toBeUndefined();
+
+		const config = await loadConfig(mcpServer);
+		config.types = ["Bug", "Epic"];
+		await mcpServer.filesystem.saveConfig(config);
+
+		const customServer = new McpServer(TEST_DIR, "Test instructions");
+		try {
+			registerTaskTools(customServer, await loadConfig(customServer));
+
+			const customTools = await customServer.testInterface.listTools();
+			const customCreateSchema = customTools.tools.find((tool) => tool.name === "task_create")?.inputSchema as
+				| JsonSchema
+				| undefined;
+			expect(customCreateSchema?.properties?.type?.enum).toEqual(["Bug", "Epic"]);
+
+			const createResult = await customServer.testInterface.callTool({
+				params: {
+					name: "task_create",
+					arguments: {
+						title: "Configured type task",
+						type: "bug",
+					},
+				},
+			});
+			expect(getText(createResult.content)).toContain("Type: Bug");
+
+			const invalidResult = await customServer.testInterface.callTool({
+				params: {
+					name: "task_create",
+					arguments: {
+						title: "Rejected type task",
+						type: "feature",
+					},
+				},
+			});
+			expect(invalidResult.isError).toBe(true);
+			expect(getText(invalidResult.content)).toContain("must be one of: Bug, Epic");
+		} finally {
+			await customServer.stop().catch(() => {});
+		}
 	});
 });

--- a/src/types/task-edit-args.ts
+++ b/src/types/task-edit-args.ts
@@ -3,6 +3,7 @@ export interface TaskEditArgs {
 	description?: string;
 	status?: string;
 	priority?: "high" | "medium" | "low";
+	type?: string;
 	milestone?: string | null;
 	labels?: string[];
 	addLabels?: string[];

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -44,6 +44,10 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		updateInput.priority = args.priority;
 	}
 
+	if (typeof args.type === "string") {
+		updateInput.type = args.type;
+	}
+
 	if (args.milestone === null) {
 		updateInput.milestone = null;
 	} else if (typeof args.milestone === "string") {


### PR DESCRIPTION
Part of BACK-355 (task type field). Builds on the core support merged in #720.

## What changed
- **Schemas** (`src/mcp/utils/schema-generators.ts`): new `generateTypeFieldSchema(config)` wired into `task_create` and `task_edit` input schemas next to `priority`. Mirrors the dynamic status-enum pattern: enum values come from config `types` (fallback: bug, feature, enhancement, task, chore, docs, spike), case-insensitive input canonicalized to configured casing, no default (absent = untyped). Invalid values are rejected at the MCP boundary with the standard enum validation error listing the valid values, same as status.
- **Handlers**: `type` added to `TaskCreateArgs` and passed through `createTaskFromInput`; `type` added to `TaskEditArgs` and mapped in the shared `buildTaskUpdateInput`, so core `normalizeTaskType` validation applies on both paths (and the CLI edit path in BACK-355.02 gets the same mapping for free).
- **Outputs**: `Type: <type>` line in the shared plain-text formatter (MCP `task_view`, CLI `--plain` view) next to Priority; `[<type>]` indicator in MCP `task_list`/`task_search` summary lines next to `[PRIORITY]`. Untyped tasks render no type anywhere.
- **Descriptions**: `task_edit` tool description now enumerates type among metadata; the `type` field description lists the valid values dynamically.

## Tests
Three new integration tests in `src/test/mcp-tasks.test.ts`:
- create/edit with type incl. case-insensitive canonicalization, type shown in view + list, untyped task shows no type
- invalid type rejected through both `task_create` and `task_edit` with valid values in the error
- schemas expose the config-driven enum without a default; custom `types` config (`Bug`, `Epic`) drives the enum, canonical casing, and rejection of default types

`bunx tsc --noEmit`, `bunx biome check`, and `bun test` pass (only pre-existing flaky timeouts in `cli-priority-filtering` and `server-search-endpoint`, which fail identically on clean main).