### PR TITLE
BACK-524 - Fix Windows priority test timeout

### DIFF
--- a/backlog/tasks/back-524 - Speed-up-CI-test-workflow.md
+++ b/backlog/tasks/back-524 - Speed-up-CI-test-workflow.md
@@ -5,12 +5,13 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-08 20:25'
-updated_date: '2026-07-08 21:47'
+updated_date: '2026-07-08 22:10'
 labels: []
 dependencies: []
 modified_files:
   - .github/workflows/ci.yml
   - scripts/list-test-shard.ts
+  - src/test/cli-priority-filtering.test.ts
 priority: medium
 ordinal: 167000
 ---
@@ -63,6 +64,8 @@ Rebased tasks/back-524-speed-up-ci onto PR #737 (tasks/back-525-browser-bundling
 Post-rebase validation on Bun 1.3.14: bun install --frozen-lockfile --linker=isolated passed; shard helper covers all 173 test files exactly once across three shards (58/58/57); bun run check:types passed; bun run check . passed; full isolated test command passed with 1445 pass, 2 skip, 0 fail across 173 files in 163.86s; CI-style local build smoke using bun scripts/build.ts produced /tmp/backlog-ci-build and --version reported 1.47.1.
 
 Second rebase per request: moved tasks/back-524-speed-up-ci onto updated PR #737 head 765bb22 using git rebase --onto, then reapplied the BACK-524 patch cleanly. Validation on the updated stack: bun install --frozen-lockfile --linker=isolated passed; shard helper still covers all 173 tests exactly once across shards 58/58/57; bun run check:types passed; bun run check . passed; git diff --check passed. Full isolated test run completed with 1444 pass, 2 skip, and one timeout in ContentStore > removes decisions when files are deleted after 187.32s; rerunning src/test/content-store.test.ts directly with the same 10000ms timeout passed all 5 tests in 61ms, indicating an isolated watcher timing flake rather than a deterministic regression.
+
+CI follow-up from main run 28978320635: Windows shard 1/3 failed because CLI Priority Filtering > case insensitive priority filtering kept a hardcoded 10000ms per-test timeout while Windows shards now rely on a 30000ms command timeout. Updated that test to use getPlatformTimeout(10000), preserving the 10s timeout off Windows and giving Windows the standard platform headroom. Verified with bun test src/test/cli-priority-filtering.test.ts --timeout=30000, bunx tsc --noEmit, bun run check ., and git diff --check.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/test/cli-priority-filtering.test.ts
+++ b/src/test/cli-priority-filtering.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { $ } from "bun";
+import { getPlatformTimeout } from "./test-utils.ts";
 
 describe("CLI Priority Filtering", () => {
 	test("task list --priority high shows only high priority tasks", async () => {
@@ -116,34 +117,38 @@ describe("CLI Priority Filtering", () => {
 		}
 	});
 
-	test("case insensitive priority filtering", async () => {
-		const upperResult = await $`bun run cli task list --priority HIGH --plain`.quiet();
-		const lowerResult = await $`bun run cli task list --priority high --plain`.quiet();
-		const mixedResult = await $`bun run cli task list --priority High --plain`.quiet();
+	test(
+		"case insensitive priority filtering",
+		async () => {
+			const upperResult = await $`bun run cli task list --priority HIGH --plain`.quiet();
+			const lowerResult = await $`bun run cli task list --priority high --plain`.quiet();
+			const mixedResult = await $`bun run cli task list --priority High --plain`.quiet();
 
-		expect(upperResult.exitCode).toBe(0);
-		expect(lowerResult.exitCode).toBe(0);
-		expect(mixedResult.exitCode).toBe(0);
+			expect(upperResult.exitCode).toBe(0);
+			expect(lowerResult.exitCode).toBe(0);
+			expect(mixedResult.exitCode).toBe(0);
 
-		const [upperOutput, lowerOutput, mixedOutput] = [
-			upperResult.stdout.toString(),
-			lowerResult.stdout.toString(),
-			mixedResult.stdout.toString(),
-		];
-		const listUpper = upperOutput.split("\n").filter((line) => line.includes("task-"));
-		const listLower = lowerOutput.split("\n").filter((line) => line.includes("task-"));
-		const listMixed = mixedOutput.split("\n").filter((line) => line.includes("task-"));
-		if (listLower.length > 0) {
-			expect(listUpper).toEqual(listLower);
-			expect(listMixed).toEqual(listLower);
-		}
-
-		for (const output of [upperOutput, lowerOutput, mixedOutput]) {
-			if (output.includes("task-")) {
-				expect(output).toMatch(/\[HIGH\]/);
-				expect(output).not.toMatch(/\[MEDIUM\]/);
-				expect(output).not.toMatch(/\[LOW\]/);
+			const [upperOutput, lowerOutput, mixedOutput] = [
+				upperResult.stdout.toString(),
+				lowerResult.stdout.toString(),
+				mixedResult.stdout.toString(),
+			];
+			const listUpper = upperOutput.split("\n").filter((line) => line.includes("task-"));
+			const listLower = lowerOutput.split("\n").filter((line) => line.includes("task-"));
+			const listMixed = mixedOutput.split("\n").filter((line) => line.includes("task-"));
+			if (listLower.length > 0) {
+				expect(listUpper).toEqual(listLower);
+				expect(listMixed).toEqual(listLower);
 			}
-		}
-	}, 10000);
+
+			for (const output of [upperOutput, lowerOutput, mixedOutput]) {
+				if (output.includes("task-")) {
+					expect(output).toMatch(/\[HIGH\]/);
+					expect(output).not.toMatch(/\[MEDIUM\]/);
+					expect(output).not.toMatch(/\[LOW\]/);
+				}
+			}
+		},
+		getPlatformTimeout(10000),
+	);
 });


### PR DESCRIPTION
## Summary

Fixes the Windows shard failure from [run 28978320635](https://github.com/MrLesk/Backlog.md/actions/runs/28978320635).

- The failed shard timed out in `CLI Priority Filtering > case insensitive priority filtering` after exactly 10s.
- The Windows shard command allows 30s, but this test still had a hardcoded per-test `10000` ms timeout.
- Switched that test to `getPlatformTimeout(10000)`, preserving the 10s timeout on non-Windows and allowing the standard Windows headroom.

## Validation

- `bun test src/test/cli-priority-filtering.test.ts --timeout=30000`
- `bunx tsc --noEmit`
- `bun run check .`
- `git diff --check`