### PR TITLE
BACK-528 - Fix All Tasks ID sorting for subtasks

### DIFF
--- a/backlog/tasks/back-528 - Fix-All-Tasks-ID-sorting-for-subtasks.md
+++ b/backlog/tasks/back-528 - Fix-All-Tasks-ID-sorting-for-subtasks.md
@@ -5,14 +5,16 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-09 05:56'
-updated_date: '2026-07-09 06:02'
+updated_date: '2026-07-09 07:24'
 labels: []
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/734'
 modified_files:
   - src/web/components/TaskList.tsx
+  - src/utils/task-sorting.ts
   - src/test/web-task-list-labels-menu.test.tsx
+  - src/test/task-sorting.test.ts
 ordinal: 168000
 ---
 
@@ -41,6 +43,10 @@ GitHub issue #734 reports that the web UI All Tasks table sorts dotted subtask I
 
 <!-- SECTION:NOTES:BEGIN -->
 Reproduced issue #734 with a focused TaskList Web UI test: before the fix, ascending ID sort returned task-1, task-3.01, task-2, task-3.02, task-3. Replaced TaskList’s local trailing-number parser with the shared compareTaskIds helper so dotted subtask IDs sort hierarchically. Validation passed: bun test src/test/web-task-list-labels-menu.test.tsx; bun test src/test/task-sorting.test.ts; bunx tsc --noEmit; bun run check .; bun test (1446 pass, 2 skip, 0 fail).
+
+PR #741 review follow-up: preserved the locale/numeric fallback when compareTaskIds returns equality for distinct task IDs, so nonnumeric IDs like task-alpha/task-beta sort deterministically without regressing dotted subtask ordering. Added a focused nonnumeric ID regression test. Additional validation passed: bun test src/test/web-task-list-labels-menu.test.tsx src/test/task-sorting.test.ts; bun test src/test/build.test.ts; bun run check .; bunx tsc --noEmit.
+
+Simplification pass moved the deterministic fallback into the shared compareTaskIds helper so TaskList and other task ID sort paths use one implementation. Revalidated with bun test src/test/web-task-list-labels-menu.test.tsx src/test/task-sorting.test.ts src/test/build.test.ts; bunx tsc --noEmit; bun run check .
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-528 - Fix-All-Tasks-ID-sorting-for-subtasks.md
+++ b/backlog/tasks/back-528 - Fix-All-Tasks-ID-sorting-for-subtasks.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-09 05:56'
-updated_date: '2026-07-09 07:24'
+updated_date: '2026-07-09 07:36'
 labels: []
 dependencies: []
 references:
@@ -47,6 +47,8 @@ Reproduced issue #734 with a focused TaskList Web UI test: before the fix, ascen
 PR #741 review follow-up: preserved the locale/numeric fallback when compareTaskIds returns equality for distinct task IDs, so nonnumeric IDs like task-alpha/task-beta sort deterministically without regressing dotted subtask ordering. Added a focused nonnumeric ID regression test. Additional validation passed: bun test src/test/web-task-list-labels-menu.test.tsx src/test/task-sorting.test.ts; bun test src/test/build.test.ts; bun run check .; bunx tsc --noEmit.
 
 Simplification pass moved the deterministic fallback into the shared compareTaskIds helper so TaskList and other task ID sort paths use one implementation. Revalidated with bun test src/test/web-task-list-labels-menu.test.tsx src/test/task-sorting.test.ts src/test/build.test.ts; bunx tsc --noEmit; bun run check .
+
+PR #741 second review follow-up: fixed default ID-desc sorting so root task groups still sort descending while parent tasks remain before dotted subtasks. Added shared compareTaskIdsDescending coverage and a TaskList default-sort regression. Validation passed: bun test src/test/web-task-list-labels-menu.test.tsx src/test/task-sorting.test.ts; bun test src/test/build.test.ts; bunx tsc --noEmit; bun run check .
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-528 - Fix-All-Tasks-ID-sorting-for-subtasks.md
+++ b/backlog/tasks/back-528 - Fix-All-Tasks-ID-sorting-for-subtasks.md
@@ -1,0 +1,57 @@
+---
+id: BACK-528
+title: Fix All Tasks ID sorting for subtasks
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-09 05:56'
+updated_date: '2026-07-09 06:02'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/734'
+modified_files:
+  - src/web/components/TaskList.tsx
+  - src/test/web-task-list-labels-menu.test.tsx
+ordinal: 168000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+GitHub issue #734 reports that the web UI All Tasks table sorts dotted subtask IDs such as BACK-354.01 by only the trailing suffix, placing them near unrelated root tasks. The All Tasks table should use the same hierarchical task ID ordering used elsewhere so subtasks appear immediately after their parent task.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 All Tasks ID sorting orders root tasks and dotted subtasks hierarchically, for example TASK-001, TASK-002, TASK-003, TASK-003.01, TASK-003.02.
+- [x] #2 The Web UI table reuses the existing hierarchical task ID comparator instead of maintaining a divergent numeric suffix parser.
+- [x] #3 A regression test covers dotted subtask ID ordering in the All Tasks table sorting behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the All Tasks dotted-ID ordering bug with a focused Web UI regression test.
+2. Replace TaskList’s local trailing-number ID comparator with the shared hierarchical compareTaskIds helper.
+3. Run the targeted Web UI test, task-sorting test, type-check, and project check before publishing the PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced issue #734 with a focused TaskList Web UI test: before the fix, ascending ID sort returned task-1, task-3.01, task-2, task-3.02, task-3. Replaced TaskList’s local trailing-number parser with the shared compareTaskIds helper so dotted subtask IDs sort hierarchically. Validation passed: bun test src/test/web-task-list-labels-menu.test.tsx; bun test src/test/task-sorting.test.ts; bunx tsc --noEmit; bun run check .; bun test (1446 pass, 2 skip, 0 fail).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed All Tasks ID sorting for dotted subtasks by reusing the shared hierarchical task ID comparator in TaskList. Added a Web UI regression test covering task-3, task-3.01, and task-3.02 ordering; targeted checks, type-check, Biome, and the full Bun test suite pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/test/task-sorting.test.ts
+++ b/src/test/task-sorting.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { compareTaskIds, parseTaskId, sortByPriority, sortByTaskId, sortTasks } from "../utils/task-sorting.ts";
+import {
+	compareTaskIds,
+	compareTaskIdsDescending,
+	parseTaskId,
+	sortByPriority,
+	sortByTaskId,
+	sortTasks,
+} from "../utils/task-sorting.ts";
 
 describe("parseTaskId", () => {
 	test("parses simple task IDs", () => {
@@ -66,6 +73,22 @@ describe("compareTaskIds", () => {
 		expect(compareTaskIds("task-alpha", "task-beta")).toBeLessThan(0);
 		expect(compareTaskIds("task-beta", "task-alpha")).toBeGreaterThan(0);
 		expect(compareTaskIds("task-alpha", "task-alpha")).toBe(0);
+	});
+});
+
+describe("compareTaskIdsDescending", () => {
+	test("sorts root task groups descending while keeping parents before subtasks", () => {
+		const ids = ["task-1", "task-3.01", "task-2", "task-3.02", "task-3"];
+
+		const sorted = [...ids].sort(compareTaskIdsDescending);
+
+		expect(sorted).toEqual(["task-3", "task-3.02", "task-3.01", "task-2", "task-1"]);
+	});
+
+	test("sorts distinct nonnumeric IDs deterministically", () => {
+		expect(compareTaskIdsDescending("task-alpha", "task-beta")).toBeGreaterThan(0);
+		expect(compareTaskIdsDescending("task-beta", "task-alpha")).toBeLessThan(0);
+		expect(compareTaskIdsDescending("task-alpha", "task-alpha")).toBe(0);
 	});
 });
 

--- a/src/test/task-sorting.test.ts
+++ b/src/test/task-sorting.test.ts
@@ -61,6 +61,12 @@ describe("compareTaskIds", () => {
 		expect(compareTaskIds("task-draft2", "task-draft10")).toBeLessThan(0);
 		expect(compareTaskIds("task-draft10", "task-draft2")).toBeGreaterThan(0);
 	});
+
+	test("sorts distinct nonnumeric IDs deterministically", () => {
+		expect(compareTaskIds("task-alpha", "task-beta")).toBeLessThan(0);
+		expect(compareTaskIds("task-beta", "task-alpha")).toBeGreaterThan(0);
+		expect(compareTaskIds("task-alpha", "task-alpha")).toBe(0);
+	});
 });
 
 describe("sortByTaskId", () => {

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -175,6 +175,23 @@ describe("TaskList labels filter menu", () => {
 		expect(getRenderedTaskIds(container)).toEqual(["task-1", "task-2", "task-3", "task-3.01", "task-3.02"]);
 	});
 
+	it("sorts distinct nonnumeric task IDs deterministically when sorting by ID", async () => {
+		const container = renderTaskList(undefined, {
+			tasks: [
+				createTask({ id: "task-beta", title: "Beta task" }),
+				createTask({ id: "task-alpha", title: "Alpha task" }),
+			],
+		});
+
+		const idButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("ID"));
+		expect(idButton).toBeTruthy();
+
+		await clickElement(idButton as HTMLButtonElement);
+		await waitFor(() => getRenderedTaskIds(container)[0] === "task-alpha");
+
+		expect(getRenderedTaskIds(container)).toEqual(["task-alpha", "task-beta"]);
+	});
+
 	it("renders and sorts by ordinal with task ID as the tie-breaker", async () => {
 		const container = renderTaskList(undefined, {
 			tasks: [

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -155,6 +155,26 @@ describe("TaskList labels filter menu", () => {
 		expect(container.querySelector("input[placeholder='Search tasks']")).toBeNull();
 	});
 
+	it("sorts dotted subtask IDs under their parent when sorting by ID", async () => {
+		const container = renderTaskList(undefined, {
+			tasks: [
+				createTask({ id: "task-1", title: "First task" }),
+				createTask({ id: "task-2", title: "Second task" }),
+				createTask({ id: "task-3", title: "Parent task" }),
+				createTask({ id: "task-3.01", title: "First subtask" }),
+				createTask({ id: "task-3.02", title: "Second subtask" }),
+			],
+		});
+
+		const idButton = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("ID"));
+		expect(idButton).toBeTruthy();
+
+		await clickElement(idButton as HTMLButtonElement);
+		await waitFor(() => getRenderedTaskIds(container)[0] === "task-1");
+
+		expect(getRenderedTaskIds(container)).toEqual(["task-1", "task-2", "task-3", "task-3.01", "task-3.02"]);
+	});
+
 	it("renders and sorts by ordinal with task ID as the tie-breaker", async () => {
 		const container = renderTaskList(undefined, {
 			tasks: [

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -175,6 +175,20 @@ describe("TaskList labels filter menu", () => {
 		expect(getRenderedTaskIds(container)).toEqual(["task-1", "task-2", "task-3", "task-3.01", "task-3.02"]);
 	});
 
+	it("keeps parent tasks before subtasks in the default ID descending sort", () => {
+		const container = renderTaskList(undefined, {
+			tasks: [
+				createTask({ id: "task-1", title: "First task" }),
+				createTask({ id: "task-2", title: "Second task" }),
+				createTask({ id: "task-3.01", title: "First subtask" }),
+				createTask({ id: "task-3.02", title: "Second subtask" }),
+				createTask({ id: "task-3", title: "Parent task" }),
+			],
+		});
+
+		expect(getRenderedTaskIds(container)).toEqual(["task-3", "task-3.02", "task-3.01", "task-2", "task-1"]);
+	});
+
 	it("sorts distinct nonnumeric task IDs deterministically when sorting by ID", async () => {
 		const container = renderTaskList(undefined, {
 			tasks: [

--- a/src/utils/task-sorting.ts
+++ b/src/utils/task-sorting.ts
@@ -61,6 +61,30 @@ export function compareTaskIds(a: string, b: string): number {
 	return a.localeCompare(b, undefined, { sensitivity: "base", numeric: true });
 }
 
+function isAncestorTaskId(parentId: string, childId: string): boolean {
+	const parentParts = parseTaskId(parentId);
+	const childParts = parseTaskId(childId);
+
+	if (parentParts.length >= childParts.length) {
+		return false;
+	}
+
+	return parentParts.every((part, index) => part === childParts[index]);
+}
+
+/**
+ * Compare two task IDs in descending order while keeping parents before children.
+ */
+export function compareTaskIdsDescending(a: string, b: string): number {
+	if (isAncestorTaskId(a, b)) {
+		return -1;
+	}
+	if (isAncestorTaskId(b, a)) {
+		return 1;
+	}
+	return compareTaskIds(b, a);
+}
+
 /**
  * Sort an array of objects by their task ID property numerically.
  * Returns a new sorted array without mutating the original.

--- a/src/utils/task-sorting.ts
+++ b/src/utils/task-sorting.ts
@@ -57,8 +57,8 @@ export function compareTaskIds(a: string, b: string): number {
 		}
 	}
 
-	// All parts are equal
-	return 0;
+	// All numeric parts are equal; use the original ID as a deterministic fallback.
+	return a.localeCompare(b, undefined, { sensitivity: "base", numeric: true });
 }
 
 /**

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -8,6 +8,7 @@ import type {
 	TaskSearchResult,
 } from "../../types";
 import { collectAvailableLabels } from "../../utils/label-filter.ts";
+import { compareTaskIds } from "../../utils/task-sorting.ts";
 import { isTerminalStatus } from "../../utils/terminal-status.ts";
 import { collectArchivedMilestoneKeys, getMilestoneLabel, milestoneKey } from "../utils/milestones";
 import { formatStoredUtcDateForCompactDisplay, parseStoredUtcDate } from "../utils/date-display";
@@ -44,22 +45,8 @@ const PRIORITY_RANK: Record<string, number> = {
 	low: 1,
 };
 
-function extractTaskNumericId(taskId: string): number | null {
-	const match = taskId.trim().match(/(\d+)$/);
-	if (!match?.[1]) return null;
-	return Number.parseInt(match[1], 10);
-}
-
 function compareTaskIdsAscending(a: Task, b: Task): number {
-	const idA = extractTaskNumericId(a.id);
-	const idB = extractTaskNumericId(b.id);
-
-	if (idA !== null && idB !== null) {
-		return idA - idB;
-	}
-	if (idA !== null) return -1;
-	if (idB !== null) return 1;
-	return a.id.localeCompare(b.id, undefined, { sensitivity: "base", numeric: true });
+	return compareTaskIds(a.id, b.id);
 }
 
 function sortTasksByIdDescending(list: Task[]): Task[] {

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -8,7 +8,7 @@ import type {
 	TaskSearchResult,
 } from "../../types";
 import { collectAvailableLabels } from "../../utils/label-filter.ts";
-import { compareTaskIds } from "../../utils/task-sorting.ts";
+import { compareTaskIds, compareTaskIdsDescending } from "../../utils/task-sorting.ts";
 import { isTerminalStatus } from "../../utils/terminal-status.ts";
 import { collectArchivedMilestoneKeys, getMilestoneLabel, milestoneKey } from "../utils/milestones";
 import { formatStoredUtcDateForCompactDisplay, parseStoredUtcDate } from "../utils/date-display";
@@ -50,7 +50,7 @@ function compareTaskIdsAscending(a: Task, b: Task): number {
 }
 
 function sortTasksByIdDescending(list: Task[]): Task[] {
-	return [...list].sort((a, b) => compareTaskIdsAscending(b, a));
+	return [...list].sort((a, b) => compareTaskIdsDescending(a.id, b.id));
 }
 
 function getAssigneeInitials(value: string): string {
@@ -514,7 +514,8 @@ const TaskList: React.FC<TaskListProps> = ({
 			let result = 0;
 			switch (sortColumn) {
 				case "id": {
-					result = withDirection(compareTaskIdsAscending(a, b));
+					result =
+						sortDirection === "asc" ? compareTaskIdsAscending(a, b) : compareTaskIdsDescending(a.id, b.id);
 					break;
 				}
 				case "title": {
@@ -567,7 +568,7 @@ const TaskList: React.FC<TaskListProps> = ({
 
 			if (result !== 0) return result;
 			if (sortColumn === "ordinal") return compareTaskIdsAscending(a, b);
-			return compareTaskIdsAscending(b, a);
+			return compareTaskIdsDescending(a.id, b.id);
 		});
 	}, [displayTasks, milestoneEntities, sortColumn, sortDirection]);
 


### PR DESCRIPTION
## Summary

Fixes #734.

The Web UI All Tasks table was sorting task IDs with a local trailing-number parser, so dotted subtask IDs like `TASK-003.01` were ordered by the `.01` suffix instead of under `TASK-003`. This PR removes that divergent parser and reuses the shared hierarchical `compareTaskIds` helper already used elsewhere.

## Validation

- Reproduced before the fix with a focused TaskList regression test: ascending ID sort returned `task-1, task-3.01, task-2, task-3.02, task-3`.
- `bun test src/test/web-task-list-labels-menu.test.tsx`
- `bun test src/test/task-sorting.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test` (`1446 pass`, `2 skip`, `0 fail`)