### PR TITLE
BACK-355.04 - Add task type filtering

### DIFF
--- a/backlog/tasks/back-355.04 - Filtering-Add-type-based-filtering-to-task-list-and-search.md
+++ b/backlog/tasks/back-355.04 - Filtering-Add-type-based-filtering-to-task-list-and-search.md
@@ -1,15 +1,37 @@
 ---
 id: BACK-355.04
 title: 'Filtering: Add type-based filtering to task list and search'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex-types-filter'
 created_date: '2026-01-01 23:37'
+updated_date: '2026-07-09 22:49'
 labels:
   - core
   - cli
   - mcp
 dependencies:
   - task-355.01
+modified_files:
+  - src/cli.ts
+  - src/commands/help-schema.ts
+  - src/completions/helper.ts
+  - src/types/index.ts
+  - src/core/backlog.ts
+  - src/core/content-store.ts
+  - src/core/search-service.ts
+  - src/file-system/operations.ts
+  - src/utils/task-search.ts
+  - src/utils/task-type-config.ts
+  - src/mcp/tools/tasks/handlers.ts
+  - src/mcp/tools/tasks/index.ts
+  - src/mcp/tools/tasks/schemas.ts
+  - src/mcp/utils/schema-generators.ts
+  - src/guidelines/cli-instructions/task-creation.md
+  - src/guidelines/mcp/overview.md
+  - src/guidelines/mcp/overview-tools.md
+  - src/test/task-type-filtering.test.ts
+  - src/test/mcp-task-type-filtering.test.ts
 parent_task_id: BACK-355
 priority: medium
 ---
@@ -22,10 +44,43 @@ Enable filtering tasks by type in list views, search, and board views. This supp
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 TaskListFilter interface includes optional 'type' field
-- [ ] #2 CLI task list accepts --type filter flag
-- [ ] #3 MCP task_list tool accepts type filter parameter
-- [ ] #4 Search filters support type field
-- [ ] #5 Multiple types can be specified for OR filtering (e.g., --type bug,feature)
-- [ ] #6 Filter tests cover type filtering scenarios
+- [x] #1 TaskListFilter interface includes optional 'type' field
+- [x] #2 CLI task list accepts --type filter flag
+- [x] #3 MCP task_list tool accepts type filter parameter
+- [x] #4 Search filters support type field
+- [x] #5 Multiple types can be specified for OR filtering (e.g., --type bug,feature)
+- [x] #6 Filter tests cover type filtering scenarios
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reuse the shared task-type configuration resolver from BACK-355.02 so filter inputs are validated case-insensitively, preserve configured casing, and deduplicate without a second normalizer.
+2. Extend TaskListFilter, SearchFilters, the Core query path, ContentStore/FileSystem filters, SearchService, and in-memory task-search helpers with OR-based task-type matching; untyped tasks do not match a configured type filter.
+3. Expose CLI filtering as repeatable/comma-separated task list --type and search --task-type (search --type remains the existing result-kind selector), compose with existing filters, and document the configured input schema/help.
+4. Add config-driven MCP task_list/task_search type arrays as thin adapters over the shared Core/search semantics, including the Draft path.
+5. Add focused core/store/search, CLI list/search/help/custom/multiple/composition, and MCP schema/adapter tests; run targeted tests, typecheck, Biome, build, and the full suite.
+6. Rebase or stack on the BACK-355.02 shared utility as required, update task evidence via the CLI, commit, push, and open a ready PR linked to #746 without merging.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented CLI-first type filtering with shared OR semantics across Core, ContentStore, FileSystem, SearchService, and the in-memory search used by interactive views. CLI task list uses repeatable/comma-separated --type; global search uses --task-type because --type already selects task/document/decision result kinds. Configured values are validated case-insensitively and returned in canonical casing. Untyped tasks do not match an explicit type filter; no synthetic untyped token was introduced.
+
+MCP task_list and task_search are thin adapters over the shared behavior with configuration-derived schemas, including draft filtering and type-only search. Public CLI and legacy MCP guidance were updated.
+
+Validation on the stack over PR #747: focused type integration 31 pass; full suite 1508 pass, 2 intentional interactive PTY skips, 0 fail; bunx tsc --noEmit, bun run check ., and bun run build all pass.
+
+Final dependency integration: rebased onto corrected PR #747 head f72664c44578abe82764af593018d4310266b79a after its independent review fixes. On that exact stack, 31 focused task-type tests passed; the full suite passed 1508 with 2 documented interactive PTY skips and 0 failures; typecheck, Biome across 313 files, and build all passed.
+
+Final scope ownership: rebased onto PR #747 head 571b3bbd7cbe224e063da57ecb5efbe4e397ae73 after its minimal-API cleanup. BACK-355.04 now owns resolveTaskTypeValues, plural task-type help schema support, and search --task-type completion, each beside a live filtering caller. On the final source tree, 30 focused tests passed with 181 assertions; bunx tsc --noEmit, Biome across 313 files, and bun run build passed. The source implementation matches the immediately prior full-suite-tested stack except for added completion coverage; that run passed 1507 tests with 2 documented interactive PTY skips and 0 failures.
+
+PR #748 review follow-up on final main base a89045999208a374c4ef4e41d405db5ffa7f70aa: replaced default-only filter examples with configured values in help and shipped CLI guidance; completed task list --type and top-level search --task-type completion while rejecting unsupported contexts; and routed MCP enum generation through getTaskTypeValues so whitespace, case duplicates, and empty configured entries cannot diverge from CLI/core semantics. Regression coverage verifies advertised Bug/Epic commands, positive and negative completion contexts, and MCP normalization from [Bug with whitespace, Epic, lowercase duplicate bug, empty] to [Bug, Epic]. Final validation: focused 30 pass with 190 assertions; full suite 1507 pass, 2 documented interactive PTY skips, 0 fail, 5197 assertions; typecheck, Biome across 313 files, build, and compiled Bug/Epic smokes all passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added CLI-first task type filtering: repeatable/comma-separated task list --type and search --task-type with configured validation, canonical casing, OR semantics, composition with existing filters, and no implicit match for untyped tasks. Shared Core/search/store filtering supports later human-facing interfaces; MCP list/search reuse it through configuration-derived adapter schemas. Verified with direct Core/store/in-memory search, CLI/help/custom/multiple/composition, MCP/schema/draft tests, full suite, typecheck, Biome, and build.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,7 +86,7 @@ import {
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
 import { normalizeTaskId, taskIdsEqual } from "./utils/task-path.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
-import { getTaskTypeValues } from "./utils/task-type-config.ts";
+import { formatValidTaskTypeValues, getTaskTypeValues, resolveTaskTypeValues } from "./utils/task-type-config.ts";
 import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
 import { formatUtcDateForDisplay } from "./utils/utc-date-display.ts";
 import { getVersion } from "./utils/version.ts";
@@ -292,6 +292,19 @@ async function normalizeCliPriority(core: Core, value: string): Promise<string |
 		return null;
 	}
 	return normalized;
+}
+
+async function normalizeCliTaskTypes(core: Core, values: string[], optionName: string): Promise<string[] | null> {
+	const config = await core.filesystem.loadConfig();
+	const { values: canonicalTypes, invalid } = resolveTaskTypeValues(values, config);
+	if (invalid.length > 0) {
+		console.error(
+			`Invalid ${optionName}: ${invalid.join(", ")}. Valid types are: ${formatValidTaskTypeValues(config)}`,
+		);
+		process.exitCode = 1;
+		return null;
+	}
+	return canonicalTypes;
 }
 
 function formatToolResultText(result: CallToolResult): string {
@@ -1774,6 +1787,11 @@ addHelpSchema(program.command("search [query]"), {
 			type: choiceType(["task", "document", "decision"], { multiple: true }),
 			description: "Result types",
 		},
+		{
+			name: "task-type",
+			type: () => taskType({ multiple: true }),
+			description: "Filter task results by one or more configured task types; repeat or comma-separate values",
+		},
 		{ name: "status", type: statusType, description: "Filter task results by status; case-insensitive" },
 		{
 			name: "exclude-status",
@@ -1789,10 +1807,19 @@ addHelpSchema(program.command("search [query]"), {
 		{ name: "limit", type: "Integer", description: "Maximum number of results" },
 	],
 	output: "Interactive search UI or plain text with --plain",
-	examples: ['backlog search "auth" --plain', 'backlog search "api" --type task --status "<active status>"'],
+	examples: [
+		'backlog search "auth" --plain',
+		'backlog search "api" --type task --status "<active status>"',
+		`backlog search "crash" --task-type ${TASK_TYPE_EXAMPLE} --plain`,
+	],
 })
 	.description("search tasks, documents, and decisions using the shared index")
 	.option("--type <type>", "limit results to type (task, document, decision)", createMultiValueAccumulator())
+	.option(
+		"--task-type <type>",
+		"filter task results by configured task type (repeatable or comma-separated)",
+		createMultiValueAccumulator(),
+	)
 	.option("--status <status>", "filter task results by status")
 	.option(
 		"--exclude-status <status>",
@@ -1818,6 +1845,7 @@ addHelpSchema(program.command("search [query]"), {
 		};
 
 		const modifiedFileFilters = parseDelimitedStringList(options.modifiedFile);
+		const rawTaskTypes = parseDelimitedStringList(options.taskType) ?? [];
 		const rawTypes = options.type ? (Array.isArray(options.type) ? options.type : [options.type]) : undefined;
 		const allowedTypes: SearchResultType[] = ["task", "document", "decision"];
 		const types = rawTypes
@@ -1830,13 +1858,20 @@ addHelpSchema(program.command("search [query]"), {
 						}
 						return true;
 					})
-			: modifiedFileFilters?.length
+			: modifiedFileFilters?.length || rawTaskTypes.length > 0
 				? ["task"]
 				: allowedTypes;
+		if (rawTaskTypes.length > 0 && rawTypes && !types.includes("task")) {
+			console.error("--task-type filters task results. Include --type task or omit --type.");
+			cleanup();
+			process.exitCode = 1;
+			return;
+		}
 
 		const filters: {
 			status?: string;
 			excludeStatus?: string[];
+			type?: string[];
 			priority?: SearchPriorityFilter;
 			modifiedFiles?: string[];
 		} = {};
@@ -1851,6 +1886,14 @@ addHelpSchema(program.command("search [query]"), {
 				return;
 			}
 			filters.excludeStatus = canonicalExcludeStatuses;
+		}
+		if (rawTaskTypes.length > 0) {
+			const canonicalTaskTypes = await normalizeCliTaskTypes(core, rawTaskTypes, "task-type");
+			if (!canonicalTaskTypes) {
+				cleanup();
+				return;
+			}
+			filters.type = canonicalTaskTypes;
 		}
 		if (options.priority) {
 			const priority = await normalizeCliPriority(core, String(options.priority));
@@ -1902,8 +1945,8 @@ addHelpSchema(program.command("search [query]"), {
 			return;
 		}
 
-		const hasModifiedFileFilter = Boolean(modifiedFileFilters?.length);
-		const interactiveTasks = hasModifiedFileFilter ? searchResultTasks : allTasks;
+		const requiresPrefilteredTaskSet = Boolean(modifiedFileFilters?.length || filters.type?.length);
+		const interactiveTasks = requiresPrefilteredTaskSet ? searchResultTasks : allTasks;
 		if (interactiveTasks.length === 0) {
 			printSearchResults(searchResults);
 			cleanup();
@@ -1926,6 +1969,7 @@ addHelpSchema(program.command("search [query]"), {
 				filterDescription: buildSearchFilterDescription({
 					status: statusFilter,
 					excludeStatus: filters.excludeStatus,
+					type: filters.type,
 					priority: priorityFilter,
 					query: query ?? "",
 					modifiedFiles: modifiedFileFilters ?? [],
@@ -1942,6 +1986,7 @@ addHelpSchema(program.command("search [query]"), {
 function buildSearchFilterDescription(filters: {
 	status?: string;
 	excludeStatus?: string[];
+	type?: string[];
 	priority?: SearchPriorityFilter;
 	query?: string;
 	modifiedFiles?: string[];
@@ -1955,6 +2000,9 @@ function buildSearchFilterDescription(filters: {
 	}
 	if (filters.excludeStatus?.length) {
 		parts.push(`Exclude status: ${filters.excludeStatus.join(", ")}`);
+	}
+	if (filters.type?.length) {
+		parts.push(`Type: ${filters.type.join(", ")}`);
 	}
 	if (filters.priority) {
 		parts.push(`Priority: ${filters.priority}`);
@@ -2110,6 +2158,11 @@ addHelpSchema(taskCmd.command("list"), {
 		{ name: "parent", type: "Task ID", description: "Show subtasks of a parent task" },
 		{ name: "priority", type: priorityType, description: "Filter by task priority" },
 		{
+			name: "type",
+			type: () => taskType({ multiple: true }),
+			description: "Filter by one or more configured task types; repeat or comma-separate values",
+		},
+		{
 			name: "labels",
 			type: "Comma-separated strings",
 			description: "Require every listed label; repeat --labels or use label1,label2",
@@ -2122,6 +2175,7 @@ addHelpSchema(taskCmd.command("list"), {
 	examples: [
 		'backlog task list --status "<todo status>" --plain',
 		"backlog task list --parent {{TASK_ID:1}}",
+		`backlog task list --type ${TASK_TYPE_EXAMPLE} --plain`,
 		'backlog task list --labels frontend,bug --search "login" --limit 10 --plain',
 	],
 })
@@ -2137,6 +2191,11 @@ addHelpSchema(taskCmd.command("list"), {
 	.option("-m, --milestone <milestone>", "filter tasks by milestone (closest match, case-insensitive)")
 	.option("-p, --parent <taskId>", "filter tasks by parent task ID")
 	.option("--priority <priority>", "filter tasks by priority (configured priorities)")
+	.option(
+		"--type <type>",
+		"filter tasks by configured task type (repeatable or comma-separated)",
+		createMultiValueAccumulator(),
+	)
 	.option(
 		"-l, --labels <labels>",
 		"filter tasks by labels; require every comma-separated label (repeatable)",
@@ -2188,6 +2247,15 @@ addHelpSchema(taskCmd.command("list"), {
 				return;
 			}
 			baseFilters.priority = priority;
+		}
+		const rawTaskTypes = parseDelimitedStringList(options.type) ?? [];
+		if (rawTaskTypes.length > 0) {
+			const canonicalTaskTypes = await normalizeCliTaskTypes(core, rawTaskTypes, "type");
+			if (!canonicalTaskTypes) {
+				cleanup();
+				return;
+			}
+			baseFilters.type = canonicalTaskTypes;
 		}
 
 		const labelFilters = parseDelimitedStringList(options.labels) ?? [];
@@ -2334,6 +2402,10 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 		if (options.milestone) activeFilters.push(`Milestone: ${options.milestone}`);
 		if (baseFilters.priority) activeFilters.push(`Priority: ${baseFilters.priority}`);
+		if (baseFilters.type) {
+			const taskTypes = Array.isArray(baseFilters.type) ? baseFilters.type : [baseFilters.type];
+			activeFilters.push(`Type: ${taskTypes.join(", ")}`);
+		}
 		if (labelFilters.length > 0) activeFilters.push(`Labels: ${labelFilters.join(", ")}`);
 		if (searchQuery) activeFilters.push(`Search: ${searchQuery}`);
 		if (taskLimit !== undefined) activeFilters.push(`Limit: ${taskLimit}`);
@@ -2385,6 +2457,9 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 		if (parentId) {
 			interactiveLoaderFilters.parentTaskId = parentId;
+		}
+		if (baseFilters.type) {
+			interactiveLoaderFilters.type = baseFilters.type;
 		}
 		await runUnifiedView({
 			core,

--- a/src/commands/help-schema.ts
+++ b/src/commands/help-schema.ts
@@ -243,7 +243,11 @@ export function taskIdExample(body: string): string {
 }
 
 export function renderConfiguredTaskIds(text: string): string {
+	const taskTypes = getCliTaskTypeValues();
 	return text
+		.replace(/\{\{TASK_TYPE:(\d+)\}\}/g, (_match, index: string) => {
+			return JSON.stringify(taskTypes[Number(index) - 1] ?? "<configured task type>");
+		})
 		.replace(/\{\{TASK_ID:(\d+(?:\.\d+)*)\}\}/g, (_match, body: string) => taskIdExample(body))
 		.replace(/\b(?:BACK|TASK)-(\d+(?:\.\d+)*)\b/g, (_match, body: string) => taskIdExample(body));
 }
@@ -260,6 +264,7 @@ export function priorityType(): string {
 	return `one of configured priorities: ${getCliPriorityValues().join(", ")}`;
 }
 
-export function taskType(): string {
-	return `one of configured task types: ${getCliTaskTypeValues().join(", ")}`;
+export function taskType(options?: { multiple?: boolean }): string {
+	const cardinality = options?.multiple ? "one or more of" : "one of";
+	return `${cardinality} configured task types: ${getCliTaskTypeValues().join(", ")}`;
 }

--- a/src/completions/helper.ts
+++ b/src/completions/helper.ts
@@ -123,9 +123,12 @@ async function getFlagValueCompletions(flagName: string, context: CompletionCont
 		case "priority":
 			return await getPriorities();
 		case "type":
-			return context.command === "task" && (context.subcommand === "create" || context.subcommand === "edit")
+			return context.command === "task" &&
+				(context.subcommand === "create" || context.subcommand === "edit" || context.subcommand === "list")
 				? await getTaskTypes()
 				: [];
+		case "task-type":
+			return context.command === "search" ? await getTaskTypes() : [];
 		case "labels":
 		case "label":
 			return await getLabels();

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -57,7 +57,7 @@ import {
 } from "../utils/task-builders.ts";
 import { getTaskFilename, getTaskPath, normalizeTaskId, taskIdsEqual } from "../utils/task-path.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
-import { formatValidTaskTypeValues, resolveTaskTypeValue } from "../utils/task-type-config.ts";
+import { formatValidTaskTypeValues, matchesTaskTypeFilter, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
 import { isTerminalStatus } from "../utils/terminal-status.ts";
 import { migrateConfig, needsMigration } from "./config-migration.ts";
@@ -322,6 +322,9 @@ export class Core {
 				result = result.filter((task) => !excluded.has((task.status ?? "").toLowerCase()));
 			}
 		}
+		if (filters.type) {
+			result = result.filter((task) => matchesTaskTypeFilter(task.type, filters.type));
+		}
 		if (filters.assignee) {
 			const assigneeLower = filters.assignee.toLowerCase();
 			result = result.filter((task) => (task.assignee ?? []).some((value) => value.toLowerCase() === assigneeLower));
@@ -482,6 +485,9 @@ export class Core {
 		}
 		if (filters?.excludeStatus) {
 			searchFilters.excludeStatus = filters.excludeStatus;
+		}
+		if (filters?.type) {
+			searchFilters.type = filters.type;
 		}
 		if (filters?.priority) {
 			searchFilters.priority = filters.priority;

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -8,6 +8,7 @@ import { normalizeDocumentRelativePath } from "../utils/document-path.ts";
 import { normalizePriorityValue } from "../utils/priority-config.ts";
 import { normalizeTaskId, normalizeTaskIdentity, taskIdsEqual } from "../utils/task-path.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
+import { matchesTaskTypeFilter } from "../utils/task-type-config.ts";
 
 interface ContentSnapshot {
 	tasks: Task[];
@@ -121,6 +122,9 @@ export class ContentStore {
 			if (excluded.size > 0) {
 				tasks = tasks.filter((task) => !excluded.has(task.status.toLowerCase()));
 			}
+		}
+		if (filter?.type) {
+			tasks = tasks.filter((task) => matchesTaskTypeFilter(task.type, filter.type));
 		}
 		if (filter?.assignee) {
 			const assignee = filter.assignee;

--- a/src/core/search-service.ts
+++ b/src/core/search-service.ts
@@ -12,6 +12,7 @@ import type {
 } from "../types/index.ts";
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "../utils/modified-files.ts";
 import { normalizePriorityValue } from "../utils/priority-config.ts";
+import { matchesTaskTypeFilter } from "../utils/task-type-config.ts";
 import type { ContentStore, ContentStoreEvent } from "./content-store.ts";
 
 interface BaseSearchEntity {
@@ -48,6 +49,7 @@ type SearchEntity = TaskSearchEntity | DocumentSearchEntity | DecisionSearchEnti
 type NormalizedFilters = {
 	statuses?: string[];
 	excludedStatuses?: string[];
+	taskTypes?: string[];
 	priorities?: SearchPriorityFilter[];
 	assignees?: string[];
 	labels?: string[];
@@ -327,6 +329,9 @@ export class SearchService {
 			const excludedStatuses = new Set(filters.excludedStatuses);
 			filtered = filtered.filter((task) => !excludedStatuses.has(task.statusLower));
 		}
+		if (filters.taskTypes && filters.taskTypes.length > 0) {
+			filtered = filtered.filter((task) => matchesTaskTypeFilter(task.task.type, filters.taskTypes));
+		}
 		if (filters.priorities && filters.priorities.length > 0) {
 			const allowedPriorities = new Set(filters.priorities);
 			filtered = filtered.filter((task) => {
@@ -367,6 +372,9 @@ export class SearchService {
 			}
 		}
 		if (filters.excludedStatuses?.includes(task.statusLower)) {
+			return false;
+		}
+		if (filters.taskTypes && !matchesTaskTypeFilter(task.task.type, filters.taskTypes)) {
 			return false;
 		}
 
@@ -412,6 +420,7 @@ export class SearchService {
 
 		const statuses = this.normalizeStringArray(filters.status);
 		const excludedStatuses = this.normalizeStringArray(filters.excludeStatus);
+		const taskTypes = this.normalizeStringArray(filters.type);
 		const priorities = this.normalizePriorityArray(filters.priority);
 		const assignees = this.normalizeStringArray(filters.assignee);
 		const labels = this.normalizeLabelsArray(filters.labels);
@@ -420,6 +429,7 @@ export class SearchService {
 		return {
 			statuses,
 			excludedStatuses,
+			taskTypes,
 			priorities,
 			assignees,
 			labels,

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -19,6 +19,7 @@ import {
 } from "../utils/prefix-config.ts";
 import { getTaskFilename, getTaskPath, normalizeTaskIdentity, taskIdsEqual } from "../utils/task-path.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
+import { matchesTaskTypeFilter } from "../utils/task-type-config.ts";
 
 // Interface for task path resolution context
 interface TaskPathContext {
@@ -460,6 +461,9 @@ export class FileSystem {
 			if (excluded.size > 0) {
 				tasks = tasks.filter((t) => !excluded.has(t.status.toLowerCase()));
 			}
+		}
+		if (filter?.type) {
+			tasks = tasks.filter((task) => matchesTaskTypeFilter(task.type, filter.type));
 		}
 
 		if (filter?.assignee) {

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -12,9 +12,10 @@ Recommended CLI commands:
 - `backlog task list --status "<todo status>" --plain`
 - `backlog task list --status "<active status>" --plain`
 - `backlog task list --exclude-status "<terminal status>" --plain`
+- `backlog task list --type {{TASK_TYPE:1}} --plain`
 - `backlog task list --search "desktop app" --labels frontend,bug --limit 20 --plain`
 
-Avoid broad unfiltered listing when the project may have many tasks. Use `--status`, `--exclude-status`, `--assignee`, `--unassigned`, `--parent`, `--priority`, `--labels`, `--search`, or `--limit` where applicable. Repeat `--exclude-status` or pass comma-separated configured statuses to exclude multiple states.
+Avoid broad unfiltered listing when the project may have many tasks. Use `--status`, `--exclude-status`, `--type`, `--assignee`, `--unassigned`, `--parent`, `--priority`, `--labels`, `--search`, or `--limit` where applicable. Repeat `--exclude-status` or pass comma-separated configured statuses to exclude multiple states. Repeat `--type` or pass comma-separated configured task types to include multiple types.
 
 Use `backlog task view {{TASK_ID:123}} --plain` to read full context for likely matches.
 

--- a/src/guidelines/mcp/overview-tools.md
+++ b/src/guidelines/mcp/overview-tools.md
@@ -48,7 +48,7 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 
 - `get_backlog_instructions`
 - `task_list`, `task_search`, `task_view`, `task_create`, `task_edit`, `task_complete`, `task_archive`
-- `task_search` accepts `modifiedFiles` for case-insensitive substring filtering against project-root-relative modified file paths
+- `task_list` and `task_search` accept configured task types with OR semantics; `task_search` also accepts `modifiedFiles` for case-insensitive substring filtering against project-root-relative modified file paths
 - `task_edit` accepts `commentsAppend` and optional `commentAuthor` to append task discussion or review comments
 - Comment bodies may contain Markdown, but standalone `---` lines are reserved as comment delimiters
 - `document_list`, `document_view`, `document_create`, `document_update`, `document_search`

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -52,8 +52,8 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 
 **Note:** "Done" tasks stay in the Done column until periodic cleanup moves them to the completed folder. Don't use `task_complete` immediately after finishing—it's for batch cleanup, not per-task workflow.
 
-- `task_list` — list tasks with optional filtering by status, assignee (or `unassigned: true`), milestone, labels, search, or limit
-- `task_search` — search tasks by title and description, or use `modifiedFiles` to filter by project-root-relative modified file path substrings
+- `task_list` — list tasks with optional filtering by status, configured task type, assignee (or `unassigned: true`), milestone, labels, search, or limit
+- `task_search` — search tasks by title and description, or filter by configured task type and project-root-relative `modifiedFiles` path substrings
 - `task_view` — read full task context (description, plan, notes, comments, final summary, acceptance criteria, Definition of Done)
 - `definition_of_done_defaults_get` — read project-level Definition of Done defaults from config
 - `definition_of_done_defaults_upsert` — replace project-level Definition of Done defaults in config

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -47,6 +47,7 @@ export type TaskCreateArgs = {
 
 export type TaskListArgs = {
 	status?: string;
+	type?: string[];
 	assignee?: string;
 	unassigned?: boolean;
 	milestone?: string;
@@ -58,6 +59,7 @@ export type TaskListArgs = {
 export type TaskSearchArgs = {
 	query?: string;
 	status?: string;
+	type?: string[];
 	priority?: SearchPriorityFilter;
 	modifiedFiles?: string[];
 	limit?: number;
@@ -156,9 +158,9 @@ export class TaskHandlers {
 		const priorities = config?.priorities;
 		if (this.isDraftStatus(args.status)) {
 			let drafts = await this.core.filesystem.listDrafts();
-			if (args.search) {
+			if (args.search || args.type?.length) {
 				const draftSearch = createTaskSearchIndex(drafts);
-				drafts = draftSearch.search({ query: args.search, status: "Draft" });
+				drafts = draftSearch.search({ query: args.search, status: "Draft", type: args.type });
 			}
 
 			if (args.assignee) {
@@ -227,6 +229,9 @@ export class TaskHandlers {
 		const filters: TaskListFilter = {};
 		if (args.status) {
 			filters.status = args.status;
+		}
+		if (args.type?.length) {
+			filters.type = args.type;
 		}
 		if (args.assignee) {
 			filters.assignee = args.assignee;
@@ -340,8 +345,8 @@ export class TaskHandlers {
 	async searchTasks(args: TaskSearchArgs): Promise<CallToolResult> {
 		const query = args.query?.trim() ?? "";
 		const modifiedFiles = args.modifiedFiles?.map((file) => file.trim()).filter((file) => file.length > 0);
-		if (!query && (!modifiedFiles || modifiedFiles.length === 0)) {
-			throw new BacklogToolError("Search query or modifiedFiles filter is required", "VALIDATION_ERROR");
+		if (!query && (!modifiedFiles || modifiedFiles.length === 0) && !args.type?.length) {
+			throw new BacklogToolError("Search query, modifiedFiles, or type filter is required", "VALIDATION_ERROR");
 		}
 
 		if (this.isDraftStatus(args.status)) {
@@ -350,6 +355,7 @@ export class TaskHandlers {
 			let draftMatches = searchIndex.search({
 				query,
 				status: "Draft",
+				type: args.type,
 				priority: args.priority,
 				modifiedFiles,
 			});
@@ -388,6 +394,7 @@ export class TaskHandlers {
 		let taskMatches = searchIndex.search({
 			query,
 			status: args.status,
+			type: args.type,
 			priority: args.priority,
 			modifiedFiles,
 		});

--- a/src/mcp/tools/tasks/index.ts
+++ b/src/mcp/tools/tasks/index.ts
@@ -4,18 +4,20 @@ import type { McpToolHandler } from "../../types.ts";
 import {
 	generateTaskCreateSchema,
 	generateTaskEditSchema,
+	generateTaskListSchema,
 	generateTaskSearchSchema,
 } from "../../utils/schema-generators.ts";
 import { createSimpleValidatedTool } from "../../validation/tool-wrapper.ts";
 import type { TaskCreateArgs, TaskEditRequest, TaskListArgs, TaskSearchArgs } from "./handlers.ts";
 import { TaskHandlers } from "./handlers.ts";
-import { taskArchiveSchema, taskCompleteSchema, taskListSchema, taskViewSchema } from "./schemas.ts";
+import { taskArchiveSchema, taskCompleteSchema, taskViewSchema } from "./schemas.ts";
 
 export function registerTaskTools(server: McpServer, config: BacklogConfig): void {
 	const handlers = new TaskHandlers(server);
 
 	const taskCreateSchema = generateTaskCreateSchema(config);
 	const taskEditSchema = generateTaskEditSchema(config);
+	const taskListSchema = generateTaskListSchema(config);
 	const taskSearchSchema = generateTaskSearchSchema(config);
 
 	const createTaskTool: McpToolHandler = createSimpleValidatedTool(
@@ -33,7 +35,7 @@ export function registerTaskTools(server: McpServer, config: BacklogConfig): voi
 		{
 			name: "task_list",
 			description:
-				"List Backlog.md tasks with optional filtering by status, assignee (or unassigned: true for tasks with no assignee), milestone, labels, and search",
+				"List Backlog.md tasks with optional filtering by status, type, assignee (or unassigned: true for tasks with no assignee), milestone, labels, and search",
 			inputSchema: taskListSchema,
 			annotations: { title: "List Tasks", readOnlyHint: true, destructiveHint: false },
 		},
@@ -44,7 +46,7 @@ export function registerTaskTools(server: McpServer, config: BacklogConfig): voi
 	const searchTaskTool: McpToolHandler = createSimpleValidatedTool(
 		{
 			name: "task_search",
-			description: "Search Backlog.md tasks by title, description, and modified file path filters",
+			description: "Search Backlog.md tasks by title, description, task type, and modified file path filters",
 			inputSchema: taskSearchSchema,
 			annotations: { title: "Search Tasks", readOnlyHint: true, destructiveHint: false },
 		},

--- a/src/mcp/tools/tasks/schemas.ts
+++ b/src/mcp/tools/tasks/schemas.ts
@@ -1,73 +1,9 @@
-import { getPriorityLabels } from "../../../utils/priority-config.ts";
+import { generateTaskListSchema, generateTaskSearchSchema } from "../../utils/schema-generators.ts";
 import type { JsonSchema } from "../../validation/validators.ts";
 
-export const taskListSchema: JsonSchema = {
-	type: "object",
-	properties: {
-		status: {
-			type: "string",
-			maxLength: 100,
-		},
-		assignee: {
-			type: "string",
-			maxLength: 100,
-		},
-		unassigned: {
-			type: "boolean",
-			description: "When true, only return tasks with no assignee. Cannot be combined with assignee.",
-		},
-		milestone: {
-			type: "string",
-			maxLength: 100,
-		},
-		labels: {
-			type: "array",
-			items: { type: "string", maxLength: 50 },
-		},
-		search: {
-			type: "string",
-			maxLength: 200,
-		},
-		limit: {
-			type: "number",
-			minimum: 1,
-			maximum: 1000,
-		},
-	},
-	required: [],
-	additionalProperties: false,
-};
+export const taskListSchema: JsonSchema = generateTaskListSchema({});
 
-export const taskSearchSchema: JsonSchema = {
-	type: "object",
-	properties: {
-		query: {
-			type: "string",
-			maxLength: 200,
-		},
-		status: {
-			type: "string",
-			maxLength: 100,
-		},
-		priority: {
-			type: "string",
-			enum: getPriorityLabels(),
-			enumCaseInsensitive: true,
-		},
-		modifiedFiles: {
-			type: "array",
-			items: { type: "string", maxLength: 500 },
-			description: "Filter tasks by case-insensitive substring match against modified file paths",
-		},
-		limit: {
-			type: "number",
-			minimum: 1,
-			maximum: 100,
-		},
-	},
-	required: [],
-	additionalProperties: false,
-};
+export const taskSearchSchema: JsonSchema = generateTaskSearchSchema({});
 
 export const taskViewSchema: JsonSchema = {
 	type: "object",

--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -1,6 +1,7 @@
-import { DEFAULT_STATUSES, DEFAULT_TASK_TYPES } from "../../constants/index.ts";
+import { DEFAULT_STATUSES } from "../../constants/index.ts";
 import type { BacklogConfig } from "../../types/index.ts";
 import { getPriorityLabels } from "../../utils/priority-config.ts";
+import { getTaskTypeValues } from "../../utils/task-type-config.ts";
 import type { JsonSchema } from "../validation/validators.ts";
 
 /**
@@ -39,8 +40,8 @@ export function generateStatusFieldSchema(config: BacklogConfig): JsonSchema {
  * Generates a task type field schema with dynamic enum values sourced from config.
  * No default is set: tasks without a type stay untyped.
  */
-function generateTypeFieldSchema(config: BacklogConfig): JsonSchema {
-	const types = config.types?.length ? config.types.map((type) => type.trim()) : [...DEFAULT_TASK_TYPES];
+function generateTypeFieldSchema(config: Pick<BacklogConfig, "types">): JsonSchema {
+	const types = getTaskTypeValues(config);
 
 	return {
 		type: "string",
@@ -51,10 +52,59 @@ function generateTypeFieldSchema(config: BacklogConfig): JsonSchema {
 	};
 }
 
+function generateTypeFilterSchema(config: Pick<BacklogConfig, "types">): JsonSchema {
+	return {
+		type: "array",
+		items: generateTypeFieldSchema(config),
+		maxItems: 50,
+		description: "Filter tasks by one or more configured task types (OR semantics).",
+	};
+}
+
+export function generateTaskListSchema(config: Pick<BacklogConfig, "types">): JsonSchema {
+	return {
+		type: "object",
+		properties: {
+			status: {
+				type: "string",
+				maxLength: 100,
+			},
+			type: generateTypeFilterSchema(config),
+			assignee: {
+				type: "string",
+				maxLength: 100,
+			},
+			unassigned: {
+				type: "boolean",
+				description: "When true, only return tasks with no assignee. Cannot be combined with assignee.",
+			},
+			milestone: {
+				type: "string",
+				maxLength: 100,
+			},
+			labels: {
+				type: "array",
+				items: { type: "string", maxLength: 50 },
+			},
+			search: {
+				type: "string",
+				maxLength: 200,
+			},
+			limit: {
+				type: "number",
+				minimum: 1,
+				maximum: 1000,
+			},
+		},
+		required: [],
+		additionalProperties: false,
+	};
+}
+
 /**
  * Generates a priority field schema with dynamic enum values sourced from config.
  */
-function generatePriorityFieldSchema(config: BacklogConfig): JsonSchema {
+function generatePriorityFieldSchema(config: Pick<BacklogConfig, "priorities">): JsonSchema {
 	const priorities = getPriorityLabels(config);
 
 	return {
@@ -439,7 +489,7 @@ export function generateTaskEditSchema(config: BacklogConfig): JsonSchema {
 	};
 }
 
-export function generateTaskSearchSchema(config: BacklogConfig): JsonSchema {
+export function generateTaskSearchSchema(config: Pick<BacklogConfig, "priorities" | "types">): JsonSchema {
 	return {
 		type: "object",
 		properties: {
@@ -451,6 +501,7 @@ export function generateTaskSearchSchema(config: BacklogConfig): JsonSchema {
 				type: "string",
 				maxLength: 100,
 			},
+			type: generateTypeFilterSchema(config),
 			priority: generatePriorityFieldSchema(config),
 			modifiedFiles: {
 				type: "array",

--- a/src/test/mcp-task-type-filtering.test.ts
+++ b/src/test/mcp-task-type-filtering.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { $ } from "bun";
+import { McpServer } from "../mcp/server.ts";
+import { registerTaskTools } from "../mcp/tools/tasks/index.ts";
+import type { JsonSchema } from "../mcp/validation/validators.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let testDir: string;
+let server: McpServer;
+
+function getText(content: unknown[] | undefined): string {
+	return (content ?? [])
+		.map((item) => (item as { text?: string }).text ?? "")
+		.filter(Boolean)
+		.join("\n\n");
+}
+
+describe("MCP task type filtering adapter", () => {
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("mcp-task-type-filtering");
+		server = new McpServer(testDir, "Test instructions");
+		await server.filesystem.ensureBacklogStructure();
+		await $`git init -b main`.cwd(testDir).quiet();
+		await $`git config user.name "Test User"`.cwd(testDir).quiet();
+		await $`git config user.email test@example.com`.cwd(testDir).quiet();
+		await initializeTestProject(server, "MCP Type Filter Project");
+
+		const config = await server.filesystem.loadConfig();
+		if (!config) throw new Error("Expected test config");
+		config.types = [" Bug ", "Epic", "bug", ""];
+		await server.filesystem.saveConfig(config);
+		registerTaskTools(server, config);
+
+		for (const args of [
+			{ title: "Typed bug", type: "bug", status: "To Do" },
+			{ title: "Typed epic", type: "epic", status: "In Progress" },
+			{ title: "Untyped legacy", status: "To Do" },
+		]) {
+			const result = await server.testInterface.callTool({
+				params: { name: "task_create", arguments: args },
+			});
+			expect(result.isError).not.toBe(true);
+		}
+	});
+
+	afterEach(async () => {
+		try {
+			await server.stop();
+		} catch {
+			// ignore cleanup errors
+		}
+		await safeCleanup(testDir);
+	});
+
+	it("exposes configured type arrays in list and search schemas", async () => {
+		const tools = await server.testInterface.listTools();
+		const byName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+		for (const toolName of ["task_list", "task_search"]) {
+			const schema = byName.get(toolName)?.inputSchema as JsonSchema | undefined;
+			const typeFilter = schema?.properties?.type;
+			expect(typeFilter?.type).toBe("array");
+			expect(typeFilter?.items?.enum).toEqual(["Bug", "Epic"]);
+			expect(typeFilter?.items?.enumCaseInsensitive).toBe(true);
+		}
+	});
+
+	it("reuses OR filtering and canonical casing for task_list", async () => {
+		const bugResult = await server.testInterface.callTool({
+			params: { name: "task_list", arguments: { type: ["BUG"] } },
+		});
+		const bugText = getText(bugResult.content);
+		expect(bugText).toContain("Typed bug");
+		expect(bugText).not.toContain("Typed epic");
+		expect(bugText).not.toContain("Untyped legacy");
+
+		const composedResult = await server.testInterface.callTool({
+			params: { name: "task_list", arguments: { type: ["bug", "EPIC"], status: "To Do" } },
+		});
+		const composedText = getText(composedResult.content);
+		expect(composedText).toContain("Typed bug");
+		expect(composedText).not.toContain("Typed epic");
+		expect(composedText).not.toContain("Untyped legacy");
+	});
+
+	it("supports type-only and text-plus-type task_search calls", async () => {
+		const typeOnly = await server.testInterface.callTool({
+			params: { name: "task_search", arguments: { type: ["Epic"] } },
+		});
+		const typeOnlyText = getText(typeOnly.content);
+		expect(typeOnlyText).toContain("Typed epic");
+		expect(typeOnlyText).not.toContain("Typed bug");
+		expect(typeOnlyText).not.toContain("Untyped legacy");
+
+		const searched = await server.testInterface.callTool({
+			params: { name: "task_search", arguments: { query: "Typed", type: ["bug"] } },
+		});
+		const searchedText = getText(searched.content);
+		expect(searchedText).toContain("Typed bug");
+		expect(searchedText).not.toContain("Typed epic");
+	});
+
+	it("validates filters against configured task types", async () => {
+		const result = await server.testInterface.callTool({
+			params: { name: "task_list", arguments: { type: ["feature"] } },
+		});
+		expect(result.isError).toBe(true);
+		expect(getText(result.content)).toContain("must be one of: Bug, Epic");
+	});
+
+	it("applies the same type filter to drafts", async () => {
+		for (const args of [
+			{ title: "Bug draft", type: "Bug", status: "Draft" },
+			{ title: "Epic draft", type: "Epic", status: "Draft" },
+		]) {
+			const result = await server.testInterface.callTool({
+				params: { name: "task_create", arguments: args },
+			});
+			expect(result.isError).not.toBe(true);
+		}
+
+		const listed = await server.testInterface.callTool({
+			params: { name: "task_list", arguments: { status: "Draft", type: ["Bug"] } },
+		});
+		const listedText = getText(listed.content);
+		expect(listedText).toContain("Bug draft");
+		expect(listedText).not.toContain("Epic draft");
+
+		const searched = await server.testInterface.callTool({
+			params: { name: "task_search", arguments: { query: "draft", status: "Draft", type: ["Epic"] } },
+		});
+		const searchedText = getText(searched.content);
+		expect(searchedText).toContain("Epic draft");
+		expect(searchedText).not.toContain("Bug draft");
+	});
+});

--- a/src/test/task-type-filtering.test.ts
+++ b/src/test/task-type-filtering.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { ContentStore } from "../core/content-store.ts";
+import { createTaskSearchIndex } from "../utils/task-search.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let testDir: string;
+let core: Core;
+
+describe("task type filtering", () => {
+	const cliPath = join(process.cwd(), "src", "cli.ts");
+
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("task-type-filtering");
+		await mkdir(testDir, { recursive: true });
+		core = new Core(testDir);
+		await $`git init -b main`.cwd(testDir).quiet();
+		await $`git config user.name "Test User"`.cwd(testDir).quiet();
+		await $`git config user.email test@example.com`.cwd(testDir).quiet();
+
+		await initializeTestProject(core, "Task Type Filtering");
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Expected test config");
+		await core.filesystem.saveConfig({ ...config, types: ["Bug", "Feature", "Spike"] });
+
+		await core.createTaskFromInput(
+			{
+				title: "Shared API failure",
+				type: "bug",
+				status: "To Do",
+				priority: "high",
+				labels: ["api", "urgent"],
+			},
+			false,
+		);
+		await core.createTaskFromInput(
+			{
+				title: "Shared API capability",
+				type: "feature",
+				status: "In Progress",
+				priority: "medium",
+				labels: ["api"],
+			},
+			false,
+		);
+		await core.createTaskFromInput(
+			{
+				title: "Shared API exploration",
+				type: "spike",
+				status: "To Do",
+				priority: "low",
+				labels: ["research"],
+			},
+			false,
+		);
+		await core.createTaskFromInput({ title: "Shared legacy task", status: "To Do" }, false);
+	});
+
+	afterEach(async () => {
+		core.disposeSearchService();
+		core.disposeContentStore();
+		await safeCleanup(testDir);
+	});
+
+	it("applies OR type semantics through Core queries with and without search text", async () => {
+		const bugs = await core.queryTasks({ filters: { type: "bug" }, includeCrossBranch: false });
+		expect(bugs.map((task) => task.title)).toEqual(["Shared API failure"]);
+
+		const bugsAndSpikes = await core.queryTasks({
+			query: "Shared API",
+			filters: { type: ["BUG", "spike"] },
+			includeCrossBranch: false,
+		});
+		expect(bugsAndSpikes.map((task) => task.title).sort()).toEqual(["Shared API exploration", "Shared API failure"]);
+		expect(bugsAndSpikes.some((task) => task.type === undefined)).toBe(false);
+	});
+
+	it("composes type with status, priority, labels, and exclude-status filters", async () => {
+		const tasks = await core.queryTasks({
+			filters: {
+				type: ["Bug", "Feature"],
+				status: "To Do",
+				excludeStatus: "Done",
+				priority: "high",
+				labels: ["urgent"],
+			},
+			includeCrossBranch: false,
+		});
+		expect(tasks.map((task) => task.title)).toEqual(["Shared API failure"]);
+	});
+
+	it("uses the same type semantics in direct filesystem, content-store, and interactive search helpers", async () => {
+		const filesystemTasks = await core.filesystem.listTasks({ type: ["feature", "SPIKE"] });
+		expect(filesystemTasks.map((task) => task.title).sort()).toEqual([
+			"Shared API capability",
+			"Shared API exploration",
+		]);
+
+		const store = new ContentStore(core.filesystem);
+		try {
+			await store.ensureInitialized();
+			expect(store.getTasks({ type: "BUG" }).map((task) => task.title)).toEqual(["Shared API failure"]);
+			const interactiveMatches = createTaskSearchIndex(store.getTasks()).search({
+				query: "Shared API",
+				type: ["Bug", "Spike"],
+			});
+			expect(interactiveMatches.map((task) => task.title).sort()).toEqual([
+				"Shared API exploration",
+				"Shared API failure",
+			]);
+		} finally {
+			store.dispose();
+		}
+	});
+
+	it("filters CLI task list with repeated and comma-separated canonicalized values", async () => {
+		const comma = await $`bun ${cliPath} task list --type bug,spike --plain`.cwd(testDir).quiet();
+		const repeated = await $`bun ${cliPath} task list --type BUG --type Spike --plain`.cwd(testDir).quiet();
+
+		for (const result of [comma, repeated]) {
+			expect(result.exitCode).toBe(0);
+			const output = result.stdout.toString();
+			expect(output).toContain("Shared API failure");
+			expect(output).toContain("Shared API exploration");
+			expect(output).not.toContain("Shared API capability");
+			expect(output).not.toContain("Shared legacy task");
+		}
+	});
+
+	it("filters CLI search by task type and composes with existing filters", async () => {
+		const search =
+			await $`bun ${cliPath} search "Shared API" --task-type bug,feature --status "To Do" --priority high --plain`
+				.cwd(testDir)
+				.quiet();
+		expect(search.exitCode).toBe(0);
+		const output = search.stdout.toString();
+		expect(output).toContain("Shared API failure");
+		expect(output).not.toContain("Shared API capability");
+		expect(output).not.toContain("Shared API exploration");
+
+		const typeOnly = await $`bun ${cliPath} search --task-type Feature --plain`.cwd(testDir).quiet();
+		expect(typeOnly.stdout.toString()).toContain("Shared API capability");
+		expect(typeOnly.stdout.toString()).not.toContain("Documents:");
+	});
+
+	it("rejects invalid configured task types clearly", async () => {
+		const list = await $`bun ${cliPath} task list --type chore --plain`.cwd(testDir).nothrow().quiet();
+		expect(list.exitCode).toBe(1);
+		expect(list.stderr.toString()).toContain("Invalid type: chore. Valid types are: Bug, Feature, Spike");
+
+		const search = await $`bun ${cliPath} search --task-type chore --plain`.cwd(testDir).nothrow().quiet();
+		expect(search.exitCode).toBe(1);
+		expect(search.stderr.toString()).toContain("Invalid task-type: chore. Valid types are: Bug, Feature, Spike");
+	});
+
+	it("documents configured task-type filters without changing search result-type semantics", async () => {
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Expected test config");
+		await core.filesystem.saveConfig({ ...config, types: ["Bug", "Epic"] });
+
+		const listHelp = await $`bun ${cliPath} task list --help`.cwd(testDir).text();
+		const searchHelp = await $`bun ${cliPath} search --help`.cwd(testDir).text();
+		expect(listHelp).toContain("--type <type>");
+		expect(listHelp).toContain("type: one or more of configured task types: Bug, Epic");
+		expect(listHelp).toContain('backlog task list --type "Bug" --plain');
+		expect(searchHelp).toContain("--type <type>");
+		expect(searchHelp).toContain("--task-type <type>");
+		expect(searchHelp).toContain("task-type: one or more of configured task types: Bug, Epic");
+		expect(searchHelp).toContain('backlog search "crash" --task-type "Bug" --plain');
+
+		const taskCreationGuide = await $`bun ${cliPath} instructions task-creation`.cwd(testDir).text();
+		expect(taskCreationGuide).toContain('backlog task list --type "Bug" --plain');
+		expect(taskCreationGuide).not.toContain("--type bug,spike");
+
+		const advertisedList = await $`bun ${cliPath} task list --type Bug --plain`.cwd(testDir).quiet();
+		const advertisedSearch = await $`bun ${cliPath} search "Shared API" --task-type Bug --plain`.cwd(testDir).quiet();
+		expect(advertisedList.exitCode).toBe(0);
+		expect(advertisedSearch.exitCode).toBe(0);
+
+		for (const completionLine of ["backlog task list --type ", "backlog search --task-type "]) {
+			const completion =
+				await $`bun ${cliPath} completion __complete ${completionLine} ${String(completionLine.length)}`
+					.cwd(testDir)
+					.quiet();
+			expect(completion.stdout.toString().trim().split("\n")).toEqual(["Bug", "Epic"]);
+		}
+		for (const unsupportedLine of ["backlog task create --task-type ", "backlog task list --task-type "]) {
+			const completion =
+				await $`bun ${cliPath} completion __complete ${unsupportedLine} ${String(unsupportedLine.length)}`
+					.cwd(testDir)
+					.quiet();
+			expect(completion.stdout.toString().trim()).toBe("");
+		}
+
+		const incompatible = await $`bun ${cliPath} search --type document --task-type Bug --plain`
+			.cwd(testDir)
+			.nothrow()
+			.quiet();
+		expect(incompatible.exitCode).toBe(1);
+		expect(incompatible.stderr.toString()).toContain(
+			"--task-type filters task results. Include --type task or omit --type.",
+		);
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -173,6 +173,7 @@ export interface TaskUpdateInput {
 export interface TaskListFilter {
 	status?: string;
 	excludeStatus?: string | string[];
+	type?: string | string[];
 	assignee?: string;
 	unassigned?: boolean;
 	priority?: string;
@@ -247,6 +248,7 @@ export interface SearchMatch {
 export interface SearchFilters {
 	status?: string | string[];
 	excludeStatus?: string | string[];
+	type?: string | string[];
 	priority?: SearchPriorityFilter | SearchPriorityFilter[];
 	assignee?: string | string[];
 	labels?: string | string[];

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -9,6 +9,7 @@ import { labelsToLower } from "./label-filter.ts";
 import { NO_MILESTONE_FILTER_VALUE } from "./milestone-filter.ts";
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "./modified-files.ts";
 import { normalizePriorityValue } from "./priority-config.ts";
+import { matchesTaskTypeFilter } from "./task-type-config.ts";
 
 export type LabelMatchMode = "any" | "all";
 
@@ -16,6 +17,7 @@ export interface TaskSearchOptions {
 	query?: string;
 	status?: string;
 	excludeStatus?: string | string[];
+	type?: string | string[];
 	priority?: string;
 	labels?: string[];
 	labelMatch?: LabelMatchMode;
@@ -25,6 +27,7 @@ export interface TaskSearchOptions {
 export interface SharedTaskFilterOptions {
 	query?: string;
 	excludeStatus?: string | string[];
+	type?: string | string[];
 	priority?: string;
 	labels?: string[];
 	labelMatch?: LabelMatchMode;
@@ -188,6 +191,9 @@ export function createTaskSearchIndex(tasks: Task[]): TaskSearchIndex {
 					results = results.filter((t) => !excluded.has(t.statusLower));
 				}
 			}
+			if (options.type) {
+				results = results.filter((task) => matchesTaskTypeFilter(task.task.type, options.type));
+			}
 
 			// Apply priority filter
 			if (options.priority) {
@@ -249,6 +255,7 @@ export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, inde
 		query ||
 			options.status ||
 			options.excludeStatus ||
+			options.type ||
 			options.priority ||
 			(options.labels && options.labels.length > 0) ||
 			(options.modifiedFiles && options.modifiedFiles.length > 0),
@@ -259,6 +266,7 @@ export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, inde
 				query,
 				status: options.status,
 				excludeStatus: options.excludeStatus,
+				type: options.type,
 				priority: options.priority,
 				labels: options.labels,
 				labelMatch: options.labelMatch,
@@ -283,6 +291,7 @@ export function applySharedTaskFilters(
 		{
 			query: options.query,
 			excludeStatus: options.excludeStatus,
+			type: options.type,
 			priority: options.priority,
 			labels: options.labels,
 			labelMatch: options.labelMatch,

--- a/src/utils/task-type-config.ts
+++ b/src/utils/task-type-config.ts
@@ -41,6 +41,44 @@ export function resolveTaskTypeValue(
 	return getTaskTypeValues(configOrTypes).find((type) => normalizeTaskTypeValue(type) === normalized);
 }
 
+export function resolveTaskTypeValues(
+	inputs: readonly string[],
+	configOrTypes?: TaskTypeConfig,
+): { values: string[]; invalid: string[] } {
+	const values: string[] = [];
+	const invalid: string[] = [];
+	const seen = new Set<string>();
+
+	for (const input of inputs) {
+		const canonical = resolveTaskTypeValue(input, configOrTypes);
+		if (!canonical) {
+			invalid.push(input);
+			continue;
+		}
+		const normalized = normalizeTaskTypeValue(canonical);
+		if (!normalized || seen.has(normalized)) {
+			continue;
+		}
+		seen.add(normalized);
+		values.push(canonical);
+	}
+
+	return { values, invalid };
+}
+
+export function matchesTaskTypeFilter(
+	taskType: string | null | undefined,
+	filter: string | readonly string[] | null | undefined,
+): boolean {
+	const filters = typeof filter === "string" ? [filter] : (filter ?? []);
+	const allowed = new Set(filters.map(normalizeTaskTypeValue).filter((value): value is string => Boolean(value)));
+	if (allowed.size === 0) {
+		return true;
+	}
+	const normalizedTaskType = normalizeTaskTypeValue(taskType);
+	return normalizedTaskType ? allowed.has(normalizedTaskType) : false;
+}
+
 export function formatValidTaskTypeValues(configOrTypes?: TaskTypeConfig): string {
 	return getTaskTypeValues(configOrTypes).join(", ");
 }


### PR DESCRIPTION
Alex's Agent: Adds CLI-first task-type filtering through the shared task query/search paths, with MCP retained as a thin compatibility adapter.

#747 has merged. This branch is rebased as one BACK-355.04 commit on main at a89045999208a374c4ef4e41d405db5ffa7f70aa.

What changed

- backlog task list --type accepts repeated or comma-separated configured types with OR semantics.
- backlog search --task-type filters task results while preserving the existing search --type result-kind contract.
- Filter values validate case-insensitively and retain configured casing; untyped tasks do not match an explicit filter, and no synthetic untyped value is introduced.
- Core, ContentStore, FileSystem, SearchService, and interactive task search share the same matching behavior and compose with status, exclude-status, priority, and labels.
- MCP task_list and task_search reuse the shared behavior with configuration-derived schemas, including drafts and type-only searches.
- Help schemas, shipped CLI guidance, and shell completion derive configured type values and expose them only for supported commands.
- MCP schemas use the canonical task-type normalizer, removing whitespace, empty entries, and case-insensitive duplicates.
- This PR does not add Web or TUI controls.

Verification

- Focused task-type suite: 30 passed, 190 assertions, 0 failed.
- Full suite: 1,507 passed, 2 documented interactive PTY skips, 0 failed, 5,197 assertions.
- bunx tsc --noEmit passed.
- bun run check . passed across 313 files.
- bun run build passed.
- Compiled Bug/Epic help, shipped-guide, list, search, and positive/negative completion smokes passed.

Refs #746
Builds on #747
