### PR TITLE
BACK-523 - Add plain support to doc view

### DIFF
--- a/backlog/tasks/back-523 - Add-plain-support-to-doc-view.md
+++ b/backlog/tasks/back-523 - Add-plain-support-to-doc-view.md
@@ -1,0 +1,68 @@
+---
+id: BACK-523
+title: Add plain support to doc view
+status: Done
+assignee:
+  - '@gpt-5'
+created_date: '2026-07-08 20:15'
+updated_date: '2026-07-08 20:16'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/723'
+  - 'https://github.com/MrLesk/Backlog.md/pull/729'
+modified_files:
+  - src/cli.ts
+  - src/test/cli-doc-view.test.ts
+ordinal: 116000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add a non-interactive plain-text path for `backlog doc view` so agents, scripts, pipes, and CI can read Backlog documents through the public CLI without launching the interactive viewer.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `backlog doc view <docId> --plain` prints the document content to stdout without launching the interactive viewer
+- [x] #2 `backlog doc view <docId>` automatically emits plain output when stdout is not a TTY
+- [x] #3 `backlog doc view --help` documents the `--plain` option and includes a plain-output example
+- [x] #4 Focused CLI tests cover explicit plain output and non-TTY auto-plain behavior for document view
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Follow the existing CLI plain-output pattern used by other read commands.
+2. Add `--plain` to `backlog doc view`, using `isPlainRequested(options) || shouldAutoPlain` before falling back to the scrollable viewer.
+3. Update the command help schema and examples.
+4. Add focused CLI tests for explicit `--plain` and non-TTY auto-plain behavior.
+5. Verify with focused tests, typecheck, and Biome.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created after PR #729 implementation review to attach the required Backlog task record to the existing scoped GitHub issue #723 and PR.
+
+Verification on PR #729 branch:
+- `bun test src/test/cli-doc-view.test.ts` passed (2 tests).
+- `bunx tsc --noEmit` passed.
+- `bun run check .` passed.
+- `bun run cli doc view --help` shows `--plain` and the `backlog doc view doc-1 --plain` example.
+- Full `bun test` was attempted; it hit the existing `src/test/cli-priority-filtering.test.ts` timeout in `case insensitive priority filtering`, which also reproduces when that unrelated file is run alone.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added `--plain` support to `backlog doc view`, including non-TTY auto-plain behavior and command help/schema documentation. Verified with the focused doc-view CLI test, TypeScript check, Biome check, and help output inspection. Full-suite verification was attempted, but an unrelated priority-filtering timeout reproduces outside this PR scope.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3752,18 +3752,24 @@ addHelpSchema(docCmd.command("search <query>"), {
 addHelpSchema(docCmd.command("view <docId>"), {
 	reads: "Document metadata and markdown body",
 	required: [{ name: "docId", type: "Document ID", description: "Document to display" }],
-	optional: [],
+	optional: [{ name: "plain", type: "Boolean", description: "Use text output instead of interactive UI" }],
 	output: "Document metadata and markdown content",
-	examples: ["backlog doc view doc-1"],
+	examples: ["backlog doc view doc-1", "backlog doc view doc-1 --plain"],
 })
 	.description("view a document")
-	.action(async (docId: string) => {
+	.option("--plain", "use plain text output instead of interactive UI")
+	.action(async (docId: string, options) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		try {
 			const content = await core.getDocumentContent(docId);
 			if (content === null) {
 				console.error(`Document ${docId} not found.`);
+				return;
+			}
+			const usePlainOutput = isPlainRequested(options) || shouldAutoPlain;
+			if (usePlainOutput) {
+				console.log(content);
 				return;
 			}
 			await scrollableViewer(content);

--- a/src/test/cli-doc-view.test.ts
+++ b/src/test/cli-doc-view.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+describe("CLI doc view command", () => {
+	const cliPath = join(process.cwd(), "src", "cli.ts");
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-cli-doc-view");
+		await mkdir(TEST_DIR, { recursive: true });
+
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await initializeTestProject(core, "Doc View Project");
+
+		await core.createDocument({
+			id: "doc-1",
+			title: "Architecture Overview",
+			type: "guide",
+			createdDate: "2026-07-04",
+			rawContent: "Service topology and indexing architecture details.",
+		});
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("prints document content with --plain", async () => {
+		const result = await $`bun ${cliPath} doc view doc-1 --plain`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("Architecture Overview");
+		expect(stdout).toContain("Service topology and indexing architecture details.");
+	});
+
+	it("falls back to plain output without --plain when not attached to a TTY", async () => {
+		const result = await $`bun ${cliPath} doc view doc-1`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("Service topology and indexing architecture details.");
+		expect(stdout).not.toContain("[");
+	});
+});


### PR DESCRIPTION
## Summary
Adds `--plain` support to `backlog doc view` so agents, scripts, pipes, and CI can read documents through the public CLI without launching the interactive viewer.

## Related Issue or Task
Closes #723

Backlog task: BACK-523

## Task Checklist
- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Testing
- `bun test src/test/cli-doc-view.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run cli doc view --help`
- Full `bun test` was attempted locally; it hit the existing `src/test/cli-priority-filtering.test.ts` timeout in `case insensitive priority filtering`, which also reproduces when that unrelated file is run alone.