### PR TITLE
BACK-531 - Add creation-date sorting to board column menu

### DIFF
--- a/backlog/tasks/back-531 - Add-creation-date-sorting-to-board-column-menu.md
+++ b/backlog/tasks/back-531 - Add-creation-date-sorting-to-board-column-menu.md
@@ -1,0 +1,60 @@
+---
+id: BACK-531
+title: Add creation-date sorting to board column menu
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-09 06:50'
+updated_date: '2026-07-09 06:56'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/694'
+ordinal: 168000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+GitHub issue #694 asks for a Web board column menu action to sort tasks by creation date. Scope is intentionally narrow: add creation-date sort actions beside the existing Sort by Priority action, using the existing task createdDate field and current column reorder behavior without introducing a generic sorting framework.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Board column menu exposes creation-date sorting beside the existing priority sort action.
+- [x] #2 Creation-date sorting supports both oldest-first and newest-first ordering within the selected column.
+- [x] #3 Sorting uses each task createdDate and falls back predictably when a task has no created date.
+- [x] #4 The change is covered by focused Web board tests.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a small TaskColumn-local sort helper for creation date ordering, reusing the existing reorder payload flow.
+2. Extend the column actions menu with two creation-date actions: oldest first and newest first.
+3. Add focused TaskColumn DOM tests for both directions and missing-date fallback behavior.
+4. Run the Web column test, type-check, Biome, and relevant broader tests.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced issue #694 by rendering TaskColumn with multiple tasks and opening the column menu; the only menu item is "Sort by Priority", with no creation-date sort action.
+
+Implemented two TaskColumn menu actions for creation-date sorting: oldest first and newest first. Both actions reuse the existing column reorder payload flow and keep missing/invalid created dates at the end with task ID as the deterministic tie-breaker.
+
+Validation passed: DOM reproduction now shows Sort by Priority, Sort by Creation Date (oldest first), and Sort by Creation Date (newest first); bun test src/test/web-task-column-sort.test.tsx; bunx tsc --noEmit; bun run check .; bun run build; bun test src/test/web-task-column-sort.test.tsx src/web/lib/lanes.test.ts src/test/board.test.ts src/test/board-ui.test.ts; bun test (1449 pass, 2 skip, 0 fail).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added creation-date sorting to the Web board column menu using the existing reorder behavior. Users can sort a column oldest-first or newest-first; missing created dates sort last and ties fall back to task ID. Added focused TaskColumn tests for both directions and fallback behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/test/web-task-column-sort.test.tsx
+++ b/src/test/web-task-column-sort.test.tsx
@@ -64,6 +64,14 @@ const openActionsMenu = async (container: HTMLElement) => {
 	await clickElement(actionsButton as Element);
 };
 
+const findMenuButton = (container: HTMLElement, label: string): HTMLButtonElement => {
+	const button = Array.from(container.querySelectorAll("button")).find((button) =>
+		button.textContent?.includes(label),
+	);
+	expect(button).toBeTruthy();
+	return button as HTMLButtonElement;
+};
+
 afterEach(() => {
 	if (activeRoot) {
 		act(() => {
@@ -87,11 +95,7 @@ describe("TaskColumn priority sorting", () => {
 		);
 
 		await openActionsMenu(container);
-		const sortButton = Array.from(container.querySelectorAll("button")).find((button) =>
-			button.textContent?.includes("Sort by Priority"),
-		);
-		expect(sortButton).toBeTruthy();
-		await clickElement(sortButton as Element);
+		await clickElement(findMenuButton(container, "Sort by Priority"));
 
 		expect(payloads).toEqual([
 			{
@@ -115,13 +119,80 @@ describe("TaskColumn priority sorting", () => {
 		);
 
 		await openActionsMenu(container);
-		const sortButton = Array.from(container.querySelectorAll("button")).find((button) =>
-			button.textContent?.includes("Sort by Priority"),
-		);
-		expect(sortButton).toBeTruthy();
-		await clickElement(sortButton as Element);
+		await clickElement(findMenuButton(container, "Sort by Priority"));
 
 		expect(payloads).toEqual([]);
+	});
+});
+
+describe("TaskColumn creation-date sorting", () => {
+	it("emits a full-column reorder payload sorted by oldest created date first", async () => {
+		const payloads: ReorderTaskPayload[] = [];
+		const container = renderTaskColumn(
+			[
+				createTask({ id: "TASK-3", title: "Newer", createdDate: "2026-01-03" }),
+				createTask({ id: "TASK-1", title: "Older", createdDate: "2026-01-01" }),
+				createTask({ id: "TASK-2", title: "Middle", createdDate: "2026-01-02" }),
+			],
+			(payload) => payloads.push(payload),
+		);
+
+		await openActionsMenu(container);
+		await clickElement(findMenuButton(container, "Sort by Creation Date (oldest first)"));
+
+		expect(payloads).toEqual([
+			{
+				taskId: "TASK-1",
+				targetStatus: "To Do",
+				orderedTaskIds: ["TASK-1", "TASK-2", "TASK-3"],
+			},
+		]);
+	});
+
+	it("emits a full-column reorder payload sorted by newest created date first", async () => {
+		const payloads: ReorderTaskPayload[] = [];
+		const container = renderTaskColumn(
+			[
+				createTask({ id: "TASK-1", title: "Older", createdDate: "2026-01-01" }),
+				createTask({ id: "TASK-2", title: "Middle", createdDate: "2026-01-02" }),
+				createTask({ id: "TASK-3", title: "Newer", createdDate: "2026-01-03" }),
+			],
+			(payload) => payloads.push(payload),
+		);
+
+		await openActionsMenu(container);
+		await clickElement(findMenuButton(container, "Sort by Creation Date (newest first)"));
+
+		expect(payloads).toEqual([
+			{
+				taskId: "TASK-3",
+				targetStatus: "To Do",
+				orderedTaskIds: ["TASK-3", "TASK-2", "TASK-1"],
+			},
+		]);
+	});
+
+	it("places missing created dates last and falls back to task ID for ties", async () => {
+		const payloads: ReorderTaskPayload[] = [];
+		const container = renderTaskColumn(
+			[
+				createTask({ id: "TASK-9", title: "Missing", createdDate: "" }),
+				createTask({ id: "TASK-2", title: "Same date later ID", createdDate: "2026-01-01" }),
+				createTask({ id: "TASK-1", title: "Same date earlier ID", createdDate: "2026-01-01" }),
+			],
+			(payload) => payloads.push(payload),
+		);
+
+		await openActionsMenu(container);
+		await clickElement(findMenuButton(container, "Sort by Creation Date (oldest first)"));
+
+		expect(payloads).toEqual([
+			{
+				taskId: "TASK-1",
+				targetStatus: "To Do",
+				orderedTaskIds: ["TASK-1", "TASK-2", "TASK-9"],
+			},
+		]);
 	});
 });
 

--- a/src/web/components/TaskColumn.tsx
+++ b/src/web/components/TaskColumn.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { type Task } from '../../types';
-import { sortByPriority } from '../../utils/task-sorting';
+import { compareTaskIds, sortByPriority } from '../../utils/task-sorting';
 import type { ReorderTaskPayload } from '../lib/api';
+import { parseStoredUtcDate } from '../utils/date-display';
 import TaskCard from './TaskCard';
 
 interface TaskColumnProps {
@@ -18,6 +19,34 @@ interface TaskColumnProps {
   laneId?: string;
   targetMilestone?: string | null;
 }
+
+type CreatedDateSortDirection = 'asc' | 'desc';
+
+const getCreatedDateTime = (task: Task): number | null => {
+  const parsed = parseStoredUtcDate(task.createdDate ?? '');
+  return parsed ? parsed.getTime() : null;
+};
+
+const sortByCreatedDate = (tasks: Task[], direction: CreatedDateSortDirection): Task[] => {
+  return tasks.slice().sort((a, b) => {
+    const aTime = getCreatedDateTime(a);
+    const bTime = getCreatedDateTime(b);
+
+    if (aTime === null && bTime === null) {
+      return compareTaskIds(a.id, b.id);
+    }
+    if (aTime === null) {
+      return 1;
+    }
+    if (bTime === null) {
+      return -1;
+    }
+    if (aTime !== bTime) {
+      return direction === 'asc' ? aTime - bTime : bTime - aTime;
+    }
+    return compareTaskIds(a.id, b.id);
+  });
+};
 
 const TaskColumn: React.FC<TaskColumnProps> = ({
   title,
@@ -39,7 +68,7 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
   const [showMenu, setShowMenu] = React.useState(false);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const columnActionsId = React.useId();
-  const canSortByPriority = Boolean(onTaskReorder) && tasks.length > 1 && tasks.every(task => !task.branch);
+  const canReorderColumn = Boolean(onTaskReorder) && tasks.length > 1 && tasks.every(task => !task.branch);
 
   React.useEffect(() => {
     if (!showMenu) return;
@@ -53,14 +82,11 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showMenu]);
 
-  const handleSortByPriority = () => {
-    if (!onTaskReorder || !canSortByPriority) {
+  const emitColumnReorder = (orderedTaskIds: string[]) => {
+    if (!onTaskReorder || !canReorderColumn) {
       setShowMenu(false);
       return;
     }
-
-    const sortedTasks = sortByPriority(tasks);
-    const orderedTaskIds = sortedTasks.map(t => t.id);
 
     const currentIds = tasks.map(t => t.id);
     const hasChanged = orderedTaskIds.some((id, index) => id !== currentIds[index]);
@@ -76,6 +102,14 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
     }
 
     setShowMenu(false);
+  };
+
+  const handleSortByPriority = () => {
+    emitColumnReorder(sortByPriority(tasks).map(t => t.id));
+  };
+
+  const handleSortByCreatedDate = (direction: CreatedDateSortDirection) => {
+    emitColumnReorder(sortByCreatedDate(tasks, direction).map(t => t.id));
   };
 
   const getStatusBadgeClass = (status: string) => {
@@ -192,7 +226,7 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
           </span>
         </div>
         
-        {canSortByPriority && (
+        {canReorderColumn && (
           <div className="relative" ref={menuRef}>
             <button
               type="button"
@@ -225,6 +259,28 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12" />
                   </svg>
                   Sort by Priority
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => handleSortByCreatedDate('asc')}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2 transition-colors duration-150"
+                >
+                  <svg className="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3M5 11h14M7 21h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v12a2 2 0 002 2zm5-7v4m0 0l-2-2m2 2l2-2" />
+                  </svg>
+                  Sort by Creation Date (oldest first)
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => handleSortByCreatedDate('desc')}
+                  className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2 transition-colors duration-150"
+                >
+                  <svg className="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3M5 11h14M7 21h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v12a2 2 0 002 2zm5 11v-4m0 0l-2 2m2-2l2 2" />
+                  </svg>
+                  Sort by Creation Date (newest first)
                 </button>
               </div>
             )}


### PR DESCRIPTION
## Summary

- Add two Web board column menu actions for creation-date sorting: oldest first and newest first.
- Reuse the existing column reorder payload flow, keeping the scope limited to the current column menu.
- Sort missing or invalid created dates last and use task ID as the deterministic tie-breaker.
- Add focused TaskColumn tests for both sort directions and fallback behavior.

Closes #694.

## Validation

- Reproduced the issue by rendering `TaskColumn` and confirming the menu only showed `Sort by Priority` before the change.
- Confirmed after the change that the menu shows `Sort by Priority`, `Sort by Creation Date (oldest first)`, and `Sort by Creation Date (newest first)`.
- `bun test src/test/web-task-column-sort.test.tsx`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- `bun test src/test/web-task-column-sort.test.tsx src/web/lib/lanes.test.ts src/test/board.test.ts src/test/board-ui.test.ts`
- `bun test` (1449 pass, 2 skip, 0 fail)