### PR TITLE
BACK-529 - Sort browser label filters alphabetically

### DIFF
--- a/backlog/tasks/back-529 - Sort-browser-label-filters-alphabetically.md
+++ b/backlog/tasks/back-529 - Sort-browser-label-filters-alphabetically.md
@@ -1,0 +1,58 @@
+---
+id: BACK-529
+title: Sort browser label filters alphabetically
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-09 06:09'
+updated_date: '2026-07-09 06:14'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/733'
+modified_files:
+  - src/utils/label-filter.ts
+  - src/test/label-filter.test.ts
+  - src/test/web-task-list-labels-menu.test.tsx
+ordinal: 168000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+GitHub issue #733 reports that the Web UI All Tasks Labels dropdown shows labels in creation/configuration order rather than alphabetical order. The browser label filter menu should present labels lexicographically so users can scan and select labels predictably.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The All Tasks Labels dropdown renders available labels in alphabetical/lexicographic order regardless of task creation order.
+- [x] #2 Label sorting is case-insensitive and deterministic for configured labels and labels discovered from tasks.
+- [x] #3 A Web UI regression test covers unordered input labels rendering alphabetically in the Labels dropdown.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused Web UI regression test showing unordered configured/task labels render in the All Tasks Labels dropdown in the wrong order.
+2. Sort de-duplicated available labels case-insensitively in the shared label filter utility used by the browser task list and board filters.
+3. Run targeted label/Web tests, type-check, Biome, and the full Bun test suite before publishing the PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced issue #733 with a focused TaskList Web UI test: before the fix, the Labels dropdown rendered zeta before Alpha because available labels preserved insertion order. Updated collectAvailableLabels to sort de-duplicated labels case-insensitively while preserving first-seen casing. Validation passed: bun test src/test/web-task-list-labels-menu.test.tsx src/test/label-filter.test.ts; bunx tsc --noEmit; bun run check .; bun test (1447 pass, 2 skip, 0 fail).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed browser label filter ordering by sorting collected label options alphabetically in the shared label utility used by the All Tasks and board label dropdowns. Added a Web UI regression test for unordered configured/task labels and updated utility test coverage; targeted checks, type-check, Biome, and the full Bun test suite pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-529 - Sort-browser-label-filters-alphabetically.md
+++ b/backlog/tasks/back-529 - Sort-browser-label-filters-alphabetically.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-09 06:09'
-updated_date: '2026-07-09 06:14'
+updated_date: '2026-07-09 20:53'
 labels: []
 dependencies: []
 references:
@@ -33,21 +33,28 @@ GitHub issue #733 reports that the Web UI All Tasks Labels dropdown shows labels
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add a focused Web UI regression test showing unordered configured/task labels render in the All Tasks Labels dropdown in the wrong order.
-2. Sort de-duplicated available labels case-insensitively in the shared label filter utility used by the browser task list and board filters.
-3. Run targeted label/Web tests, type-check, Biome, and the full Bun test suite before publishing the PR.
+1. Review the shared label collector, its callers, existing tests, and nearby deterministic string-ordering conventions.
+2. Replace locale-sensitive label ordering with locale-independent normalized sort keys and a final raw code-unit tie-breaker while preserving case-insensitive de-duplication and first-seen spelling.
+3. Add focused utility tests for accented cross-locale ordering and reversed NFC/NFD input, retaining the existing Web regression coverage.
+4. Run focused label/Web tests, TypeScript, Biome, and build; do not run the full suite from the live worktree.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Reproduced issue #733 with a focused TaskList Web UI test: before the fix, the Labels dropdown rendered zeta before Alpha because available labels preserved insertion order. Updated collectAvailableLabels to sort de-duplicated labels case-insensitively while preserving first-seen casing. Validation passed: bun test src/test/web-task-list-labels-menu.test.tsx src/test/label-filter.test.ts; bunx tsc --noEmit; bun run check .; bun test (1447 pass, 2 skip, 0 fail).
+
+Reopened to address the confirmed review gap: label ordering must be independent of host locale and input order for canonically equivalent Unicode forms. Full bun test is intentionally excluded in this live worktree because of the known destructive worktree-test interaction.
+
+Replaced the host-default Intl.Collator and localeCompare ordering with locale-independent UTF-16 code-unit comparison over lowercase NFD sort keys, followed by the original label as a raw code-unit tie-breaker. Case-insensitive de-duplication and first-seen spelling remain unchanged.
+
+Added focused coverage for accented ordering across locale expectations, reversed NFC/NFD inputs, and first-seen casing. Validation passed: bun test src/test/label-filter.test.ts src/test/web-task-list-labels-menu.test.tsx (12 pass); label utility tests also passed under en_US.UTF-8 and sv_SE.UTF-8; bunx tsc --noEmit; bun run check .; bun run build. The full suite was not run from this live worktree because of the reported destructive worktree-test interaction; GitHub CI will run the full matrix after push.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed browser label filter ordering by sorting collected label options alphabetically in the shared label utility used by the All Tasks and board label dropdowns. Added a Web UI regression test for unordered configured/task labels and updated utility test coverage; targeted checks, type-check, Biome, and the full Bun test suite pass.
+Made browser label ordering deterministic across host locales and input order by sorting on lowercase NFD keys with a raw code-unit tie-breaker, while preserving case-insensitive de-duplication and first-seen spelling. Added accented and NFC/NFD regression coverage; focused label/Web tests, TypeScript, Biome, and build pass. The full suite is delegated to GitHub CI because it is unsafe in the live worktree.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/src/test/label-filter.test.ts
+++ b/src/test/label-filter.test.ts
@@ -24,11 +24,26 @@ describe("label filter utilities", () => {
 				dependencies: [],
 			},
 		];
-		const configured = ["backend", "bug"];
+		const configured = ["backend", "BUG"];
 
 		const labels = collectAvailableLabels(tasks, configured);
 
-		expect(labels).toEqual(["backend", "bug", "infra", "UI"]);
+		expect(labels).toEqual(["backend", "BUG", "infra", "UI"]);
+	});
+
+	test("collectAvailableLabels sorts accented labels with locale-independent normalized keys", () => {
+		const labels = collectAvailableLabels([], ["Zulu", "Öl", "Ärger"]);
+
+		expect(labels).toEqual(["Ärger", "Öl", "Zulu"]);
+	});
+
+	test("collectAvailableLabels orders equivalent Unicode spellings independently of input order", () => {
+		const composed = "café";
+		const decomposed = "cafe\u0301";
+		const expected = [decomposed, composed];
+
+		expect(collectAvailableLabels([], [composed, decomposed])).toEqual(expected);
+		expect(collectAvailableLabels([], [decomposed, composed])).toEqual(expected);
 	});
 
 	test("formatLabelSummary produces concise summaries", () => {

--- a/src/test/label-filter.test.ts
+++ b/src/test/label-filter.test.ts
@@ -3,7 +3,7 @@ import type { Task } from "../types/index.ts";
 import { collectAvailableLabels, formatLabelSummary, labelsToLower } from "../utils/label-filter.ts";
 
 describe("label filter utilities", () => {
-	test("collectAvailableLabels merges configured labels and task labels without duplicates", () => {
+	test("collectAvailableLabels merges configured labels and task labels without duplicates sorted alphabetically", () => {
 		const tasks: Task[] = [
 			{
 				id: "task-1",
@@ -28,7 +28,7 @@ describe("label filter utilities", () => {
 
 		const labels = collectAvailableLabels(tasks, configured);
 
-		expect(labels).toEqual(["backend", "bug", "UI", "infra"]);
+		expect(labels).toEqual(["backend", "bug", "infra", "UI"]);
 	});
 
 	test("formatLabelSummary produces concise summaries", () => {

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -61,13 +61,14 @@ const setupDom = () => {
 
 const renderTaskList = (
 	initialEntries?: string[],
-	options: { tasks?: Task[]; availableStatuses?: string[] } = {},
+	options: { tasks?: Task[]; availableStatuses?: string[]; availableLabels?: string[] } = {},
 ): HTMLElement => {
 	setupDom();
 	const container = document.getElementById("root");
 	expect(container).toBeTruthy();
 	const renderedTasks = options.tasks ?? tasks;
 	const renderedStatuses = options.availableStatuses ?? ["To Do", "In Progress", "Done"];
+	const renderedLabels = options.availableLabels ?? ["bug", "docs"];
 	activeRoot = createRoot(container as HTMLElement);
 	act(() => {
 		activeRoot?.render(
@@ -75,7 +76,7 @@ const renderTaskList = (
 				<TaskList
 					tasks={renderedTasks}
 					availableStatuses={renderedStatuses}
-					availableLabels={["bug", "docs"]}
+					availableLabels={renderedLabels}
 					availableMilestones={[]}
 					milestoneEntities={[]}
 					archivedMilestones={[]}
@@ -129,6 +130,11 @@ const getLabelsButton = (container: HTMLElement): HTMLButtonElement => {
 	return button as HTMLButtonElement;
 };
 
+const getLabelOptions = (container: HTMLElement): string[] =>
+	Array.from(container.querySelectorAll("#task-list-labels-menu label span")).map(
+		(element) => element.textContent?.trim() ?? "",
+	);
+
 const getZIndexClass = (element: Element): number | null => {
 	const match = element.className.match(/\bz-(\d+)\b/);
 	const value = match?.[1];
@@ -153,6 +159,20 @@ describe("TaskList labels filter menu", () => {
 		const container = renderTaskList(["/?query=docs"]);
 
 		expect(container.querySelector("input[placeholder='Search tasks']")).toBeNull();
+	});
+
+	it("renders label filter options alphabetically", async () => {
+		const container = renderTaskList(undefined, {
+			availableLabels: ["zeta", "Alpha"],
+			tasks: [
+				createTask({ id: "task-101", labels: ["beta"] }),
+				createTask({ id: "task-102", labels: ["delta"] }),
+			],
+		});
+
+		await clickElement(getLabelsButton(container));
+
+		expect(getLabelOptions(container)).toEqual(["Alpha", "beta", "delta", "zeta"]);
 	});
 
 	it("renders and sorts by ordinal with task ID as the tie-breaker", async () => {

--- a/src/utils/label-filter.ts
+++ b/src/utils/label-filter.ts
@@ -4,9 +4,11 @@ function normalizeLabel(label: string): string {
 	return label.trim().toLowerCase();
 }
 
+const LABEL_SORT_COLLATOR = new Intl.Collator(undefined, { sensitivity: "base" });
+
 /**
- * Collect available labels from configuration and tasks, de-duplicated but preserving
- * the first-seen casing so UI surfaces familiar labels.
+ * Collect available labels from configuration and tasks, de-duplicated and sorted
+ * alphabetically while preserving the first-seen casing so UI surfaces familiar labels.
  */
 export function collectAvailableLabels(tasks: Task[], configured: string[] = []): string[] {
 	const seen = new Set<string>();
@@ -31,7 +33,10 @@ export function collectAvailableLabels(tasks: Task[], configured: string[] = [])
 		}
 	}
 
-	return ordered;
+	return ordered.sort((left, right) => {
+		const result = LABEL_SORT_COLLATOR.compare(left, right);
+		return result !== 0 ? result : left.localeCompare(right);
+	});
 }
 
 /**

--- a/src/utils/label-filter.ts
+++ b/src/utils/label-filter.ts
@@ -4,7 +4,11 @@ function normalizeLabel(label: string): string {
 	return label.trim().toLowerCase();
 }
 
-const LABEL_SORT_COLLATOR = new Intl.Collator(undefined, { sensitivity: "base" });
+function compareCodeUnits(left: string, right: string): number {
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
 
 /**
  * Collect available labels from configuration and tasks, de-duplicated and sorted
@@ -34,8 +38,10 @@ export function collectAvailableLabels(tasks: Task[], configured: string[] = [])
 	}
 
 	return ordered.sort((left, right) => {
-		const result = LABEL_SORT_COLLATOR.compare(left, right);
-		return result !== 0 ? result : left.localeCompare(right);
+		const leftKey = normalizeLabel(left).normalize("NFD");
+		const rightKey = normalizeLabel(right).normalize("NFD");
+		const result = compareCodeUnits(leftKey, rightKey);
+		return result !== 0 ? result : compareCodeUnits(left, right);
 	});
 }
 


### PR DESCRIPTION
## Summary

Fixes #733.

The browser label filters were using `collectAvailableLabels`, which de-duplicated configured and task-discovered labels but preserved insertion order. That made the All Tasks Labels dropdown depend on configuration/task creation order instead of being easy to scan alphabetically.

This PR sorts the de-duplicated label options case-insensitively in the shared label utility while preserving the first-seen casing. The same utility feeds the All Tasks and board label dropdowns.

## Validation

- Reproduced before the fix with a focused TaskList regression test: the dropdown rendered `zeta` before `Alpha`.
- `bun test src/test/web-task-list-labels-menu.test.tsx src/test/label-filter.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test` (`1447 pass`, `2 skip`, `0 fail`)