### PR TITLE
BACK-355.02 - Add CLI task type support

### DIFF
--- a/backlog/tasks/back-355.02 - CLI-Add-type-flag-to-task-create-and-edit-commands.md
+++ b/backlog/tasks/back-355.02 - CLI-Add-type-flag-to-task-create-and-edit-commands.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-355.02
 title: 'CLI: Add --type flag to task create and edit commands'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex-types-cli'
 created_date: '2026-01-01 23:37'
+updated_date: '2026-07-09 22:34'
 labels:
   - cli
 dependencies:
@@ -20,10 +22,75 @@ Extend CLI commands to support the type field, allowing users to specify and mod
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 task create command accepts --type flag with autocomplete for configured types
-- [ ] #2 task edit command accepts --type flag to modify existing task type
-- [ ] #3 task list output displays type field (abbreviated in table view)
-- [ ] #4 task view (plain mode) includes type in output
-- [ ] #5 Invalid type values produce clear error message listing valid options
-- [ ] #6 CLI help text documents the --type flag
+- [x] #1 task create command accepts --type flag with autocomplete for configured types
+- [x] #2 task edit command accepts --type flag to modify existing task type
+- [x] #3 task list output displays type field (abbreviated in table view)
+- [x] #4 task view (plain mode) includes type in output
+- [x] #5 Invalid type values produce clear error message listing valid options
+- [x] #6 CLI help text documents the --type flag
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Centralize configured task-type values, case-insensitive canonicalization, and valid-value formatting in one shared utility; reuse it from Core and CLI surfaces.
+2. Add --type to task create/edit, pass values through Core validation, and add configured type selection with an explicit untyped option to the shared Clack create/edit wizard.
+3. Add configured task-type shell completion and dynamic help schema/examples sourced from the project config.
+4. Expose types through read-only config get/list, without adding a config set surface.
+5. Show [type] in plain task-list rows when present while preserving omission for untyped tasks; retain the existing Type line in plain detail output.
+6. Add focused utility, wizard, completion, config, help, and CLI integration tests, then run targeted tests, typecheck, Biome, build, and the full suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented one shared task-type configuration resolver and reused it from Core, dynamic CLI help, shell completion, and the Clack create/edit wizard. CLI create/edit now accept --type with configured-value canonicalization; edit and the wizard can clear the value; untyped tasks remain untyped. Plain task lists show a compact [type] badge, while shared plain details show Type only when present. config get types and config list expose configured/default values; config set remains unsupported.
+
+Validation: 47 focused tests passed; bunx tsc --noEmit passed; bun run check . passed across 311 files; bun run build passed; full bun test passed 1496 with 2 documented interactive TUI skips and 0 failures; compiled dist/backlog create/edit/list/config/help smoke passed.
+
+Independent review follow-up: plain task-list rows now share one formatter, so --sort priority preserves the same priority and type badges as grouped plain output. Create/edit help examples now quote the first configured task type instead of hard-coding default values; custom Bug/Epic projects advertise only valid commands.
+
+Review-fix validation: 35 focused tests passed; bunx tsc --noEmit passed; bun run check . passed across 311 files; bun run build passed; full bun test passed 1496 with 2 documented interactive TUI skips and 0 failures.
+
+Exact-head simplicity cleanup: removed the unused exported resolveTaskTypeValues helper and its future-only unit test. BACK-355.04 will introduce the plural resolver together with its production list/search caller. Existing singular resolution, validation, help, completion, and output behavior is unchanged.
+
+Cleanup validation: rg confirms no resolveTaskTypeValues references remain; 19 directly affected tests passed; bunx tsc --noEmit passed; bun run check . passed across 311 files; bun run build passed. A full 1496-test run had already passed on the immediately preceding head; this removal had no production caller, so the full suite was not repeated.
+
+Final scope cleanup: reduced taskType to its parameterless single-value help contract and removed completion support for undeclared --task-type. BACK-355.04 will add plural schema wording and task-type completion with the filtering commands that consume them. Current create/edit help and context-gated --type completion behavior is unchanged.
+
+Final cleanup validation: no multiple taskType call or task-type completion branch remains; 21 affected tests passed; bunx tsc --noEmit passed; bun run check . passed across 311 files; bun run build passed. Full suite was not repeated because this exact diff only deletes unreachable future hooks and the immediately preceding functional head passed 1496 tests with 0 failures.
+<!-- SECTION:NOTES:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @codex-types-cli
+created: 2026-07-09 22:13
+---
+Implementation complete and ready for independent review; task remains In Progress until review and merge.
+---
+
+author: @codex-types-cli
+created: 2026-07-09 22:24
+---
+Addressed both independent review blockers; ready for exact-head re-review after push.
+---
+
+author: @codex-types-cli
+created: 2026-07-09 22:31
+---
+Removed the final review-blocking future-only API surface; ready for exact-head re-review after push.
+---
+
+author: @codex-types-cli
+created: 2026-07-09 22:34
+---
+Removed the remaining BACK-355.04-only help and completion hooks; ready for exact-head re-review after push.
+---
+<!-- COMMENTS:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added canonical CLI task-type support across create/edit flags, interactive selection, configured casing and validation, shell completion, help, read-only config output, and plain human-readable task output. Existing untyped tasks remain untyped. Verified with focused integration tests, typecheck, Biome, build, the full 1496-test suite, and compiled-binary smoke.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,14 @@ import { Command } from "commander";
 import { runAdvancedConfigWizard } from "./commands/advanced-config-wizard.ts";
 import { type CompletionInstallResult, installCompletion, registerCompletionCommand } from "./commands/completion.ts";
 import { configureAdvancedSettings } from "./commands/configure-advanced-settings.ts";
-import { addHelpSchema, choiceType, priorityType, statusType } from "./commands/help-schema.ts";
+import {
+	addHelpSchema,
+	choiceType,
+	getCliTaskTypeValues,
+	priorityType,
+	statusType,
+	taskType,
+} from "./commands/help-schema.ts";
 import { registerInstructionsCommand } from "./commands/instructions.ts";
 import { registerMcpCommand } from "./commands/mcp.ts";
 import { pickTaskForEditWizard, runTaskCreateWizard, runTaskEditWizard } from "./commands/task-wizard.ts";
@@ -79,6 +86,7 @@ import {
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
 import { normalizeTaskId, taskIdsEqual } from "./utils/task-path.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
+import { getTaskTypeValues } from "./utils/task-type-config.ts";
 import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
 import { formatUtcDateForDisplay } from "./utils/utc-date-display.ts";
 import { getVersion } from "./utils/version.ts";
@@ -92,6 +100,7 @@ const CONFIG_GET_KEYS = [
 	"statuses",
 	"labels",
 	"priorities",
+	"types",
 	"milestones",
 	"definitionOfDone",
 	"dateFormat",
@@ -174,6 +183,7 @@ const DOCUMENT_SEARCH_QUERY_MAX_LENGTH = 200;
 const DOCUMENT_SEARCH_LIMIT_MAX = 100;
 const TASK_SORT_FIELDS = ["priority", "id", "ordinal"];
 const TASK_SORT_FIELD_LIST = TASK_SORT_FIELDS.join(", ");
+const TASK_TYPE_EXAMPLE = JSON.stringify(getCliTaskTypeValues()[0] ?? "<configured-type>");
 
 async function openUrlInBrowser(url: string): Promise<void> {
 	let cmd: string[];
@@ -254,6 +264,13 @@ function taskMatchesAllLabels(task: Task, labels: string[]): boolean {
 	return requiredLabels.every((label) => taskLabels.has(label));
 }
 
+function formatPlainTaskListRow(task: Task, options: { includeStatus?: boolean } = {}): string {
+	const priorityIndicator = task.priority ? `[${task.priority.toUpperCase()}] ` : "";
+	const typeIndicator = task.type ? `[${task.type}] ` : "";
+	const statusIndicator = options.includeStatus && task.status ? ` (${task.status})` : "";
+	return `  ${priorityIndicator}${typeIndicator}${task.id} - ${task.title}${statusIndicator}`;
+}
+
 async function normalizeCliStatusList(core: Core, values: string[], optionName: string): Promise<string[] | null> {
 	const { values: canonicalStatuses, invalid, validStatuses } = await getCanonicalStatuses(values, core);
 	if (invalid.length > 0) {
@@ -326,6 +343,7 @@ function hasCreateFieldFlags(options: Record<string, unknown>): boolean {
 			options.status !== undefined ||
 			options.labels !== undefined ||
 			options.priority !== undefined ||
+			options.type !== undefined ||
 			options.ordinal !== undefined ||
 			options.milestone !== undefined ||
 			options.plain ||
@@ -355,6 +373,7 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.status !== undefined ||
 			options.label !== undefined ||
 			options.priority !== undefined ||
+			options.type !== undefined ||
 			options.ordinal !== undefined ||
 			options.milestone !== undefined ||
 			options.clearMilestone ||
@@ -1575,6 +1594,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 		{ name: "assignee", type: "Assignee list", description: "One or more @names" },
 		{ name: "labels", type: "Comma-separated strings", description: "Task labels" },
 		{ name: "priority", type: priorityType, description: "Task priority" },
+		{ name: "type", type: taskType, description: "Task type; case-insensitive" },
 		{ name: "acceptanceCriteria", type: "Markdown list item text", description: "Repeat --ac for multiple criteria" },
 		{ name: "ordinal", type: "Integer", description: "Non-negative manual ordering value" },
 		{ name: "parent", type: "Task ID", description: "Existing parent task for subtasks; not a milestone ID" },
@@ -1583,6 +1603,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 	output: "Created task details; use --plain for text output",
 	examples: [
 		'backlog task create "Add OAuth" --ac "Login succeeds"',
+		`backlog task create "Fix session expiry" --type ${TASK_TYPE_EXAMPLE}`,
 		'backlog task create -p {{TASK_ID:1}} "Add tests"',
 	],
 })
@@ -1592,6 +1613,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 	.option("-s, --status <status>")
 	.option("-l, --labels <labels>")
 	.option("--priority <priority>", "set task priority (configured priorities)")
+	.option("--type <type>", "set task type (configured task types)")
 	.option("--plain", "use plain text output after creating")
 	.option("--ac <criteria>", "add acceptance criteria (can be used multiple times)", createMultiValueAccumulator())
 	.option(
@@ -1654,7 +1676,11 @@ addHelpSchema(taskCmd.command("create [title]"), {
 		if (shouldUseWizard) {
 			const statuses = await getValidStatuses(core);
 			const config = await core.filesystem.loadConfig();
-			const wizardInput = await runTaskCreateWizard({ statuses, priorities: config?.priorities });
+			const wizardInput = await runTaskCreateWizard({
+				statuses,
+				priorities: config?.priorities,
+				types: config?.types,
+			});
 			if (!wizardInput) {
 				clack.cancel("Task create cancelled.");
 				return;
@@ -1708,6 +1734,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 				modifiedFiles: parseDelimitedStringList(options.modifiedFile),
 				parentTaskId: options.parent ? String(options.parent) : undefined,
 				priority: options.priority ? String(options.priority) : undefined,
+				type: options.type !== undefined ? String(options.type) : undefined,
 				...(ordinalValue !== undefined ? { ordinal: ordinalValue } : {}),
 				milestone,
 				implementationPlan: options.plan ? String(options.plan) : undefined,
@@ -2251,9 +2278,7 @@ addHelpSchema(taskCmd.command("list"), {
 			if (options.sort && options.sort.toLowerCase() === "priority") {
 				console.log("Tasks (sorted by priority):");
 				for (const t of displayTasks) {
-					const priorityIndicator = t.priority ? `[${t.priority.toUpperCase()}] ` : "";
-					const statusIndicator = t.status ? ` (${t.status})` : "";
-					console.log(`  ${priorityIndicator}${t.id} - ${t.title}${statusIndicator}`);
+					console.log(formatPlainTaskListRow(t, { includeStatus: true }));
 				}
 				cleanup();
 				return;
@@ -2284,8 +2309,7 @@ addHelpSchema(taskCmd.command("list"), {
 				if (!list) continue;
 				console.log(`${status || "No Status"}:`);
 				list.forEach((task) => {
-					const priorityIndicator = task.priority ? `[${task.priority.toUpperCase()}] ` : "";
-					console.log(`  ${priorityIndicator}${task.id} - ${task.title}`);
+					console.log(formatPlainTaskListRow(task));
 				});
 				console.log();
 			}
@@ -2444,6 +2468,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		{ name: "title", type: "String", description: "Replacement task title" },
 		{ name: "description", type: "Markdown", description: "Replacement description" },
 		{ name: "status", type: statusType, description: "Project task status; case-insensitive" },
+		{ name: "type", type: taskType, description: "Replacement task type; case-insensitive" },
 		{
 			name: "label",
 			type: "Comma-separated strings",
@@ -2474,6 +2499,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 	output: "Updated task details; use --plain for text output",
 	examples: [
 		'backlog task edit {{TASK_ID:1}} --status "<active status>" -a @sara',
+		`backlog task edit {{TASK_ID:1}} --type ${TASK_TYPE_EXAMPLE}`,
 		"backlog task edit {{TASK_ID:1}} --check-ac 1",
 	],
 })
@@ -2489,6 +2515,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		createMultiValueAccumulator(),
 	)
 	.option("--priority <priority>", "set task priority (configured priorities)")
+	.option("--type <type>", "set task type (configured task types; pass an empty value to clear)")
 	.option("--ordinal <number>", "set task ordinal for custom ordering")
 	.option("-m, --milestone <milestone>", "assign task to milestone by ID or title")
 	.option("--clear-milestone", "clear task milestone assignment")
@@ -2627,6 +2654,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 				task: existingTaskForWizard,
 				statuses,
 				priorities: config?.priorities,
+				types: config?.types,
 			});
 			if (!wizardInput) {
 				clack.cancel("Task edit cancelled.");
@@ -2789,6 +2817,9 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		}
 		if (normalizedPriority) {
 			editArgs.priority = normalizedPriority;
+		}
+		if (options.type !== undefined) {
+			editArgs.type = String(options.type);
 		}
 		if (ordinalValue !== undefined) {
 			editArgs.ordinal = ordinalValue;
@@ -4049,7 +4080,7 @@ addHelpSchema(configCmd.command("get <key>"), {
 	required: [{ name: "key", type: choiceType(CONFIG_GET_KEYS), description: "Configuration value to print" }],
 	optional: [],
 	output: "The selected configuration value",
-	examples: ["backlog config get defaultEditor"],
+	examples: ["backlog config get defaultEditor", "backlog config get types"],
 })
 	.description("get a configuration value")
 	.action(async (key: string) => {
@@ -4091,6 +4122,9 @@ addHelpSchema(configCmd.command("get <key>"), {
 							.map((priority) => priority.label)
 							.join(", "),
 					);
+					break;
+				case "types":
+					console.log(getTaskTypeValues(config).join(", "));
 					break;
 				case "milestones": {
 					const milestones = await core.filesystem.listMilestones();
@@ -4139,7 +4173,7 @@ addHelpSchema(configCmd.command("get <key>"), {
 				default:
 					console.error(`Unknown config key: ${key}`);
 					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, priorities, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
+						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, priorities, types, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
 					);
 					process.exit(1);
 			}
@@ -4394,6 +4428,7 @@ addHelpSchema(configCmd.command("list"), {
 					.map((priority) => priority.label)
 					.join(", ")}]`,
 			);
+			console.log(`  types: [${getTaskTypeValues(config).join(", ")}]`);
 			const milestones = await core.filesystem.listMilestones();
 			console.log(`  milestones: [${milestones.map((milestone) => milestone.id).join(", ")}]`);
 			console.log(`  definitionOfDone: [${(config.definitionOfDone ?? []).join(", ")}]`);

--- a/src/commands/help-schema.ts
+++ b/src/commands/help-schema.ts
@@ -5,6 +5,7 @@ import { DEFAULT_STATUSES } from "../constants/index.ts";
 import { resolveBacklogDirectory } from "../utils/backlog-directory.ts";
 import { getPriorityLabels } from "../utils/priority-config.ts";
 import { BACKLOG_CWD_ENV } from "../utils/runtime-cwd.ts";
+import { getTaskTypeValues } from "../utils/task-type-config.ts";
 
 export interface HelpField {
 	name: string;
@@ -128,6 +129,10 @@ function parsePrioritiesFromConfig(content: string): string[] | null {
 	return parseArrayFromConfig(content, "priorities");
 }
 
+function parseTaskTypesFromConfig(content: string): string[] | null {
+	return parseArrayFromConfig(content, "types");
+}
+
 function parseStringValueFromConfig(content: string, keys: string[]): string | null {
 	for (const rawLine of content.split(/\r?\n/)) {
 		const line = rawLine.trim();
@@ -208,6 +213,19 @@ export function getCliPriorityValues(): string[] {
 	return getPriorityLabels();
 }
 
+export function getCliTaskTypeValues(): string[] {
+	const configPath = findBacklogConfigPathSync(getRuntimeConfigStartDir());
+	if (configPath) {
+		try {
+			const parsed = parseTaskTypesFromConfig(readFileSync(configPath, "utf8"));
+			return getTaskTypeValues(parsed);
+		} catch {
+			return getTaskTypeValues();
+		}
+	}
+	return getTaskTypeValues();
+}
+
 export function getCliTaskPrefix(): string {
 	const configPath = findBacklogConfigPathSync(getRuntimeConfigStartDir());
 	if (configPath) {
@@ -240,4 +258,8 @@ export function statusType(options?: { includeDraft?: boolean }): string {
 
 export function priorityType(): string {
 	return `one of configured priorities: ${getCliPriorityValues().join(", ")}`;
+}
+
+export function taskType(): string {
+	return `one of configured task types: ${getCliTaskTypeValues().join(", ")}`;
 }

--- a/src/commands/task-wizard.ts
+++ b/src/commands/task-wizard.ts
@@ -5,12 +5,14 @@ import { DEFAULT_STATUSES } from "../constants/index.ts";
 import type { AcceptanceCriterion, Task, TaskCreateInput, TaskUpdateInput } from "../types/index.ts";
 import { getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
 import { normalizeDependencies, normalizeStringList } from "../utils/task-builders.ts";
+import { getTaskTypeValues, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 
 interface TaskWizardValues {
 	title: string;
 	description: string;
 	status: string;
 	priority: string;
+	type: string;
 	assignee: string;
 	labels: string;
 	acceptanceCriteria: string;
@@ -63,6 +65,7 @@ interface ChecklistEntry {
 interface WizardOptions {
 	statuses: string[];
 	priorities?: string[];
+	types?: string[];
 	promptImpl?: TaskWizardPromptRunner;
 }
 
@@ -191,6 +194,30 @@ function buildPriorityPromptValues(
 	return {
 		options: [{ label: `${initialPriority} (current)`, value: normalizedInitial }, ...options],
 		initial: normalizedInitial,
+	};
+}
+
+function buildTaskTypePromptValues(
+	initialType: string,
+	types?: string[],
+): {
+	options: PromptChoice[];
+	initial: string;
+} {
+	const canonicalInitial = resolveTaskTypeValue(initialType, types) ?? initialType.trim();
+	const options: PromptChoice[] = [
+		{ label: "None", value: "", hint: "No task type" },
+		...getTaskTypeValues(types).map((type) => ({ label: type, value: type })),
+	];
+	if (!canonicalInitial) {
+		return { options, initial: "" };
+	}
+	if (options.some((option) => option.value === canonicalInitial)) {
+		return { options, initial: canonicalInitial };
+	}
+	return {
+		options: [{ label: `${initialType} (current)`, value: initialType }, ...options],
+		initial: initialType,
 	};
 }
 
@@ -350,6 +377,7 @@ async function runTaskWizardValues(params: {
 	mode: "create" | "edit";
 	statuses: string[];
 	priorities?: string[];
+	types?: string[];
 	initialValues: TaskWizardValues;
 	promptImpl?: TaskWizardPromptRunner;
 }): Promise<TaskWizardValues | null> {
@@ -362,12 +390,14 @@ async function runTaskWizardValues(params: {
 		initialStatus: initial.status,
 	});
 	const priorityPrompt = buildPriorityPromptValues(initial.priority, params.priorities);
+	const taskTypePrompt = buildTaskTypePromptValues(initial.type, params.types);
 
 	try {
 		const values: TaskWizardValues = {
 			...initial,
 			status: statusPrompt.initial,
 			priority: priorityPrompt.initial,
+			type: taskTypePrompt.initial,
 		};
 		const questions: TaskWizardValueQuestion[] = [
 			{
@@ -398,6 +428,12 @@ async function runTaskWizardValues(params: {
 				name: "priority",
 				message: "Priority",
 				options: priorityPrompt.options,
+			},
+			{
+				type: "select",
+				name: "type",
+				message: "Type",
+				options: taskTypePrompt.options,
 			},
 			{
 				type: "text",
@@ -505,6 +541,7 @@ async function runTaskWizardValues(params: {
 			description: values.description,
 			status: canonicalStatus,
 			priority: normalizePriorityValue(values.priority) ?? "",
+			type: resolveTaskTypeValue(values.type, params.types) ?? values.type.trim(),
 			assignee: values.assignee,
 			labels: values.labels,
 			acceptanceCriteria: values.acceptanceCriteria,
@@ -559,6 +596,7 @@ function toInitialWizardValues(input: { title?: string } & Partial<Task>): TaskW
 		description: input.description ?? "",
 		status: input.status ?? "",
 		priority: input.priority ?? "",
+		type: input.type ?? "",
 		assignee: formatListInput(input.assignee),
 		labels: formatListInput(input.labels),
 		acceptanceCriteria: formatChecklistInput(input.acceptanceCriteriaItems),
@@ -581,6 +619,7 @@ export async function runTaskCreateWizard(
 		mode: "create",
 		statuses: options.statuses,
 		priorities: options.priorities,
+		types: options.types,
 		initialValues,
 		promptImpl: options.promptImpl,
 	});
@@ -590,6 +629,8 @@ export async function runTaskCreateWizard(
 
 	const priority = values.priority.trim();
 	const parsedPriority = priority.length > 0 ? priority : undefined;
+	const type = values.type.trim();
+	const parsedType = type.length > 0 ? type : undefined;
 	const assignee = parseListInput(values.assignee);
 	const labels = parseListInput(values.labels);
 	const references = parseListInput(values.references);
@@ -606,6 +647,7 @@ export async function runTaskCreateWizard(
 		...(values.description.trim().length > 0 && { description: values.description }),
 		...(values.status.trim().length > 0 && { status: values.status }),
 		...(parsedPriority && { priority: parsedPriority }),
+		...(parsedType && { type: parsedType }),
 		...(assignee.length > 0 && { assignee }),
 		...(labels.length > 0 && { labels }),
 		...(dependencies.length > 0 && { dependencies }),
@@ -629,6 +671,7 @@ export async function runTaskEditWizard(
 		mode: "edit",
 		statuses: options.statuses,
 		priorities: options.priorities,
+		types: options.types,
 		initialValues: initial,
 		promptImpl: options.promptImpl,
 	});
@@ -648,6 +691,9 @@ export async function runTaskEditWizard(
 	}
 	if (values.priority !== initial.priority && values.priority.trim().length > 0) {
 		updateInput.priority = values.priority;
+	}
+	if (values.type !== initial.type) {
+		updateInput.type = values.type;
 	}
 
 	const initialAssignee = parseListInput(initial.assignee);

--- a/src/completions/data-providers.ts
+++ b/src/completions/data-providers.ts
@@ -1,6 +1,7 @@
 import { Core } from "../index.ts";
 import type { BacklogConfig } from "../types/index.ts";
 import { getPriorityValues } from "../utils/priority-config.ts";
+import { getTaskTypeValues } from "../utils/task-type-config.ts";
 
 type CoreCallback<T> = (core: Core) => Promise<T>;
 
@@ -59,6 +60,16 @@ export async function getPriorities(): Promise<string[]> {
 		const config: BacklogConfig | null = await core.filesystem.loadConfig();
 		return getPriorityValues(config);
 	}, getPriorityValues());
+}
+
+/**
+ * Get configured task type values.
+ */
+export async function getTaskTypes(): Promise<string[]> {
+	return await withCore(async (core) => {
+		const config: BacklogConfig | null = await core.filesystem.loadConfig();
+		return getTaskTypeValues(config);
+	}, getTaskTypeValues());
 }
 
 /**

--- a/src/completions/helper.ts
+++ b/src/completions/helper.ts
@@ -6,7 +6,15 @@ import {
 	getSubcommandNames,
 	getTopLevelCommands,
 } from "./command-structure.ts";
-import { getAssignees, getDocumentIds, getLabels, getPriorities, getStatuses, getTaskIds } from "./data-providers.ts";
+import {
+	getAssignees,
+	getDocumentIds,
+	getLabels,
+	getPriorities,
+	getStatuses,
+	getTaskIds,
+	getTaskTypes,
+} from "./data-providers.ts";
 
 export interface CompletionContext {
 	words: string[];
@@ -106,7 +114,7 @@ async function getArgumentCompletions(argumentName: string): Promise<string[]> {
 /**
  * Get completions for flag values based on flag name
  */
-async function getFlagValueCompletions(flagName: string): Promise<string[]> {
+async function getFlagValueCompletions(flagName: string, context: CompletionContext): Promise<string[]> {
 	const cleanFlag = flagName.replace(/^-+/, "");
 
 	switch (cleanFlag) {
@@ -114,6 +122,10 @@ async function getFlagValueCompletions(flagName: string): Promise<string[]> {
 			return await getStatuses();
 		case "priority":
 			return await getPriorities();
+		case "type":
+			return context.command === "task" && (context.subcommand === "create" || context.subcommand === "edit")
+				? await getTaskTypes()
+				: [];
 		case "labels":
 		case "label":
 			return await getLabels();
@@ -135,7 +147,7 @@ export async function getCompletions(program: Command, line: string, point: numb
 
 	// If completing a flag value
 	if (context.lastFlag) {
-		const flagCompletions = await getFlagValueCompletions(context.lastFlag);
+		const flagCompletions = await getFlagValueCompletions(context.lastFlag, context);
 		return filterCompletions(flagCompletions, context.partial);
 	}
 

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1,6 +1,6 @@
 import { rename as moveFile, stat, unlink } from "node:fs/promises";
 import { isAbsolute, join, relative } from "node:path";
-import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, DEFAULT_TASK_TYPES, FALLBACK_STATUS } from "../constants/index.ts";
+import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
 import { FileSystem, isCreateLockError } from "../file-system/operations.ts";
 import { GitOperations } from "../git/operations.ts";
 import {
@@ -57,6 +57,7 @@ import {
 } from "../utils/task-builders.ts";
 import { getTaskFilename, getTaskPath, normalizeTaskId, taskIdsEqual } from "../utils/task-path.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
+import { formatValidTaskTypeValues, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
 import { isTerminalStatus } from "../utils/terminal-status.ts";
 import { migrateConfig, needsMigration } from "./config-migration.ts";
@@ -391,11 +392,9 @@ export class Core {
 			return undefined;
 		}
 		const config = await this.fs.loadConfig();
-		const allowed = config?.types?.length ? config.types : [...DEFAULT_TASK_TYPES];
-		const normalized = value.trim().toLowerCase();
-		const canonical = allowed.find((type) => type.toLowerCase() === normalized);
+		const canonical = resolveTaskTypeValue(value, config);
 		if (!canonical) {
-			throw new Error(`Invalid type: ${value}. Valid types are: ${allowed.join(", ")}`);
+			throw new Error(`Invalid type: ${value}. Valid types are: ${formatValidTaskTypeValues(config)}`);
 		}
 		return canonical;
 	}

--- a/src/test/cli-task-type.test.ts
+++ b/src/test/cli-task-type.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+let TEST_DIR: string;
+let core: Core;
+
+describe("CLI task types", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-cli-task-type");
+		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
+		await mkdir(TEST_DIR, { recursive: true });
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		core = new Core(TEST_DIR);
+		await initializeTestProject(core, "CLI Task Type Project");
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Expected test config");
+		config.types = ["Bug", "Epic"];
+		await core.filesystem.saveConfig(config);
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR).catch(() => {});
+	});
+
+	it("creates and edits typed tasks with configured canonical casing", async () => {
+		const created = await $`bun ${CLI_PATH} task create "Typed task" --type ePiC --plain`.cwd(TEST_DIR).quiet();
+		expect(created.exitCode).toBe(0);
+		expect(created.stdout.toString()).toContain("Type: Epic");
+		expect((await core.filesystem.loadTask("TASK-1"))?.type).toBe("Epic");
+		const viewed = await $`bun ${CLI_PATH} task view TASK-1 --plain`.cwd(TEST_DIR).quiet();
+		expect(viewed.stdout.toString()).toContain("Type: Epic");
+
+		const edited = await $`bun ${CLI_PATH} task edit TASK-1 --type BUG --plain`.cwd(TEST_DIR).quiet();
+		expect(edited.exitCode).toBe(0);
+		expect(edited.stdout.toString()).toContain("Type: Bug");
+		expect((await core.filesystem.loadTask("TASK-1"))?.type).toBe("Bug");
+
+		await $`bun ${CLI_PATH} task edit TASK-1 --title "Still typed"`.cwd(TEST_DIR).quiet();
+		expect((await core.filesystem.loadTask("TASK-1"))?.type).toBe("Bug");
+
+		const cleared = await $`bun ${CLI_PATH} task edit TASK-1 --type "" --plain`.cwd(TEST_DIR).quiet();
+		expect(cleared.stdout.toString()).not.toContain("Type:");
+		expect((await core.filesystem.loadTask("TASK-1"))?.type).toBeUndefined();
+	});
+
+	it("rejects invalid values and keeps untyped tasks untyped", async () => {
+		const invalidCreate = await $`bun ${CLI_PATH} task create "Invalid type" --type feature`
+			.cwd(TEST_DIR)
+			.quiet()
+			.nothrow();
+		expect(invalidCreate.exitCode).toBe(1);
+		expect(invalidCreate.stderr.toString()).toContain("Invalid type: feature. Valid types are: Bug, Epic");
+
+		await $`bun ${CLI_PATH} task create "Untyped task"`.cwd(TEST_DIR).quiet();
+		const invalidEdit = await $`bun ${CLI_PATH} task edit TASK-1 --type feature`.cwd(TEST_DIR).quiet().nothrow();
+		expect(invalidEdit.exitCode).toBe(1);
+		expect(invalidEdit.stderr.toString()).toContain("Invalid type: feature. Valid types are: Bug, Epic");
+
+		const edited = await $`bun ${CLI_PATH} task edit TASK-1 --title "Still untyped" --plain`.cwd(TEST_DIR).quiet();
+		expect(edited.stdout.toString()).not.toContain("Type:");
+		expect((await core.filesystem.loadTask("TASK-1"))?.type).toBeUndefined();
+	});
+
+	it("shows type badges in plain task lists and omits them for untyped tasks", async () => {
+		await $`bun ${CLI_PATH} task create "Typed list task" --type epic --priority high`.cwd(TEST_DIR).quiet();
+		await $`bun ${CLI_PATH} task create "Untyped list task"`.cwd(TEST_DIR).quiet();
+
+		const result = await $`bun ${CLI_PATH} task list --plain`.cwd(TEST_DIR).quiet();
+		const output = result.stdout.toString();
+		expect(output).toContain("[HIGH] [Epic] TASK-1 - Typed list task");
+		expect(output).toContain("  TASK-2 - Untyped list task");
+
+		const sortedResult = await $`bun ${CLI_PATH} task list --plain --sort priority`.cwd(TEST_DIR).quiet();
+		const sortedOutput = sortedResult.stdout.toString();
+		expect(sortedOutput).toContain("[HIGH] [Epic] TASK-1 - Typed list task (To Do)");
+		expect(sortedOutput).toContain("  TASK-2 - Untyped list task (To Do)");
+	});
+
+	it("documents configured values and exposes them through read-only config commands", async () => {
+		const getOutput = await $`bun ${CLI_PATH} config get types`.cwd(TEST_DIR).text();
+		expect(getOutput.trim()).toBe("Bug, Epic");
+
+		const listOutput = await $`bun ${CLI_PATH} config list`.cwd(TEST_DIR).text();
+		expect(listOutput).toContain("types: [Bug, Epic]");
+
+		const createHelp = await $`bun ${CLI_PATH} task create --help`.cwd(TEST_DIR).text();
+		const editHelp = await $`bun ${CLI_PATH} task edit --help`.cwd(TEST_DIR).text();
+		for (const output of [createHelp, editHelp]) {
+			expect(output).toContain("--type <type>");
+			expect(output).toContain("type: one of configured task types: Bug, Epic");
+		}
+		expect(createHelp).toContain('backlog task create "Fix session expiry" --type "Bug"');
+		expect(editHelp).toContain('backlog task edit TASK-1 --type "Bug"');
+		expect(createHelp).not.toContain("--type bug");
+		expect(editHelp).not.toContain("--type feature");
+	});
+
+	it("completes configured task types only for task type flags", async () => {
+		for (const line of ["backlog task create --type ", "backlog task edit TASK-1 --type "]) {
+			const result = await $`bun ${CLI_PATH} completion __complete ${line} ${String(line.length)}`
+				.cwd(TEST_DIR)
+				.quiet();
+			expect(result.stdout.toString().trim().split("\n")).toEqual(["Bug", "Epic"]);
+		}
+
+		const searchLine = "backlog search --type ";
+		const searchResult = await $`bun ${CLI_PATH} completion __complete ${searchLine} ${String(searchLine.length)}`
+			.cwd(TEST_DIR)
+			.quiet();
+		expect(searchResult.stdout.toString()).not.toContain("Epic");
+	});
+});

--- a/src/test/task-type-config.test.ts
+++ b/src/test/task-type-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_TASK_TYPES } from "../constants/index.ts";
+import { formatValidTaskTypeValues, getTaskTypeValues, resolveTaskTypeValue } from "../utils/task-type-config.ts";
+
+describe("task type configuration", () => {
+	it("uses defaults when task types are not configured", () => {
+		expect(getTaskTypeValues()).toEqual([...DEFAULT_TASK_TYPES]);
+		expect(formatValidTaskTypeValues()).toBe(DEFAULT_TASK_TYPES.join(", "));
+	});
+
+	it("normalizes configured values while preserving canonical casing", () => {
+		const config = { types: [" Bug ", "Epic", "bug", ""] };
+
+		expect(getTaskTypeValues(config)).toEqual(["Bug", "Epic"]);
+		expect(resolveTaskTypeValue(" ePiC ", config)).toBe("Epic");
+		expect(resolveTaskTypeValue("feature", config)).toBeUndefined();
+	});
+});

--- a/src/test/task-wizard.test.ts
+++ b/src/test/task-wizard.test.ts
@@ -40,6 +40,7 @@ describe("task wizard", () => {
 			description: "Wizard description",
 			status: "In Progress",
 			priority: "medium",
+			type: "epic",
 			assignee: "alice, @bob",
 			labels: "cli, wizard",
 			acceptanceCriteria: "[x] First criterion, Second criterion",
@@ -53,6 +54,7 @@ describe("task wizard", () => {
 
 		const input = await runTaskCreateWizard({
 			statuses: ["To Do", "In Progress", "Done"],
+			types: ["Bug", "Epic"],
 			promptImpl: prompt,
 		});
 
@@ -61,6 +63,7 @@ describe("task wizard", () => {
 		expect(input?.description).toBe("Wizard description");
 		expect(input?.status).toBe("In Progress");
 		expect(input?.priority).toBe("medium");
+		expect(input?.type).toBe("Epic");
 		expect(input?.assignee).toEqual(["alice", "@bob"]);
 		expect(input?.labels).toEqual(["cli", "wizard"]);
 		expect(input?.acceptanceCriteria).toEqual([
@@ -81,6 +84,7 @@ describe("task wizard", () => {
 			title: "Old title",
 			status: "To Do",
 			priority: "low",
+			type: "Bug",
 			assignee: ["alice"],
 			createdDate: "2026-02-20 12:00",
 			labels: ["existing"],
@@ -105,6 +109,7 @@ describe("task wizard", () => {
 			description: "New description",
 			status: "In Progress",
 			priority: "high",
+			type: "Epic",
 			assignee: "alice, bob",
 			labels: "existing, cli",
 			acceptanceCriteria: "[x] New AC 1, [ ] New AC 2",
@@ -119,6 +124,7 @@ describe("task wizard", () => {
 		const updateInput = await runTaskEditWizard({
 			task: existingTask,
 			statuses: ["To Do", "In Progress", "Done"],
+			types: ["Bug", "Epic"],
 			promptImpl: prompt,
 		});
 
@@ -127,6 +133,7 @@ describe("task wizard", () => {
 		expect(updateInput?.description).toBe("New description");
 		expect(updateInput?.status).toBe("In Progress");
 		expect(updateInput?.priority).toBe("high");
+		expect(updateInput?.type).toBe("Epic");
 		expect(updateInput?.assignee).toEqual(["alice", "bob"]);
 		expect(updateInput?.labels).toEqual(["existing", "cli"]);
 		expect(updateInput?.dependencies).toEqual(["TASK-2", "TASK-3"]);
@@ -254,7 +261,7 @@ describe("task wizard", () => {
 		expect(input?.status).toBe("To Do");
 	});
 
-	it("uses select prompts for status and priority with create defaults", async () => {
+	it("uses select prompts for status, priority, and type with create defaults", async () => {
 		const questions: Record<
 			string,
 			{ type: string; message: string; initial?: string; optionsCount: number; optionValues: string[] }
@@ -272,6 +279,7 @@ describe("task wizard", () => {
 
 		const input = await runTaskCreateWizard({
 			statuses: ["Backlog", "To Do", "In Progress", "Done"],
+			types: ["Bug", "Epic"],
 			promptImpl: prompt,
 		});
 
@@ -285,6 +293,33 @@ describe("task wizard", () => {
 		expect(questions.priority?.type).toBe("select");
 		expect(questions.priority?.initial).toBe("");
 		expect((questions.priority?.optionsCount ?? 0) > 0).toBe(true);
+		expect(questions.type?.type).toBe("select");
+		expect(questions.type?.initial).toBe("");
+		expect(questions.type?.optionValues).toEqual(["", "Bug", "Epic"]);
+	});
+
+	it("clears an existing type when None is selected", async () => {
+		const existingTask: Task = {
+			id: "task-9",
+			title: "Typed task",
+			status: "To Do",
+			type: "Epic",
+			assignee: [],
+			createdDate: "2026-02-20 12:00",
+			labels: [],
+			dependencies: [],
+			rawContent: "",
+		};
+		const prompt = createPromptRunner({ type: "" });
+
+		const updateInput = await runTaskEditWizard({
+			task: existingTask,
+			statuses: ["To Do", "In Progress", "Done"],
+			types: ["Bug", "Epic"],
+			promptImpl: prompt,
+		});
+
+		expect(updateInput?.type).toBe("");
 	});
 
 	it("falls back to default statuses and keeps create default on To Do", async () => {

--- a/src/utils/task-type-config.ts
+++ b/src/utils/task-type-config.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_TASK_TYPES } from "../constants/index.ts";
+import type { BacklogConfig } from "../types/index.ts";
+
+type TaskTypeConfig = Pick<BacklogConfig, "types"> | readonly string[] | null | undefined;
+
+function normalizeTaskTypeValue(value: string | null | undefined): string | undefined {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+export function getTaskTypeValues(configOrTypes?: TaskTypeConfig): string[] {
+	const configuredTypes: readonly string[] = Array.isArray(configOrTypes)
+		? configOrTypes
+		: ((configOrTypes as Pick<BacklogConfig, "types"> | null | undefined)?.types ?? []);
+	const values: string[] = [];
+	const seen = new Set<string>();
+
+	for (const entry of configuredTypes) {
+		const value = String(entry ?? "").trim();
+		const normalized = normalizeTaskTypeValue(value);
+		if (!normalized || seen.has(normalized)) {
+			continue;
+		}
+		seen.add(normalized);
+		values.push(value);
+	}
+
+	return values.length > 0 ? values : [...DEFAULT_TASK_TYPES];
+}
+
+export function resolveTaskTypeValue(
+	value: string | null | undefined,
+	configOrTypes?: TaskTypeConfig,
+): string | undefined {
+	const normalized = normalizeTaskTypeValue(value);
+	if (!normalized) {
+		return undefined;
+	}
+	return getTaskTypeValues(configOrTypes).find((type) => normalizeTaskTypeValue(type) === normalized);
+}
+
+export function formatValidTaskTypeValues(configOrTypes?: TaskTypeConfig): string {
+	return getTaskTypeValues(configOrTypes).join(", ");
+}


### PR DESCRIPTION
Alex's Agent: Completes the human-facing CLI workflow for task types, making the CLI the canonical surface while MCP remains an optional adapter.

Part of #746.

## What changed

- adds `--type` to `backlog task create` and `backlog task edit`
- validates case-insensitively against configured task types and preserves canonical casing
- keeps existing tasks untyped unless a type is explicitly selected
- adds configured type selection, preservation, and clearing to the interactive create/edit wizard
- adds configured shell completions and dynamic CLI help/examples
- exposes task types through `config get types` and `config list` without adding a config-set surface
- displays compact type badges in plain task lists and the existing conditional Type field in plain details
- centralizes type resolution so CLI and downstream filters reuse the same behavior

## Validation

- `bun test src/test/task-type-config.test.ts src/test/task-type.test.ts src/test/task-wizard.test.ts src/test/cli-task-type.test.ts src/completions/helper.test.ts` — 47 passed
- `bunx tsc --noEmit`
- `bun run check .` — 311 files checked
- `bun run build`
- `bun test` — 1,496 passed, 2 documented interactive TUI tests skipped, 0 failed
- compiled `dist/backlog` smoke: create, edit, list, config get, and help

No release, tag, version, or publishing changes are included.
