### PR TITLE
BACK-355.05 - TUI: Display task type in board and detail views

### DIFF
--- a/backlog/tasks/back-355.05 - TUI-Display-task-type-in-board-and-detail-views.md
+++ b/backlog/tasks/back-355.05 - TUI-Display-task-type-in-board-and-detail-views.md
@@ -1,13 +1,30 @@
 ---
 id: BACK-355.05
 title: 'TUI: Display task type in board and detail views'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@impl_types_tui'
 created_date: '2026-01-01 23:37'
+updated_date: '2026-07-09 23:09'
 labels:
   - tui
 dependencies:
   - task-355.01
+modified_files:
+  - src/cli.ts
+  - src/ui/board.ts
+  - src/ui/components/filter-header.ts
+  - src/ui/components/filter-popup.ts
+  - src/ui/components/help-popup.ts
+  - src/ui/enhanced-views.ts
+  - src/ui/simple-unified-view.ts
+  - src/ui/task-type.ts
+  - src/ui/task-viewer-with-search.ts
+  - src/ui/unified-view.ts
+  - src/test/board-ui.test.ts
+  - src/test/help-popup.test.ts
+  - src/test/tui-task-type.test.ts
+  - src/test/unified-view-filters.test.ts
 parent_task_id: BACK-355
 priority: medium
 ---
@@ -20,8 +37,43 @@ Add visual representation of task types in the terminal UI board view and task d
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Task cards on kanban board display type with icon or abbreviated badge
-- [ ] #2 Task detail view shows type field
-- [ ] #3 Type uses distinct visual styling (color or icon) for quick recognition
-- [ ] #4 Board can be filtered by type (keyboard shortcut or menu option)
+- [x] #1 Task cards on kanban board display type with icon or abbreviated badge
+- [x] #2 Task detail view shows type field
+- [x] #3 Type uses distinct visual styling (color or icon) for quick recognition
+- [x] #4 Board can be filtered by type (keyboard shortcut or menu option)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Extend the shared TUI filter header/state with a configured multi-select task-type control and T shortcut.
+2. Carry task-type filter state through CLI-seeded unified list/board views and apply the existing shared type matcher.
+3. Add one compact, styled task-type badge used by board cards, task-list rows, and detail metadata while leaving untyped tasks unbadged.
+4. Add focused regression coverage, then verify focused/full tests, typecheck, Biome, build, and real source plus compiled TUI interaction in a PTY.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Discovery: L2 TUI/state change. Reusing label multi-select, priority configured-value plumbing, shared task-search type matching, and the existing task popup metadata path. Interactive CLI --type must become session filter state rather than an irreversible prefiltered dataset.
+
+Implemented shared configured multi-select task-type filtering across task-list and Kanban TUI views with the T shortcut. CLI-seeded --type filters now remain editable session state instead of permanently narrowing the loaded dataset. Added a shared magenta [type] badge before titles so it stays visible in narrow board columns; the detail pane/popup renders Type metadata, while untyped tasks remain unbadged. Simplification/UX pass also removed duplicated text from shared multi-select choices.
+
+Validation: focused TUI/type suite 38 pass; full suite 1511 pass, 2 expected interactive skips, 0 fail; bunx tsc --noEmit; bun run check .; bun run build; git diff --check. Manual PTY QA covered source and compiled binaries, picker selection, list/board state sharing, detail popup, default types, custom Bug/Epic casing, and untyped behavior.
+<!-- SECTION:NOTES:END -->
+
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @impl_types_tui
+created: 2026-07-09 23:09
+---
+Ready for independent review. PTY QA found and fixed the duplicated multi-select copy before handoff.
+---
+<!-- COMMENTS:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed human-facing TUI task-type support: compact styled badges in list/board, Type metadata in details, and configurable multi-select filtering shared across views and seeded from CLI --type. Verified default/custom/untyped flows in real PTYs and the compiled binary, with 1511 tests passing and all static/build checks green.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1945,7 +1945,7 @@ addHelpSchema(program.command("search [query]"), {
 			return;
 		}
 
-		const requiresPrefilteredTaskSet = Boolean(modifiedFileFilters?.length || filters.type?.length);
+		const requiresPrefilteredTaskSet = Boolean(modifiedFileFilters?.length);
 		const interactiveTasks = requiresPrefilteredTaskSet ? searchResultTasks : allTasks;
 		if (interactiveTasks.length === 0) {
 			printSearchResults(searchResults);
@@ -1976,6 +1976,7 @@ addHelpSchema(program.command("search [query]"), {
 				}),
 				status: statusFilter,
 				excludeStatus: filters.excludeStatus,
+				type: filters.type,
 				priority: priorityFilter,
 				searchQuery: query ?? "", // Pre-populate search with the query
 			},
@@ -2420,6 +2421,7 @@ addHelpSchema(taskCmd.command("list"), {
 			excludeStatus?: string[];
 			assignee?: string;
 			milestone?: string;
+			type?: string[];
 			priority?: string;
 			sort?: string;
 			labels?: string[];
@@ -2434,6 +2436,7 @@ addHelpSchema(taskCmd.command("list"), {
 			excludeStatus: Array.isArray(baseFilters.excludeStatus) ? baseFilters.excludeStatus : undefined,
 			assignee: options.assignee,
 			milestone: options.milestone,
+			type: Array.isArray(baseFilters.type) ? baseFilters.type : baseFilters.type ? [baseFilters.type] : undefined,
 			priority: baseFilters.priority,
 			sort: options.sort,
 			labels: labelFilters,
@@ -2457,9 +2460,6 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 		if (parentId) {
 			interactiveLoaderFilters.parentTaskId = parentId;
-		}
-		if (baseFilters.type) {
-			interactiveLoaderFilters.type = baseFilters.type;
 		}
 		await runUnifiedView({
 			core,

--- a/src/test/board-ui.test.ts
+++ b/src/test/board-ui.test.ts
@@ -62,6 +62,7 @@ describe("Board TUI Logic", () => {
 			searchQuery: "",
 			excludeStatus: [],
 			priorityFilter: "",
+			typeFilter: [],
 			labelFilter: [],
 			milestoneFilter: "",
 		};
@@ -72,6 +73,7 @@ describe("Board TUI Logic", () => {
 
 		it("blocks moves when visible board filters are active", () => {
 			expect(hasMoveBlockingBoardFilters({ ...baseFilters, searchQuery: "auth" })).toBe(true);
+			expect(hasMoveBlockingBoardFilters({ ...baseFilters, typeFilter: ["bug"] })).toBe(true);
 			expect(hasMoveBlockingBoardFilters({ ...baseFilters, labelFilter: ["bug"] })).toBe(true);
 		});
 	});

--- a/src/test/help-popup.test.ts
+++ b/src/test/help-popup.test.ts
@@ -8,6 +8,7 @@ describe("help popup shortcuts", () => {
 		const keys = keysFor("board");
 
 		expect(keys).toContain("F");
+		expect(keys).toContain("T");
 		expect(keys).toContain("M");
 		expect(keys).toContain("←→");
 	});
@@ -16,6 +17,7 @@ describe("help popup shortcuts", () => {
 		const keys = keysFor("task-list");
 
 		expect(keys).toContain("s");
+		expect(keys).toContain("t");
 		expect(keys).toContain("l");
 		expect(keys).not.toContain("F");
 		expect(keys).not.toContain("M");

--- a/src/test/tui-task-type.test.ts
+++ b/src/test/tui-task-type.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "../types/index.ts";
+import { formatTaskListItem } from "../ui/board.ts";
+import { formatTaskTypeBadge } from "../ui/task-type.ts";
+import { createTaskPopup } from "../ui/task-viewer-with-search.ts";
+import { createScreen } from "../ui/tui.ts";
+
+const createTask = (overrides: Partial<Task> = {}): Task => ({
+	id: "TASK-1",
+	title: "Typed task",
+	status: "To Do",
+	assignee: [],
+	createdDate: "2026-07-10",
+	labels: [],
+	dependencies: [],
+	...overrides,
+});
+
+const getPopupContent = (contentArea: unknown): string => {
+	const content = contentArea as { getContent?: () => string; content?: string } | undefined;
+	return String(content?.getContent ? content.getContent() : (content?.content ?? ""));
+};
+
+describe("TUI task type display", () => {
+	it("formats configured values as a distinct badge and omits untyped values", () => {
+		expect(formatTaskTypeBadge(" Epic ")).toBe("{magenta-fg}[Epic]{/}");
+		expect(formatTaskTypeBadge(undefined)).toBe("");
+		expect(formatTaskTypeBadge("   ")).toBe("");
+	});
+
+	it("shows the type badge on board task cards", () => {
+		const typed = formatTaskListItem(createTask({ type: "Epic" }));
+		const untyped = formatTaskListItem(createTask());
+
+		expect(typed).toContain("{magenta-fg}[Epic]{/}");
+		expect(untyped).not.toContain("{magenta-fg}");
+	});
+
+	it("shows the type field in task details and hides it for untyped tasks", async () => {
+		const screen = createScreen({ smartCSR: false });
+		const originalIsTTY = process.stdout.isTTY;
+		let patchedTTY = false;
+
+		try {
+			if (process.stdout.isTTY === false) {
+				Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+				patchedTTY = true;
+			}
+
+			const typedPopup = await createTaskPopup(screen, createTask({ type: "Epic" }));
+			const typedContent = getPopupContent(typedPopup?.contentArea);
+			expect(typedContent).toContain("Type:");
+			expect(typedContent).toContain("[Epic]");
+			typedPopup?.close();
+
+			const untypedPopup = await createTaskPopup(screen, createTask({ id: "TASK-2" }));
+			const untypedContent = getPopupContent(untypedPopup?.contentArea);
+			expect(untypedContent).not.toContain("Type:");
+			untypedPopup?.close();
+		} finally {
+			if (patchedTTY) {
+				Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, configurable: true });
+			}
+			screen.destroy();
+		}
+	});
+});

--- a/src/test/unified-view-filters.test.ts
+++ b/src/test/unified-view-filters.test.ts
@@ -11,6 +11,46 @@ import { NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
 import { applyTaskFilters } from "../utils/task-search.ts";
 
 describe("unified view filter state", () => {
+	it("carries task type filters into kanban and applies them to typed tasks only", () => {
+		const tasks: Task[] = [
+			{
+				id: "task-1",
+				title: "Epic task",
+				status: "To Do",
+				type: "Epic",
+				assignee: [],
+				createdDate: "2026-07-10",
+				labels: [],
+				dependencies: [],
+			},
+			{
+				id: "task-2",
+				title: "Bug task",
+				status: "To Do",
+				type: "Bug",
+				assignee: [],
+				createdDate: "2026-07-10",
+				labels: [],
+				dependencies: [],
+			},
+			{
+				id: "task-3",
+				title: "Untyped task",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2026-07-10",
+				labels: [],
+				dependencies: [],
+			},
+		];
+		const unified = createUnifiedViewFilters({ type: ["Epic"] });
+		const shared = createKanbanSharedFilters(unified);
+
+		expect(unified.typeFilter).toEqual(["Epic"]);
+		expect(shared.typeFilter).toEqual(["Epic"]);
+		expect(filterTasksForKanban(tasks, shared).map((task) => task.id)).toEqual(["task-1"]);
+	});
+
 	it("initializes milestone filter from options", () => {
 		const labels = ["backend"];
 		const filters = createUnifiedViewFilters({
@@ -47,6 +87,7 @@ describe("unified view filter state", () => {
 			searchQuery: "api",
 			statusFilter: "To Do",
 			excludeStatus: [],
+			typeFilter: [],
 			priorityFilter: "",
 			labelFilter: ["infra"],
 			milestoneFilter: "Sprint 7",
@@ -71,6 +112,7 @@ describe("unified view filter state", () => {
 			searchQuery: "api auth",
 			statusFilter: "",
 			excludeStatus: [],
+			typeFilter: [],
 			priorityFilter: "high",
 			labelFilter: ["frontend", "bug"],
 			milestoneFilter: "",
@@ -108,6 +150,7 @@ describe("unified view filter state", () => {
 			searchQuery: "api",
 			statusFilter: "",
 			excludeStatus: [],
+			typeFilter: [],
 			priorityFilter: "",
 			labelFilter: [],
 			milestoneFilter: "",
@@ -128,6 +171,7 @@ describe("unified view filter state", () => {
 			searchQuery: "auth",
 			statusFilter: "",
 			excludeStatus: [],
+			typeFilter: [],
 			priorityFilter: "",
 			labelFilter: ["frontend", "bug"],
 			milestoneFilter: "",
@@ -147,6 +191,7 @@ describe("unified view filter state", () => {
 			searchQuery: "",
 			statusFilter: "",
 			excludeStatus: [],
+			typeFilter: [],
 			priorityFilter: "",
 			labelFilter: ["frontend", "bug"],
 			labelMatch: "any",

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -14,6 +14,7 @@ import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../utils/m
 import { getPriorityOptions } from "../utils/priority-config.ts";
 import { applySharedTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { compareTaskIds } from "../utils/task-sorting.ts";
+import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
 import { createFilterHeader, type FilterHeader, type FilterState } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
@@ -21,6 +22,7 @@ import { openHelpPopup } from "./components/help-popup.ts";
 import { formatFooterContent } from "./footer-content.ts";
 import { getStatusIcon } from "./status-icon.ts";
 import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-lifecycle.ts";
+import { formatTaskTypeBadge } from "./task-type.ts";
 import {
 	createTaskPopup,
 	resolveSearchExitTargetIndex,
@@ -37,6 +39,7 @@ export type ColumnData = {
 type BoardSharedFilters = {
 	searchQuery: string;
 	excludeStatus?: string[];
+	typeFilter?: string[];
 	priorityFilter: string;
 	labelFilter: string[];
 	milestoneFilter: string;
@@ -46,6 +49,7 @@ type BoardSharedFilters = {
 export function hasMoveBlockingBoardFilters(filters: BoardSharedFilters): boolean {
 	return Boolean(
 		filters.searchQuery.trim() ||
+			(filters.typeFilter?.length ?? 0) > 0 ||
 			filters.priorityFilter ||
 			filters.labelFilter.length > 0 ||
 			filters.milestoneFilter ||
@@ -138,11 +142,13 @@ export function formatTaskListItem(task: Task, isMoving = false): string {
 		? ` {cyan-fg}${task.assignee[0].startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
 		: "";
 	const labels = task.labels?.length ? ` {yellow-fg}[${task.labels.join(", ")}]{/}` : "";
+	const typeBadge = formatTaskTypeBadge(task.type);
+	const type = typeBadge ? ` ${typeBadge}` : "";
 	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 	const branch = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
 
 	// Cross-branch tasks are dimmed to indicate read-only status
-	const content = `{bold}${task.id}{/bold} - ${task.title}${assignee}${labels}${branch}`;
+	const content = `{bold}${task.id}{/bold}${type} - ${task.title}${assignee}${labels}${branch}`;
 	if (isMoving) {
 		return `{magenta-fg}► ${content}{/}`;
 	}
@@ -165,7 +171,7 @@ function formatColumnLabel(status: string, count: number): string {
 }
 
 const DEFAULT_FOOTER_CONTENT =
-	" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[P/F/I]{/} Filter | {cyan-fg}[←→/↑↓]{/} Nav | {cyan-fg}[Enter]{/} Details | {cyan-fg}[E/M/C/A]{/} Edit/Move/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
+	" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[T/P/F/I]{/} Filter | {cyan-fg}[←→/↑↓]{/} Nav | {cyan-fg}[Enter]{/} Details | {cyan-fg}[E/M/C/A]{/} Edit/Move/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 
 export function shouldRebuildColumns(current: ColumnData[], next: ColumnData[]): boolean {
 	if (current.length !== next.length) {
@@ -210,6 +216,7 @@ export async function renderBoardTui(
 		filters?: {
 			searchQuery: string;
 			excludeStatus?: string[];
+			typeFilter?: string[];
 			priorityFilter: string;
 			labelFilter: string[];
 			labelMatch?: LabelMatchMode;
@@ -219,9 +226,11 @@ export async function renderBoardTui(
 		availableLabels?: string[];
 		availableMilestones?: string[];
 		priorities?: string[];
+		types?: string[];
 		onFilterChange?: (filters: {
 			searchQuery: string;
 			excludeStatus?: string[];
+			typeFilter: string[];
 			priorityFilter: string;
 			labelFilter: string[];
 			labelMatch?: LabelMatchMode;
@@ -275,9 +284,11 @@ export async function renderBoardTui(
 		let modalOpen = false;
 		let pendingSearchWrap: "to-first" | "to-last" | null = null;
 		let programmaticColumnSelection = false;
+		const configuredTaskTypes = getTaskTypeValues(options?.types);
 		const sharedFilters = {
 			searchQuery: options?.filters?.searchQuery ?? "",
 			excludeStatus: [...(options?.filters?.excludeStatus ?? [])],
+			typeFilter: resolveTaskTypeValues(options?.filters?.typeFilter ?? [], configuredTaskTypes).values,
 			priorityFilter: options?.filters?.priorityFilter ?? "",
 			labelFilter: [...(options?.filters?.labelFilter ?? [])],
 			labelMatch: options?.filters?.labelMatch ?? "any",
@@ -329,6 +340,7 @@ export async function renderBoardTui(
 			Boolean(
 				sharedFilters.searchQuery.trim() ||
 					sharedFilters.excludeStatus.length > 0 ||
+					sharedFilters.typeFilter.length > 0 ||
 					sharedFilters.priorityFilter ||
 					sharedFilters.labelFilter.length > 0 ||
 					sharedFilters.milestoneFilter ||
@@ -339,6 +351,7 @@ export async function renderBoardTui(
 			options?.onFilterChange?.({
 				searchQuery: sharedFilters.searchQuery,
 				excludeStatus: [...sharedFilters.excludeStatus],
+				typeFilter: [...sharedFilters.typeFilter],
 				priorityFilter: sharedFilters.priorityFilter,
 				labelFilter: [...sharedFilters.labelFilter],
 				labelMatch: sharedFilters.labelMatch,
@@ -357,6 +370,7 @@ export async function renderBoardTui(
 					{
 						query: sharedFilters.searchQuery,
 						excludeStatus: sharedFilters.excludeStatus,
+						type: sharedFilters.typeFilter,
 						priority: sharedFilters.priorityFilter || undefined,
 						labels: sharedFilters.labelFilter,
 						labelMatch: sharedFilters.labelMatch,
@@ -660,11 +674,14 @@ export async function renderBoardTui(
 			return columns;
 		};
 
-		const focusFilterControl = (filterId: "search" | "priority" | "milestone" | "labels") => {
+		const focusFilterControl = (filterId: "search" | "type" | "priority" | "milestone" | "labels") => {
 			if (!filterHeader) return;
 			switch (filterId) {
 				case "search":
 					filterHeader.focusSearch();
+					break;
+				case "type":
+					filterHeader.focusType();
 					break;
 				case "priority":
 					filterHeader.focusPriority();
@@ -678,12 +695,28 @@ export async function renderBoardTui(
 			}
 		};
 
-		const openFilterPicker = async (filterId: "priority" | "milestone" | "labels") => {
+		const openFilterPicker = async (filterId: "type" | "priority" | "milestone" | "labels") => {
 			if (filterPopupOpen || modalOpen || moveOp || !filterHeader) {
 				return;
 			}
 			filterPopupOpen = true;
 			try {
+				if (filterId === "type") {
+					const nextTypes = await openMultiSelectFilterPopup({
+						screen,
+						title: "Task Type Filter",
+						items: configuredTaskTypes,
+						selectedItems: sharedFilters.typeFilter,
+					});
+					if (nextTypes !== null) {
+						sharedFilters.typeFilter = nextTypes;
+						filterHeader.setFilters({ taskTypes: nextTypes });
+						emitFilterChange();
+						renderView();
+					}
+					return;
+				}
+
 				if (filterId === "labels") {
 					const nextLabels = await openMultiSelectFilterPopup({
 						screen,
@@ -748,9 +781,10 @@ export async function renderBoardTui(
 			statuses: [],
 			availableLabels: configuredLabels,
 			availableMilestones,
-			visibleFilters: ["search", "priority", "milestone", "labels"],
+			visibleFilters: ["search", "type", "priority", "milestone", "labels"],
 			initialFilters: {
 				search: sharedFilters.searchQuery,
+				taskTypes: sharedFilters.typeFilter,
 				priority: sharedFilters.priorityFilter,
 				labels: sharedFilters.labelFilter,
 				milestone: sharedFilters.milestoneFilter,
@@ -758,6 +792,7 @@ export async function renderBoardTui(
 			onFilterChange: (filters: FilterState) => {
 				const labelsChanged = !areLabelSelectionsEqual(sharedFilters.labelFilter, filters.labels);
 				sharedFilters.searchQuery = filters.search;
+				sharedFilters.typeFilter = filters.taskTypes;
 				sharedFilters.priorityFilter = filters.priority;
 				sharedFilters.labelFilter = filters.labels;
 				if (labelsChanged) {
@@ -928,6 +963,11 @@ export async function renderBoardTui(
 		screen.key(["p", "P"], () => {
 			if (popupOpen || filterPopupOpen || modalOpen || moveOp) return;
 			void openFilterPicker("priority");
+		});
+
+		screen.key(["t", "T"], () => {
+			if (popupOpen || filterPopupOpen || modalOpen || moveOp) return;
+			void openFilterPicker("type");
 		});
 
 		screen.key(["f", "F"], () => {

--- a/src/ui/components/filter-header.ts
+++ b/src/ui/components/filter-header.ts
@@ -8,11 +8,12 @@ import { box, textbox } from "neo-neo-bblessed";
 import { formatLabelSummary } from "../../utils/label-filter.ts";
 import { NO_MILESTONE_FILTER_LABEL, NO_MILESTONE_FILTER_VALUE } from "../../utils/milestone-filter.ts";
 
-export type FilterControlId = "search" | "status" | "priority" | "labels" | "milestone";
+export type FilterControlId = "search" | "status" | "type" | "priority" | "labels" | "milestone";
 
 export interface FilterState {
 	search: string;
 	status: string;
+	taskTypes: string[];
 	priority: string;
 	labels: string[];
 	milestone: string;
@@ -50,6 +51,7 @@ interface LayoutResult {
 const ALL_FILTER_ITEMS: FilterItem[] = [
 	{ id: "search", labelText: "Search:", labelWidth: 8, minWidth: 28, flexGrow: true },
 	{ id: "status", labelText: "Status:", labelWidth: 8, minWidth: 22, flexGrow: false },
+	{ id: "type", labelText: "Type:", labelWidth: 6, minWidth: 18, flexGrow: false },
 	{ id: "priority", labelText: "Priority:", labelWidth: 9, minWidth: 20, flexGrow: false },
 	{ id: "milestone", labelText: "Milestone:", labelWidth: 10, minWidth: 22, flexGrow: false },
 	{ id: "labels", labelText: "Labels:", labelWidth: 8, minWidth: 18, flexGrow: false },
@@ -130,6 +132,7 @@ export class FilterHeader {
 	// Element references for focus management and updates
 	private searchInput: TextboxInterface | null = null;
 	private statusButton: BoxInterface | null = null;
+	private typeButton: BoxInterface | null = null;
 	private priorityButton: BoxInterface | null = null;
 	private milestoneButton: BoxInterface | null = null;
 	private labelsButton: BoxInterface | null = null;
@@ -148,6 +151,7 @@ export class FilterHeader {
 		this.state = {
 			search: options.initialFilters?.search ?? "",
 			status: options.initialFilters?.status ?? "",
+			taskTypes: options.initialFilters?.taskTypes ?? [],
 			priority: options.initialFilters?.priority ?? "",
 			labels: options.initialFilters?.labels ?? [],
 			milestone: options.initialFilters?.milestone ?? "",
@@ -197,6 +201,10 @@ export class FilterHeader {
 			this.state.status = filters.status;
 			this.updateStatusButton();
 		}
+		if (filters.taskTypes !== undefined) {
+			this.state.taskTypes = filters.taskTypes;
+			this.updateTypeButton();
+		}
 		if (filters.priority !== undefined) {
 			this.state.priority = filters.priority;
 			this.updatePriorityButton();
@@ -235,6 +243,10 @@ export class FilterHeader {
 
 	focusStatus(): void {
 		this.statusButton?.focus();
+	}
+
+	focusType(): void {
+		this.typeButton?.focus();
 	}
 
 	focusPriority(): void {
@@ -339,6 +351,9 @@ export class FilterHeader {
 			case "status":
 				this.focusStatus();
 				break;
+			case "type":
+				this.focusType();
+				break;
 			case "priority":
 				this.focusPriority();
 				break;
@@ -358,6 +373,7 @@ export class FilterHeader {
 		this.elements = [];
 		this.searchInput = null;
 		this.statusButton = null;
+		this.typeButton = null;
 		this.priorityButton = null;
 		this.milestoneButton = null;
 		this.labelsButton = null;
@@ -415,6 +431,9 @@ export class FilterHeader {
 				break;
 			case "status":
 				this.buildPopupButton("status", controlX, y, controlWidth);
+				break;
+			case "type":
+				this.buildPopupButton("type", controlX, y, controlWidth);
 				break;
 			case "priority":
 				this.buildPopupButton("priority", controlX, y, controlWidth);
@@ -540,6 +559,7 @@ export class FilterHeader {
 		this.elements.push(button);
 
 		if (field === "status") this.statusButton = button;
+		if (field === "type") this.typeButton = button;
 		if (field === "priority") this.priorityButton = button;
 		if (field === "milestone") this.milestoneButton = button;
 		if (field === "labels") this.labelsButton = button;
@@ -599,6 +619,10 @@ export class FilterHeader {
 		switch (field) {
 			case "status":
 				return this.state.status ? `${this.state.status} ▼` : "All ▼";
+			case "type":
+				if (this.state.taskTypes.length === 0) return "All ▼";
+				if (this.state.taskTypes.length === 1) return `${this.state.taskTypes[0]} ▼`;
+				return `${this.state.taskTypes.length} selected ▼`;
 			case "priority":
 				return this.state.priority ? `${this.state.priority} ▼` : "All ▼";
 			case "milestone":
@@ -616,6 +640,11 @@ export class FilterHeader {
 	private updateStatusButton(): void {
 		if (!this.statusButton) return;
 		this.statusButton.setContent(this.getPopupButtonContent("status"));
+	}
+
+	private updateTypeButton(): void {
+		if (!this.typeButton) return;
+		this.typeButton.setContent(this.getPopupButtonContent("type"));
 	}
 
 	private updatePriorityButton(): void {

--- a/src/ui/components/filter-popup.ts
+++ b/src/ui/components/filter-popup.ts
@@ -254,6 +254,7 @@ export async function openMultiSelectFilterPopup(options: {
 			title: "",
 			items: selectableItems,
 			multiSelect: true,
+			itemRenderer: (item) => item.title,
 			selectedIndices,
 			top: 0,
 			left: 0,

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -12,6 +12,7 @@ type Shortcut = {
 const BOARD_SHORTCUTS: Shortcut[] = [
 	{ key: "Tab", desc: "Switch View (Kanban/List)" },
 	{ key: "/", desc: "Search tasks" },
+	{ key: "T", desc: "Filter by Type" },
 	{ key: "P", desc: "Filter by Priority" },
 	{ key: "F", desc: "Filter by Labels" },
 	{ key: "I", desc: "Filter by Milestone" },
@@ -31,6 +32,7 @@ const TASK_LIST_SHORTCUTS: Shortcut[] = [
 	{ key: "Tab", desc: "Switch View (Kanban/List)" },
 	{ key: "/", desc: "Search tasks" },
 	{ key: "s", desc: "Filter by Status" },
+	{ key: "t", desc: "Filter by Type" },
 	{ key: "p", desc: "Filter by Priority" },
 	{ key: "l", desc: "Filter by Labels" },
 	{ key: "i", desc: "Filter by Milestone" },

--- a/src/ui/enhanced-views.ts
+++ b/src/ui/enhanced-views.ts
@@ -187,6 +187,7 @@ async function renderBoardTuiWithSwitching(
 	return renderBoardTui(tasks, statuses, layout, maxColumnWidth, {
 		dateFormat: config?.dateFormat,
 		priorities: config?.priorities,
+		types: config?.types,
 	});
 }
 

--- a/src/ui/simple-unified-view.ts
+++ b/src/ui/simple-unified-view.ts
@@ -123,6 +123,7 @@ export async function runSimpleUnifiedView(options: SimpleUnifiedViewOptions): P
 			},
 			dateFormat: config?.dateFormat,
 			priorities: config?.priorities,
+			types: config?.types,
 		});
 
 		isRunning = false;

--- a/src/ui/task-type.ts
+++ b/src/ui/task-type.ts
@@ -1,0 +1,4 @@
+export function formatTaskTypeBadge(taskType: string | null | undefined): string {
+	const value = taskType?.trim();
+	return value ? `{magenta-fg}[${value}]{/}` : "";
+}

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -18,6 +18,7 @@ import { hasAnyPrefix } from "../utils/prefix-config.ts";
 import { formatPriorityLabel, getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
 import { applyTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
+import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
 import { formatChecklistItem } from "./checklist.ts";
 import { transformCodePaths } from "./code-path.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
@@ -35,6 +36,7 @@ import { formatHeading } from "./heading.ts";
 import { createLoadingScreen } from "./loading.ts";
 import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-icon.ts";
 import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-lifecycle.ts";
+import { formatTaskTypeBadge } from "./task-type.ts";
 import { addScrollKeys, createScreen } from "./tui.ts";
 
 function getPriorityDisplay(priority?: string): string {
@@ -171,6 +173,7 @@ export async function viewTaskEnhanced(
 		searchQuery?: string;
 		statusFilter?: string;
 		excludeStatus?: string[];
+		typeFilter?: string[];
 		priorityFilter?: string;
 		milestoneFilter?: string;
 		labelFilter?: string[];
@@ -185,6 +188,7 @@ export async function viewTaskEnhanced(
 			searchQuery: string;
 			statusFilter: string;
 			excludeStatus: string[];
+			typeFilter: string[];
 			priorityFilter: string;
 			labelFilter: string[];
 			labelMatch?: LabelMatchMode;
@@ -206,6 +210,7 @@ export async function viewTaskEnhanced(
 	let statuses: string[];
 	let labels: string[];
 	let priorityOptions = getPriorityOptions();
+	let configuredTaskTypes = getTaskTypeValues();
 	let availableLabels: string[] = [];
 	// When tasks are provided, use in-memory search; otherwise use ContentStore-backed search
 	let taskSearchIndex: ReturnType<typeof createTaskSearchIndex> | null = null;
@@ -223,6 +228,7 @@ export async function viewTaskEnhanced(
 		statuses = config?.statuses || ["To Do", "In Progress", "Done"];
 		labels = config?.labels || [];
 		priorityOptions = getPriorityOptions(config);
+		configuredTaskTypes = getTaskTypeValues(config);
 		dateFormat = config?.dateFormat;
 		taskSearchIndex = createTaskSearchIndex(allTasks);
 	} else {
@@ -234,6 +240,7 @@ export async function viewTaskEnhanced(
 			statuses = config?.statuses || ["To Do", "In Progress", "Done"];
 			labels = config?.labels || [];
 			priorityOptions = getPriorityOptions(config);
+			configuredTaskTypes = getTaskTypeValues(config);
 			dateFormat = config?.dateFormat;
 
 			loadingScreen?.update("Loading tasks from branches...");
@@ -263,6 +270,7 @@ export async function viewTaskEnhanced(
 	}
 	const excludeStatusFilter = [...(options.excludeStatus ?? [])];
 
+	let taskTypeFilter = resolveTaskTypeValues(options.typeFilter ?? [], configuredTaskTypes).values;
 	let priorityFilter = normalizePriorityValue(options.priorityFilter) || "";
 	let labelFilter: string[] = [];
 	let milestoneFilter = options.milestoneFilter || "";
@@ -279,6 +287,7 @@ export async function viewTaskEnhanced(
 		searchQuery ||
 			statusFilter ||
 			excludeStatusFilter.length > 0 ||
+			taskTypeFilter.length > 0 ||
 			priorityFilter ||
 			labelFilter.length > 0 ||
 			milestoneFilter ||
@@ -323,6 +332,9 @@ export async function viewTaskEnhanced(
 			case "status":
 				filterHeader.focusStatus();
 				break;
+			case "type":
+				filterHeader.focusType();
+				break;
 			case "priority":
 				filterHeader.focusPriority();
 				break;
@@ -342,6 +354,22 @@ export async function viewTaskEnhanced(
 		filterPopupOpen = true;
 
 		try {
+			if (filterId === "type") {
+				const nextTypes = await openMultiSelectFilterPopup({
+					screen,
+					title: "Task Type Filter",
+					items: configuredTaskTypes,
+					selectedItems: taskTypeFilter,
+				});
+				if (nextTypes !== null) {
+					taskTypeFilter = nextTypes;
+					filterHeader.setFilters({ taskTypes: nextTypes });
+					applyFilters();
+					notifyFilterChange();
+				}
+				return;
+			}
+
 			if (filterId === "labels") {
 				const nextLabels = await openMultiSelectFilterPopup({
 					screen,
@@ -425,6 +453,7 @@ export async function viewTaskEnhanced(
 		initialFilters: {
 			search: searchQuery,
 			status: statusFilter,
+			taskTypes: taskTypeFilter,
 			priority: priorityFilter,
 			labels: labelFilter,
 			milestone: milestoneFilter,
@@ -433,6 +462,7 @@ export async function viewTaskEnhanced(
 			const labelsChanged = !areLabelSelectionsEqual(labelFilter, filters.labels);
 			searchQuery = filters.search;
 			statusFilter = filters.status;
+			taskTypeFilter = filters.taskTypes;
 			priorityFilter = filters.priority;
 			labelFilter = filters.labels;
 			if (labelsChanged) {
@@ -596,6 +626,7 @@ export async function viewTaskEnhanced(
 				searchQuery,
 				statusFilter,
 				excludeStatus: excludeStatusFilter,
+				typeFilter: taskTypeFilter,
 				priorityFilter,
 				labelFilter,
 				labelMatch,
@@ -610,6 +641,7 @@ export async function viewTaskEnhanced(
 			searchQuery.trim() ||
 				statusFilter ||
 				excludeStatusFilter.length > 0 ||
+				taskTypeFilter.length > 0 ||
 				priorityFilter ||
 				labelFilter.length > 0 ||
 				milestoneFilter,
@@ -624,6 +656,7 @@ export async function viewTaskEnhanced(
 					query: searchQuery,
 					status: statusFilter || undefined,
 					excludeStatus: excludeStatusFilter,
+					type: taskTypeFilter,
 					priority: priorityFilter || undefined,
 					labels: labelFilter,
 					labelMatch,
@@ -638,6 +671,7 @@ export async function viewTaskEnhanced(
 				filters: {
 					status: statusFilter || undefined,
 					excludeStatus: excludeStatusFilter,
+					type: taskTypeFilter,
 					priority: priorityFilter || undefined,
 					labels: labelFilter.length > 0 ? labelFilter : undefined,
 				},
@@ -686,6 +720,9 @@ export async function viewTaskEnhanced(
 			}
 			if (excludeStatusFilter.length > 0) {
 				activeFilters.push(`Exclude status: {cyan-fg}${excludeStatusFilter.join(", ")}{/}`);
+			}
+			if (taskTypeFilter.length > 0) {
+				activeFilters.push(`Type: {magenta-fg}${taskTypeFilter.join(", ")}{/}`);
 			}
 			if (priorityFilter) {
 				activeFilters.push(`Priority: {cyan-fg}${priorityFilter}{/}`);
@@ -820,11 +857,13 @@ export async function viewTaskEnhanced(
 					? ` {cyan-fg}${task.assignee[0]?.startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
 					: "";
 				const labelsText = task.labels?.length ? ` {yellow-fg}[${task.labels.join(", ")}]{/}` : "";
+				const typeBadge = formatTaskTypeBadge(task.type);
+				const typeText = typeBadge ? ` ${typeBadge}` : "";
 				const priorityText = getPriorityDisplay(task.priority);
 				const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 				const branchText = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
 
-				const content = `${wrapStatusColor(statusIcon, statusColor)} {bold}${task.id}{/bold} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
+				const content = `${wrapStatusColor(statusIcon, statusColor)} {bold}${task.id}{/bold}${typeText} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
 				// Dim cross-branch tasks to indicate read-only status
 				return isCrossBranch ? `{gray-fg}${content}{/}` : content;
 			},
@@ -1071,7 +1110,7 @@ export async function viewTaskEnhanced(
 		} else {
 			// Task list help
 			content =
-				" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[s/p/i/l]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
+				" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[s/t/p/i/l]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 		}
 
 		setHelpBarContent(content);
@@ -1227,6 +1266,11 @@ export async function viewTaskEnhanced(
 	screen.key(["s", "S"], () => {
 		if (modalOpen) return;
 		void openFilterPicker("status");
+	});
+
+	screen.key(["t", "T"], () => {
+		if (modalOpen || filterPopupOpen) return;
+		void openFilterPicker("type");
 	});
 
 	screen.key(["p", "P"], () => {
@@ -1406,6 +1450,9 @@ function generateDetailContent(
 		const priorityDisplay = getPriorityDisplay(task.priority);
 		const priorityText = formatPriorityLabel(task.priority);
 		metadata.push(`{bold}Priority:{/bold} ${priorityText}${priorityDisplay}`);
+	}
+	if (task.type) {
+		metadata.push(`{bold}Type:{/bold} ${formatTaskTypeBadge(task.type)}`);
 	}
 	if (task.assignee?.length) {
 		const assigneeList = task.assignee.map((a) => (a.startsWith("@") ? a : `@${a}`)).join(", ");

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -26,6 +26,7 @@ export interface UnifiedViewOptions {
 	filter?: {
 		status?: string;
 		assignee?: string;
+		type?: string[];
 		priority?: string;
 		labels?: string[];
 		labelMatch?: LabelMatchMode;
@@ -60,6 +61,7 @@ export interface UnifiedViewFilters {
 	searchQuery: string;
 	statusFilter: string;
 	excludeStatus: string[];
+	typeFilter: string[];
 	priorityFilter: string;
 	labelFilter: string[];
 	labelMatch?: LabelMatchMode;
@@ -67,12 +69,13 @@ export interface UnifiedViewFilters {
 	limit?: number;
 }
 
-type UnifiedViewFilterUpdate = Omit<UnifiedViewFilters, "excludeStatus"> &
-	Partial<Pick<UnifiedViewFilters, "excludeStatus">>;
+type UnifiedViewFilterUpdate = Omit<UnifiedViewFilters, "excludeStatus" | "typeFilter"> &
+	Partial<Pick<UnifiedViewFilters, "excludeStatus" | "typeFilter">>;
 
 export interface KanbanSharedFilters {
 	searchQuery: string;
 	excludeStatus: string[];
+	typeFilter?: string[];
 	priorityFilter: string;
 	labelFilter: string[];
 	labelMatch?: LabelMatchMode;
@@ -84,6 +87,7 @@ export function createKanbanSharedFilters(filters: UnifiedViewFilters): KanbanSh
 	return {
 		searchQuery: filters.searchQuery,
 		excludeStatus: [...filters.excludeStatus],
+		typeFilter: [...filters.typeFilter],
 		priorityFilter: filters.priorityFilter,
 		labelFilter: [...filters.labelFilter],
 		labelMatch: filters.labelMatch,
@@ -100,6 +104,7 @@ export function filterTasksForKanban(
 	if (
 		!filters.searchQuery.trim() &&
 		filters.excludeStatus.length === 0 &&
+		(filters.typeFilter?.length ?? 0) === 0 &&
 		!filters.priorityFilter &&
 		filters.labelFilter.length === 0 &&
 		!filters.milestoneFilter
@@ -113,6 +118,7 @@ export function filterTasksForKanban(
 		{
 			query: filters.searchQuery,
 			excludeStatus: filters.excludeStatus,
+			type: filters.typeFilter,
 			priority: filters.priorityFilter || undefined,
 			labels: filters.labelFilter,
 			labelMatch: filters.labelMatch ?? "any",
@@ -129,6 +135,7 @@ export function createUnifiedViewFilters(filter: UnifiedViewOptions["filter"] | 
 		searchQuery: filter?.searchQuery || "",
 		statusFilter: filter?.status || "",
 		excludeStatus: [...(filter?.excludeStatus || [])],
+		typeFilter: [...(filter?.type || [])],
 		priorityFilter: filter?.priority || "",
 		labelFilter: [...(filter?.labels || [])],
 		labelMatch: filter?.labelMatch ?? "any",
@@ -146,6 +153,7 @@ export function mergeUnifiedViewFilters(
 		searchQuery: update.searchQuery,
 		statusFilter: update.statusFilter,
 		excludeStatus: [...(update.excludeStatus ?? current.excludeStatus)],
+		typeFilter: [...(update.typeFilter ?? current.typeFilter)],
 		priorityFilter: update.priorityFilter,
 		labelFilter: [...update.labelFilter],
 		labelMatch: update.labelMatch ?? current.labelMatch ?? "any",
@@ -363,6 +371,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					searchQuery: currentFilters.searchQuery,
 					statusFilter: currentFilters.statusFilter,
 					excludeStatus: currentFilters.excludeStatus,
+					typeFilter: currentFilters.typeFilter,
 					priorityFilter: currentFilters.priorityFilter,
 					labelFilter: currentFilters.labelFilter,
 					labelMatch: currentFilters.labelMatch,
@@ -420,6 +429,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 							searchQuery: filters.searchQuery,
 							statusFilter: currentFilters.statusFilter,
 							excludeStatus: filters.excludeStatus,
+							typeFilter: [...filters.typeFilter],
 							priorityFilter: filters.priorityFilter,
 							labelFilter: [...filters.labelFilter],
 							labelMatch: filters.labelMatch ?? currentFilters.labelMatch ?? "any",
@@ -436,6 +446,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					startupWarning,
 					dateFormat: config?.dateFormat,
 					priorities: config?.priorities,
+					types: config?.types,
 				}).then(() => {
 					// If user wants to exit, do it immediately
 					if (result === "exit") {


### PR DESCRIPTION
Alex's Agent: Completes the human-facing TUI portion of task type support.

## Summary

- show a compact magenta `[type]` badge before task titles in task-list and Kanban views, while leaving untyped tasks unbadged
- show the Type field in the task detail pane and popup
- add a configured multi-select Task Type filter with the `T` shortcut, shared across list and board views
- keep CLI-seeded `--type` values as editable TUI session state so users can change or clear them
- keep picker copy compact and preserve configured custom type casing

## UX verification

Tested in real PTYs against both the source CLI and rebuilt compiled binary: default types, custom `Bug`/`Epic` values, picker selection, list-to-board state sharing, board detail popup, and untyped behavior.

## Validation

- `bun test` — 1511 pass, 2 expected interactive skips, 0 fail
- focused TUI/type suite — 38 pass, 0 fail
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- `git diff --check`

Refs #746