### PR TITLE
BACK-530 - Support user-defined priority values

### DIFF
--- a/ADVANCED-CONFIG.md
+++ b/ADVANCED-CONFIG.md
@@ -24,6 +24,7 @@ Running `backlog config` with no arguments launches the interactive advanced wiz
 | `defaultStatus`   | First column       | `To Do`                       |
 | `definition_of_done` | Default DoD checklist items for new tasks | `(not set)` |
 | `statuses`        | Board columns      | `[To Do, In Progress, Done]`  |
+| `priorities`      | Ordered task priority labels | `[High, Medium, Low]` |
 | `dateFormat`      | Display-only date format | `yyyy-mm-dd`            |
 | `includeDatetimeInDates` | Add time to new dates | `true`              |
 | `defaultEditor`   | Editor for 'E' key | Platform default (nano/notepad) |
@@ -50,6 +51,8 @@ Running `backlog config` with no arguments launches the interactive advanced wiz
 > **Performance**: Cross-branch checking ensures accurate task tracking across all active branches but may impact performance on large repositories. You can disable it by setting `checkActiveBranches: false` for maximum speed, or adjust `activeBranchDays` to control how far back to look for branch activity (lower values = better performance).
 
 > **Status Change Callbacks**: Set `onStatusChange` to run a shell command whenever a task's status changes. Available variables: `$TASK_ID`, `$OLD_STATUS`, `$NEW_STATUS`, `$TASK_TITLE`. Per-task override via `onStatusChange` in task frontmatter. Example: `'if [ "$NEW_STATUS" = "In Progress" ]; then claude "Task $TASK_ID ($TASK_TITLE) has been assigned to you. Please implement it." & fi'`
+
+> **Priority Values**: Set `priorities` to an ordered list of labels such as `["Very High", "High", "Medium", "Low", "Very Low"]`. The first value sorts highest. CLI, MCP, and Web inputs accept configured values case-insensitively and store normalized lowercase values in task frontmatter.
 
 > **Date/Time Support**: Backlog.md now supports datetime precision for all dates. New items automatically include time (YYYY-MM-DD HH:mm format in UTC), while existing date-only entries remain unchanged for backward compatibility. Use the migration script `bun src/scripts/migrate-dates.ts` to optionally add time to existing items.
 

--- a/backlog/tasks/back-530 - Support-user-defined-priority-values.md
+++ b/backlog/tasks/back-530 - Support-user-defined-priority-values.md
@@ -1,0 +1,61 @@
+---
+id: BACK-530
+title: Support user-defined priority values
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-09 06:18'
+updated_date: '2026-07-09 06:48'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/732'
+ordinal: 168000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+GitHub issue #732 requests configurable task priority values beyond the built-in high/medium/low set, for example Very High, High, Medium, Low, Very Low. Backlog.md should allow a project to define its priority list in configuration while preserving the current default priorities for existing projects.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Projects can configure an ordered list of task priorities, and existing projects without configuration continue to use high, medium, low.
+- [x] #2 CLI create, edit, list, search, help text, and task wizard accept and display configured priority values case-insensitively.
+- [x] #3 MCP task schemas and handlers expose and validate configured priority values instead of a fixed high/medium/low enum.
+- [x] #4 Web task filters and task editing surfaces use the configured priority list and reject unsupported priority filters consistently.
+- [x] #5 Priority parsing, sorting, and statistics handle configured priority values without dropping custom priorities.
+- [x] #6 Regression tests cover a custom priority list with values beyond high/medium/low.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a shared priority configuration helper that normalizes configured values, preserves the default high/medium/low list, formats labels, and provides ordering/rank checks.
+2. Extend Backlog config load/save/types/help to support a priorities array without requiring existing projects to change.
+3. Replace fixed priority validation in core, parser, CLI, MCP schemas, API filters, completions, and task wizard with config-aware normalization.
+4. Pass configured priorities through web and TUI list/board/edit surfaces so filters, display, and sort-by-priority use the same ordered list.
+5. Add regression tests for custom configured priorities across config parsing, CLI create/list/search, sorting, MCP schema generation, API filters, and web filters.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented custom priority configuration across config parsing, core validation, CLI/help/search/list/edit flows, MCP schemas/handlers, server API filters, statistics, TUI/web filters, display, and sorting. Parser now preserves arbitrary stored priorities, while write/filter paths validate against the configured ordered list.
+
+Validation passed: bunx tsc --noEmit; bun run check .; bun run build; bun test src/test/search-command-query.test.ts src/test/cli-priority-filtering.test.ts; bun test (1453 pass, 2 skip, 0 fail).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added configurable ordered priority values with defaults preserved for existing projects. CLI, MCP, server API, web/TUI surfaces, completions, sorting, statistics, parsing, docs, and regression tests now use the configured priority list and accept values case-insensitively.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-530 - Support-user-defined-priority-values.md
+++ b/backlog/tasks/back-530 - Support-user-defined-priority-values.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-09 06:18'
-updated_date: '2026-07-09 06:48'
+updated_date: '2026-07-09 21:02'
 labels: []
 dependencies: []
 references:
@@ -32,11 +32,10 @@ GitHub issue #732 requests configurable task priority values beyond the built-in
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add a shared priority configuration helper that normalizes configured values, preserves the default high/medium/low list, formats labels, and provides ordering/rank checks.
-2. Extend Backlog config load/save/types/help to support a priorities array without requiring existing projects to change.
-3. Replace fixed priority validation in core, parser, CLI, MCP schemas, API filters, completions, and task wizard with config-aware normalization.
-4. Pass configured priorities through web and TUI list/board/edit surfaces so filters, display, and sort-by-priority use the same ordered list.
-5. Add regression tests for custom configured priorities across config parsing, CLI create/list/search, sorting, MCP schema generation, API filters, and web filters.
+1. Fix canonical Bash completion generation so configured multi-word priorities remain single candidates on Bash 3.2+, regenerate committed completion artifacts through the existing script, and add regression coverage.
+2. Centralize Web priority query canonicalization against configured priorities for Board and All Tasks, clear unsupported URL values using existing filter-state patterns, and test mixed-case valid plus unsupported values.
+3. Make statistics represent configured priority "None" separately from missing priority without changing MCP guidance, and add collision regressions.
+4. Run focused tests, type-check, Biome, build, and targeted simplification; update task notes/final summary and return to Done.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -45,12 +44,18 @@ GitHub issue #732 requests configurable task priority values beyond the built-in
 Implemented custom priority configuration across config parsing, core validation, CLI/help/search/list/edit flows, MCP schemas/handlers, server API filters, statistics, TUI/web filters, display, and sorting. Parser now preserves arbitrary stored priorities, while write/filter paths validate against the configured ordered list.
 
 Validation passed: bunx tsc --noEmit; bun run check .; bun run build; bun test src/test/search-command-query.test.ts src/test/cli-priority-filtering.test.ts; bun test (1453 pass, 2 skip, 0 fail).
+
+PR #743 review follow-up started from 1dea690: addressing completion quoting, Web URL canonicalization, and configured priority None statistics collision in a dedicated clean worktree.
+
+PR #743 review follow-up completed. Bash completion now preserves newline-delimited multi-word priorities as single candidates with Bash 3.2-compatible syntax in both committed and embedded scripts. Board and All Tasks canonicalize configured priority URL values case-insensitively after config loads and clear unsupported values without invalid searches. Statistics now stores missing priorities in noPriorityCount, leaving configured None and other custom values distinct.
+
+Validation: bun test src/commands/completion.test.ts src/test/statistics.test.ts src/test/web-board-filters.test.tsx src/test/web-task-list-labels-menu.test.tsx (32 pass, 0 fail); bunx tsc --noEmit; bun run check .; bun run build; compiled-binary Bash completion smoke test on Bash 3.2.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added configurable ordered priority values with defaults preserved for existing projects. CLI, MCP, server API, web/TUI surfaces, completions, sorting, statistics, parsing, docs, and regression tests now use the configured priority list and accept values case-insensitively.
+Completed configurable priority support and closed the PR #743 edge cases: multi-word Bash completions remain atomic on Bash 3.2+, Board and All Tasks normalize or clear priority URL filters consistently, and statistics distinguish configured None from tasks with no priority. Focused regressions, type checking, Biome, the production build, and the compiled completion smoke test all pass.
 <!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done

--- a/completions/backlog.bash
+++ b/completions/backlog.bash
@@ -10,7 +10,7 @@
 #   - Or source directly in ~/.bashrc: source /path/to/backlog.bash
 #
 # Requirements:
-#   - Bash 4.x or 5.x
+#   - Bash 3.2 or later
 #   - bash-completion package (optional but recommended)
 
 # Main completion function for backlog CLI
@@ -45,11 +45,13 @@ _backlog() {
 		return 0
 	fi
 
-	# Generate completion replies using compgen
-	# -W: wordlist - splits completions by whitespace
-	# --: end of options
-	# "$cur": current word being completed
-	COMPREPLY=( $(compgen -W "$completions" -- "$cur") )
+	# Preserve each newline-delimited result as one completion candidate.
+	# This loop is compatible with Bash 3.2 (which does not provide mapfile).
+	COMPREPLY=()
+	local completion
+	while IFS= read -r completion; do
+		[[ -n "$completion" && "$completion" == "$cur"* ]] && COMPREPLY+=("$completion")
+	done <<< "$completions"
 
 	# Return success
 	return 0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { Command } from "commander";
 import { runAdvancedConfigWizard } from "./commands/advanced-config-wizard.ts";
 import { type CompletionInstallResult, installCompletion, registerCompletionCommand } from "./commands/completion.ts";
 import { configureAdvancedSettings } from "./commands/configure-advanced-settings.ts";
-import { addHelpSchema, choiceType, statusType } from "./commands/help-schema.ts";
+import { addHelpSchema, choiceType, priorityType, statusType } from "./commands/help-schema.ts";
 import { registerInstructionsCommand } from "./commands/instructions.ts";
 import { registerMcpCommand } from "./commands/mcp.ts";
 import { pickTaskForEditWizard, runTaskCreateWizard, runTaskEditWizard } from "./commands/task-wizard.ts";
@@ -66,6 +66,7 @@ import {
 import { createMilestoneFilterValueResolver, resolveClosestMilestoneFilterValue } from "./utils/milestone-filter.ts";
 import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
 import { hasAnyPrefix } from "./utils/prefix-config.ts";
+import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
 import { type RuntimeCwdResolution, resolveRuntimeCwd } from "./utils/runtime-cwd.ts";
 import { formatValidStatuses, getCanonicalStatus, getValidStatuses } from "./utils/status.ts";
 import {
@@ -90,6 +91,7 @@ const CONFIG_GET_KEYS = [
 	"defaultStatus",
 	"statuses",
 	"labels",
+	"priorities",
 	"milestones",
 	"definitionOfDone",
 	"dateFormat",
@@ -250,6 +252,17 @@ function taskMatchesAllLabels(task: Task, labels: string[]): boolean {
 	}
 	const taskLabels = new Set(labelsToLower(task.labels ?? []));
 	return requiredLabels.every((label) => taskLabels.has(label));
+}
+
+async function normalizeCliPriority(core: Core, value: string): Promise<string | null> {
+	const config = await core.filesystem.loadConfig();
+	const normalized = resolvePriorityValue(value, config);
+	if (!normalized) {
+		console.error(`Invalid priority: ${value}. Valid values are: ${formatValidPriorityValues(config)}`);
+		process.exitCode = 1;
+		return null;
+	}
+	return normalized;
 }
 
 function formatToolResultText(result: CallToolResult): string {
@@ -1549,7 +1562,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 		},
 		{ name: "assignee", type: "Assignee list", description: "One or more @names" },
 		{ name: "labels", type: "Comma-separated strings", description: "Task labels" },
-		{ name: "priority", type: choiceType(["high", "medium", "low"]), description: "Task priority" },
+		{ name: "priority", type: priorityType, description: "Task priority" },
 		{ name: "acceptanceCriteria", type: "Markdown list item text", description: "Repeat --ac for multiple criteria" },
 		{ name: "ordinal", type: "Integer", description: "Non-negative manual ordering value" },
 		{ name: "parent", type: "Task ID", description: "Existing parent task for subtasks; not a milestone ID" },
@@ -1566,7 +1579,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 	.option("-a, --assignee <assignee>")
 	.option("-s, --status <status>")
 	.option("-l, --labels <labels>")
-	.option("--priority <priority>", "set task priority (high, medium, low)")
+	.option("--priority <priority>", "set task priority (configured priorities)")
 	.option("--plain", "use plain text output after creating")
 	.option("--ac <criteria>", "add acceptance criteria (can be used multiple times)", createMultiValueAccumulator())
 	.option(
@@ -1628,7 +1641,8 @@ addHelpSchema(taskCmd.command("create [title]"), {
 
 		if (shouldUseWizard) {
 			const statuses = await getValidStatuses(core);
-			const wizardInput = await runTaskCreateWizard({ statuses });
+			const config = await core.filesystem.loadConfig();
+			const wizardInput = await runTaskCreateWizard({ statuses, priorities: config?.priorities });
 			if (!wizardInput) {
 				clack.cancel("Task create cancelled.");
 				return;
@@ -1681,7 +1695,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 				documentation: parseDelimitedStringList(options.doc),
 				modifiedFiles: parseDelimitedStringList(options.modifiedFile),
 				parentTaskId: options.parent ? String(options.parent) : undefined,
-				priority: options.priority ? (String(options.priority).toLowerCase() as "high" | "medium" | "low") : undefined,
+				priority: options.priority ? String(options.priority) : undefined,
 				...(ordinalValue !== undefined ? { ordinal: ordinalValue } : {}),
 				milestone,
 				implementationPlan: options.plan ? String(options.plan) : undefined,
@@ -1722,7 +1736,7 @@ addHelpSchema(program.command("search [query]"), {
 			description: "Result types",
 		},
 		{ name: "status", type: statusType, description: "Filter task results by status; case-insensitive" },
-		{ name: "priority", type: choiceType(["high", "medium", "low"]), description: "Filter task results by priority" },
+		{ name: "priority", type: priorityType, description: "Filter task results by priority" },
 		{
 			name: "modified-file",
 			type: "Project-root-relative path",
@@ -1736,7 +1750,7 @@ addHelpSchema(program.command("search [query]"), {
 	.description("search tasks, documents, and decisions using the shared index")
 	.option("--type <type>", "limit results to type (task, document, decision)", createMultiValueAccumulator())
 	.option("--status <status>", "filter task results by status")
-	.option("--priority <priority>", "filter task results by priority (high, medium, low)")
+	.option("--priority <priority>", "filter task results by priority (configured priorities)")
 	.option(
 		"--modified-file <path>",
 		"filter task results by modified file path substring",
@@ -1776,15 +1790,12 @@ addHelpSchema(program.command("search [query]"), {
 			filters.status = options.status;
 		}
 		if (options.priority) {
-			const priorityLower = String(options.priority).toLowerCase();
-			const validPriorities: SearchPriorityFilter[] = ["high", "medium", "low"];
-			if (!validPriorities.includes(priorityLower as SearchPriorityFilter)) {
-				console.error("Invalid priority. Valid values: high, medium, low");
+			const priority = await normalizeCliPriority(core, String(options.priority));
+			if (!priority) {
 				cleanup();
-				process.exitCode = 1;
 				return;
 			}
-			filters.priority = priorityLower as SearchPriorityFilter;
+			filters.priority = priority;
 		}
 		if (modifiedFileFilters?.length) {
 			filters.modifiedFiles = modifiedFileFilters;
@@ -2023,7 +2034,7 @@ addHelpSchema(taskCmd.command("list"), {
 		},
 		{ name: "milestone", type: "Milestone ID or title", description: "Closest case-insensitive match" },
 		{ name: "parent", type: "Task ID", description: "Show subtasks of a parent task" },
-		{ name: "priority", type: choiceType(["high", "medium", "low"]), description: "Filter by task priority" },
+		{ name: "priority", type: priorityType, description: "Filter by task priority" },
 		{
 			name: "labels",
 			type: "Comma-separated strings",
@@ -2046,7 +2057,7 @@ addHelpSchema(taskCmd.command("list"), {
 	.option("--unassigned", "filter tasks without an assignee (cannot be combined with --assignee)")
 	.option("-m, --milestone <milestone>", "filter tasks by milestone (closest match, case-insensitive)")
 	.option("-p, --parent <taskId>", "filter tasks by parent task ID")
-	.option("--priority <priority>", "filter tasks by priority (high, medium, low)")
+	.option("--priority <priority>", "filter tasks by priority (configured priorities)")
 	.option(
 		"-l, --labels <labels>",
 		"filter tasks by labels; require every comma-separated label (repeatable)",
@@ -2083,15 +2094,12 @@ addHelpSchema(taskCmd.command("list"), {
 			baseFilters.milestone = options.milestone;
 		}
 		if (options.priority) {
-			const priorityLower = options.priority.toLowerCase();
-			const validPriorities = ["high", "medium", "low"] as const;
-			if (!validPriorities.includes(priorityLower as (typeof validPriorities)[number])) {
-				console.error(`Invalid priority: ${options.priority}. Valid values are: high, medium, low`);
-				process.exitCode = 1;
+			const priority = await normalizeCliPriority(core, String(options.priority));
+			if (!priority) {
 				cleanup();
 				return;
 			}
-			baseFilters.priority = priorityLower as (typeof validPriorities)[number];
+			baseFilters.priority = priority;
 		}
 
 		const labelFilters = parseDelimitedStringList(options.labels) ?? [];
@@ -2153,9 +2161,9 @@ addHelpSchema(taskCmd.command("list"), {
 					cleanup();
 					return;
 				}
-				sortedTasks = sortTasks(tasks, sortField);
+				sortedTasks = sortTasks(tasks, sortField, config?.priorities);
 			} else {
-				sortedTasks = sortTasks(tasks, "priority");
+				sortedTasks = sortTasks(tasks, "priority", config?.priorities);
 			}
 
 			let filtered = sortedTasks;
@@ -2234,7 +2242,7 @@ addHelpSchema(taskCmd.command("list"), {
 			activeFilters.push(`Parent: ${normalizeTaskId(String(options.parent))}`);
 		}
 		if (options.milestone) activeFilters.push(`Milestone: ${options.milestone}`);
-		if (options.priority) activeFilters.push(`Priority: ${options.priority}`);
+		if (baseFilters.priority) activeFilters.push(`Priority: ${baseFilters.priority}`);
 		if (labelFilters.length > 0) activeFilters.push(`Labels: ${labelFilters.join(", ")}`);
 		if (searchQuery) activeFilters.push(`Search: ${searchQuery}`);
 		if (taskLimit !== undefined) activeFilters.push(`Limit: ${taskLimit}`);
@@ -2261,7 +2269,7 @@ addHelpSchema(taskCmd.command("list"), {
 			status: options.status,
 			assignee: options.assignee,
 			milestone: options.milestone,
-			priority: options.priority,
+			priority: baseFilters.priority,
 			sort: options.sort,
 			labels: labelFilters,
 			labelMatch: labelFilters.length > 0 ? "all" : undefined,
@@ -2321,9 +2329,9 @@ addHelpSchema(taskCmd.command("list"), {
 					if (!TASK_SORT_FIELDS.includes(sortField)) {
 						throw new Error(`Invalid sort field: ${options.sort}. Valid values are: ${TASK_SORT_FIELD_LIST}`);
 					}
-					sortedTasks = sortTasks(tasks, sortField);
+					sortedTasks = sortTasks(tasks, sortField, config?.priorities);
 				} else {
-					sortedTasks = sortTasks(tasks, "priority");
+					sortedTasks = sortTasks(tasks, "priority", config?.priorities);
 				}
 
 				let filtered = sortedTasks;
@@ -2411,7 +2419,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		"replace all task labels (comma-separated or repeatable; cannot combine with --add-label/--remove-label)",
 		createMultiValueAccumulator(),
 	)
-	.option("--priority <priority>", "set task priority (high, medium, low)")
+	.option("--priority <priority>", "set task priority (configured priorities)")
 	.option("--ordinal <number>", "set task ordinal for custom ordering")
 	.option("-m, --milestone <milestone>", "assign task to milestone by ID or title")
 	.option("--clear-milestone", "clear task milestone assignment")
@@ -2545,7 +2553,12 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			}
 
 			const statuses = await getValidStatuses(core);
-			const wizardInput = await runTaskEditWizard({ task: existingTaskForWizard, statuses });
+			const config = await core.filesystem.loadConfig();
+			const wizardInput = await runTaskEditWizard({
+				task: existingTaskForWizard,
+				statuses,
+				priorities: config?.priorities,
+			});
 			if (!wizardInput) {
 				clack.cancel("Task edit cancelled.");
 				return;
@@ -2584,16 +2597,13 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			canonicalStatus = canonical;
 		}
 
-		let normalizedPriority: "high" | "medium" | "low" | undefined;
+		let normalizedPriority: string | undefined;
 		if (options.priority) {
-			const priority = String(options.priority).toLowerCase();
-			const validPriorities = ["high", "medium", "low"] as const;
-			if (!validPriorities.includes(priority as (typeof validPriorities)[number])) {
-				console.error(`Invalid priority: ${priority}. Valid values are: high, medium, low`);
-				process.exitCode = 1;
+			const priority = await normalizeCliPriority(core, String(options.priority));
+			if (!priority) {
 				return;
 			}
-			normalizedPriority = priority as "high" | "medium" | "low";
+			normalizedPriority = priority;
 		}
 
 		let ordinalValue: number | undefined;
@@ -3040,6 +3050,7 @@ draftCmd
 
 		// Apply sorting - default to priority sorting like the web UI
 		const { sortTasks } = await import("./utils/task-sorting.ts");
+		const config = await core.filesystem.loadConfig();
 		let sortedDrafts = drafts;
 
 		if (options.sort) {
@@ -3049,10 +3060,10 @@ draftCmd
 				process.exitCode = 1;
 				return;
 			}
-			sortedDrafts = sortTasks(drafts, sortField);
+			sortedDrafts = sortTasks(drafts, sortField, config?.priorities);
 		} else {
 			// Default to priority sorting to match web UI behavior
-			sortedDrafts = sortTasks(drafts, "priority");
+			sortedDrafts = sortTasks(drafts, "priority", config?.priorities);
 		}
 
 		const usePlainOutput = isPlainRequested(options) || shouldAutoPlain;
@@ -4005,6 +4016,13 @@ addHelpSchema(configCmd.command("get <key>"), {
 				case "labels":
 					console.log(config.labels.join(", "));
 					break;
+				case "priorities":
+					console.log(
+						getPriorityOptions(config)
+							.map((priority) => priority.label)
+							.join(", "),
+					);
+					break;
 				case "milestones": {
 					const milestones = await core.filesystem.listMilestones();
 					console.log(milestones.map((milestone) => milestone.id).join(", "));
@@ -4052,7 +4070,7 @@ addHelpSchema(configCmd.command("get <key>"), {
 				default:
 					console.error(`Unknown config key: ${key}`);
 					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
+						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, priorities, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
 					);
 					process.exit(1);
 			}
@@ -4234,6 +4252,7 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 				}
 				case "statuses":
 				case "labels":
+				case "priorities":
 				case "milestones":
 				case "definitionOfDone":
 					if (key === "milestones") {
@@ -4301,6 +4320,11 @@ addHelpSchema(configCmd.command("list"), {
 			console.log(`  defaultStatus: ${config.defaultStatus || "(not set)"}`);
 			console.log(`  statuses: [${config.statuses.join(", ")}]`);
 			console.log(`  labels: [${config.labels.join(", ")}]`);
+			console.log(
+				`  priorities: [${getPriorityOptions(config)
+					.map((priority) => priority.label)
+					.join(", ")}]`,
+			);
 			const milestones = await core.filesystem.listMilestones();
 			console.log(`  milestones: [${milestones.map((milestone) => milestone.id).join(", ")}]`);
 			console.log(`  definitionOfDone: [${(config.definitionOfDone ?? []).join(", ")}]`);

--- a/src/commands/completion.test.ts
+++ b/src/commands/completion.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,6 +32,35 @@ afterEach(async () => {
 });
 
 describe("installCompletion", () => {
+	test("preserves multi-word Bash completion candidates", async () => {
+		if (!existsSync("/bin/bash")) {
+			return;
+		}
+
+		const tempDir = await makeTempDir();
+		const result = await installCompletion("bash", { homeDir: tempDir });
+		const shellScript = [
+			'backlog() { printf "%s\\n" "very high" "very low"; }',
+			'source "$1"',
+			'COMP_WORDS=(backlog task create --priority "")',
+			"COMP_CWORD=4",
+			'COMP_LINE="backlog task create --priority "',
+			"COMP_POINT=31",
+			"_backlog",
+			"declare -p COMPREPLY",
+		].join("\n");
+
+		const execution = spawnSync("/bin/bash", ["--noprofile", "--norc", "-c", shellScript, "bash", result.installPath], {
+			encoding: "utf-8",
+		});
+
+		expect(execution.status).toBe(0);
+		expect(execution.stderr).toBe("");
+		expect(execution.stdout).toContain('[0]="very high"');
+		expect(execution.stdout).toContain('[1]="very low"');
+		expect(execution.stdout).not.toContain("[2]=");
+	});
+
 	test("installs PowerShell completions relative to CurrentUserAllHosts profile", async () => {
 		const tempDir = await makeTempDir();
 		const profilePath = join(tempDir, "PowerShell", "profile.ps1");

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -146,7 +146,7 @@ function getEmbeddedCompletionScript(shell: Shell): string {
 #   - Or source directly in ~/.bashrc: source /path/to/backlog.bash
 #
 # Requirements:
-#   - Bash 4.x or 5.x
+#   - Bash 3.2 or later
 #   - bash-completion package (optional but recommended)
 
 # Main completion function for backlog CLI
@@ -181,11 +181,13 @@ _backlog() {
 		return 0
 	fi
 
-	# Generate completion replies using compgen
-	# -W: wordlist - splits completions by whitespace
-	# --: end of options
-	# "$cur": current word being completed
-	COMPREPLY=( $(compgen -W "$completions" -- "$cur") )
+	# Preserve each newline-delimited result as one completion candidate.
+	# This loop is compatible with Bash 3.2 (which does not provide mapfile).
+	COMPREPLY=()
+	local completion
+	while IFS= read -r completion; do
+		[[ -n "$completion" && "$completion" == "$cur"* ]] && COMPREPLY+=("$completion")
+	done <<< "$completions"
 
 	# Return success
 	return 0

--- a/src/commands/help-schema.ts
+++ b/src/commands/help-schema.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path";
 import type { Command } from "commander";
 import { DEFAULT_STATUSES } from "../constants/index.ts";
 import { resolveBacklogDirectory } from "../utils/backlog-directory.ts";
+import { getPriorityLabels } from "../utils/priority-config.ts";
 import { BACKLOG_CWD_ENV } from "../utils/runtime-cwd.ts";
 
 export interface HelpField {
@@ -80,14 +81,14 @@ function parseFlowList(value: string): string[] | null {
 	return trimmed.slice(1, -1).split(",").map(stripYamlScalar).filter(Boolean);
 }
 
-function parseStatusesFromConfig(content: string): string[] | null {
+function parseArrayFromConfig(content: string, keyName: string): string[] | null {
 	const lines = content.split(/\r?\n/);
 	for (let index = 0; index < lines.length; index++) {
 		const line = lines[index]?.trim() ?? "";
 		if (!line || line.startsWith("#")) {
 			continue;
 		}
-		const match = line.match(/^statuses\s*:\s*(.*)$/);
+		const match = line.match(new RegExp(`^${keyName}\\s*:\\s*(.*)$`));
 		if (!match) {
 			continue;
 		}
@@ -117,6 +118,14 @@ function parseStatusesFromConfig(content: string): string[] | null {
 	}
 
 	return null;
+}
+
+function parseStatusesFromConfig(content: string): string[] | null {
+	return parseArrayFromConfig(content, "statuses");
+}
+
+function parsePrioritiesFromConfig(content: string): string[] | null {
+	return parseArrayFromConfig(content, "priorities");
 }
 
 function parseStringValueFromConfig(content: string, keys: string[]): string | null {
@@ -184,6 +193,21 @@ export function getCliStatusValues(options?: { includeDraft?: boolean }): string
 	return options?.includeDraft ? includeDraftStatus(normalizedStatuses) : normalizedStatuses;
 }
 
+export function getCliPriorityValues(): string[] {
+	const configPath = findBacklogConfigPathSync(getRuntimeConfigStartDir());
+	if (configPath) {
+		try {
+			const parsed = parsePrioritiesFromConfig(readFileSync(configPath, "utf8"));
+			if (parsed && parsed.length > 0) {
+				return getPriorityLabels(parsed);
+			}
+		} catch {
+			return getPriorityLabels();
+		}
+	}
+	return getPriorityLabels();
+}
+
 export function getCliTaskPrefix(): string {
 	const configPath = findBacklogConfigPathSync(getRuntimeConfigStartDir());
 	if (configPath) {
@@ -212,4 +236,8 @@ export function choiceType(values: readonly string[], options?: { multiple?: boo
 
 export function statusType(options?: { includeDraft?: boolean }): string {
 	return `one of configured statuses: ${getCliStatusValues(options).join(", ")}`;
+}
+
+export function priorityType(): string {
+	return `one of configured priorities: ${getCliPriorityValues().join(", ")}`;
 }

--- a/src/commands/overview.ts
+++ b/src/commands/overview.ts
@@ -21,6 +21,7 @@ export async function runOverviewCommand(core: Core): Promise<void> {
 			tasks: activeTasks,
 			drafts,
 			statuses,
+			priorities,
 		} = await core.loadAllTasksForStatistics((msg) =>
 			loadingScreen?.update(`${msg} in ${formatTime(performance.now() - loadStart)}`),
 		);
@@ -29,7 +30,7 @@ export async function runOverviewCommand(core: Core): Promise<void> {
 
 		// Calculate statistics
 		const statsStart = performance.now();
-		const statistics = getTaskStatistics(activeTasks, drafts, statuses);
+		const statistics = getTaskStatistics(activeTasks, drafts, statuses, priorities);
 		const statsTime = Math.round(performance.now() - statsStart);
 
 		// Display the TUI

--- a/src/commands/task-wizard.ts
+++ b/src/commands/task-wizard.ts
@@ -3,9 +3,8 @@ import * as clack from "@clack/prompts";
 import picocolors from "picocolors";
 import { DEFAULT_STATUSES } from "../constants/index.ts";
 import type { AcceptanceCriterion, Task, TaskCreateInput, TaskUpdateInput } from "../types/index.ts";
+import { getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
 import { normalizeDependencies, normalizeStringList } from "../utils/task-builders.ts";
-
-type WizardPriority = "high" | "medium" | "low";
 
 interface TaskWizardValues {
 	title: string;
@@ -63,6 +62,7 @@ interface ChecklistEntry {
 
 interface WizardOptions {
 	statuses: string[];
+	priorities?: string[];
 	promptImpl?: TaskWizardPromptRunner;
 }
 
@@ -167,21 +167,25 @@ function buildStatusPromptValues(params: { statuses: string[]; mode: "create" | 
 	};
 }
 
-function buildPriorityPromptValues(initialPriority: string): {
+function buildPriorityPromptValues(
+	initialPriority: string,
+	priorities?: string[],
+): {
 	options: PromptChoice[];
 	initial: string;
 } {
-	const normalizedInitial = initialPriority.trim().toLowerCase();
+	const normalizedInitial = normalizePriorityValue(initialPriority) ?? "";
 	const options: PromptChoice[] = [
 		{ label: "None", value: "", hint: "No priority" },
-		{ label: "High", value: "high" },
-		{ label: "Medium", value: "medium" },
-		{ label: "Low", value: "low" },
+		...getPriorityOptions(priorities).map((priority) => ({
+			label: priority.label,
+			value: priority.value,
+		})),
 	];
 	if (!normalizedInitial) {
 		return { options, initial: "" };
 	}
-	if (normalizedInitial === "high" || normalizedInitial === "medium" || normalizedInitial === "low") {
+	if (options.some((option) => option.value === normalizedInitial)) {
 		return { options, initial: normalizedInitial };
 	}
 	return {
@@ -345,6 +349,7 @@ async function promptSelect(
 async function runTaskWizardValues(params: {
 	mode: "create" | "edit";
 	statuses: string[];
+	priorities?: string[];
 	initialValues: TaskWizardValues;
 	promptImpl?: TaskWizardPromptRunner;
 }): Promise<TaskWizardValues | null> {
@@ -356,7 +361,7 @@ async function runTaskWizardValues(params: {
 		mode: params.mode,
 		initialStatus: initial.status,
 	});
-	const priorityPrompt = buildPriorityPromptValues(initial.priority);
+	const priorityPrompt = buildPriorityPromptValues(initial.priority, params.priorities);
 
 	try {
 		const values: TaskWizardValues = {
@@ -499,7 +504,7 @@ async function runTaskWizardValues(params: {
 			title: values.title.trim(),
 			description: values.description,
 			status: canonicalStatus,
-			priority: values.priority.trim().toLowerCase(),
+			priority: normalizePriorityValue(values.priority) ?? "",
 			assignee: values.assignee,
 			labels: values.labels,
 			acceptanceCriteria: values.acceptanceCriteria,
@@ -575,6 +580,7 @@ export async function runTaskCreateWizard(
 	const values = await runTaskWizardValues({
 		mode: "create",
 		statuses: options.statuses,
+		priorities: options.priorities,
 		initialValues,
 		promptImpl: options.promptImpl,
 	});
@@ -583,7 +589,7 @@ export async function runTaskCreateWizard(
 	}
 
 	const priority = values.priority.trim();
-	const parsedPriority = priority.length > 0 ? (priority as WizardPriority) : undefined;
+	const parsedPriority = priority.length > 0 ? priority : undefined;
 	const assignee = parseListInput(values.assignee);
 	const labels = parseListInput(values.labels);
 	const references = parseListInput(values.references);
@@ -622,6 +628,7 @@ export async function runTaskEditWizard(
 	const values = await runTaskWizardValues({
 		mode: "edit",
 		statuses: options.statuses,
+		priorities: options.priorities,
 		initialValues: initial,
 		promptImpl: options.promptImpl,
 	});
@@ -640,7 +647,7 @@ export async function runTaskEditWizard(
 		updateInput.status = values.status;
 	}
 	if (values.priority !== initial.priority && values.priority.trim().length > 0) {
-		updateInput.priority = values.priority as WizardPriority;
+		updateInput.priority = values.priority;
 	}
 
 	const initialAssignee = parseListInput(initial.assignee);

--- a/src/completions/data-providers.ts
+++ b/src/completions/data-providers.ts
@@ -1,5 +1,6 @@
 import { Core } from "../index.ts";
 import type { BacklogConfig } from "../types/index.ts";
+import { getPriorityValues } from "../utils/priority-config.ts";
 
 type CoreCallback<T> = (core: Core) => Promise<T>;
 
@@ -53,8 +54,11 @@ export async function getStatuses(): Promise<string[]> {
 /**
  * Get priority values
  */
-export function getPriorities(): string[] {
-	return ["high", "medium", "low"];
+export async function getPriorities(): Promise<string[]> {
+	return await withCore(async (core) => {
+		const config: BacklogConfig | null = await core.filesystem.loadConfig();
+		return getPriorityValues(config);
+	}, getPriorityValues());
 }
 
 /**

--- a/src/completions/helper.ts
+++ b/src/completions/helper.ts
@@ -113,7 +113,7 @@ async function getFlagValueCompletions(flagName: string): Promise<string[]> {
 		case "status":
 			return await getStatuses();
 		case "priority":
-			return getPriorities();
+			return await getPriorities();
 		case "labels":
 		case "label":
 			return await getLabels();

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -42,6 +42,7 @@ import {
 	getPrefixForType,
 	normalizeId,
 } from "../utils/prefix-config.ts";
+import { formatValidPriorityValues, normalizePriorityValue, resolvePriorityValue } from "../utils/priority-config.ts";
 import {
 	getCanonicalStatus as resolveCanonicalStatus,
 	getValidStatuses as resolveValidStatuses,
@@ -319,8 +320,8 @@ export class Core {
 			result = result.filter((task) => !(task.assignee ?? []).some((value) => value.trim().length > 0));
 		}
 		if (filters.priority) {
-			const priorityLower = String(filters.priority).toLowerCase();
-			result = result.filter((task) => (task.priority ?? "").toLowerCase() === priorityLower);
+			const priorityLower = normalizePriorityValue(String(filters.priority));
+			result = result.filter((task) => normalizePriorityValue(task.priority) === priorityLower);
 		}
 		if (filters.milestone) {
 			const milestoneFilter = resolveClosestMilestoneFilterValue(
@@ -364,16 +365,16 @@ export class Core {
 		throw new Error(`Invalid status: ${status}. Valid statuses are: ${validStatuses.join(", ")}`);
 	}
 
-	private normalizePriority(value: string | undefined): ("high" | "medium" | "low") | undefined {
-		if (value === undefined || value === "") {
+	private async normalizePriority(value: string | undefined): Promise<string | undefined> {
+		if (value === undefined || value.trim() === "") {
 			return undefined;
 		}
-		const normalized = value.toLowerCase();
-		const allowed = ["high", "medium", "low"] as const;
-		if (!allowed.includes(normalized as (typeof allowed)[number])) {
-			throw new Error(`Invalid priority: ${value}. Valid values are: high, medium, low`);
+		const config = await this.fs.loadConfig();
+		const normalized = resolvePriorityValue(value, config);
+		if (!normalized) {
+			throw new Error(`Invalid priority: ${value}. Valid values are: ${formatValidPriorityValues(config)}`);
 		}
-		return normalized as "high" | "medium" | "low";
+		return normalized;
 	}
 
 	private async normalizeTaskType(value: string | undefined): Promise<string | undefined> {
@@ -1156,7 +1157,7 @@ export class Core {
 			}
 		}
 
-		const priority = this.normalizePriority(input.priority);
+		const priority = await this.normalizePriority(input.priority);
 		const type = await this.normalizeTaskType(input.type);
 		const createdDate = new Date().toISOString().slice(0, 16).replace("T", " ");
 		if (
@@ -1332,7 +1333,7 @@ export class Core {
 		}
 
 		if (input.priority !== undefined) {
-			const normalizedPriority = this.normalizePriority(String(input.priority));
+			const normalizedPriority = await this.normalizePriority(String(input.priority));
 			if (task.priority !== normalizedPriority) {
 				task.priority = normalizedPriority;
 				mutated = true;
@@ -2850,9 +2851,10 @@ export class Core {
 	 */
 	async loadAllTasksForStatistics(
 		progressCallback?: (msg: string) => void,
-	): Promise<{ tasks: Task[]; drafts: Task[]; statuses: string[] }> {
+	): Promise<{ tasks: Task[]; drafts: Task[]; statuses: string[]; priorities: string[] }> {
 		const config = await this.fs.loadConfig();
 		const statuses = (config?.statuses || DEFAULT_STATUSES) as string[];
+		const priorities = config?.priorities ?? [];
 		const resolutionStrategy = config?.taskResolutionStrategy || "most_progressed";
 
 		// Load local and completed tasks first
@@ -2926,7 +2928,7 @@ export class Core {
 		progressCallback?.("Loading drafts...");
 		const drafts = await this.fs.listDrafts();
 
-		return { tasks: activeTasks, drafts, statuses: statuses as string[] };
+		return { tasks: activeTasks, drafts, statuses: statuses as string[], priorities };
 	}
 
 	/**

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -5,6 +5,7 @@ import type { FileSystem } from "../file-system/operations.ts";
 import { parseDecision, parseDocument, parseTask } from "../markdown/parser.ts";
 import type { Decision, Document, Task, TaskListFilter } from "../types/index.ts";
 import { normalizeDocumentRelativePath } from "../utils/document-path.ts";
+import { normalizePriorityValue } from "../utils/priority-config.ts";
 import { normalizeTaskId, normalizeTaskIdentity, taskIdsEqual } from "../utils/task-path.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
 
@@ -117,8 +118,8 @@ export class ContentStore {
 			tasks = tasks.filter((task) => task.assignee.includes(assignee));
 		}
 		if (filter?.priority) {
-			const priority = filter.priority.toLowerCase();
-			tasks = tasks.filter((task) => (task.priority ?? "").toLowerCase() === priority);
+			const priority = normalizePriorityValue(filter.priority);
+			tasks = tasks.filter((task) => normalizePriorityValue(task.priority) === priority);
 		}
 		if (filter?.parentTaskId) {
 			const parentFilter = filter.parentTaskId;

--- a/src/core/search-service.ts
+++ b/src/core/search-service.ts
@@ -11,6 +11,7 @@ import type {
 	Task,
 } from "../types/index.ts";
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "../utils/modified-files.ts";
+import { normalizePriorityValue } from "../utils/priority-config.ts";
 import type { ContentStore, ContentStoreEvent } from "./content-store.ts";
 
 interface BaseSearchEntity {
@@ -226,7 +227,7 @@ export class SearchService {
 			bodyText: buildTaskBodyText(task),
 			task,
 			statusLower: task.status.toLowerCase(),
-			priorityLower: task.priority ? (task.priority.toLowerCase() as SearchPriorityFilter) : undefined,
+			priorityLower: normalizePriorityValue(task.priority),
 			assigneesLower: (task.assignee ?? []).map((assignee) => assignee.toLowerCase()),
 			labelsLower: (task.labels || []).map((label) => label.toLowerCase()),
 			idVariants: createTaskIdVariants(task.id),
@@ -447,10 +448,8 @@ export class SearchService {
 
 		const values = Array.isArray(value) ? value : [value];
 		const normalized = values
-			.map((item) => item.trim().toLowerCase())
-			.filter((item): item is SearchPriorityFilter => {
-				return item === "high" || item === "medium" || item === "low";
-			});
+			.map((item) => normalizePriorityValue(item))
+			.filter((item): item is SearchPriorityFilter => Boolean(item));
 
 		return normalized.length > 0 ? normalized : undefined;
 	}

--- a/src/core/statistics.ts
+++ b/src/core/statistics.ts
@@ -4,6 +4,7 @@ import { getPriorityValues, normalizePriorityValue } from "../utils/priority-con
 export interface TaskStatistics {
 	statusCounts: Map<string, number>;
 	priorityCounts: Map<string, number>;
+	noPriorityCount: number;
 	totalTasks: number;
 	completedTasks: number;
 	completionPercentage: number;
@@ -40,9 +41,9 @@ export function getTaskStatistics(
 	for (const priority of getPriorityValues(priorityOrder)) {
 		priorityCounts.set(priority, 0);
 	}
-	priorityCounts.set("none", 0);
 
 	let completedTasks = 0;
+	let noPriorityCount = 0;
 	const now = new Date();
 	const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
 	const oneMonthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -71,9 +72,13 @@ export function getTaskStatistics(
 		}
 
 		// Count by priority
-		const priority = normalizePriorityValue(task.priority) || "none";
-		const priorityCount = priorityCounts.get(priority) || 0;
-		priorityCounts.set(priority, priorityCount + 1);
+		const priority = normalizePriorityValue(task.priority);
+		if (priority) {
+			const priorityCount = priorityCounts.get(priority) || 0;
+			priorityCounts.set(priority, priorityCount + 1);
+		} else {
+			noPriorityCount++;
+		}
 
 		// Track recent activity
 		if (task.createdDate) {
@@ -151,6 +156,7 @@ export function getTaskStatistics(
 	return {
 		statusCounts,
 		priorityCounts,
+		noPriorityCount,
 		totalTasks,
 		completedTasks,
 		completionPercentage,

--- a/src/core/statistics.ts
+++ b/src/core/statistics.ts
@@ -1,4 +1,5 @@
 import type { Task } from "../types/index.ts";
+import { getPriorityValues, normalizePriorityValue } from "../utils/priority-config.ts";
 
 export interface TaskStatistics {
 	statusCounts: Map<string, number>;
@@ -21,7 +22,12 @@ export interface TaskStatistics {
 /**
  * Calculate comprehensive task statistics for the overview
  */
-export function getTaskStatistics(tasks: Task[], drafts: Task[], statuses: string[]): TaskStatistics {
+export function getTaskStatistics(
+	tasks: Task[],
+	drafts: Task[],
+	statuses: string[],
+	priorityOrder?: readonly string[],
+): TaskStatistics {
 	const statusCounts = new Map<string, number>();
 	const priorityCounts = new Map<string, number>();
 
@@ -31,9 +37,9 @@ export function getTaskStatistics(tasks: Task[], drafts: Task[], statuses: strin
 	}
 
 	// Initialize priority counts
-	priorityCounts.set("high", 0);
-	priorityCounts.set("medium", 0);
-	priorityCounts.set("low", 0);
+	for (const priority of getPriorityValues(priorityOrder)) {
+		priorityCounts.set(priority, 0);
+	}
 	priorityCounts.set("none", 0);
 
 	let completedTasks = 0;
@@ -65,7 +71,7 @@ export function getTaskStatistics(tasks: Task[], drafts: Task[], statuses: strin
 		}
 
 		// Count by priority
-		const priority = task.priority || "none";
+		const priority = normalizePriorityValue(task.priority) || "none";
 		const priorityCount = priorityCounts.get(priority) || 0;
 		priorityCounts.set(priority, priorityCount + 1);
 

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1420,6 +1420,7 @@ ${description || `Milestone: ${title}`}`,
 				case "statuses":
 				case "labels":
 				case "types":
+				case "priorities":
 					if (value.startsWith("[") && value.endsWith("]")) {
 						const arrayContent = value.slice(1, -1);
 						config[key] = arrayContent
@@ -1495,6 +1496,7 @@ ${description || `Milestone: ${title}`}`,
 			statuses: config.statuses || [...DEFAULT_STATUSES],
 			labels: config.labels || [],
 			types: config.types,
+			priorities: config.priorities,
 			definitionOfDone: config.definitionOfDone,
 			defaultStatus: config.defaultStatus,
 			dateFormat: config.dateFormat || "yyyy-mm-dd",
@@ -1526,6 +1528,9 @@ ${description || `Milestone: ${title}`}`,
 			`statuses: [${config.statuses.map((s) => `"${s}"`).join(", ")}]`,
 			`labels: [${config.labels.map((l) => `"${l}"`).join(", ")}]`,
 			...(config.types && config.types.length > 0 ? [`types: [${config.types.map((t) => `"${t}"`).join(", ")}]`] : []),
+			...(config.priorities && config.priorities.length > 0
+				? [`priorities: [${config.priorities.map((p) => `"${p}"`).join(", ")}]`]
+				: []),
 			...(Array.isArray(normalizedDefinitionOfDone)
 				? [`definition_of_done: [${normalizedDefinitionOfDone.map((item) => JSON.stringify(item)).join(", ")}]`]
 				: []),

--- a/src/formatters/task-plain-text.ts
+++ b/src/formatters/task-plain-text.ts
@@ -2,6 +2,7 @@ import type { Task } from "../types/index.ts";
 import type { ChecklistItem } from "../ui/checklist.ts";
 import { transformCodePathsPlain } from "../ui/code-path.ts";
 import { formatStatusWithIcon } from "../ui/status-icon.ts";
+import { formatPriorityLabel } from "../utils/priority-config.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
 import { formatUtcDateForDisplay, type UtcDateDisplayOptions } from "../utils/utc-date-display.ts";
 
@@ -42,10 +43,9 @@ export function formatAcceptanceCriteriaLines(items: ChecklistItem[]): string[] 
 	});
 }
 
-function formatPriority(priority?: "high" | "medium" | "low"): string | null {
+function formatPriority(priority?: string): string | null {
 	if (!priority) return null;
-	const label = priority.charAt(0).toUpperCase() + priority.slice(1);
-	return label;
+	return formatPriorityLabel(priority);
 }
 
 function formatAssignees(assignee?: string[]): string | null {

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -468,6 +468,7 @@ backlog search --modified-file src/server/api.ts --plain
 ```
 
 **Key points:**
+- Priority values are project-configured (`priorities` in config) and are accepted case-insensitively. Use CLI/MCP help or `backlog config get priorities` when you need the exact list.
 - Uses fuzzy matching - finds "authentication" when searching "auth"
 - Searches task titles, descriptions, and content
 - Also searches `modified_files`; `--modified-file` applies a case-insensitive path substring filter

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -1,5 +1,6 @@
 import matter from "gray-matter";
 import type { AcceptanceCriterion, Decision, Document, Milestone, ParsedMarkdown, Task } from "../types/index.ts";
+import { normalizePriorityValue } from "../utils/priority-config.ts";
 import {
 	AcceptanceCriteriaManager,
 	CommentsManager,
@@ -147,11 +148,7 @@ export function parseMarkdown(content: string): ParsedMarkdown {
 export function parseTask(content: string): Task {
 	const { frontmatter, content: rawContent } = parseMarkdown(content);
 
-	// Validate priority field
-	const priority = frontmatter.priority ? String(frontmatter.priority).toLowerCase() : undefined;
-	const validPriorities = ["high", "medium", "low"];
-	const validatedPriority =
-		priority && validPriorities.includes(priority) ? (priority as "high" | "medium" | "low") : undefined;
+	const priority = normalizePriorityValue(frontmatter.priority ? String(frontmatter.priority) : undefined);
 
 	// Parse structured acceptance criteria (checked/text/index) from all sections
 	const structuredCriteria: AcceptanceCriterion[] = AcceptanceCriteriaManager.parseAllCriteria(rawContent);
@@ -192,7 +189,7 @@ export function parseTask(content: string): Task {
 		finalSummary: finalSummarySection,
 		parentTaskId: frontmatter.parent_task_id ? String(frontmatter.parent_task_id) : undefined,
 		subtasks: Array.isArray(frontmatter.subtasks) ? frontmatter.subtasks.map(String) : undefined,
-		priority: validatedPriority,
+		priority,
 		type: frontmatter.type ? String(frontmatter.type) : undefined,
 		ordinal: frontmatter.ordinal !== undefined ? Number(frontmatter.ordinal) : undefined,
 		onStatusChange: frontmatter.onStatusChange ? String(frontmatter.onStatusChange) : undefined,

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -29,7 +29,7 @@ export type TaskCreateArgs = {
 	description?: string;
 	labels?: string[];
 	assignee?: string[];
-	priority?: "high" | "medium" | "low";
+	priority?: string;
 	type?: string;
 	ordinal?: number;
 	status?: string;
@@ -152,6 +152,8 @@ export class TaskHandlers {
 		if (args.assignee && args.unassigned) {
 			throw new BacklogToolError("unassigned cannot be combined with assignee.", "VALIDATION_ERROR");
 		}
+		const config = await this.core.filesystem.loadConfig();
+		const priorities = config?.priorities;
 		if (this.isDraftStatus(args.status)) {
 			let drafts = await this.core.filesystem.listDrafts();
 			if (args.search) {
@@ -203,7 +205,7 @@ export class TaskHandlers {
 				};
 			}
 
-			let sortedDrafts = sortByOrdinalAndPriority(drafts);
+			let sortedDrafts = sortByOrdinalAndPriority(drafts, priorities);
 			if (typeof args.limit === "number" && args.limit >= 0) {
 				sortedDrafts = sortedDrafts.slice(0, args.limit);
 			}
@@ -262,7 +264,6 @@ export class TaskHandlers {
 			};
 		}
 
-		const config = await this.core.filesystem.loadConfig();
 		const statuses = config?.statuses ?? [];
 
 		const canonicalByLower = new Map<string, string>();
@@ -289,7 +290,7 @@ export class TaskHandlers {
 		let remaining = typeof args.limit === "number" && args.limit >= 0 ? args.limit : undefined;
 		for (const status of orderedStatuses) {
 			const bucket = grouped.get(status) ?? [];
-			const sortedBucket = sortByOrdinalAndPriority(bucket);
+			const sortedBucket = sortByOrdinalAndPriority(bucket, priorities);
 			const limitedBucket = remaining !== undefined ? sortedBucket.slice(0, remaining) : sortedBucket;
 			if (remaining !== undefined) {
 				remaining -= limitedBucket.length;

--- a/src/mcp/tools/tasks/index.ts
+++ b/src/mcp/tools/tasks/index.ts
@@ -1,17 +1,22 @@
 import type { BacklogConfig } from "../../../types/index.ts";
 import type { McpServer } from "../../server.ts";
 import type { McpToolHandler } from "../../types.ts";
-import { generateTaskCreateSchema, generateTaskEditSchema } from "../../utils/schema-generators.ts";
+import {
+	generateTaskCreateSchema,
+	generateTaskEditSchema,
+	generateTaskSearchSchema,
+} from "../../utils/schema-generators.ts";
 import { createSimpleValidatedTool } from "../../validation/tool-wrapper.ts";
 import type { TaskCreateArgs, TaskEditRequest, TaskListArgs, TaskSearchArgs } from "./handlers.ts";
 import { TaskHandlers } from "./handlers.ts";
-import { taskArchiveSchema, taskCompleteSchema, taskListSchema, taskSearchSchema, taskViewSchema } from "./schemas.ts";
+import { taskArchiveSchema, taskCompleteSchema, taskListSchema, taskViewSchema } from "./schemas.ts";
 
 export function registerTaskTools(server: McpServer, config: BacklogConfig): void {
 	const handlers = new TaskHandlers(server);
 
 	const taskCreateSchema = generateTaskCreateSchema(config);
 	const taskEditSchema = generateTaskEditSchema(config);
+	const taskSearchSchema = generateTaskSearchSchema(config);
 
 	const createTaskTool: McpToolHandler = createSimpleValidatedTool(
 		{

--- a/src/mcp/tools/tasks/schemas.ts
+++ b/src/mcp/tools/tasks/schemas.ts
@@ -1,3 +1,4 @@
+import { getPriorityLabels } from "../../../utils/priority-config.ts";
 import type { JsonSchema } from "../../validation/validators.ts";
 
 export const taskListSchema: JsonSchema = {
@@ -50,7 +51,8 @@ export const taskSearchSchema: JsonSchema = {
 		},
 		priority: {
 			type: "string",
-			enum: ["high", "medium", "low"],
+			enum: getPriorityLabels(),
+			enumCaseInsensitive: true,
 		},
 		modifiedFiles: {
 			type: "array",

--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_STATUSES, DEFAULT_TASK_TYPES } from "../../constants/index.ts";
 import type { BacklogConfig } from "../../types/index.ts";
+import { getPriorityLabels } from "../../utils/priority-config.ts";
 import type { JsonSchema } from "../validation/validators.ts";
 
 /**
@@ -51,6 +52,21 @@ function generateTypeFieldSchema(config: BacklogConfig): JsonSchema {
 }
 
 /**
+ * Generates a priority field schema with dynamic enum values sourced from config.
+ */
+function generatePriorityFieldSchema(config: BacklogConfig): JsonSchema {
+	const priorities = getPriorityLabels(config);
+
+	return {
+		type: "string",
+		maxLength: 50,
+		enum: priorities,
+		enumCaseInsensitive: true,
+		description: `Optional task priority (case-insensitive). Valid values: ${priorities.join(", ")}`,
+	};
+}
+
+/**
  * Generates the task_create input schema with dynamic status enum
  */
 export function generateTaskCreateSchema(config: BacklogConfig): JsonSchema {
@@ -67,10 +83,7 @@ export function generateTaskCreateSchema(config: BacklogConfig): JsonSchema {
 				maxLength: 10000,
 			},
 			status: generateStatusFieldSchema(config),
-			priority: {
-				type: "string",
-				enum: ["high", "medium", "low"],
-			},
+			priority: generatePriorityFieldSchema(config),
 			type: generateTypeFieldSchema(config),
 			ordinal: {
 				type: "number",
@@ -187,10 +200,7 @@ export function generateTaskEditSchema(config: BacklogConfig): JsonSchema {
 				maxLength: 10000,
 			},
 			status: generateStatusFieldSchema(config),
-			priority: {
-				type: "string",
-				enum: ["high", "medium", "low"],
-			},
+			priority: generatePriorityFieldSchema(config),
 			type: generateTypeFieldSchema(config),
 			ordinal: {
 				type: "number",
@@ -425,6 +435,35 @@ export function generateTaskEditSchema(config: BacklogConfig): JsonSchema {
 			},
 		},
 		required: ["id"],
+		additionalProperties: false,
+	};
+}
+
+export function generateTaskSearchSchema(config: BacklogConfig): JsonSchema {
+	return {
+		type: "object",
+		properties: {
+			query: {
+				type: "string",
+				maxLength: 200,
+			},
+			status: {
+				type: "string",
+				maxLength: 100,
+			},
+			priority: generatePriorityFieldSchema(config),
+			modifiedFiles: {
+				type: "array",
+				items: { type: "string", maxLength: 500 },
+				description: "Filter tasks by case-insensitive substring match against modified file paths",
+			},
+			limit: {
+				type: "number",
+				minimum: 1,
+				maximum: 100,
+			},
+		},
+		required: [],
 		additionalProperties: false,
 	};
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,7 @@ import {
 import { watchConfig } from "../utils/config-watcher.ts";
 import { detectDuplicateTaskIds } from "../utils/duplicate-detection.ts";
 import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
+import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import { getVersion } from "../utils/version.ts";
 
 // Regex pattern to match any prefix (letters followed by dash)
@@ -639,14 +640,17 @@ export class BacklogServer {
 		}
 		const labels = labelParams.map((label) => label.trim()).filter((label) => label.length > 0);
 
-		let priority: "high" | "medium" | "low" | undefined;
+		const config = await this.core.filesystem.loadConfig();
+		let priority: string | undefined;
 		if (priorityParam) {
-			const normalizedPriority = priorityParam.toLowerCase();
-			const allowed = ["high", "medium", "low"];
-			if (!allowed.includes(normalizedPriority)) {
-				return Response.json({ error: "Invalid priority filter" }, { status: 400 });
+			const normalizedPriority = resolvePriorityValue(priorityParam, config);
+			if (!normalizedPriority) {
+				return Response.json(
+					{ error: `Invalid priority filter. Valid values are: ${formatValidPriorityValues(config)}` },
+					{ status: 400 },
+				);
 			}
-			priority = normalizedPriority as "high" | "medium" | "low";
+			priority = normalizedPriority;
 		}
 
 		// Resolve parent task ID if provided
@@ -745,18 +749,18 @@ export class BacklogServer {
 			}
 
 			if (priorityParamsRaw.length > 0) {
-				const allowedPriorities: SearchPriorityFilter[] = ["high", "medium", "low"];
-				const normalizedPriorities = priorityParamsRaw.map((value) => value.toLowerCase());
-				const invalidPriority = normalizedPriorities.find(
-					(value) => !allowedPriorities.includes(value as SearchPriorityFilter),
-				);
+				const config = await this.core.filesystem.loadConfig();
+				const normalizedPriorities = priorityParamsRaw.map((value) => resolvePriorityValue(value, config));
+				const invalidPriority = priorityParamsRaw[normalizedPriorities.findIndex((value) => !value)];
 				if (invalidPriority) {
 					return Response.json(
-						{ error: `Unsupported priority '${invalidPriority}'. Use high, medium, or low.` },
+						{
+							error: `Unsupported priority '${invalidPriority}'. Use ${formatValidPriorityValues(config)}.`,
+						},
 						{ status: 400 },
 					);
 				}
-				const casted = normalizedPriorities as SearchPriorityFilter[];
+				const casted = normalizedPriorities.filter((value): value is SearchPriorityFilter => Boolean(value));
 				filters.priority = casted.length === 1 ? casted[0] : casted;
 			}
 
@@ -1645,10 +1649,10 @@ export class BacklogServer {
 	private async handleGetStatistics(): Promise<Response> {
 		try {
 			// Load tasks using the same logic as CLI overview
-			const { tasks, drafts, statuses } = await this.core.loadAllTasksForStatistics();
+			const { tasks, drafts, statuses, priorities } = await this.core.loadAllTasksForStatistics();
 
 			// Calculate statistics using the exact same function as CLI
-			const statistics = getTaskStatistics(tasks, drafts, statuses);
+			const statistics = getTaskStatistics(tasks, drafts, statuses, priorities);
 
 			// Convert Maps to objects for JSON serialization
 			const response = {

--- a/src/test/cli-priority-filtering.test.ts
+++ b/src/test/cli-priority-filtering.test.ts
@@ -46,7 +46,7 @@ describe("CLI Priority Filtering", () => {
 		const result = await $`bun run cli task list --priority invalid --plain`.nothrow().quiet();
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr.toString()).toContain("Invalid priority: invalid");
-		expect(result.stderr.toString()).toContain("Valid values are: high, medium, low");
+		expect(result.stderr.toString()).toContain("Valid values are: High, Medium, Low");
 	});
 
 	test("task list --sort priority sorts by priority", async () => {

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -286,11 +286,11 @@ describe("CLI Integration", () => {
 			expect(createHelp).toContain("title: String");
 			expect(createHelp).toContain("description: Markdown");
 			expect(createHelp).toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
-			expect(createHelp).toContain("priority: one of: high, medium, low");
+			expect(createHelp).toContain("priority: one of configured priorities: High, Medium, Low");
 			expect(createHelp).toContain("ordinal: Integer");
 			expect(listHelp).toContain("status: one of configured statuses: To Do, In Progress, Done");
 			expect(listHelp).not.toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
-			expect(listHelp).toContain("priority: one of: high, medium, low");
+			expect(listHelp).toContain("priority: one of configured priorities: High, Medium, Low");
 			expect(listHelp).toContain("labels: Comma-separated strings");
 			expect(listHelp).toContain("search: String");
 			expect(listHelp).toContain("limit: Positive integer");
@@ -361,7 +361,7 @@ describe("CLI Integration", () => {
 			expect(searchHelp).toContain("type: one or more of: task, document, decision");
 			expect(searchHelp).toContain("status: one of configured statuses: To Do, In Progress, Done");
 			expect(searchHelp).not.toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
-			expect(searchHelp).toContain("priority: one of: high, medium, low");
+			expect(searchHelp).toContain("priority: one of configured priorities: High, Medium, Low");
 			expect(searchHelp).toContain("modified-file: Project-root-relative path");
 			expect(cleanupHelp).toContain("Writes:");
 		});
@@ -405,7 +405,7 @@ describe("CLI Integration", () => {
 			const docPathOutput = docPath.stdout.toString() + docPath.stderr.toString();
 
 			expect(priority.exitCode).not.toBe(0);
-			expect(priorityOutput).toContain("Invalid priority: urgent. Valid values are: high, medium, low");
+			expect(priorityOutput).toContain("Invalid priority: urgent. Valid values are: High, Medium, Low");
 			expect(priorityOutput).not.toContain("Error:");
 			expect(docPath.exitCode).not.toBe(0);
 			expect(docPathOutput).toContain("Document path cannot include traversal segments.");
@@ -1261,6 +1261,40 @@ describe("CLI Integration", () => {
 			expect(out).toContain("[HIGH] TASK-2 - High Priority Later ID");
 			expect(out).not.toContain("To Do:");
 			expect(out).not.toContain("TASK-1 - Low Priority First ID");
+		});
+
+		it("should use configured custom priorities for create, list, search, and help", async () => {
+			const core = new Core(TEST_DIR);
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected test config to exist");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				priorities: ["Very High", "High", "Medium", "Low", "Very Low"],
+			});
+
+			await $`bun ${CLI_PATH} task create "Custom priority urgent task" --priority "Very High" --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+			await $`bun ${CLI_PATH} task create "Custom priority later task" --priority "Very Low" --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			const listResult = await $`bun ${CLI_PATH} task list --plain --priority "very high"`.cwd(TEST_DIR).quiet();
+			const listOutput = listResult.stdout.toString();
+			expect(listOutput).toContain("[VERY HIGH] TASK-1 - Custom priority urgent task");
+			expect(listOutput).not.toContain("Custom priority later task");
+
+			const searchResult = await $`bun ${CLI_PATH} search "Custom priority" --priority "VERY HIGH" --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+			const searchOutput = searchResult.stdout.toString();
+			expect(searchOutput).toContain("TASK-1 - Custom priority urgent task");
+			expect(searchOutput).not.toContain("TASK-2 - Custom priority later task");
+
+			const helpOutput = await $`bun ${CLI_PATH} task create --help`.cwd(TEST_DIR).text();
+			expect(helpOutput).toContain("priority: one of configured priorities: Very High, High, Medium, Low, Very Low");
 		});
 
 		it("should combine search, labels, and existing task list filters", async () => {

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -473,6 +473,49 @@ describe("MCP task tools (MVP)", () => {
 		expect(editStatusSchema?.enumNormalizeWhitespace).toBe(true);
 	});
 
+	it("exposes configured priority enums and accepts custom priority values", async () => {
+		const config = await loadConfig(mcpServer);
+		config.priorities = ["Very High", "High", "Medium", "Low", "Very Low"];
+		await mcpServer.filesystem.saveConfig(config);
+
+		const customServer = new McpServer(TEST_DIR, "Test instructions");
+		try {
+			registerTaskTools(customServer, config);
+			const tools = await customServer.testInterface.listTools();
+			const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+
+			const createPrioritySchema = (toolByName.get("task_create")?.inputSchema as JsonSchema | undefined)?.properties
+				?.priority;
+			const editPrioritySchema = (toolByName.get("task_edit")?.inputSchema as JsonSchema | undefined)?.properties
+				?.priority;
+			const searchPrioritySchema = (toolByName.get("task_search")?.inputSchema as JsonSchema | undefined)?.properties
+				?.priority;
+
+			const expected = ["Very High", "High", "Medium", "Low", "Very Low"];
+			expect(createPrioritySchema?.enum).toEqual(expected);
+			expect(createPrioritySchema?.enumCaseInsensitive).toBe(true);
+			expect(editPrioritySchema?.enum).toEqual(expected);
+			expect(editPrioritySchema?.enumCaseInsensitive).toBe(true);
+			expect(searchPrioritySchema?.enum).toEqual(expected);
+			expect(searchPrioritySchema?.enumCaseInsensitive).toBe(true);
+
+			const createResult = await customServer.testInterface.callTool({
+				params: {
+					name: "task_create",
+					arguments: {
+						title: "Custom priority MCP task",
+						priority: "VERY HIGH",
+					},
+				},
+			});
+			expect(createResult.isError).not.toBe(true);
+			const task = await customServer.getTask("task-1");
+			expect(task?.priority).toBe("very high");
+		} finally {
+			await customServer.stop();
+		}
+	});
+
 	it("describes Definition of Done fields as task-level in schemas", async () => {
 		const tools = await mcpServer.testInterface.listTools();
 		const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));

--- a/src/test/priority.test.ts
+++ b/src/test/priority.test.ts
@@ -1,9 +1,49 @@
 import { describe, expect, it } from "bun:test";
+import { FileSystem } from "../file-system/operations.ts";
 import { parseTask } from "../markdown/parser.ts";
 import { serializeTask } from "../markdown/serializer.ts";
 import type { Task } from "../types/index.ts";
+import { getPriorityOptions, getPriorityRank, resolvePriorityValue } from "../utils/priority-config.ts";
+import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
 
 describe("Priority functionality", () => {
+	describe("priority configuration", () => {
+		it("normalizes configured priorities while preserving labels", () => {
+			const config = { priorities: ["Very High", "High", "Medium", "Low", "Very Low"] };
+
+			expect(getPriorityOptions(config)).toEqual([
+				{ label: "Very High", value: "very high" },
+				{ label: "High", value: "high" },
+				{ label: "Medium", value: "medium" },
+				{ label: "Low", value: "low" },
+				{ label: "Very Low", value: "very low" },
+			]);
+			expect(resolvePriorityValue("VERY HIGH", config)).toBe("very high");
+			expect(getPriorityRank("very high", config)).toBe(5);
+			expect(getPriorityRank("very low", config)).toBe(1);
+		});
+
+		it("round-trips configured priorities through config.yml", async () => {
+			const testDir = createUniqueTestDir("priority-config");
+			const filesystem = new FileSystem(testDir);
+			try {
+				await filesystem.ensureBacklogStructure();
+				await filesystem.saveConfig({
+					projectName: "Priority Config",
+					statuses: ["To Do", "Done"],
+					labels: [],
+					priorities: ["Very High", "High", "Medium", "Low", "Very Low"],
+					dateFormat: "yyyy-mm-dd",
+				});
+
+				const reloaded = await new FileSystem(testDir).loadConfig();
+				expect(reloaded?.priorities).toEqual(["Very High", "High", "Medium", "Low", "Very Low"]);
+			} finally {
+				await safeCleanup(testDir);
+			}
+		});
+	});
+
 	describe("parseTask", () => {
 		it("should parse task with priority field", () => {
 			const content = `---
@@ -52,12 +92,12 @@ This is a ${priority} priority task.`;
 			}
 		});
 
-		it("should handle invalid priority values gracefully", () => {
+		it("should preserve non-default priority values", () => {
 			const content = `---
 id: task-1
-title: "Invalid priority task"
+title: "Custom priority task"
 status: "To Do"
-priority: invalid
+priority: Very High
 assignee: []
 created_date: "2025-06-20"
 labels: []
@@ -66,11 +106,11 @@ dependencies: []
 
 ## Description
 
-This task has an invalid priority.`;
+This task has a custom priority.`;
 
 			const task = parseTask(content);
 
-			expect(task.priority).toBeUndefined();
+			expect(task.priority).toBe("very high");
 		});
 
 		it("should handle task without priority field", () => {
@@ -152,7 +192,7 @@ This task has mixed case priority.`;
 		});
 
 		it("should round-trip priority values correctly", () => {
-			const priorities: Array<"high" | "medium" | "low"> = ["high", "medium", "low"];
+			const priorities = ["very high", "high", "medium", "low", "very low"];
 
 			for (const priority of priorities) {
 				const originalTask: Task = {

--- a/src/test/search-command-query.test.ts
+++ b/src/test/search-command-query.test.ts
@@ -47,8 +47,8 @@ describe("parseSearchCommandQuery", () => {
 	});
 
 	it("keeps malformed and unsupported tokens in the text query", () => {
-		expect(parseSearchCommandQuery('status: priority:urgent type:note status:"In Progress fix')).toEqual({
-			query: 'status: priority:urgent type:note status:"In Progress fix',
+		expect(parseSearchCommandQuery('status: type:note status:"In Progress fix')).toEqual({
+			query: 'status: type:note status:"In Progress fix',
 		});
 	});
 

--- a/src/test/server-search-endpoint.test.ts
+++ b/src/test/server-search-endpoint.test.ts
@@ -60,6 +60,21 @@ const dependentTask: Task = {
 	modifiedFiles: ["src/ui/task-viewer-with-search.ts"],
 };
 
+const customPriorityTask: Task = {
+	id: "TASK-0009",
+	title: "Custom priority escalation",
+	status: "In Progress",
+	assignee: ["@codex"],
+	reporter: "@codex",
+	createdDate: "2025-09-20 11:00",
+	updatedDate: "2025-09-20 11:00",
+	labels: ["search"],
+	dependencies: [],
+	description: "Custom priority lookup target",
+	priority: "very high",
+	modifiedFiles: ["src/server/index.ts"],
+};
+
 describe("BacklogServer search endpoint", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("server-search");
@@ -69,6 +84,7 @@ describe("BacklogServer search endpoint", () => {
 			projectName: "Server Search",
 			statuses: ["To Do", "In Progress", "Done"],
 			labels: [],
+			priorities: ["Very High", "High", "Medium", "Low", "Very Low"],
 			milestones: [],
 			dateFormat: "YYYY-MM-DD",
 			remoteOperations: false,
@@ -76,6 +92,7 @@ describe("BacklogServer search endpoint", () => {
 
 		await filesystem.saveTask(baseTask);
 		await filesystem.saveTask(dependentTask);
+		await filesystem.saveTask(customPriorityTask);
 		await filesystem.saveDocument(baseDoc);
 		await filesystem.saveDecision(baseDecision);
 
@@ -130,6 +147,17 @@ describe("BacklogServer search endpoint", () => {
 		expect(results).toHaveLength(1);
 		expect(results[0]?.type).toBe("task");
 		expect(results[0]?.task?.id).toBe(baseTask.id);
+	});
+
+	it("uses configured custom priorities for task and search filters", async () => {
+		const taskResults = await fetchJson<Task[]>("/api/tasks?priority=VERY%20HIGH");
+		expect(taskResults.map((task) => task.id)).toEqual([customPriorityTask.id]);
+
+		const searchResults = await fetchJson<Array<{ type: string; task?: Task }>>(
+			"/api/search?type=task&query=custom&priority=Very%20High",
+		);
+		expect(searchResults).toHaveLength(1);
+		expect(searchResults[0]?.task?.id).toBe(customPriorityTask.id);
 	});
 
 	it("filters search results by assignee and labels", async () => {

--- a/src/test/statistics.test.ts
+++ b/src/test/statistics.test.ts
@@ -63,7 +63,21 @@ describe("getTaskStatistics", () => {
 		expect(stats.priorityCounts.get("high")).toBe(2);
 		expect(stats.priorityCounts.get("medium")).toBe(1);
 		expect(stats.priorityCounts.get("low")).toBe(1);
+		expect(stats.noPriorityCount).toBe(1);
+	});
+
+	test("keeps configured None distinct from tasks without priority", () => {
+		const tasks: Task[] = [
+			createTask({ id: "task-1", priority: "None" }),
+			createTask({ id: "task-2", priority: "Very High" }),
+			createTask({ id: "task-3" }),
+		];
+
+		const stats = getTaskStatistics(tasks, [], statuses, ["None", "Very High"]);
+
 		expect(stats.priorityCounts.get("none")).toBe(1);
+		expect(stats.priorityCounts.get("very high")).toBe(1);
+		expect(stats.noPriorityCount).toBe(1);
 	});
 
 	test("counts drafts correctly", () => {

--- a/src/test/task-sorting.test.ts
+++ b/src/test/task-sorting.test.ts
@@ -139,6 +139,19 @@ describe("sortByPriority", () => {
 		]);
 	});
 
+	test("sorts tasks by configured custom priority order", () => {
+		const tasks = [
+			{ id: "task-1", priority: "low" },
+			{ id: "task-2", priority: "very high" },
+			{ id: "task-3", priority: "very low" },
+			{ id: "task-4", priority: "medium" },
+			{ id: "task-5" },
+		];
+
+		const sorted = sortByPriority(tasks, ["Very High", "High", "Medium", "Low", "Very Low"]);
+		expect(sorted.map((task) => task.id)).toEqual(["task-2", "task-4", "task-1", "task-3", "task-5"]);
+	});
+
 	test("sorts tasks with same priority by task ID", () => {
 		const tasks = [
 			{ id: "task-10", priority: "high" as const },

--- a/src/test/test-helpers.ts
+++ b/src/test/test-helpers.ts
@@ -269,7 +269,7 @@ Options:
   -a, --assignee <assignee>        assign to user
   -s, --status <status>           set task status
   -l, --labels <labels>           add labels (comma-separated)
-  --priority <priority>           set task priority (high, medium, low)
+  --priority <priority>           set task priority (configured priorities)
   --ac <criteria>                 acceptance criteria (comma-separated)
   --dod <item>                    add Definition of Done item (can be used multiple times)
   --no-dod-defaults               disable Definition of Done defaults

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -90,7 +90,13 @@ const setupDom = (url = "http://localhost/board") => {
 
 const renderBoardPage = (
 	url?: string,
-	options: { tasks?: Task[]; statuses?: string[]; availableLabels?: string[]; dateFormat?: string } = {},
+	options: {
+		tasks?: Task[];
+		statuses?: string[];
+		availableLabels?: string[];
+		availablePriorities?: string[];
+		dateFormat?: string;
+	} = {},
 ): HTMLElement => {
 	setupDom(url);
 	const container = document.getElementById("root");
@@ -106,6 +112,7 @@ const renderBoardPage = (
 					statuses={renderedStatuses}
 					milestones={[]}
 					availableLabels={options.availableLabels ?? ["bug", "docs", "enhancement"]}
+					availablePriorities={options.availablePriorities}
 					milestoneEntities={[]}
 					archivedMilestones={[]}
 					isLoading={false}
@@ -250,6 +257,38 @@ describe("Web board filters", () => {
 		await setSelectValue(getSelectByFirstOption(container, "All priorities"), "high");
 		expect(new URLSearchParams(window.location.search).get("priority")).toBe("high");
 		expectVisibleTasks(container, ["Fix login bug"]);
+	});
+
+	it("renders and filters configured custom priorities", async () => {
+		const customTasks = [
+			...tasks,
+			createTask({
+				id: "task-105",
+				title: "Escalate production incident",
+				priority: "very high",
+			}),
+		];
+		const container = renderBoardPage(undefined, {
+			tasks: customTasks,
+			availablePriorities: ["Very High", "High", "Medium", "Low", "Very Low"],
+		});
+
+		const prioritySelect = getSelectByFirstOption(container, "All priorities");
+		expect(Array.from(prioritySelect.options).map((option) => option.textContent)).toEqual([
+			"All priorities",
+			"Very High",
+			"High",
+			"Medium",
+			"Low",
+			"Very Low",
+		]);
+
+		await setSelectValue(prioritySelect, "very high");
+		const text = container.textContent ?? "";
+		expect(new URLSearchParams(window.location.search).get("priority")).toBe("very high");
+		expect(text).toContain("Escalate production incident");
+		expect(text).toContain("Very High");
+		expect(text).not.toContain("Fix login bug");
 	});
 
 	it("matches configured label casing against task labels", async () => {

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -291,6 +291,36 @@ describe("Web board filters", () => {
 		expect(text).not.toContain("Fix login bug");
 	});
 
+	it("canonicalizes mixed-case configured priority URL values", async () => {
+		const customTasks = [
+			...tasks,
+			createTask({
+				id: "task-105",
+				title: "Escalate production incident",
+				priority: "very high",
+			}),
+		];
+		const container = renderBoardPage("http://localhost/board?priority=VeRy%20HiGh", {
+			tasks: customTasks,
+			availablePriorities: ["Very High", "High", "Medium", "Low"],
+		});
+
+		await waitFor(() => new URLSearchParams(window.location.search).get("priority") === "very high");
+
+		expect(getSelectByFirstOption(container, "All priorities").value).toBe("very high");
+		expect(container.textContent).toContain("Escalate production incident");
+		expect(container.textContent).not.toContain("Fix login bug");
+	});
+
+	it("clears unsupported priority URL values", async () => {
+		const container = renderBoardPage("http://localhost/board?priority=urgent");
+
+		await waitFor(() => new URLSearchParams(window.location.search).get("priority") === null);
+
+		expect(getSelectByFirstOption(container, "All priorities").value).toBe("");
+		expectVisibleTasks(container, ["Fix login bug", "Write docs", "Improve board", "Triage unassigned issue"]);
+	});
+
 	it("matches configured label casing against task labels", async () => {
 		const container = renderBoardPage(undefined, {
 			availableLabels: ["Bug", "Docs", "enhancement"],

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { JSDOM } from "jsdom";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import type { Task } from "../types/index.ts";
 import TaskList from "../web/components/TaskList.tsx";
 
@@ -59,9 +59,14 @@ const setupDom = () => {
 	}
 };
 
+const LocationSearch = () => {
+	const location = useLocation();
+	return <output data-testid="location-search">{location.search}</output>;
+};
+
 const renderTaskList = (
 	initialEntries?: string[],
-	options: { tasks?: Task[]; availableStatuses?: string[] } = {},
+	options: { tasks?: Task[]; availableStatuses?: string[]; availablePriorities?: string[] } = {},
 ): HTMLElement => {
 	setupDom();
 	const container = document.getElementById("root");
@@ -77,11 +82,13 @@ const renderTaskList = (
 					availableStatuses={renderedStatuses}
 					availableLabels={["bug", "docs"]}
 					availableMilestones={[]}
+					availablePriorities={options.availablePriorities}
 					milestoneEntities={[]}
 					archivedMilestones={[]}
 					onEditTask={() => {}}
 					onNewTask={() => {}}
 				/>
+				<LocationSearch />
 			</MemoryRouter>,
 		);
 	});
@@ -137,6 +144,9 @@ const getZIndexClass = (element: Element): number | null => {
 
 const getRenderedTaskIds = (container: HTMLElement): string[] =>
 	Array.from(container.querySelectorAll("tbody tr td:first-child")).map((cell) => cell.textContent?.trim() ?? "");
+
+const getLocationSearch = (container: HTMLElement): string =>
+	container.querySelector("[data-testid='location-search']")?.textContent ?? "";
 
 afterEach(() => {
 	globalThis.fetch = originalFetch;
@@ -232,6 +242,56 @@ describe("TaskList labels filter menu", () => {
 
 		expect(labelsButton.textContent).toContain("All");
 		expect(container.querySelector("#task-list-labels-menu")).toBeNull();
+	});
+
+	it("canonicalizes mixed-case configured priority URL values", async () => {
+		const customTask = createTask({ id: "task-301", title: "Escalate incident", priority: "very high" });
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () => [{ type: "task", score: 0, task: customTask }],
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(["/?priority=VeRy%20HiGh"], {
+			tasks: [],
+			availablePriorities: ["Very High", "High", "Medium", "Low"],
+		});
+		await waitFor(() =>
+			fetchCalls.length === 1 &&
+			new URLSearchParams(getLocationSearch(container)).get("priority") === "very high" &&
+			(container.textContent ?? "").includes("Escalate incident"),
+		);
+
+		expect(new URL(fetchCalls[0] ?? "", "http://localhost").searchParams.get("priority")).toBe("very high");
+		expect(getSelectByFirstOption(container, "All priorities").value).toBe("very high");
+		expect(container.textContent).toContain("Escalate incident");
+	});
+
+	it("clears unsupported priority URL values without searching", async () => {
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () => [],
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(["/?priority=urgent"]);
+		await waitFor(() => new URLSearchParams(getLocationSearch(container)).get("priority") === null);
+
+		expect(fetchCalls).toEqual([]);
+		expect(getSelectByFirstOption(container, "All priorities").value).toBe("");
+		expect(getRenderedTaskIds(container)).toEqual(["task-102", "task-101"]);
 	});
 
 	it("shows cleanup when filtering by the final configured status", async () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,7 +64,7 @@ export interface Task {
 	parentTaskTitle?: string;
 	subtasks?: string[];
 	subtaskSummaries?: Array<{ id: string; title: string }>;
-	priority?: "high" | "medium" | "low";
+	priority?: string;
 	/** Semantic task type (e.g. bug, feature). Allowed values come from config `types` (defaults to DEFAULT_TASK_TYPES); absent means untyped. */
 	type?: string;
 	branch?: string;
@@ -106,7 +106,7 @@ export interface TaskCreateInput {
 	title: string;
 	description?: string;
 	status?: TaskStatus;
-	priority?: "high" | "medium" | "low";
+	priority?: string;
 	type?: string;
 	ordinal?: number;
 	milestone?: string;
@@ -130,7 +130,7 @@ export interface TaskUpdateInput {
 	title?: string;
 	description?: string;
 	status?: TaskStatus;
-	priority?: "high" | "medium" | "low";
+	priority?: string;
 	type?: string;
 	milestone?: string | null;
 	labels?: string[];
@@ -174,7 +174,7 @@ export interface TaskListFilter {
 	status?: string;
 	assignee?: string;
 	unassigned?: boolean;
-	priority?: "high" | "medium" | "low";
+	priority?: string;
 	milestone?: string;
 	parentTaskId?: string;
 	labels?: string[];
@@ -235,7 +235,7 @@ export interface DocumentUpdateInput {
 
 export type SearchResultType = "task" | "document" | "decision";
 
-export type SearchPriorityFilter = "high" | "medium" | "low";
+export type SearchPriorityFilter = string;
 
 export interface SearchMatch {
 	key?: string;
@@ -299,6 +299,8 @@ export interface BacklogConfig {
 	labels: string[];
 	/** Allowed task types. Defaults to DEFAULT_TASK_TYPES when not configured. */
 	types?: string[];
+	/** Ordered task priority labels. Defaults to High, Medium, Low when not configured. */
+	priorities?: string[];
 	/** @deprecated Milestones are sourced from milestone files, not config. */
 	milestones?: string[];
 	definitionOfDone?: string[];

--- a/src/types/task-edit-args.ts
+++ b/src/types/task-edit-args.ts
@@ -2,7 +2,7 @@ export interface TaskEditArgs {
 	title?: string;
 	description?: string;
 	status?: string;
-	priority?: "high" | "medium" | "low";
+	priority?: string;
 	type?: string;
 	milestone?: string | null;
 	labels?: string[];

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -11,6 +11,7 @@ import type { Milestone, Task } from "../types/index.ts";
 import { copyToClipboard } from "../utils/clipboard.ts";
 import { areLabelSelectionsEqual, collectAvailableLabels } from "../utils/label-filter.ts";
 import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
+import { getPriorityOptions } from "../utils/priority-config.ts";
 import { applySharedTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { compareTaskIds } from "../utils/task-sorting.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
@@ -197,6 +198,7 @@ export async function renderBoardTui(
 		};
 		availableLabels?: string[];
 		availableMilestones?: string[];
+		priorities?: string[];
 		onFilterChange?: (filters: {
 			searchQuery: string;
 			priorityFilter: string;
@@ -269,6 +271,7 @@ export async function renderBoardTui(
 			}
 		};
 		let configuredLabels = collectAvailableLabels(initialTasks, options?.availableLabels ?? []);
+		const priorityOptions = getPriorityOptions(options?.priorities);
 		let availableMilestones = [...(options?.availableMilestones ?? [])];
 		const milestoneLabelByKey = new Map<string, string>();
 		for (const milestone of options?.milestoneEntities ?? []) {
@@ -328,7 +331,7 @@ export async function renderBoardTui(
 					currentTasks,
 					{
 						query: sharedFilters.searchQuery,
-						priority: sharedFilters.priorityFilter as "high" | "medium" | "low" | undefined,
+						priority: sharedFilters.priorityFilter || undefined,
 						labels: sharedFilters.labelFilter,
 						labelMatch: sharedFilters.labelMatch,
 						milestone: sharedFilters.milestoneFilter || undefined,
@@ -673,14 +676,13 @@ export async function renderBoardTui(
 				}
 
 				if (filterId === "priority") {
-					const priorities = ["high", "medium", "low"];
 					const selected = await openSingleSelectFilterPopup({
 						screen,
 						title: "Priority Filter",
 						selectedValue: sharedFilters.priorityFilter,
 						choices: [
 							{ label: "All", value: "" },
-							...priorities.map((priority) => ({ label: priority, value: priority })),
+							...priorityOptions.map((priority) => ({ label: priority.label, value: priority.value })),
 						],
 					});
 					if (selected !== null) {

--- a/src/ui/enhanced-views.ts
+++ b/src/ui/enhanced-views.ts
@@ -184,7 +184,10 @@ async function renderBoardTuiWithSwitching(
 
 	// For now, use the original function but we'll need to modify it to support Tab switching
 	// This is a placeholder - we'll need to modify the actual board.ts
-	return renderBoardTui(tasks, statuses, layout, maxColumnWidth, { dateFormat: config?.dateFormat });
+	return renderBoardTui(tasks, statuses, layout, maxColumnWidth, {
+		dateFormat: config?.dateFormat,
+		priorities: config?.priorities,
+	});
 }
 
 // Re-export for convenience

--- a/src/ui/overview-tui.ts
+++ b/src/ui/overview-tui.ts
@@ -1,7 +1,29 @@
 import { box } from "neo-neo-bblessed";
 import type { TaskStatistics } from "../core/statistics.ts";
+import { formatPriorityLabel } from "../utils/priority-config.ts";
 import { getStatusIcon } from "./status-icon.ts";
 import { createScreen } from "./tui.ts";
+
+const priorityColors: Record<string, string> = {
+	high: "red",
+	medium: "yellow",
+	low: "green",
+	none: "gray",
+};
+
+function getPriorityBreakdownRows(statistics: TaskStatistics): Array<{ label: string; count: number; color: string }> {
+	const rows = Array.from(statistics.priorityCounts)
+		.filter(([, count]) => count > 0)
+		.map(([priority, count]) => ({
+			label: formatPriorityLabel(priority),
+			count,
+			color: priorityColors[priority] ?? "white",
+		}));
+	if (statistics.noPriorityCount > 0) {
+		rows.push({ label: "No Priority", count: statistics.noPriorityCount, color: "gray" });
+	}
+	return rows;
+}
 
 /**
  * Render the project overview in an interactive TUI
@@ -89,20 +111,9 @@ export async function renderOverviewTui(statistics: TaskStatistics, projectName:
 		});
 
 		let priorityContent = "";
-		const priorityColors = {
-			high: "red",
-			medium: "yellow",
-			low: "green",
-			none: "gray",
-		};
-		for (const [priority, count] of statistics.priorityCounts) {
-			if (count > 0) {
-				const color = priorityColors[priority as keyof typeof priorityColors] || "white";
-				const percentage = statistics.totalTasks > 0 ? Math.round((count / statistics.totalTasks) * 100) : 0;
-				const displayPriority =
-					priority === "none" ? "No Priority" : priority.charAt(0).toUpperCase() + priority.slice(1);
-				priorityContent += `  {${color}-fg}${displayPriority}:{/${color}-fg} ${count} tasks (${percentage}%)\n`;
-			}
+		for (const { label, count, color } of getPriorityBreakdownRows(statistics)) {
+			const percentage = statistics.totalTasks > 0 ? Math.round((count / statistics.totalTasks) * 100) : 0;
+			priorityContent += `  {${color}-fg}${label}:{/${color}-fg} ${count} tasks (${percentage}%)\n`;
 		}
 		priorityBox.setContent(priorityContent);
 
@@ -231,13 +242,9 @@ function renderPlainTextOverview(statistics: TaskStatistics, projectName: string
 	}
 
 	console.log("\nPriority Breakdown:");
-	for (const [priority, count] of statistics.priorityCounts) {
-		if (count > 0) {
-			const percentage = statistics.totalTasks > 0 ? Math.round((count / statistics.totalTasks) * 100) : 0;
-			const displayPriority =
-				priority === "none" ? "No Priority" : priority.charAt(0).toUpperCase() + priority.slice(1);
-			console.log(`  ${displayPriority}: ${count} tasks (${percentage}%)`);
-		}
+	for (const { label, count } of getPriorityBreakdownRows(statistics)) {
+		const percentage = statistics.totalTasks > 0 ? Math.round((count / statistics.totalTasks) * 100) : 0;
+		console.log(`  ${label}: ${count} tasks (${percentage}%)`);
 	}
 
 	console.log("\nRecent Activity:");

--- a/src/ui/simple-unified-view.ts
+++ b/src/ui/simple-unified-view.ts
@@ -122,6 +122,7 @@ export async function runSimpleUnifiedView(options: SimpleUnifiedViewOptions): P
 				await switchView();
 			},
 			dateFormat: config?.dateFormat,
+			priorities: config?.priorities,
 		});
 
 		isRunning = false;

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -15,6 +15,7 @@ import { copyToClipboard } from "../utils/clipboard.ts";
 import { areLabelSelectionsEqual, collectAvailableLabels, labelsToLower } from "../utils/label-filter.ts";
 import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
+import { formatPriorityLabel, getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
 import { applyTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { formatChecklistItem } from "./checklist.ts";
@@ -36,8 +37,8 @@ import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-
 import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-lifecycle.ts";
 import { addScrollKeys, createScreen } from "./tui.ts";
 
-function getPriorityDisplay(priority?: "high" | "medium" | "low"): string {
-	switch (priority) {
+function getPriorityDisplay(priority?: string): string {
+	switch (normalizePriorityValue(priority)) {
 		case "high":
 			return " {red-fg}●{/}";
 		case "medium":
@@ -202,6 +203,7 @@ export async function viewTaskEnhanced(
 	let allTasks: Task[];
 	let statuses: string[];
 	let labels: string[];
+	let priorityOptions = getPriorityOptions();
 	let availableLabels: string[] = [];
 	// When tasks are provided, use in-memory search; otherwise use ContentStore-backed search
 	let taskSearchIndex: ReturnType<typeof createTaskSearchIndex> | null = null;
@@ -218,6 +220,7 @@ export async function viewTaskEnhanced(
 		const config = await core.filesystem.loadConfig();
 		statuses = config?.statuses || ["To Do", "In Progress", "Done"];
 		labels = config?.labels || [];
+		priorityOptions = getPriorityOptions(config);
 		dateFormat = config?.dateFormat;
 		taskSearchIndex = createTaskSearchIndex(allTasks);
 	} else {
@@ -228,6 +231,7 @@ export async function viewTaskEnhanced(
 			const config = await core.filesystem.loadConfig();
 			statuses = config?.statuses || ["To Do", "In Progress", "Done"];
 			labels = config?.labels || [];
+			priorityOptions = getPriorityOptions(config);
 			dateFormat = config?.dateFormat;
 
 			loadingScreen?.update("Loading tasks from branches...");
@@ -256,8 +260,7 @@ export async function viewTaskEnhanced(
 		statusFilter = matchedStatus || "";
 	}
 
-	// Priority is already lowercase
-	let priorityFilter = options.priorityFilter || "";
+	let priorityFilter = normalizePriorityValue(options.priorityFilter) || "";
 	let labelFilter: string[] = [];
 	let milestoneFilter = options.milestoneFilter || "";
 	let labelMatch: LabelMatchMode = options.labelMatch ?? "any";
@@ -369,14 +372,13 @@ export async function viewTaskEnhanced(
 			}
 
 			if (filterId === "priority") {
-				const priorities = ["high", "medium", "low"];
 				const selected = await openSingleSelectFilterPopup({
 					screen,
 					title: "Priority Filter",
 					selectedValue: priorityFilter,
 					choices: [
 						{ label: "All", value: "" },
-						...priorities.map((priority) => ({ label: priority, value: priority })),
+						...priorityOptions.map((priority) => ({ label: priority.label, value: priority.value })),
 					],
 				});
 				if (selected !== null) {
@@ -611,7 +613,7 @@ export async function viewTaskEnhanced(
 				{
 					query: searchQuery,
 					status: statusFilter || undefined,
-					priority: priorityFilter as "high" | "medium" | "low" | undefined,
+					priority: priorityFilter || undefined,
 					labels: labelFilter,
 					labelMatch,
 					milestone: milestoneFilter || undefined,
@@ -624,7 +626,7 @@ export async function viewTaskEnhanced(
 				query: searchQuery,
 				filters: {
 					status: statusFilter || undefined,
-					priority: priorityFilter as "high" | "medium" | "low" | undefined,
+					priority: priorityFilter || undefined,
 					labels: labelFilter.length > 0 ? labelFilter : undefined,
 				},
 				types: ["task"],
@@ -1387,7 +1389,7 @@ function generateDetailContent(
 	}
 	if (task.priority) {
 		const priorityDisplay = getPriorityDisplay(task.priority);
-		const priorityText = task.priority.charAt(0).toUpperCase() + task.priority.slice(1);
+		const priorityText = formatPriorityLabel(task.priority);
 		metadata.push(`{bold}Priority:{/bold} ${priorityText}${priorityDisplay}`);
 	}
 	if (task.assignee?.length) {

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -104,7 +104,7 @@ export function filterTasksForKanban(
 		tasks,
 		{
 			query: filters.searchQuery,
-			priority: filters.priorityFilter as "high" | "medium" | "low" | undefined,
+			priority: filters.priorityFilter || undefined,
 			labels: filters.labelFilter,
 			labelMatch: filters.labelMatch ?? "any",
 			milestone: filters.milestoneFilter || undefined,
@@ -419,6 +419,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					milestoneEntities,
 					startupWarning,
 					dateFormat: config?.dateFormat,
+					priorities: config?.priorities,
 				}).then(() => {
 					// If user wants to exit, do it immediately
 					if (result === "exit") {

--- a/src/utils/priority-config.ts
+++ b/src/utils/priority-config.ts
@@ -1,0 +1,105 @@
+import type { BacklogConfig } from "../types/index.ts";
+
+export const DEFAULT_PRIORITY_OPTIONS = [
+	{ label: "High", value: "high" },
+	{ label: "Medium", value: "medium" },
+	{ label: "Low", value: "low" },
+] as const;
+
+export type PriorityOption = {
+	label: string;
+	value: string;
+};
+
+export function normalizePriorityValue(value: string | null | undefined): string | undefined {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/g, " ");
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+export function getPriorityOptions(
+	configOrPriorities?: Pick<BacklogConfig, "priorities"> | readonly string[] | null,
+): PriorityOption[] {
+	const configuredPriorities: readonly string[] = Array.isArray(configOrPriorities)
+		? configOrPriorities
+		: ((configOrPriorities as Pick<BacklogConfig, "priorities"> | null | undefined)?.priorities ?? []);
+	const options: PriorityOption[] = [];
+	const seen = new Set<string>();
+
+	for (const entry of configuredPriorities) {
+		const label = String(entry ?? "")
+			.trim()
+			.replace(/\s+/g, " ");
+		const value = normalizePriorityValue(label);
+		if (!value || seen.has(value)) {
+			continue;
+		}
+		seen.add(value);
+		options.push({ label, value });
+	}
+
+	return options.length > 0 ? options : DEFAULT_PRIORITY_OPTIONS.map((option) => ({ ...option }));
+}
+
+export function getPriorityValues(
+	configOrPriorities?: Pick<BacklogConfig, "priorities"> | readonly string[] | null,
+): string[] {
+	return getPriorityOptions(configOrPriorities).map((option) => option.value);
+}
+
+export function getPriorityLabels(
+	configOrPriorities?: Pick<BacklogConfig, "priorities"> | readonly string[] | null,
+): string[] {
+	return getPriorityOptions(configOrPriorities).map((option) => option.label);
+}
+
+export function resolvePriorityValue(
+	value: string | null | undefined,
+	configOrPriorities?: Pick<BacklogConfig, "priorities"> | readonly string[] | null,
+): string | undefined {
+	const normalized = normalizePriorityValue(value);
+	if (!normalized) {
+		return undefined;
+	}
+	const allowed = new Set(getPriorityValues(configOrPriorities));
+	return allowed.has(normalized) ? normalized : undefined;
+}
+
+export function formatPriorityLabel(
+	value: string | null | undefined,
+	configOrPriorities?: Pick<BacklogConfig, "priorities"> | readonly string[] | null,
+): string {
+	const normalized = normalizePriorityValue(value);
+	if (!normalized) {
+		return "";
+	}
+	const configured = getPriorityOptions(configOrPriorities).find((option) => option.value === normalized);
+	if (configured) {
+		return configured.label;
+	}
+	return normalized
+		.split(" ")
+		.map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : ""))
+		.join(" ");
+}
+
+export function getPriorityRank(
+	value: string | null | undefined,
+	configOrPriorities?: Pick<BacklogConfig, "priorities"> | readonly string[] | null,
+): number {
+	const normalized = normalizePriorityValue(value);
+	if (!normalized) {
+		return 0;
+	}
+	const values = getPriorityValues(configOrPriorities);
+	const index = values.indexOf(normalized);
+	return index === -1 ? 0 : values.length - index;
+}
+
+export function formatValidPriorityValues(
+	configOrPriorities?: Pick<BacklogConfig, "priorities"> | readonly string[] | null,
+): string {
+	return getPriorityLabels(configOrPriorities).join(", ");
+}

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -8,13 +8,14 @@ import type { Task } from "../types/index.ts";
 import { labelsToLower } from "./label-filter.ts";
 import { NO_MILESTONE_FILTER_VALUE } from "./milestone-filter.ts";
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "./modified-files.ts";
+import { normalizePriorityValue } from "./priority-config.ts";
 
 export type LabelMatchMode = "any" | "all";
 
 export interface TaskSearchOptions {
 	query?: string;
 	status?: string;
-	priority?: "high" | "medium" | "low";
+	priority?: string;
 	labels?: string[];
 	labelMatch?: LabelMatchMode;
 	modifiedFiles?: string[];
@@ -22,7 +23,7 @@ export interface TaskSearchOptions {
 
 export interface SharedTaskFilterOptions {
 	query?: string;
-	priority?: "high" | "medium" | "low";
+	priority?: string;
 	labels?: string[];
 	labelMatch?: LabelMatchMode;
 	modifiedFiles?: string[];
@@ -130,7 +131,7 @@ function buildSearchableTask(task: Task): SearchableTask {
 		idVariants: createTaskIdVariants(task.id),
 		dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdVariants(dependency)),
 		statusLower: (task.status || "").toLowerCase(),
-		priorityLower: task.priority?.toLowerCase(),
+		priorityLower: normalizePriorityValue(task.priority),
 		labelsLower: (task.labels || []).map((label) => label.toLowerCase()),
 		modifiedFiles: task.modifiedFiles ?? [],
 	};
@@ -178,7 +179,7 @@ export function createTaskSearchIndex(tasks: Task[]): TaskSearchIndex {
 
 			// Apply priority filter
 			if (options.priority) {
-				const priorityLower = options.priority.toLowerCase();
+				const priorityLower = normalizePriorityValue(options.priority);
 				results = results.filter((t) => t.priorityLower === priorityLower);
 			}
 

--- a/src/utils/task-sorting.ts
+++ b/src/utils/task-sorting.ts
@@ -1,3 +1,5 @@
+import { getPriorityRank } from "./priority-config.ts";
+
 /**
  * Parse a task ID into its numeric components for proper sorting.
  * Handles both simple IDs (task-5) and decimal IDs (task-5.2.1).
@@ -71,19 +73,16 @@ export function sortByTaskId<T extends { id: string }>(items: T[]): T[] {
 
 /**
  * Sort an array of tasks by their priority property.
- * Priority order: high > medium > low > undefined
+ * Priority order defaults to high > medium > low > undefined.
  * Tasks with the same priority are sorted by task ID.
  */
-export function sortByPriority<T extends { id: string; priority?: "high" | "medium" | "low" }>(items: T[]): T[] {
-	const priorityWeight = {
-		high: 3,
-		medium: 2,
-		low: 1,
-	};
-
+export function sortByPriority<T extends { id: string; priority?: string }>(
+	items: T[],
+	priorityOrder?: readonly string[],
+): T[] {
 	return [...items].sort((a, b) => {
-		const aWeight = a.priority ? priorityWeight[a.priority] : 0;
-		const bWeight = b.priority ? priorityWeight[b.priority] : 0;
+		const aWeight = getPriorityRank(a.priority, priorityOrder);
+		const bWeight = getPriorityRank(b.priority, priorityOrder);
 
 		// First sort by priority (higher weight = higher priority)
 		if (aWeight !== bWeight) {
@@ -126,15 +125,10 @@ export function sortByOrdinal<T extends { id: string; ordinal?: number }>(items:
  * Sort an array of tasks considering ordinal first, then priority, then ID.
  * This is the default sorting for the board view.
  */
-export function sortByOrdinalAndPriority<
-	T extends { id: string; ordinal?: number; priority?: "high" | "medium" | "low" },
->(items: T[]): T[] {
-	const priorityWeight = {
-		high: 3,
-		medium: 2,
-		low: 1,
-	};
-
+export function sortByOrdinalAndPriority<T extends { id: string; ordinal?: number; priority?: string }>(
+	items: T[],
+	priorityOrder?: readonly string[],
+): T[] {
 	return [...items].sort((a, b) => {
 		// Tasks with ordinal come before tasks without
 		if (a.ordinal !== undefined && b.ordinal === undefined) {
@@ -152,8 +146,8 @@ export function sortByOrdinalAndPriority<
 		}
 
 		// Same ordinal (or both undefined) - sort by priority
-		const aWeight = a.priority ? priorityWeight[a.priority] : 0;
-		const bWeight = b.priority ? priorityWeight[b.priority] : 0;
+		const aWeight = getPriorityRank(a.priority, priorityOrder);
+		const bWeight = getPriorityRank(b.priority, priorityOrder);
 
 		if (aWeight !== bWeight) {
 			return bWeight - aWeight;
@@ -168,19 +162,20 @@ export function sortByOrdinalAndPriority<
  * Sort tasks by a specified field with fallback to task ID sorting.
  * Supported fields: 'priority', 'id', 'ordinal'
  */
-export function sortTasks<T extends { id: string; priority?: "high" | "medium" | "low"; ordinal?: number }>(
+export function sortTasks<T extends { id: string; priority?: string; ordinal?: number }>(
 	items: T[],
 	sortField: string,
+	priorityOrder?: readonly string[],
 ): T[] {
 	switch (sortField?.toLowerCase()) {
 		case "priority":
-			return sortByPriority(items);
+			return sortByPriority(items, priorityOrder);
 		case "id":
 			return sortByTaskId(items);
 		case "ordinal":
 			return sortByOrdinal(items);
 		default:
 			// Default to ordinal + priority sorting for board view
-			return sortByOrdinalAndPriority(items);
+			return sortByOrdinalAndPriority(items, priorityOrder);
 	}
 }

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -509,6 +509,7 @@ function App() {
                 isLoading={isLoading}
                 hideEmptyColumns={config?.hideEmptyColumns ?? false}
                 dateFormat={config?.dateFormat}
+                availablePriorities={config?.priorities}
               />
             }
           />
@@ -522,6 +523,7 @@ function App() {
 	                  availableStatuses={statuses}
 	                  availableLabels={availableLabels}
 	                  availableMilestones={milestones}
+	                  availablePriorities={config?.priorities}
 	                  milestoneEntities={milestoneEntities}
 	                  archivedMilestones={archivedMilestones}
 	                  onRefreshData={refreshData}
@@ -563,6 +565,7 @@ function App() {
           onArchive={editingTask ? () => handleArchiveTask(editingTask.id) : undefined}
           availableStatuses={isDraftMode ? ['Draft', ...statuses] : statuses}
           availableMilestones={milestones}
+          availablePriorities={config?.priorities}
           milestoneEntities={milestoneEntities}
           archivedMilestoneEntities={archivedMilestones}
           isDraftMode={isDraftMode}

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -528,6 +528,7 @@ function App() {
 	                  archivedMilestones={archivedMilestones}
 	                  onRefreshData={refreshData}
 	                  dateFormat={config?.dateFormat}
+	                  isLoading={isLoading}
 	                />
 	              }
 	            />

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -5,6 +5,7 @@ import { buildLanes, DEFAULT_LANE_KEY, groupTasksByLaneAndStatus, type LaneMode 
 import { collectAvailableLabels, labelsToLower } from '../../utils/label-filter';
 import { collectArchivedMilestoneKeys, milestoneKey } from '../utils/milestones';
 import { getTerminalStatus } from '../../utils/terminal-status';
+import { getPriorityOptions, normalizePriorityValue } from '../../utils/priority-config';
 import TaskColumn from './TaskColumn';
 import CleanupModal from './CleanupModal';
 import LabelFilterDropdown from './LabelFilterDropdown';
@@ -28,17 +29,11 @@ interface BoardProps {
   filterAssignee?: string;
   filterLabels?: string[];
   filterPriority?: string;
+  availablePriorities?: string[];
   onFiltersChange?: (filters: { assignee: string; labels: string[]; priority: string }) => void;
   hideEmptyColumns?: boolean;
   dateFormat?: string;
 }
-
-const PRIORITY_OPTIONS = [
-  { label: 'All priorities', value: '' },
-  { label: 'High', value: 'high' },
-  { label: 'Medium', value: 'medium' },
-  { label: 'Low', value: 'low' },
-] as const;
 
 const BOARD_FILTER_SELECT_CLASS =
   'min-w-[140px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200';
@@ -63,6 +58,7 @@ const Board: React.FC<BoardProps> = ({
   filterAssignee = '',
   filterLabels = [],
   filterPriority = '',
+  availablePriorities,
   onFiltersChange,
   hideEmptyColumns = false,
   dateFormat,
@@ -74,6 +70,10 @@ const Board: React.FC<BoardProps> = ({
   const [cleanupSuccessMessage, setCleanupSuccessMessage] = useState<string | null>(null);
   const [collapsedLanes, setCollapsedLanes] = useState<Record<string, boolean>>({});
   const terminalStatus = getTerminalStatus(statuses);
+  const priorityOptions = useMemo(
+    () => [{ label: 'All priorities', value: '' }, ...getPriorityOptions(availablePriorities)],
+    [availablePriorities]
+  );
   const archivedMilestoneIds = useMemo(
     () => collectArchivedMilestoneKeys(archivedMilestones, milestoneEntities),
     [archivedMilestones, milestoneEntities]
@@ -249,7 +249,8 @@ const Board: React.FC<BoardProps> = ({
       result = result.filter(task => labelsToLower(task.labels).some(label => selectedLabels.has(label)));
     }
     if (filterPriority) {
-      result = result.filter(task => task.priority === filterPriority);
+      const normalizedFilterPriority = normalizePriorityValue(filterPriority);
+      result = result.filter(task => normalizePriorityValue(task.priority) === normalizedFilterPriority);
     }
     return result;
   }, [tasks, milestoneFilter, canonicalMilestoneFilter, milestoneAliasToCanonical, filterAssignee, normalizedFilterLabels, filterPriority]);
@@ -523,7 +524,7 @@ const Board: React.FC<BoardProps> = ({
                   onChange={e => onFiltersChange({ assignee: filterAssignee, labels: normalizedFilterLabels, priority: e.target.value })}
                   className={BOARD_FILTER_SELECT_CLASS}
                 >
-                  {PRIORITY_OPTIONS.map(opt => (
+                  {priorityOptions.map(opt => (
                     <option key={opt.value} value={opt.value}>{opt.label}</option>
                   ))}
                 </select>
@@ -613,6 +614,7 @@ const Board: React.FC<BoardProps> = ({
                             dragSourceLane={dragSourceLane}
                             laneId={lane.key}
                             targetMilestone={lane.milestone ?? null}
+                            priorityOrder={availablePriorities}
                             onDragStart={({ status: draggedStatus, laneId }) => {
                               setDragSourceStatus(draggedStatus);
                               setDragSourceLane(laneId ?? null);
@@ -646,6 +648,7 @@ const Board: React.FC<BoardProps> = ({
                   dragSourceStatus={dragSourceStatus}
                   dragSourceLane={dragSourceLane}
                   laneId={DEFAULT_LANE_KEY}
+                  priorityOrder={availablePriorities}
                   onDragStart={({ status: draggedStatus, laneId }) => {
                     setDragSourceStatus(draggedStatus);
                     setDragSourceLane(laneId ?? null);

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -17,6 +17,7 @@ interface BoardPageProps {
 	isLoading: boolean;
 	hideEmptyColumns?: boolean;
 	dateFormat?: string;
+	availablePriorities?: string[];
 }
 
 export default function BoardPage({
@@ -32,6 +33,7 @@ export default function BoardPage({
 	isLoading,
 	hideEmptyColumns,
 	dateFormat,
+	availablePriorities,
 }: BoardPageProps) {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [highlightTaskId, setHighlightTaskId] = useState<string | null>(null);
@@ -142,6 +144,7 @@ export default function BoardPage({
 				filterAssignee={filterAssignee}
 				filterLabels={filterLabels}
 				filterPriority={filterPriority}
+				availablePriorities={availablePriorities}
 				onFiltersChange={handleFiltersChange}
 				hideEmptyColumns={hideEmptyColumns}
 				dateFormat={dateFormat}

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import Board from './Board';
 import { type Milestone, type Task } from '../../types';
+import { resolvePriorityValue } from '../../utils/priority-config';
 import { type LaneMode } from '../lib/lanes';
 
 interface BoardPageProps {
@@ -122,7 +123,22 @@ export default function BoardPage({
 		...searchParams.getAll('label'),
 		...searchParams.getAll('labels').flatMap((value) => value.split(',')),
 	].map((label) => label.trim()).filter((label) => label.length > 0);
-	const filterPriority = searchParams.get('priority') ?? '';
+	const rawFilterPriority = searchParams.get('priority') ?? '';
+	const filterPriority = resolvePriorityValue(rawFilterPriority, availablePriorities) ?? '';
+
+	useEffect(() => {
+		if (isLoading || rawFilterPriority === filterPriority) {
+			return;
+		}
+		setSearchParams(params => {
+			if (filterPriority) {
+				params.set('priority', filterPriority);
+			} else {
+				params.delete('priority');
+			}
+			return params;
+		}, { replace: true });
+	}, [filterPriority, isLoading, rawFilterPriority, setSearchParams]);
 
 	return (
 		<div className="container mx-auto px-4 py-8 transition-colors duration-200">

--- a/src/web/components/DraftsList.tsx
+++ b/src/web/components/DraftsList.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { type Task } from '../../types';
 import { formatStoredUtcDateForDisplay } from '../utils/date-display';
+import { formatPriorityLabel } from '../../utils/priority-config';
 
 interface DraftsListProps {
   onEditTask: (task: Task) => void;
@@ -141,7 +142,7 @@ const DraftsList: React.FC<DraftsListProps> = ({ onEditTask, onNewDraft, dateFor
                       <h3 className="text-lg font-medium text-gray-900 dark:text-white">{draft.title}</h3>
                       {draft.priority && (
                         <span className={`px-2 py-1 text-xs font-medium rounded-circle ${getPriorityColor(draft.priority)}`}>
-                          {draft.priority}
+                          {formatPriorityLabel(draft.priority)}
                         </span>
                       )}
                     </div>

--- a/src/web/components/Statistics.tsx
+++ b/src/web/components/Statistics.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { apiClient } from '../lib/api';
 import type { TaskStatistics } from '../../core/statistics';
 import type { Task } from '../../types';
+import { formatPriorityLabel } from '../../utils/priority-config';
 import LoadingSpinner from './LoadingSpinner';
 import { formatStoredUtcDateForDisplay } from '../utils/date-display';
 
@@ -234,6 +235,20 @@ const Statistics: React.FC<StatisticsProps> = ({
 			default: return 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200';
 		}
 	};
+	const priorityBreakdown = [
+		...Object.entries(statistics.priorityCounts).map(([priority, count]) => ({
+			key: `priority:${priority}`,
+			priority,
+			label: formatPriorityLabel(priority),
+			count,
+		})),
+		{
+			key: 'no-priority',
+			priority: '',
+			label: 'No Priority',
+			count: statistics.noPriorityCount,
+		},
+	].filter(({ count }) => count > 0);
 
 	return (
 		<div className="max-w-7xl mx-auto p-6 space-y-8">
@@ -364,14 +379,12 @@ const Statistics: React.FC<StatisticsProps> = ({
 				<div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
 					<h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Priority Distribution</h3>
 					<div className="space-y-4">
-						{Object.entries(statistics.priorityCounts)
-							.filter(([, count]) => count > 0)
-							.map(([priority, count]) => (
-							<div key={priority} className="flex items-center justify-between">
+						{priorityBreakdown.map(({ key, priority, label, count }) => (
+							<div key={key} className="flex items-center justify-between">
 								<div className="flex items-center space-x-3">
 									<PriorityIcon priority={priority} />
 									<span className={`px-3 py-1 rounded-circle text-sm font-medium ${getPriorityColor(priority)}`}>
-										{priority === 'none' ? 'No Priority' : priority.charAt(0).toUpperCase() + priority.slice(1)}
+										{label}
 									</span>
 								</div>
 								<div className="flex items-center space-x-3">
@@ -382,7 +395,7 @@ const Statistics: React.FC<StatisticsProps> = ({
 										</div>
 									</div>
 									<div className="w-16 bg-gray-200 dark:bg-gray-700 rounded-circle h-2">
-										<div 
+										<div
 											className="bg-yellow-500 h-2 rounded-circle transition-all duration-300"
 											style={{ width: `${(count / statistics.totalTasks) * 100}%` }}
 										></div>

--- a/src/web/components/TaskCard.tsx
+++ b/src/web/components/TaskCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { type Task } from '../../types';
+import { formatPriorityLabel } from '../../utils/priority-config';
 
 interface TaskCardProps {
   task: Task;
@@ -74,7 +75,14 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEn
       case 'high': return { bg: 'bg-red-100 dark:bg-red-900/40', text: 'text-red-700 dark:text-red-300', label: 'High' };
       case 'medium': return { bg: 'bg-yellow-100 dark:bg-yellow-900/40', text: 'text-yellow-700 dark:text-yellow-300', label: 'Med' };
       case 'low': return { bg: 'bg-green-100 dark:bg-green-900/40', text: 'text-green-700 dark:text-green-300', label: 'Low' };
-      default: return null;
+      default:
+        return priority
+          ? {
+              bg: 'bg-gray-100 dark:bg-gray-600',
+              text: 'text-gray-700 dark:text-gray-200',
+              label: formatPriorityLabel(priority),
+            }
+          : null;
     }
   };
 

--- a/src/web/components/TaskColumn.tsx
+++ b/src/web/components/TaskColumn.tsx
@@ -17,6 +17,7 @@ interface TaskColumnProps {
   onCleanup?: () => void;
   laneId?: string;
   targetMilestone?: string | null;
+  priorityOrder?: string[];
 }
 
 const TaskColumn: React.FC<TaskColumnProps> = ({
@@ -31,7 +32,8 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
   onDragEnd,
   onCleanup,
   laneId,
-  targetMilestone
+  targetMilestone,
+  priorityOrder,
 }) => {
   const [isDragOver, setIsDragOver] = React.useState(false);
   const [draggedTaskId, setDraggedTaskId] = React.useState<string | null>(null);
@@ -59,7 +61,7 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
       return;
     }
 
-    const sortedTasks = sortByPriority(tasks);
+    const sortedTasks = sortByPriority(tasks, priorityOrder);
     const orderedTaskIds = sortedTasks.map(t => t.id);
 
     const currentIds = tasks.map(t => t.id);

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -9,6 +9,7 @@ import MermaidMarkdown from './MermaidMarkdown';
 import ChipInput from "./ChipInput";
 import DependencyInput from "./DependencyInput";
 import { formatStoredUtcDateForDisplay } from "../utils/date-display";
+import { getPriorityOptions } from "../../utils/priority-config";
 
 interface Props {
   task?: Task; // Optional for create mode
@@ -20,6 +21,7 @@ interface Props {
   availableStatuses?: string[]; // Available statuses for new tasks
   isDraftMode?: boolean; // Whether creating a draft
   availableMilestones?: string[];
+  availablePriorities?: string[];
   milestoneEntities?: Milestone[];
   archivedMilestoneEntities?: Milestone[];
   definitionOfDoneDefaults?: string[];
@@ -119,6 +121,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   onArchive,
   availableStatuses,
   availableMilestones: _availableMilestones,
+  availablePriorities,
   milestoneEntities,
   archivedMilestoneEntities,
   isDraftMode,
@@ -157,6 +160,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   );
   const initialDefinitionOfDone = task?.definitionOfDoneItems ?? (isCreateMode ? defaultDefinitionOfDone : []);
   const [definitionOfDone, setDefinitionOfDone] = useState<AcceptanceCriterion[]>(initialDefinitionOfDone);
+  const priorityOptions = useMemo(() => getPriorityOptions(availablePriorities), [availablePriorities]);
   const resolveMilestoneToId = useCallback((value?: string | null): string => {
     const normalized = (value ?? "").trim();
     if (!normalized) return "";
@@ -601,7 +605,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
         status,
         assignee,
         labels,
-        priority: (priority === "" ? undefined : priority) as "high" | "medium" | "low" | undefined,
+        priority: priority === "" ? undefined : priority,
         dependencies,
         milestone: milestone.trim().length > 0 ? milestone.trim() : undefined,
       };
@@ -1261,9 +1265,11 @@ export const TaskDetailsModal: React.FC<Props> = ({
               disabled={isFromOtherBranch}
             >
               <option value="">No Priority</option>
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
+              {priorityOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
             </select>
           </div>
 

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -10,7 +10,12 @@ import { collectAvailableLabels } from "../../utils/label-filter.ts";
 import { isTerminalStatus } from "../../utils/terminal-status.ts";
 import { collectArchivedMilestoneKeys, getMilestoneLabel, milestoneKey } from "../utils/milestones";
 import { formatStoredUtcDateForCompactDisplay, parseStoredUtcDate } from "../utils/date-display";
-import { formatPriorityLabel, getPriorityOptions, getPriorityRank } from "../../utils/priority-config.ts";
+import {
+	formatPriorityLabel,
+	getPriorityOptions,
+	getPriorityRank,
+	resolvePriorityValue,
+} from "../../utils/priority-config.ts";
 import CleanupModal from "./CleanupModal";
 import LabelFilterDropdown from "./LabelFilterDropdown";
 import { SuccessToast } from "./SuccessToast";
@@ -27,6 +32,7 @@ interface TaskListProps {
 	archivedMilestones: Milestone[];
 	onRefreshData?: () => Promise<void>;
 	dateFormat?: string;
+	isLoading?: boolean;
 }
 
 type TaskSortColumn = "id" | "title" | "status" | "priority" | "ordinal" | "milestone" | "created";
@@ -80,10 +86,13 @@ const TaskList: React.FC<TaskListProps> = ({
 	archivedMilestones,
 	onRefreshData,
 	dateFormat,
+	isLoading = false,
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [statusFilter, setStatusFilter] = useState(() => searchParams.get("status") ?? "");
-	const [priorityFilter, setPriorityFilter] = useState<string>(() => searchParams.get("priority") ?? "");
+	const [priorityFilter, setPriorityFilter] = useState<string>(() =>
+		isLoading ? "" : (resolvePriorityValue(searchParams.get("priority"), availablePriorities) ?? ""),
+	);
 	const [milestoneFilter, setMilestoneFilter] = useState(() => searchParams.get("milestone") ?? "");
 	const initialLabelParams = useMemo(() => {
 		const labels = [...searchParams.getAll("label"), ...searchParams.getAll("labels")];
@@ -255,7 +264,8 @@ const TaskList: React.FC<TaskListProps> = ({
 
 	useEffect(() => {
 		const paramStatus = searchParams.get("status") ?? "";
-		const paramPriority = searchParams.get("priority") ?? "";
+		const rawParamPriority = searchParams.get("priority") ?? "";
+		const paramPriority = resolvePriorityValue(rawParamPriority, availablePriorities) ?? "";
 		const paramMilestone = searchParams.get("milestone") ?? "";
 		const paramLabels = [...searchParams.getAll("label"), ...searchParams.getAll("labels")];
 		const labelsCsv = searchParams.get("labels");
@@ -267,7 +277,17 @@ const TaskList: React.FC<TaskListProps> = ({
 		if (paramStatus !== statusFilter) {
 			setStatusFilter(paramStatus);
 		}
-		if (paramPriority !== priorityFilter) {
+		if (!isLoading && rawParamPriority !== paramPriority) {
+			setSearchParams(params => {
+				if (paramPriority) {
+					params.set("priority", paramPriority);
+				} else {
+					params.delete("priority");
+				}
+				return params;
+			}, { replace: true });
+		}
+		if (!isLoading && paramPriority !== priorityFilter) {
 			setPriorityFilter(paramPriority);
 		}
 		if (paramMilestone !== milestoneFilter) {
@@ -276,7 +296,7 @@ const TaskList: React.FC<TaskListProps> = ({
 		if (normalizedLabels.join("|") !== labelFilter.join("|")) {
 			setLabelFilter(normalizedLabels);
 		}
-	}, [searchParams]);
+	}, [availablePriorities, isLoading, searchParams, setSearchParams]);
 
 	useEffect(() => {
 		if (!hasActiveFilters) {

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router-dom";
 import { apiClient } from "../lib/api";
 import type {
 	Milestone,
-	SearchPriorityFilter,
 	Task,
 	TaskSearchResult,
 } from "../../types";
@@ -11,6 +10,7 @@ import { collectAvailableLabels } from "../../utils/label-filter.ts";
 import { isTerminalStatus } from "../../utils/terminal-status.ts";
 import { collectArchivedMilestoneKeys, getMilestoneLabel, milestoneKey } from "../utils/milestones";
 import { formatStoredUtcDateForCompactDisplay, parseStoredUtcDate } from "../utils/date-display";
+import { formatPriorityLabel, getPriorityOptions, getPriorityRank } from "../../utils/priority-config.ts";
 import CleanupModal from "./CleanupModal";
 import LabelFilterDropdown from "./LabelFilterDropdown";
 import { SuccessToast } from "./SuccessToast";
@@ -22,27 +22,15 @@ interface TaskListProps {
 	availableStatuses: string[];
 	availableLabels: string[];
 	availableMilestones: string[];
+	availablePriorities?: string[];
 	milestoneEntities: Milestone[];
 	archivedMilestones: Milestone[];
 	onRefreshData?: () => Promise<void>;
 	dateFormat?: string;
 }
 
-const PRIORITY_OPTIONS: Array<{ label: string; value: "" | SearchPriorityFilter }> = [
-	{ label: "All priorities", value: "" },
-	{ label: "High", value: "high" },
-	{ label: "Medium", value: "medium" },
-	{ label: "Low", value: "low" },
-];
-
 type TaskSortColumn = "id" | "title" | "status" | "priority" | "ordinal" | "milestone" | "created";
 type SortDirection = "asc" | "desc";
-
-const PRIORITY_RANK: Record<string, number> = {
-	high: 3,
-	medium: 2,
-	low: 1,
-};
 
 function extractTaskNumericId(taskId: string): number | null {
 	const match = taskId.trim().match(/(\d+)$/);
@@ -87,6 +75,7 @@ const TaskList: React.FC<TaskListProps> = ({
 	availableStatuses,
 	availableLabels,
 	availableMilestones,
+	availablePriorities,
 	milestoneEntities,
 	archivedMilestones,
 	onRefreshData,
@@ -94,9 +83,7 @@ const TaskList: React.FC<TaskListProps> = ({
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [statusFilter, setStatusFilter] = useState(() => searchParams.get("status") ?? "");
-	const [priorityFilter, setPriorityFilter] = useState<"" | SearchPriorityFilter>(
-		() => (searchParams.get("priority") as SearchPriorityFilter | null) ?? "",
-	);
+	const [priorityFilter, setPriorityFilter] = useState<string>(() => searchParams.get("priority") ?? "");
 	const [milestoneFilter, setMilestoneFilter] = useState(() => searchParams.get("milestone") ?? "");
 	const initialLabelParams = useMemo(() => {
 		const labels = [...searchParams.getAll("label"), ...searchParams.getAll("labels")];
@@ -111,6 +98,10 @@ const TaskList: React.FC<TaskListProps> = ({
 	const [cleanupSuccessMessage, setCleanupSuccessMessage] = useState<string | null>(null);
 	const [sortColumn, setSortColumn] = useState<TaskSortColumn>("id");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+	const priorityOptions = useMemo(
+		() => [{ label: "All priorities", value: "" }, ...getPriorityOptions(availablePriorities)],
+		[availablePriorities],
+	);
 	const tableHeaderScrollRef = useRef<HTMLDivElement | null>(null);
 	const tableBodyScrollRef = useRef<HTMLDivElement | null>(null);
 	const isSyncingTableScrollRef = useRef(false);
@@ -264,7 +255,7 @@ const TaskList: React.FC<TaskListProps> = ({
 
 	useEffect(() => {
 		const paramStatus = searchParams.get("status") ?? "";
-		const paramPriority = (searchParams.get("priority") as SearchPriorityFilter | null) ?? "";
+		const paramPriority = searchParams.get("priority") ?? "";
 		const paramMilestone = searchParams.get("milestone") ?? "";
 		const paramLabels = [...searchParams.getAll("label"), ...searchParams.getAll("labels")];
 		const labelsCsv = searchParams.get("labels");
@@ -329,7 +320,7 @@ const TaskList: React.FC<TaskListProps> = ({
 				const results = await apiClient.search({
 					types: ["task"],
 					status: statusFilter || undefined,
-					priority: (priorityFilter || undefined) as SearchPriorityFilter | undefined,
+					priority: priorityFilter || undefined,
 					labels: labelFilter.length > 0 ? labelFilter : undefined,
 				});
 				if (cancelled) {
@@ -366,7 +357,7 @@ const TaskList: React.FC<TaskListProps> = ({
 
 	const syncUrl = (
 		nextStatus: string,
-		nextPriority: "" | SearchPriorityFilter,
+		nextPriority: string,
 		nextLabels: string[],
 		nextMilestone: string,
 	) => {
@@ -393,7 +384,7 @@ const TaskList: React.FC<TaskListProps> = ({
 		syncUrl(value, priorityFilter, labelFilter, milestoneFilter);
 	};
 
-	const handlePriorityChange = (value: "" | SearchPriorityFilter) => {
+	const handlePriorityChange = (value: string) => {
 		setPriorityFilter(value);
 		syncUrl(statusFilter, value, labelFilter, milestoneFilter);
 	};
@@ -539,8 +530,8 @@ const TaskList: React.FC<TaskListProps> = ({
 					break;
 				}
 				case "priority": {
-					const rankA = PRIORITY_RANK[(a.priority ?? "").toLowerCase()] ?? 0;
-					const rankB = PRIORITY_RANK[(b.priority ?? "").toLowerCase()] ?? 0;
+					const rankA = getPriorityRank(a.priority, availablePriorities);
+					const rankB = getPriorityRank(b.priority, availablePriorities);
 					result = withDirection(rankA - rankB);
 					break;
 				}
@@ -641,10 +632,10 @@ const TaskList: React.FC<TaskListProps> = ({
 
 						<select
 							value={priorityFilter}
-							onChange={(event) => handlePriorityChange(event.target.value as "" | SearchPriorityFilter)}
+							onChange={(event) => handlePriorityChange(event.target.value)}
 							className="min-w-[140px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200"
 						>
-							{PRIORITY_OPTIONS.map((option) => (
+							{priorityOptions.map((option) => (
 								<option key={option.value || "all"} value={option.value}>
 									{option.label}
 								</option>
@@ -808,7 +799,7 @@ const TaskList: React.FC<TaskListProps> = ({
 													<span
 														className={`inline-flex rounded-circle px-2 py-0.5 text-[11px] font-medium ${getPriorityColor(task.priority)}`}
 													>
-														{task.priority}
+														{formatPriorityLabel(task.priority, availablePriorities)}
 													</span>
 												) : (
 													<span className="text-xs text-gray-300 dark:text-gray-600">—</span>

--- a/src/web/utils/search-command-query.ts
+++ b/src/web/utils/search-command-query.ts
@@ -1,4 +1,5 @@
 import type { SearchPriorityFilter, SearchResultType } from "../../types/index.ts";
+import { normalizePriorityValue } from "../../utils/priority-config.ts";
 
 export interface ParsedSearchCommandQuery {
 	query: string;
@@ -16,7 +17,6 @@ interface Token {
 	malformed: boolean;
 }
 
-const PRIORITIES: SearchPriorityFilter[] = ["high", "medium", "low"];
 const RESULT_TYPES: SearchResultType[] = ["task", "document", "decision"];
 
 export function parseSearchCommandQuery(input: string): ParsedSearchCommandQuery {
@@ -54,8 +54,8 @@ function applyToken(token: Token, result: ParsedSearchCommandQuery): boolean {
 			result.status = appendFilterValue(result.status, value);
 			return true;
 		case "priority": {
-			const priority = value.toLowerCase();
-			if (!isSearchPriority(priority)) {
+			const priority = normalizePriorityValue(value);
+			if (!priority) {
 				return false;
 			}
 			result.priority = appendFilterValue(result.priority, priority);
@@ -149,10 +149,6 @@ function appendFilterValue<T extends string>(current: T | T[] | undefined, value
 		return [...current, value];
 	}
 	return [current, value];
-}
-
-function isSearchPriority(value: string): value is SearchPriorityFilter {
-	return PRIORITIES.includes(value as SearchPriorityFilter);
 }
 
 function isSearchResultType(value: string): value is SearchResultType {


### PR DESCRIPTION
## Summary

- Add a `priorities` config list with the current High/Medium/Low defaults preserved for existing projects.
- Validate and normalize configured priorities across CLI create/edit/list/search, task wizard, MCP schemas/handlers, server API filters, completions, parsing, sorting, statistics, and web/TUI surfaces.
- Document the advanced config option and add regression coverage for a custom list such as Very High/High/Medium/Low/Very Low.

Closes #732.

## Validation

- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- `bun test src/test/search-command-query.test.ts src/test/cli-priority-filtering.test.ts`
- `bun test` (1453 pass, 2 skip, 0 fail)