### PR TITLE
BACK-355.06 - Web UI: Display and edit task type

### DIFF
--- a/backlog/tasks/back-355.06 - Web-UI-Display-and-edit-task-type.md
+++ b/backlog/tasks/back-355.06 - Web-UI-Display-and-edit-task-type.md
@@ -3,13 +3,18 @@ id: BACK-355.06
 title: 'Web UI: Display and edit task type'
 status: Done
 assignee:
-  - '@impl_types_web'
+  - '@pr751-takeover'
 created_date: '2026-01-01 23:38'
-updated_date: '2026-07-09 23:25'
+updated_date: '2026-07-10 17:15'
 labels:
   - web
 dependencies:
   - task-355.01
+modified_files:
+  - src/web/components/Board.tsx
+  - src/web/components/TaskDetailsModal.tsx
+  - src/test/web-board-filters.test.tsx
+  - src/test/web-task-types.test.tsx
 parent_task_id: BACK-355
 priority: medium
 ---
@@ -42,15 +47,15 @@ Add task type display and editing capabilities to the web interface, including t
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Context brief: L2 cross-surface change. Reuse TaskCard badge, TaskDetailsModal priority selector, BoardPage/Board URL filter, and server priority mutation patterns. Use getTaskTypeValues/resolveTaskTypeValue/matchesTaskTypeFilter so custom casing and defaults remain canonical. Existing untyped tasks must render no badge and create must default to No type. Historical types removed from config must remain visible without being silently rewritten; cross-branch selectors remain disabled. Mobile is intentionally out of scope.
+Implemented the Web task-type flow through the existing Core validation path: configured and default type display, create and edit selectors with No type as the default, historical removed values preserved without silent rewrites, deterministic badges, canonical URL-backed board filtering, accessible create and edit errors, and latest-request-wins state handling. The board header now uses intentional title/action and controls rows after rendered QA exposed an accidental wrap.
 
-Implemented the Web task-type flow through the existing Core validation path: create/update API pass-through, configured/default type selector with No type as the create default, legacy configured-value preservation, deterministic distinct badges, and canonical URL-backed board filtering. Adjusted the desktop board header into intentional title/action and controls rows after visual QA exposed an accidental wrap.
+Integrated current main non-destructively and preserved the landed task-route behavior from #755: cosmetic slugs, exact task identity, board query preservation through task links and sidebar search, coherent close/Back/Forward history, focus return, stale-route rejection, and fail-closed missing or ambiguous task errors.
 
-Validation after rebasing onto origin/main f48225bd: 39 focused server/Web tests passed; bunx tsc --noEmit, bun run check ., bun run build, and the full bun test suite passed. Browser plugin was unavailable, so the permitted Playwright fallback used cached Playwright 1.60/Chromium at 1440x1000 against the compiled binary. Verified page identity, meaningful content, no framework overlay, custom/default/untyped badges, filter URL and results, create default/options, create 201, edit 200, keyboard focus, and zero console warnings/errors or page errors. Screenshots: /tmp/backlog-back-35506-web.O3wQN6/qa-screenshots/{board-types,board-filtered,task-detail-type,task-create-type,board-created}.png. Mobile remains intentionally out of scope.
+Final verification on frozen binary diff 5a51d769c15a99b1179fba4f1913f5ea70286e3b797bfa49b3c8b47ba5f0e86f: focused route/type/layout tests 37/37 passed with 314 assertions; authoritative full suite 1599 passed, 2 expected interactive TUI skips, 0 failed, 6465 assertions across 1601 tests and 185 files; bunx tsc --noEmit, bun run check ., git diff --check, and bun run build passed. Chrome QA at 1440x1000 and desktop-browser stress at 390x844 verified the two-row header, custom/default/untyped and historical badges, URL filtering, create/edit/clear and validation recovery, keyboard and history behavior, no document overflow, Kanban-owned horizontal scrolling, modal-owned vertical scrolling, zero framework overlays, and zero console warnings or errors.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Completed human-facing task types in the desktop Web UI. Task cards now show consistent, distinct badges; task detail and create flows expose configured type selectors without defaulting existing or new tasks; edits and clears persist through Core validation; and the board has a canonical URL-backed type filter. Added focused server and React coverage and verified the compiled desktop flow visually with custom and untyped tasks.
+Completed the human-facing Web task-type workflow with configured badges, create/edit/clear selectors, canonical URL filtering, accessible validation recovery, and race-safe refresh behavior. Preserved #755 route, query, history, focus, and fail-closed task identity behavior while integrating current main, and repaired the board header into intentional title/action and controls rows. Verified with 37 focused tests, the full 1599-pass suite with 2 expected skips and 0 failures, all static/build gates, and Chrome at 1440x1000 plus 390x844.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-355.06 - Web-UI-Display-and-edit-task-type.md
+++ b/backlog/tasks/back-355.06 - Web-UI-Display-and-edit-task-type.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-355.06
 title: 'Web UI: Display and edit task type'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@impl_types_web'
 created_date: '2026-01-01 23:38'
+updated_date: '2026-07-09 23:25'
 labels:
   - web
 dependencies:
@@ -20,10 +22,35 @@ Add task type display and editing capabilities to the web interface, including t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Task cards display type badge with appropriate styling
-- [ ] #2 Task detail modal shows type field
-- [ ] #3 Task create form includes type dropdown selector
-- [ ] #4 Task edit allows changing type via dropdown
-- [ ] #5 Type badges use consistent color scheme for visual distinction
-- [ ] #6 Board view can be filtered by type
+- [x] #1 Task cards display type badge with appropriate styling
+- [x] #2 Task detail modal shows type field
+- [x] #3 Task create form includes type dropdown selector
+- [x] #4 Task edit allows changing type via dropdown
+- [x] #5 Type badges use consistent color scheme for visual distinction
+- [x] #6 Board view can be filtered by type
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Pass task type through the Web create/update API while relying on core configured-value validation.
+2. Add a reusable task-type badge and configured selector to desktop task cards and task detail/create flows, preserving untyped and read-only behavior.
+3. Add a URL-backed board type filter using the shared type configuration helpers.
+4. Cover server mutations and Web display/create/edit/filter behavior with focused tests, then run desktop rendered QA and the full validation suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Context brief: L2 cross-surface change. Reuse TaskCard badge, TaskDetailsModal priority selector, BoardPage/Board URL filter, and server priority mutation patterns. Use getTaskTypeValues/resolveTaskTypeValue/matchesTaskTypeFilter so custom casing and defaults remain canonical. Existing untyped tasks must render no badge and create must default to No type. Historical types removed from config must remain visible without being silently rewritten; cross-branch selectors remain disabled. Mobile is intentionally out of scope.
+
+Implemented the Web task-type flow through the existing Core validation path: create/update API pass-through, configured/default type selector with No type as the create default, legacy configured-value preservation, deterministic distinct badges, and canonical URL-backed board filtering. Adjusted the desktop board header into intentional title/action and controls rows after visual QA exposed an accidental wrap.
+
+Validation after rebasing onto origin/main f48225bd: 39 focused server/Web tests passed; bunx tsc --noEmit, bun run check ., bun run build, and the full bun test suite passed. Browser plugin was unavailable, so the permitted Playwright fallback used cached Playwright 1.60/Chromium at 1440x1000 against the compiled binary. Verified page identity, meaningful content, no framework overlay, custom/default/untyped badges, filter URL and results, create default/options, create 201, edit 200, keyboard focus, and zero console warnings/errors or page errors. Screenshots: /tmp/backlog-back-35506-web.O3wQN6/qa-screenshots/{board-types,board-filtered,task-detail-type,task-create-type,board-created}.png. Mobile remains intentionally out of scope.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Completed human-facing task types in the desktop Web UI. Task cards now show consistent, distinct badges; task detail and create flows expose configured type selectors without defaulting existing or new tasks; edits and clears persist through Core validation; and the board has a canonical URL-backed type filter. Added focused server and React coverage and verified the compiled desktop flow visually with custom and untyped tasks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-355.06 - Web-UI-Display-and-edit-task-type.md
+++ b/backlog/tasks/back-355.06 - Web-UI-Display-and-edit-task-type.md
@@ -5,12 +5,21 @@ status: Done
 assignee:
   - '@pr751-takeover'
 created_date: '2026-01-01 23:38'
-updated_date: '2026-07-10 17:15'
+updated_date: '2026-07-10 17:22'
 labels:
   - web
 dependencies:
   - task-355.01
 modified_files:
+  - src/server/index.ts
+  - src/test/server-search-endpoint.test.ts
+  - src/test/web-task-detail-deeplink.test.tsx
+  - src/web/App.tsx
+  - src/web/components/BoardPage.tsx
+  - src/web/components/SideNavigation.tsx
+  - src/web/components/TaskCard.tsx
+  - src/web/components/TaskColumn.tsx
+  - src/web/components/TaskTypeBadge.tsx
   - src/web/components/Board.tsx
   - src/web/components/TaskDetailsModal.tsx
   - src/test/web-board-filters.test.tsx

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -883,6 +883,7 @@ export class BacklogServer {
 				description: payload.description,
 				status: payload.status,
 				priority: payload.priority,
+				type: typeof payload.type === "string" ? payload.type : undefined,
 				milestone,
 				labels: payload.labels,
 				assignee: payload.assignee,
@@ -948,6 +949,10 @@ export class BacklogServer {
 
 		if ("priority" in updates && typeof updates.priority === "string") {
 			updateInput.priority = updates.priority;
+		}
+
+		if ("type" in updates && typeof updates.type === "string") {
+			updateInput.type = updates.type;
 		}
 
 		if ("milestone" in updates && (typeof updates.milestone === "string" || updates.milestone === null)) {

--- a/src/test/server-search-endpoint.test.ts
+++ b/src/test/server-search-endpoint.test.ts
@@ -299,16 +299,33 @@ describe("BacklogServer search endpoint", () => {
 	});
 
 	it("rejects unsupported task types from the Web task API", async () => {
-		const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks`, {
+		const createResponse = await fetch(`http://127.0.0.1:${serverPort}/api/tasks`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ title: "Invalid typed task", status: "To Do", type: "Epic" }),
 		});
 
-		expect(response.status).toBe(400);
-		expect(await response.json()).toEqual({
+		expect(createResponse.status).toBe(400);
+		expect(await createResponse.json()).toEqual({
 			error: "Invalid type: Epic. Valid types are: Bug, Feature, Customer Request",
 		});
+
+		const created = await fetchJson<Task>("/api/tasks", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Keep valid type", status: "To Do", type: "Bug" }),
+		});
+		const updateResponse = await fetch(`http://127.0.0.1:${serverPort}/api/tasks/${created.id}`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ type: "Epic" }),
+		});
+
+		expect(updateResponse.status).toBe(400);
+		expect(await updateResponse.json()).toEqual({
+			error: "Invalid type: Epic. Valid types are: Bug, Feature, Customer Request",
+		});
+		expect((await fetchJson<Task>(`/api/task/${created.id}`)).type).toBe("Bug");
 	});
 
 	it("appends comments through the task update API and indexes comment text", async () => {

--- a/src/test/server-search-endpoint.test.ts
+++ b/src/test/server-search-endpoint.test.ts
@@ -85,6 +85,7 @@ describe("BacklogServer search endpoint", () => {
 			projectName: "Server Search",
 			statuses: ["To Do", "In Progress", "Done"],
 			labels: [],
+			types: ["Bug", "Feature", "Customer Request"],
 			priorities: ["Very High", "High", "Medium", "Low", "Very Low"],
 			milestones: [],
 			dateFormat: "YYYY-MM-DD",
@@ -268,6 +269,46 @@ describe("BacklogServer search endpoint", () => {
 		const fetched = await fetchJson<Task>(`/api/task/${shortId}`);
 		expect(fetched.id).toBe(created.id);
 		expect(fetched.title).toBe("Immediate fetch");
+	});
+
+	it("persists configured task types through create, edit, and clear", async () => {
+		const created = await fetchJson<Task>("/api/tasks", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				title: "Typed Web task",
+				status: "To Do",
+				type: "customer request",
+			}),
+		});
+		expect(created.type).toBe("Customer Request");
+
+		const updated = await fetchJson<Task>(`/api/tasks/${created.id}`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ type: "BUG" }),
+		});
+		expect(updated.type).toBe("Bug");
+
+		const cleared = await fetchJson<Task>(`/api/tasks/${created.id}`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ type: "" }),
+		});
+		expect(cleared.type).toBeUndefined();
+	});
+
+	it("rejects unsupported task types from the Web task API", async () => {
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Invalid typed task", status: "To Do", type: "Epic" }),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({
+			error: "Invalid type: Epic. Valid types are: Bug, Feature, Customer Request",
+		});
 	});
 
 	it("appends comments through the task update API and indexes comment text", async () => {

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -26,6 +26,7 @@ const tasks: Task[] = [
 		labels: ["bug"],
 		milestone: "m-1",
 		priority: "high",
+		type: "bug",
 	}),
 	createTask({
 		id: "task-102",
@@ -34,6 +35,7 @@ const tasks: Task[] = [
 		labels: ["docs"],
 		milestone: "m-2",
 		priority: "medium",
+		type: "docs",
 	}),
 	createTask({
 		id: "task-103",
@@ -43,6 +45,7 @@ const tasks: Task[] = [
 		labels: ["enhancement"],
 		milestone: "m-1",
 		priority: "low",
+		type: "enhancement",
 	}),
 	createTask({
 		id: "task-104",
@@ -95,6 +98,7 @@ const renderBoardPage = (
 		statuses?: string[];
 		availableLabels?: string[];
 		availablePriorities?: string[];
+		availableTypes?: string[];
 		dateFormat?: string;
 	} = {},
 ): HTMLElement => {
@@ -113,6 +117,7 @@ const renderBoardPage = (
 					milestones={[]}
 					availableLabels={options.availableLabels ?? ["bug", "docs", "enhancement"]}
 					availablePriorities={options.availablePriorities}
+					availableTypes={options.availableTypes}
 					milestoneEntities={[]}
 					archivedMilestones={[]}
 					isLoading={false}
@@ -188,7 +193,7 @@ const expectBoardFiltersInHeader = (container: HTMLElement) => {
 	const boardFilters = toolbar?.querySelector("[aria-label='Board filters']");
 	expect(boardFilters).toBeTruthy();
 
-	for (const ariaLabel of ["Filter board by assignee", "Filter board by priority"]) {
+	for (const ariaLabel of ["Filter board by assignee", "Filter board by type", "Filter board by priority"]) {
 		const select = container.querySelector(`select[aria-label='${ariaLabel}']`) as HTMLSelectElement | null;
 		expect(select).toBeTruthy();
 		expect(toolbar?.contains(select)).toBe(true);
@@ -289,6 +294,42 @@ describe("Web board filters", () => {
 		expect(text).toContain("Escalate production incident");
 		expect(text).toContain("Very High");
 		expect(text).not.toContain("Fix login bug");
+	});
+
+	it("renders configured task types and canonicalizes type filters from the URL", async () => {
+		const customTasks = [
+			createTask({ id: "task-201", title: "Fix checkout", type: "Bug" }),
+			createTask({ id: "task-202", title: "Interview customers", type: "Customer Request" }),
+			createTask({ id: "task-203", title: "Unclassified follow-up" }),
+		];
+		const container = renderBoardPage("http://localhost/board?type=customer%20request", {
+			tasks: customTasks,
+			availableTypes: ["Bug", "Customer Request"],
+		});
+
+		await waitFor(() => new URLSearchParams(window.location.search).get("type") === "Customer Request");
+
+		const typeSelect = getSelectByFirstOption(container, "All types");
+		expect(Array.from(typeSelect.options).map((option) => option.textContent)).toEqual([
+			"All types",
+			"Bug",
+			"Customer Request",
+		]);
+		expect(typeSelect.value).toBe("Customer Request");
+		expect(container.textContent).toContain("Interview customers");
+		expect(container.textContent).not.toContain("Fix checkout");
+		expect(container.textContent).not.toContain("Unclassified follow-up");
+	});
+
+	it("clears unsupported task type URL values", async () => {
+		const container = renderBoardPage("http://localhost/board?type=unsupported", {
+			availableTypes: ["Bug", "Feature"],
+		});
+
+		await waitFor(() => new URLSearchParams(window.location.search).get("type") === null);
+
+		expect(getSelectByFirstOption(container, "All types").value).toBe("");
+		expectVisibleTasks(container, ["Fix login bug", "Write docs", "Improve board", "Triage unassigned issue"]);
 	});
 
 	it("canonicalizes mixed-case configured priority URL values", async () => {

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -189,6 +189,20 @@ const expectBoardFiltersInHeader = (container: HTMLElement) => {
 	expect(toolbar).toBeTruthy();
 	expect(toolbar?.textContent).toContain("All Tasks");
 	expect(toolbar?.textContent).toContain("Milestone");
+	const heading = Array.from(container.querySelectorAll("h2")).find(
+		(element) => element.textContent?.trim() === "Kanban Board",
+	);
+	const newTaskButton = Array.from(container.querySelectorAll("button")).find(
+		(button) => button.textContent?.trim() === "+ New Task",
+	);
+	const header = heading?.parentElement?.parentElement;
+	expect(heading).toBeTruthy();
+	expect(newTaskButton).toBeTruthy();
+	expect(heading?.parentElement?.contains(newTaskButton as HTMLButtonElement)).toBe(true);
+	expect(heading?.parentElement?.className).toContain("flex-wrap");
+	expect(header?.className).toContain("space-y-3");
+	expect(toolbar?.parentElement).toBe(header);
+	expect(heading?.parentElement?.contains(toolbar as HTMLElement)).toBe(false);
 
 	const boardFilters = toolbar?.querySelector("[aria-label='Board filters']");
 	expect(boardFilters).toBeTruthy();

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -58,6 +58,20 @@ const tasks: Task[] = [
 
 const searchResults: SearchResult[] = tasks.map((task) => ({ type: "task", task, score: 1 }));
 
+const defaultConfig = {
+	projectName: "Route QA",
+	statuses: ["To Do", "In Progress", "Done"],
+	labels: ["web"],
+	types: ["Bug", "Feature", "Customer Request"],
+	milestones: [],
+	dateFormat: "YYYY-MM-DD",
+	remoteOperations: false,
+	prefixes: { task: "BACK" },
+	zeroPaddedIds: 3,
+};
+
+type ResponseFactory = () => Response | Promise<Response>;
+
 let activeRoot: Root | null = null;
 let activeDom: JSDOM | null = null;
 const originalFetch = globalThis.fetch;
@@ -69,6 +83,9 @@ const originalElement = globalThis.Element;
 const originalHTMLElement = globalThis.HTMLElement;
 const originalNode = globalThis.Node;
 let beforeTaskResponse: ((id: string) => Promise<void>) | null = null;
+let activeWebSocket: FakeWebSocket | null = null;
+let queuedConfigResponses: ResponseFactory[] = [];
+let queuedSearchResponses: ResponseFactory[] = [];
 
 class FakeWebSocket {
 	static readonly CONNECTING = 0;
@@ -79,6 +96,14 @@ class FakeWebSocket {
 	onclose: (() => void) | null = null;
 	onerror: (() => void) | null = null;
 	onmessage: ((event: { data: string }) => void) | null = null;
+
+	constructor() {
+		activeWebSocket = this;
+	}
+
+	emit(data: string) {
+		this.onmessage?.({ data });
+	}
 
 	close() {
 		this.readyState = FakeWebSocket.CLOSED;
@@ -105,20 +130,19 @@ const installFetchMock = () => {
 			return json(["To Do", "In Progress", "Done"]);
 		}
 		if (url.pathname === "/api/config") {
-			return json({
-				projectName: "Route QA",
-				statuses: ["To Do", "In Progress", "Done"],
-				labels: ["web"],
-				types: ["Bug", "Feature"],
-				milestones: [],
-				dateFormat: "YYYY-MM-DD",
-				remoteOperations: false,
-				prefixes: { task: "BACK" },
-				zeroPaddedIds: 3,
-			});
+			const queuedResponse = queuedConfigResponses.shift();
+			return queuedResponse ? await queuedResponse() : json(defaultConfig);
 		}
 		if (url.pathname === "/api/search") {
-			return json(searchResults);
+			const queuedResponse = queuedSearchResponses.shift();
+			if (queuedResponse) {
+				return await queuedResponse();
+			}
+			return json(
+				url.searchParams.has("query")
+					? searchResults.map((result) => ({ ...result, score: 0.1 }))
+					: searchResults,
+			);
 		}
 		if (url.pathname === "/api/milestones" || url.pathname === "/api/milestones/archived") {
 			return json([]);
@@ -225,6 +249,24 @@ const click = async (element: Element) => {
 	});
 };
 
+const setInputValue = async (input: HTMLInputElement, value: string) => {
+	await act(async () => {
+		const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+		input.focus();
+		valueSetter?.call(input, value);
+		input.dispatchEvent(new window.InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+		input.dispatchEvent(new window.Event("change", { bubbles: true }));
+		const reactPropsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+		if (reactPropsKey) {
+			const reactProps = (input as unknown as Record<string, { onChange?: (event: { target: HTMLInputElement }) => void }>)[
+				reactPropsKey
+			];
+			reactProps?.onChange?.({ target: input });
+		}
+		await Promise.resolve();
+	});
+};
+
 const press = async (element: Element, key: string, init: KeyboardEventInit = {}) => {
 	await act(async () => {
 		(element as HTMLElement).focus();
@@ -264,6 +306,9 @@ afterEach(async () => {
 	globalThis.HTMLElement = originalHTMLElement;
 	globalThis.Node = originalNode;
 	beforeTaskResponse = null;
+	activeWebSocket = null;
+	queuedConfigResponses = [];
+	queuedSearchResponses = [];
 });
 
 describe("task detail routes", () => {
@@ -352,6 +397,118 @@ describe("task detail routes", () => {
 			"direct filtered board close",
 		);
 		expect(window.location.search).toBe("?type=Bug&lane=none");
+	});
+
+	it("keeps the latest config and tasks when overlapping refreshes resolve out of order", async () => {
+		const container = await renderApp("/board?type=Customer%20Request");
+		await waitFor(
+			() =>
+				new URLSearchParams(window.location.search).get("type") === "Customer Request" &&
+				activeWebSocket?.onmessage !== null,
+			"initial typed board and WebSocket",
+		);
+
+		let releaseFirstConfig: (() => void) | undefined;
+		let markFirstConfigStarted: (() => void) | undefined;
+		const firstConfigGate = new Promise<void>((resolve) => {
+			releaseFirstConfig = resolve;
+		});
+		const firstConfigStarted = new Promise<void>((resolve) => {
+			markFirstConfigStarted = resolve;
+		});
+		const customerTask: Task = {
+			id: "BACK-202",
+			title: "Newest customer request",
+			status: "To Do",
+			assignee: [],
+			labels: ["web"],
+			dependencies: [],
+			createdDate: "2026-07-10",
+			type: "Customer Request",
+		};
+
+		queuedConfigResponses.push(
+			async () => {
+				markFirstConfigStarted?.();
+				await firstConfigGate;
+				return json({ ...defaultConfig, types: ["Bug"] });
+			},
+			() => json(defaultConfig),
+		);
+		queuedSearchResponses.push(
+			() => json(searchResults),
+			() => json([{ type: "task", task: customerTask, score: 1 } satisfies SearchResult]),
+		);
+
+		await act(async () => {
+			activeWebSocket?.emit("config-updated");
+			await Promise.resolve();
+		});
+		await firstConfigStarted;
+		await act(async () => {
+			activeWebSocket?.emit("tasks-updated");
+			await Promise.resolve();
+		});
+
+		await waitFor(
+			() => container.textContent?.includes(customerTask.title) ?? false,
+			"newer refresh result",
+		);
+		expect(new URLSearchParams(window.location.search).get("type")).toBe("Customer Request");
+
+		await act(async () => {
+			releaseFirstConfig?.();
+			await firstConfigGate;
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		});
+
+		expect(container.textContent).toContain(customerTask.title);
+		expect(container.textContent).not.toContain(tasks[0]?.title ?? "");
+		expect(new URLSearchParams(window.location.search).get("type")).toBe("Customer Request");
+		const typeSelect = container.querySelector("select[aria-label='Filter board by type']") as HTMLSelectElement;
+		expect(Array.from(typeSelect.options).map((option) => option.value)).toContain("Customer Request");
+	});
+
+	it("keeps a filtered board query when a sidebar search result opens and closes", async () => {
+		const container = await renderApp("/board?type=bug&lane=none");
+		await waitFor(
+			() =>
+				new URLSearchParams(window.location.search).get("type") === "Bug" &&
+				(container.textContent?.includes(tasks[0]?.title ?? "") ?? false),
+			"filtered board before sidebar search",
+		);
+		const filteredSearch = window.location.search;
+		const searchInput = container.querySelector("input[placeholder='Search (⌘K)...']") as HTMLInputElement | null;
+		expect(searchInput).toBeTruthy();
+		await setInputValue(searchInput as HTMLInputElement, "Fix labels");
+
+		await waitFor(
+			() =>
+				Array.from(container.querySelectorAll("a")).some(
+					(link) => link.textContent?.includes(tasks[0]?.title ?? "") ?? false,
+				),
+			"sidebar task search result",
+		);
+		const resultLink = Array.from(container.querySelectorAll("a")).find(
+			(link) => link.textContent?.includes(tasks[0]?.title ?? "") ?? false,
+		);
+		expect(resultLink?.getAttribute("href")).toContain(filteredSearch);
+		await click(resultLink as HTMLAnchorElement);
+
+		await waitFor(
+			() =>
+				window.location.pathname === "/board/BACK-101/fix-labels-caf-docs" &&
+				Boolean(container.querySelector("[role='dialog']")),
+			"sidebar filtered task route",
+		);
+		expect(window.location.search).toBe(filteredSearch);
+
+		await click(container.querySelector("button[aria-label='Close modal']") as HTMLButtonElement);
+		await waitFor(
+			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
+			"sidebar return to filtered board",
+		);
+		expect(window.location.search).toBe(filteredSearch);
 	});
 
 	it("keeps legacy highlight links while canonicalizing and closing them cleanly", async () => {

--- a/src/test/web-task-types.test.tsx
+++ b/src/test/web-task-types.test.tsx
@@ -199,17 +199,81 @@ describe("Web task type UI", () => {
 		expect(submitted?.type).toBe("Customer Request");
 	});
 
-	it("updates type from the task detail selector and preserves removed configured values", async () => {
+	it("keeps the selected type visible when create validation fails", async () => {
+		const container = setupDom();
+		const errorMessage = "Invalid type: Feature. Valid types are: Bug";
+		let closeCalls = 0;
+		activeRoot = createRoot(container);
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal
+						isOpen
+						onClose={() => {
+							closeCalls += 1;
+						}}
+						onSubmit={async () => {
+							throw new Error(errorMessage);
+						}}
+						availableStatuses={["To Do", "In Progress", "Done"]}
+						availableTypes={["Bug", "Feature"]}
+					/>
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+
+		const typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement;
+		const titleInput = container.querySelector("input[placeholder='Enter task title']") as HTMLInputElement;
+		await setInputValue(titleInput, "Stale configured type");
+		await setSelectValue(typeSelect, "Feature");
+		const createButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.trim() === "Create",
+		);
+		await act(async () => {
+			createButton?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+		await waitFor(() => container.querySelector("[role='alert']")?.textContent === errorMessage);
+
+		expect(typeSelect.value).toBe("Feature");
+		expect(closeCalls).toBe(0);
+	});
+
+	it("updates and clears type while preserving a removed value across a config refresh", async () => {
 		const container = setupDom();
 		const task = createTask({ type: "Legacy Type" });
-		let receivedUpdate: TaskUpdateRequest | undefined;
+		const receivedUpdates: TaskUpdateRequest[] = [];
 		apiClient.updateTask = async (taskId, updates) => {
 			expect(taskId).toBe(task.id);
-			receivedUpdate = updates;
-			return { ...task, type: typeof updates.type === "string" ? updates.type : task.type };
+			receivedUpdates.push(updates);
+			return { ...task, type: typeof updates.type === "string" && updates.type ? updates.type : undefined };
 		};
 
 		activeRoot = createRoot(container);
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal
+							task={task}
+							isOpen
+							onClose={() => {}}
+							availableTypes={["Legacy Type", "Bug", "Feature"]}
+						/>
+					</ThemeProvider>,
+				);
+			await Promise.resolve();
+		});
+
+		let typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement;
+		expect(typeSelect.value).toBe("Legacy Type");
+		expect(Array.from(typeSelect.options).map((option) => option.textContent)).toEqual([
+			"No type",
+			"Legacy Type",
+			"Bug",
+			"Feature",
+		]);
+
 		await act(async () => {
 			activeRoot?.render(
 				<ThemeProvider>
@@ -224,19 +288,66 @@ describe("Web task type UI", () => {
 			await Promise.resolve();
 		});
 
-		const typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement | null;
-		expect(typeSelect).toBeTruthy();
-		expect(typeSelect?.value).toBe("Legacy Type");
-		expect(Array.from(typeSelect?.options ?? []).map((option) => option.textContent)).toEqual([
+		typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement;
+		expect(typeSelect.value).toBe("Legacy Type");
+		expect(Array.from(typeSelect.options).map((option) => option.textContent)).toEqual([
 			"No type",
 			"Legacy Type (not configured)",
 			"Bug",
 			"Feature",
 		]);
 
-		await setSelectValue(typeSelect as HTMLSelectElement, "Feature");
-		await waitFor(() => receivedUpdate !== undefined);
+		await setSelectValue(typeSelect, "Feature");
+		await waitFor(() => receivedUpdates.length === 1);
+		expect(receivedUpdates[0]).toEqual({ type: "Feature" });
+		expect(typeSelect.value).toBe("Feature");
 
-		expect(receivedUpdate).toEqual({ type: "Feature" });
+		await setSelectValue(typeSelect, "");
+		await waitFor(() => receivedUpdates.length === 2);
+
+		expect(receivedUpdates[1]).toEqual({ type: "" });
+		expect(typeSelect.value).toBe("");
+	});
+
+	it("rolls back a rejected edit type and exposes the server error accessibly", async () => {
+		const container = setupDom();
+		const task = createTask({ type: "Bug" });
+		const errorMessage = "Invalid type: Feature. Valid types are: Bug";
+		let updateCalls = 0;
+		let savedCalls = 0;
+		apiClient.updateTask = async () => {
+			updateCalls += 1;
+			throw new Error(errorMessage);
+		};
+
+		activeRoot = createRoot(container);
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal
+						task={task}
+						isOpen
+						onClose={() => {}}
+						onSaved={async () => {
+							savedCalls += 1;
+						}}
+						availableTypes={["Bug", "Feature"]}
+					/>
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+
+		const typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement;
+		await setSelectValue(typeSelect, "Feature");
+		await waitFor(() => container.querySelector("#task-type-update-error")?.textContent?.trim() === errorMessage);
+
+		expect(updateCalls).toBe(1);
+		expect(savedCalls).toBe(0);
+		expect(typeSelect.value).toBe("Bug");
+		expect(typeSelect.disabled).toBe(false);
+		expect(typeSelect.getAttribute("aria-invalid")).toBe("true");
+		expect(typeSelect.getAttribute("aria-describedby")).toBe("task-type-update-error");
+		expect(container.querySelector("#task-type-update-error")?.getAttribute("role")).toBe("alert");
 	});
 });

--- a/src/test/web-task-types.test.tsx
+++ b/src/test/web-task-types.test.tsx
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import type { Task } from "../types/index.ts";
+import TaskCard from "../web/components/TaskCard.tsx";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
+import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
+import { apiClient, type TaskUpdateRequest } from "../web/lib/api.ts";
+
+const createTask = (overrides: Partial<Task> = {}): Task => ({
+	id: "TASK-1",
+	title: "Typed task",
+	status: "To Do",
+	assignee: [],
+	createdDate: "2026-07-09",
+	labels: [],
+	dependencies: [],
+	...overrides,
+});
+
+const originalFetchStatuses = apiClient.fetchStatuses.bind(apiClient);
+const originalFetchTasks = apiClient.fetchTasks.bind(apiClient);
+const originalUpdateTask = apiClient.updateTask.bind(apiClient);
+let activeRoot: Root | null = null;
+
+function setupDom(): HTMLElement {
+	const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: "http://localhost",
+	});
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = dom.window as unknown as Window & typeof globalThis;
+	globalThis.document = dom.window.document as Document;
+	globalThis.navigator = dom.window.navigator as Navigator;
+	globalThis.localStorage = dom.window.localStorage;
+	globalThis.HTMLElement = dom.window.HTMLElement;
+	globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+	globalThis.HTMLSelectElement = dom.window.HTMLSelectElement;
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(callback, 0);
+	globalThis.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
+
+	window.matchMedia = () =>
+		({
+			matches: false,
+			media: "",
+			onchange: null,
+			addListener: () => {},
+			removeListener: () => {},
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			dispatchEvent: () => false,
+		}) as MediaQueryList;
+
+	const htmlElementPrototype = window.HTMLElement.prototype as unknown as {
+		attachEvent?: () => void;
+		detachEvent?: () => void;
+	};
+	htmlElementPrototype.attachEvent ??= () => {};
+	htmlElementPrototype.detachEvent ??= () => {};
+
+	apiClient.fetchStatuses = async () => ["To Do", "In Progress", "Done"];
+	apiClient.fetchTasks = async () => [];
+
+	const container = document.getElementById("root");
+	expect(container).toBeTruthy();
+	return container as HTMLElement;
+}
+
+async function setInputValue(input: HTMLInputElement, value: string): Promise<void> {
+	await act(async () => {
+		const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+		input.focus();
+		valueSetter?.call(input, value);
+		input.dispatchEvent(new window.InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+		input.dispatchEvent(new window.Event("change", { bubbles: true }));
+		const reactPropsKey = Object.keys(input).find((key) => key.startsWith("__reactProps$"));
+		if (reactPropsKey) {
+			const reactProps = (input as unknown as Record<string, { onChange?: (event: { target: HTMLInputElement }) => void }>)[
+				reactPropsKey
+			];
+			reactProps?.onChange?.({ target: input });
+		}
+		await Promise.resolve();
+	});
+}
+
+async function setSelectValue(select: HTMLSelectElement, value: string): Promise<void> {
+	await act(async () => {
+		const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value")?.set;
+		valueSetter?.call(select, value);
+		select.dispatchEvent(new window.Event("change", { bubbles: true }));
+		await Promise.resolve();
+	});
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let attempts = 0; attempts < 20; attempts += 1) {
+		if (predicate()) return;
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+	}
+	expect(predicate()).toBe(true);
+}
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => activeRoot?.unmount());
+		activeRoot = null;
+	}
+	apiClient.fetchStatuses = originalFetchStatuses;
+	apiClient.fetchTasks = originalFetchTasks;
+	apiClient.updateTask = originalUpdateTask;
+});
+
+describe("Web task type UI", () => {
+	it("shows distinct type badges on cards and no badge for untyped tasks", () => {
+		const bugHtml = renderToString(
+			<TaskCard task={createTask({ type: "bug" })} onUpdate={() => {}} onEdit={() => {}} />,
+		);
+		const featureHtml = renderToString(
+			<TaskCard task={createTask({ type: "feature" })} onUpdate={() => {}} onEdit={() => {}} />,
+		);
+		const customHtml = renderToString(
+			<TaskCard
+				task={createTask({ type: "Customer Request" })}
+				onUpdate={() => {}}
+				onEdit={() => {}}
+				availableTypes={["Bug", "Customer Request", "Docs"]}
+			/>,
+		);
+		const docsHtml = renderToString(
+			<TaskCard
+				task={createTask({ type: "Docs" })}
+				onUpdate={() => {}}
+				onEdit={() => {}}
+				availableTypes={["Bug", "Customer Request", "Docs"]}
+			/>,
+		);
+		const untypedHtml = renderToString(<TaskCard task={createTask()} onUpdate={() => {}} onEdit={() => {}} />);
+
+		expect(bugHtml).toContain('data-task-type="bug"');
+		expect(bugHtml).toContain("bg-red-100");
+		expect(featureHtml).toContain('data-task-type="feature"');
+		expect(featureHtml).toContain("bg-blue-100");
+		expect(customHtml).toContain('data-task-type="Customer Request"');
+		expect(customHtml).toContain("bg-blue-100");
+		expect(docsHtml).toContain("bg-cyan-100");
+		expect(untypedHtml).not.toContain("data-task-type");
+	});
+
+	it("creates a task with a configured custom type and defaults to untyped", async () => {
+		const container = setupDom();
+		let submitted: Partial<Task> | undefined;
+		activeRoot = createRoot(container);
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal
+						isOpen
+						onClose={() => {}}
+						onSubmit={async (taskData) => {
+							submitted = taskData;
+						}}
+						availableStatuses={["To Do", "In Progress", "Done"]}
+						availableTypes={["Bug", "Customer Request"]}
+					/>
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+
+		const typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement | null;
+		expect(typeSelect).toBeTruthy();
+		expect(typeSelect?.value).toBe("");
+		expect(Array.from(typeSelect?.options ?? []).map((option) => option.textContent)).toEqual([
+			"No type",
+			"Bug",
+			"Customer Request",
+		]);
+
+		const titleInput = container.querySelector("input[placeholder='Enter task title']") as HTMLInputElement | null;
+		expect(titleInput).toBeTruthy();
+		await setInputValue(titleInput as HTMLInputElement, "Customer interview");
+		await setSelectValue(typeSelect as HTMLSelectElement, "Customer Request");
+
+		const createButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.trim() === "Create",
+		);
+		expect(createButton).toBeTruthy();
+		await act(async () => {
+			createButton?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+		await waitFor(() => submitted !== undefined);
+
+		expect(submitted?.title).toBe("Customer interview");
+		expect(submitted?.type).toBe("Customer Request");
+	});
+
+	it("updates type from the task detail selector and preserves removed configured values", async () => {
+		const container = setupDom();
+		const task = createTask({ type: "Legacy Type" });
+		let receivedUpdate: TaskUpdateRequest | undefined;
+		apiClient.updateTask = async (taskId, updates) => {
+			expect(taskId).toBe(task.id);
+			receivedUpdate = updates;
+			return { ...task, type: typeof updates.type === "string" ? updates.type : task.type };
+		};
+
+		activeRoot = createRoot(container);
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal
+						task={task}
+						isOpen
+						onClose={() => {}}
+						availableTypes={["Bug", "Feature"]}
+					/>
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+
+		const typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement | null;
+		expect(typeSelect).toBeTruthy();
+		expect(typeSelect?.value).toBe("Legacy Type");
+		expect(Array.from(typeSelect?.options ?? []).map((option) => option.textContent)).toEqual([
+			"No type",
+			"Legacy Type (not configured)",
+			"Bug",
+			"Feature",
+		]);
+
+		await setSelectValue(typeSelect as HTMLSelectElement, "Feature");
+		await waitFor(() => receivedUpdate !== undefined);
+
+		expect(receivedUpdate).toEqual({ type: "Feature" });
+	});
+});

--- a/src/test/web-task-types.test.tsx
+++ b/src/test/web-task-types.test.tsx
@@ -350,4 +350,68 @@ describe("Web task type UI", () => {
 		expect(typeSelect.getAttribute("aria-describedby")).toBe("task-type-update-error");
 		expect(container.querySelector("#task-type-update-error")?.getAttribute("role")).toBe("alert");
 	});
+
+	it("keeps an in-flight type write locked across same-task refreshes", async () => {
+		const container = setupDom();
+		const task = createTask({ type: "Bug" });
+		let updateCalls = 0;
+		let savedCalls = 0;
+		let receivedUpdate: TaskUpdateRequest | undefined;
+		let resolveUpdate: ((updatedTask: Task) => void) | undefined;
+		const updateResult = new Promise<Task>((resolve) => {
+			resolveUpdate = resolve;
+		});
+		apiClient.updateTask = async (taskId, updates) => {
+			expect(taskId).toBe(task.id);
+			updateCalls += 1;
+			receivedUpdate = updates;
+			return updateResult;
+		};
+
+		const renderModal = async (refreshedTask: Task, availableTypes: string[], availableStatuses: string[]) => {
+			await act(async () => {
+				activeRoot?.render(
+					<ThemeProvider>
+						<TaskDetailsModal
+							task={refreshedTask}
+							isOpen
+							onClose={() => {}}
+							onSaved={async () => {
+								savedCalls += 1;
+							}}
+							availableTypes={availableTypes}
+							availableStatuses={availableStatuses}
+						/>
+					</ThemeProvider>,
+				);
+				await Promise.resolve();
+			});
+		};
+
+		activeRoot = createRoot(container);
+		await renderModal(task, ["Bug", "feature"], ["To Do", "Done"]);
+		let typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement;
+		await setSelectValue(typeSelect, "feature");
+		await waitFor(() => updateCalls === 1 && typeSelect.disabled);
+
+		const refreshedTask = { ...task, description: "Refreshed while the type write is pending" };
+		await renderModal(refreshedTask, ["Bug", "Feature"], ["Backlog", "To Do", "Done"]);
+		typeSelect = container.querySelector("select[aria-label='Task type']") as HTMLSelectElement;
+		expect(typeSelect.disabled).toBe(true);
+		expect(typeSelect.value).toBe("Feature");
+
+		await setSelectValue(typeSelect, "Bug");
+		expect(updateCalls).toBe(1);
+		expect(receivedUpdate).toEqual({ type: "feature" });
+
+		await act(async () => {
+			resolveUpdate?.({ ...refreshedTask, type: "Feature" });
+			await updateResult;
+			await Promise.resolve();
+		});
+		await waitFor(() => !typeSelect.disabled && typeSelect.value === "Feature");
+
+		expect(updateCalls).toBe(1);
+		expect(savedCalls).toBe(1);
+	});
 });

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -204,6 +204,7 @@ function AppContent() {
   const { isOnline } = useHealthCheckContext();
   const previousOnlineRef = useRef<boolean | null>(null);
   const hasBeenRunningRef = useRef(false);
+  const loadAllDataRequestRef = useRef(0);
   const location = useLocation();
   const navigate = useNavigate();
   const tasksRouteWithTitle = useMatch('/tasks/:id/:title');
@@ -291,6 +292,8 @@ function AppContent() {
   }, []);
 
   const loadAllData = useCallback(async () => {
+    const requestId = loadAllDataRequestRef.current + 1;
+    loadAllDataRequestRef.current = requestId;
     try {
       setIsLoading(true);
       const [statusesData, configData, searchResults, milestonesData, archivedMilestonesData, duplicates] = await Promise.all([
@@ -301,6 +304,10 @@ function AppContent() {
         apiClient.fetchArchivedMilestones(),
         apiClient.fetchDuplicateTasks(),
       ]);
+
+      if (loadAllDataRequestRef.current !== requestId) {
+        return;
+      }
 
       const archivedKeys = new Set(collectArchivedMilestoneKeys(archivedMilestonesData, milestonesData));
       const milestoneAliases = buildMilestoneAliasMap(milestonesData, archivedMilestonesData);
@@ -319,9 +326,13 @@ function AppContent() {
         ),
       );
     } catch (error) {
-      console.error('Failed to load data:', error);
+      if (loadAllDataRequestRef.current === requestId) {
+        console.error('Failed to load data:', error);
+      }
     } finally {
-      setIsLoading(false);
+      if (loadAllDataRequestRef.current === requestId) {
+        setIsLoading(false);
+      }
     }
   }, [applySearchResults]);
 
@@ -335,31 +346,9 @@ function AppContent() {
   // Reload data when connection is restored
   React.useEffect(() => {
     if (isOnline && previousOnlineRef.current === false) {
-      // Connection restored, reload data
-      const loadData = async () => {
-        try {
-          const [results, milestonesData, archivedMilestonesData] = await Promise.all([
-            apiClient.search(),
-            apiClient.fetchMilestones(),
-            apiClient.fetchArchivedMilestones(),
-          ]);
-          const archivedKeys = new Set(collectArchivedMilestoneKeys(archivedMilestonesData, milestonesData));
-          const milestoneAliases = buildMilestoneAliasMap(milestonesData, archivedMilestonesData);
-          const { tasks: tasksList } = applySearchResults(results, archivedKeys, milestoneAliases);
-          setMilestoneEntities(milestonesData);
-          setArchivedMilestones(archivedMilestonesData);
-          setMilestones(
-            collectMilestoneIds(tasksList, milestonesData, archivedMilestonesData).filter(
-              (milestone) => !archivedKeys.has(milestoneKey(milestone)),
-            ),
-          );
-        } catch (error) {
-          console.error('Failed to reload data:', error);
-        }
-      };
-      loadData();
+      void loadAllData();
     }
-  }, [applySearchResults, isOnline]);
+  }, [isOnline, loadAllData]);
 
   // Update document title when project name changes
   React.useEffect(() => {

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -29,6 +29,7 @@ import type { DuplicateGroup } from '../utils/duplicate-detection';
 import { useHealthCheckContext } from './contexts/HealthCheckContext';
 import { getWebVersion } from './utils/version';
 import { collectArchivedMilestoneKeys, collectMilestoneIds, milestoneKey } from './utils/milestones';
+import { getTaskTypeValues } from '../utils/task-type-config';
 
 const buildMilestoneAliasMap = (milestones: Milestone[], archivedMilestones: Milestone[]): Map<string, string> => {
   const aliasMap = new Map<string, string>();
@@ -169,6 +170,7 @@ function App() {
   const [availableLabels, setAvailableLabels] = useState<string[]>([]);
   const [projectName, setProjectName] = useState<string>('');
   const [config, setConfig] = useState<BacklogConfig | null>(null);
+  const availableTypes = React.useMemo(() => getTaskTypeValues(config), [config]);
   const [milestones, setMilestones] = useState<string[]>([]);
   const [milestoneEntities, setMilestoneEntities] = useState<Milestone[]>([]);
   const [archivedMilestones, setArchivedMilestones] = useState<Milestone[]>([]);
@@ -510,6 +512,7 @@ function App() {
                 hideEmptyColumns={config?.hideEmptyColumns ?? false}
                 dateFormat={config?.dateFormat}
                 availablePriorities={config?.priorities}
+                availableTypes={availableTypes}
               />
             }
           />
@@ -567,6 +570,7 @@ function App() {
           availableStatuses={isDraftMode ? ['Draft', ...statuses] : statuses}
           availableMilestones={milestones}
           availablePriorities={config?.priorities}
+          availableTypes={availableTypes}
           milestoneEntities={milestoneEntities}
           archivedMilestoneEntities={archivedMilestones}
           isDraftMode={isDraftMode}

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -6,6 +6,7 @@ import { collectAvailableLabels, labelsToLower } from '../../utils/label-filter'
 import { collectArchivedMilestoneKeys, milestoneKey } from '../utils/milestones';
 import { getTerminalStatus } from '../../utils/terminal-status';
 import { getPriorityOptions, normalizePriorityValue } from '../../utils/priority-config';
+import { getTaskTypeValues, matchesTaskTypeFilter } from '../../utils/task-type-config';
 import TaskColumn from './TaskColumn';
 import CleanupModal from './CleanupModal';
 import LabelFilterDropdown from './LabelFilterDropdown';
@@ -30,7 +31,9 @@ interface BoardProps {
   filterLabels?: string[];
   filterPriority?: string;
   availablePriorities?: string[];
-  onFiltersChange?: (filters: { assignee: string; labels: string[]; priority: string }) => void;
+  filterType?: string;
+  availableTypes?: string[];
+  onFiltersChange?: (filters: { assignee: string; labels: string[]; priority: string; taskType: string }) => void;
   hideEmptyColumns?: boolean;
   dateFormat?: string;
 }
@@ -59,6 +62,8 @@ const Board: React.FC<BoardProps> = ({
   filterLabels = [],
   filterPriority = '',
   availablePriorities,
+  filterType = '',
+  availableTypes,
   onFiltersChange,
   hideEmptyColumns = false,
   dateFormat,
@@ -74,6 +79,7 @@ const Board: React.FC<BoardProps> = ({
     () => [{ label: 'All priorities', value: '' }, ...getPriorityOptions(availablePriorities)],
     [availablePriorities]
   );
+  const typeOptions = useMemo(() => getTaskTypeValues(availableTypes), [availableTypes]);
   const archivedMilestoneIds = useMemo(
     () => collectArchivedMilestoneKeys(archivedMilestones, milestoneEntities),
     [archivedMilestones, milestoneEntities]
@@ -231,7 +237,8 @@ const Board: React.FC<BoardProps> = ({
     [filterLabels]
   );
 
-  const hasActiveFilters = filterAssignee !== '' || normalizedFilterLabels.length > 0 || filterPriority !== '';
+  const hasActiveFilters =
+    filterAssignee !== '' || normalizedFilterLabels.length > 0 || filterPriority !== '' || filterType !== '';
 
   // Filter tasks by milestone when milestoneFilter is set, then apply assignee/label/priority filters
   const filteredTasks = useMemo(() => {
@@ -252,8 +259,11 @@ const Board: React.FC<BoardProps> = ({
       const normalizedFilterPriority = normalizePriorityValue(filterPriority);
       result = result.filter(task => normalizePriorityValue(task.priority) === normalizedFilterPriority);
     }
+    if (filterType) {
+      result = result.filter(task => matchesTaskTypeFilter(task.type, filterType));
+    }
     return result;
-  }, [tasks, milestoneFilter, canonicalMilestoneFilter, milestoneAliasToCanonical, filterAssignee, normalizedFilterLabels, filterPriority]);
+  }, [tasks, milestoneFilter, canonicalMilestoneFilter, milestoneAliasToCanonical, filterAssignee, normalizedFilterLabels, filterPriority, filterType]);
 
   // Handle highlighting a task (opening its edit popup)
   useEffect(() => {
@@ -463,10 +473,17 @@ const Board: React.FC<BoardProps> = ({
           {updateError}
         </div>
       )}
-      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-colors duration-200">Kanban Board</h2>
-          <div className="flex flex-wrap items-center gap-3" role="toolbar" aria-label="Board view controls">
+			<div className="mb-6 space-y-3">
+				<div className="flex items-center justify-between gap-3">
+					<h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-colors duration-200">Kanban Board</h2>
+					<button
+						className="inline-flex items-center px-4 py-2 bg-blue-500 dark:bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 dark:focus:ring-blue-500 dark:focus:ring-offset-gray-800 transition-colors duration-200"
+						onClick={onNewTask}
+					>
+						+ New Task
+					</button>
+				</div>
+				<div className="flex flex-wrap items-center gap-3" role="toolbar" aria-label="Board view controls">
             <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-1 bg-gray-50 dark:bg-gray-800/50 transition-colors duration-200">
               <button
                 type="button"
@@ -500,7 +517,7 @@ const Board: React.FC<BoardProps> = ({
                 <select
                   aria-label="Filter board by assignee"
                   value={filterAssignee}
-                  onChange={e => onFiltersChange({ assignee: e.target.value, labels: normalizedFilterLabels, priority: filterPriority })}
+                  onChange={e => onFiltersChange({ assignee: e.target.value, labels: normalizedFilterLabels, priority: filterPriority, taskType: filterType })}
                   className={BOARD_FILTER_SELECT_CLASS}
                 >
                   <option value="">All assignees</option>
@@ -513,15 +530,27 @@ const Board: React.FC<BoardProps> = ({
                 <LabelFilterDropdown
                   availableLabels={uniqueLabels}
                   selectedLabels={normalizedFilterLabels}
-                  onChange={labels => onFiltersChange({ assignee: filterAssignee, labels, priority: filterPriority })}
+                  onChange={labels => onFiltersChange({ assignee: filterAssignee, labels, priority: filterPriority, taskType: filterType })}
                   menuId="board-labels-filter-menu"
                   className="min-w-[200px]"
                 />
 
                 <select
+                  aria-label="Filter board by type"
+                  value={filterType}
+                  onChange={e => onFiltersChange({ assignee: filterAssignee, labels: normalizedFilterLabels, priority: filterPriority, taskType: e.target.value })}
+                  className={BOARD_FILTER_SELECT_CLASS}
+                >
+                  <option value="">All types</option>
+                  {typeOptions.map(type => (
+                    <option key={type} value={type}>{type}</option>
+                  ))}
+                </select>
+
+                <select
                   aria-label="Filter board by priority"
                   value={filterPriority}
-                  onChange={e => onFiltersChange({ assignee: filterAssignee, labels: normalizedFilterLabels, priority: e.target.value })}
+                  onChange={e => onFiltersChange({ assignee: filterAssignee, labels: normalizedFilterLabels, priority: e.target.value, taskType: filterType })}
                   className={BOARD_FILTER_SELECT_CLASS}
                 >
                   {priorityOptions.map(opt => (
@@ -532,7 +561,7 @@ const Board: React.FC<BoardProps> = ({
                 {hasActiveFilters && (
                   <button
                     type="button"
-                    onClick={() => onFiltersChange({ assignee: '', labels: [], priority: '' })}
+                    onClick={() => onFiltersChange({ assignee: '', labels: [], priority: '', taskType: '' })}
                     className={BOARD_FILTER_BUTTON_CLASS}
                   >
                     Clear filters
@@ -540,15 +569,8 @@ const Board: React.FC<BoardProps> = ({
                 )}
               </div>
             )}
-          </div>
-        </div>
-        <button
-          className="inline-flex items-center px-4 py-2 bg-blue-500 dark:bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 dark:focus:ring-blue-500 dark:focus:ring-offset-gray-800 transition-colors duration-200"
-          onClick={onNewTask}
-        >
-          + New Task
-        </button>
-      </div>
+				</div>
+			</div>
 
       {laneMode === 'milestone' ? (
         <div className="space-y-6">
@@ -615,6 +637,7 @@ const Board: React.FC<BoardProps> = ({
                             laneId={lane.key}
                             targetMilestone={lane.milestone ?? null}
                             priorityOrder={availablePriorities}
+                            availableTypes={typeOptions}
                             onDragStart={({ status: draggedStatus, laneId }) => {
                               setDragSourceStatus(draggedStatus);
                               setDragSourceLane(laneId ?? null);
@@ -649,6 +672,7 @@ const Board: React.FC<BoardProps> = ({
                   dragSourceLane={dragSourceLane}
                   laneId={DEFAULT_LANE_KEY}
                   priorityOrder={availablePriorities}
+                  availableTypes={typeOptions}
                   onDragStart={({ status: draggedStatus, laneId }) => {
                     setDragSourceStatus(draggedStatus);
                     setDragSourceLane(laneId ?? null);

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -474,10 +474,17 @@ const Board: React.FC<BoardProps> = ({
           {updateError}
         </div>
       )}
-      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
-        <div className="flex flex-wrap items-center gap-3">
+      <div className="mb-6 space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 transition-colors duration-200">Kanban Board</h2>
-          <div className="flex flex-wrap items-center gap-3" role="toolbar" aria-label="Board view controls">
+          <button
+            className="inline-flex items-center px-4 py-2 bg-blue-500 dark:bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 dark:focus:ring-blue-500 dark:focus:ring-offset-gray-800 transition-colors duration-200"
+            onClick={onNewTask}
+          >
+            + New Task
+          </button>
+        </div>
+        <div className="flex flex-wrap items-center gap-3" role="toolbar" aria-label="Board view controls">
             <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-1 bg-gray-50 dark:bg-gray-800/50 transition-colors duration-200">
               <button
                 type="button"
@@ -563,14 +570,7 @@ const Board: React.FC<BoardProps> = ({
                 )}
               </div>
             )}
-          </div>
         </div>
-        <button
-          className="inline-flex items-center px-4 py-2 bg-blue-500 dark:bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-400 dark:focus:ring-blue-500 dark:focus:ring-offset-gray-800 transition-colors duration-200"
-          onClick={onNewTask}
-        >
-          + New Task
-        </button>
       </div>
 
       {laneMode === 'milestone' ? (

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import Board from './Board';
 import { type Milestone, type Task } from '../../types';
 import { resolvePriorityValue } from '../../utils/priority-config';
+import { resolveTaskTypeValue } from '../../utils/task-type-config';
 import { type LaneMode } from '../lib/lanes';
 
 interface BoardPageProps {
@@ -19,6 +20,7 @@ interface BoardPageProps {
 	hideEmptyColumns?: boolean;
 	dateFormat?: string;
 	availablePriorities?: string[];
+	availableTypes?: string[];
 }
 
 export default function BoardPage({
@@ -35,6 +37,7 @@ export default function BoardPage({
 	hideEmptyColumns,
 	dateFormat,
 	availablePriorities,
+	availableTypes,
 }: BoardPageProps) {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [highlightTaskId, setHighlightTaskId] = useState<string | null>(null);
@@ -94,7 +97,7 @@ export default function BoardPage({
 		}, { replace: true });
 	};
 
-	const handleFiltersChange = (filters: { assignee: string; labels: string[]; priority: string }) => {
+	const handleFiltersChange = (filters: { assignee: string; labels: string[]; priority: string; taskType: string }) => {
 		setSearchParams(params => {
 			if (filters.assignee) {
 				params.set('assignee', filters.assignee);
@@ -114,6 +117,11 @@ export default function BoardPage({
 			} else {
 				params.delete('priority');
 			}
+			if (filters.taskType) {
+				params.set('type', filters.taskType);
+			} else {
+				params.delete('type');
+			}
 			return params;
 		}, { replace: true });
 	};
@@ -125,9 +133,11 @@ export default function BoardPage({
 	].map((label) => label.trim()).filter((label) => label.length > 0);
 	const rawFilterPriority = searchParams.get('priority') ?? '';
 	const filterPriority = resolvePriorityValue(rawFilterPriority, availablePriorities) ?? '';
+	const rawFilterType = searchParams.get('type') ?? '';
+	const filterType = resolveTaskTypeValue(rawFilterType, availableTypes) ?? '';
 
 	useEffect(() => {
-		if (isLoading || rawFilterPriority === filterPriority) {
+		if (isLoading || (rawFilterPriority === filterPriority && rawFilterType === filterType)) {
 			return;
 		}
 		setSearchParams(params => {
@@ -136,9 +146,14 @@ export default function BoardPage({
 			} else {
 				params.delete('priority');
 			}
+			if (filterType) {
+				params.set('type', filterType);
+			} else {
+				params.delete('type');
+			}
 			return params;
 		}, { replace: true });
-	}, [filterPriority, isLoading, rawFilterPriority, setSearchParams]);
+	}, [filterPriority, filterType, isLoading, rawFilterPriority, rawFilterType, setSearchParams]);
 
 	return (
 		<div className="container mx-auto px-4 py-8 transition-colors duration-200">
@@ -161,6 +176,8 @@ export default function BoardPage({
 				filterLabels={filterLabels}
 				filterPriority={filterPriority}
 				availablePriorities={availablePriorities}
+				filterType={filterType}
+				availableTypes={availableTypes}
 				onFiltersChange={handleFiltersChange}
 				hideEmptyColumns={hideEmptyColumns}
 				dateFormat={dateFormat}

--- a/src/web/components/SideNavigation.tsx
+++ b/src/web/components/SideNavigation.tsx
@@ -507,7 +507,9 @@ const SideNavigation = memo(function SideNavigation({
 								if (result.type === 'decision') {
 									return `/decisions/${stripIdPrefix(item.id)}/${sanitizeUrlTitle(item.title)}`;
 								}
-								return createUrlPath('/board', item.id, item.title);
+								const taskPath = createUrlPath('/board', item.id, item.title);
+								const isBoardLocation = location.pathname === '/board' || location.pathname.startsWith('/board/');
+								return isBoardLocation ? `${taskPath}${location.search}` : taskPath;
 							};
 
 							const getResultIcon = () => {

--- a/src/web/components/TaskCard.tsx
+++ b/src/web/components/TaskCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type Task } from '../../types';
 import { formatPriorityLabel } from '../../utils/priority-config';
+import TaskTypeBadge from './TaskTypeBadge';
 
 interface TaskCardProps {
   task: Task;
@@ -10,9 +11,10 @@ interface TaskCardProps {
   onDragEnd?: () => void;
   status?: string;
   laneId?: string;
+  availableTypes?: string[];
 }
 
-const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEnd, status, laneId }) => {
+const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEnd, status, laneId, availableTypes }) => {
   const [isDragging, setIsDragging] = React.useState(false);
   const [showBranchTooltip, setShowBranchTooltip] = React.useState(false);
 
@@ -126,9 +128,12 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEn
           </div>
         )}
 
-        {/* Header row with priority badge and task ID */}
+        {/* Header row with task metadata */}
         <div className="flex items-center justify-between gap-2 mb-1.5">
-          <span className="text-xs text-gray-400 dark:text-gray-500 font-mono transition-colors duration-200">{task.id}</span>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500 font-mono transition-colors duration-200">{task.id}</span>
+            <TaskTypeBadge type={task.type} availableTypes={availableTypes} className="min-w-0" />
+          </div>
           {(() => {
             const badge = getPriorityBadge(task.priority);
             return badge ? (

--- a/src/web/components/TaskColumn.tsx
+++ b/src/web/components/TaskColumn.tsx
@@ -19,6 +19,7 @@ interface TaskColumnProps {
   laneId?: string;
   targetMilestone?: string | null;
   priorityOrder?: string[];
+  availableTypes?: string[];
 }
 
 type CreatedDateSortDirection = 'asc' | 'desc';
@@ -63,6 +64,7 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
   laneId,
   targetMilestone,
   priorityOrder,
+  availableTypes,
 }) => {
   const [isDragOver, setIsDragOver] = React.useState(false);
   const [draggedTaskId, setDraggedTaskId] = React.useState<string | null>(null);
@@ -331,6 +333,7 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
               }}
               status={title}
               laneId={laneId}
+              availableTypes={availableTypes}
             />
             
             {/* Drop indicator for after this task */}

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -307,6 +307,10 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const [labels, setLabels] = useState<string[]>(task?.labels || []);
   const [priority, setPriority] = useState<string>(task?.priority || "");
   const [taskType, setTaskType] = useState<string>(task?.type || "");
+  const [typeUpdateError, setTypeUpdateError] = useState<string | null>(null);
+  const [isTypeUpdating, setIsTypeUpdating] = useState(false);
+  const typeUpdateInFlightRef = useRef(false);
+  const typeUpdateRequestRef = useRef(0);
   const [dependencies, setDependencies] = useState<string[]>(task?.dependencies || []);
   const [references, setReferences] = useState<string[]>(task?.references || []);
   const [milestone, setMilestone] = useState<string>(task?.milestone || "");
@@ -373,6 +377,10 @@ export const TaskDetailsModal: React.FC<Props> = ({
 
   // Reset local state when task changes or modal opens
   useEffect(() => {
+    typeUpdateRequestRef.current += 1;
+    typeUpdateInFlightRef.current = false;
+    setIsTypeUpdating(false);
+    setTypeUpdateError(null);
     const nextTaskId = task?.id ?? "";
     const nextFormState = buildTaskDetailsFormState({
       task,
@@ -694,6 +702,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
     // Don't allow updates for cross-branch tasks
     if (isFromOtherBranch) return;
 
+    setError(null);
+
     // Optimistic UI
     if (updates.status !== undefined) setStatus(String(updates.status));
     if (updates.assignee !== undefined) setAssignee(updates.assignee as string[]);
@@ -711,7 +721,47 @@ export const TaskDetailsModal: React.FC<Props> = ({
         if (onSaved) await onSaved();
       } catch (err) {
         console.error("Failed to update task metadata", err);
-        // No rollback for simplicity; caller can refresh
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    }
+  };
+
+  const handleTaskTypeChange = async (nextType: string) => {
+    if (isFromOtherBranch) return;
+    if (!task) {
+      setTaskType(nextType);
+      setTypeUpdateError(null);
+      return;
+    }
+    if (typeUpdateInFlightRef.current) return;
+
+    const previousType = taskType;
+    const requestId = typeUpdateRequestRef.current + 1;
+    typeUpdateRequestRef.current = requestId;
+    typeUpdateInFlightRef.current = true;
+    setIsTypeUpdating(true);
+    setTypeUpdateError(null);
+    setTaskType(nextType);
+
+    try {
+      const updatedTask = await apiClient.updateTask(task.id, { type: nextType });
+      if (typeUpdateRequestRef.current !== requestId) return;
+      setTaskType(updatedTask.type ?? "");
+      if (onSaved) {
+        try {
+          await onSaved();
+        } catch (refreshError) {
+          console.error("Task type was saved, but refreshing task data failed", refreshError);
+        }
+      }
+    } catch (updateError) {
+      if (typeUpdateRequestRef.current !== requestId) return;
+      setTaskType(previousType);
+      setTypeUpdateError(updateError instanceof Error ? updateError.message : String(updateError));
+    } finally {
+      if (typeUpdateRequestRef.current === requestId) {
+        typeUpdateInFlightRef.current = false;
+        setIsTypeUpdating(false);
       }
     }
   };
@@ -845,7 +895,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
       }
     >
       {error && (
-        <div className="mb-3 text-sm text-red-600 dark:text-red-400">{error}</div>
+        <div role="alert" className="mb-3 text-sm text-red-600 dark:text-red-400">{error}</div>
       )}
 
       {/* Cross-branch task indicator */}
@@ -1249,10 +1299,12 @@ export const TaskDetailsModal: React.FC<Props> = ({
             <SectionHeader title="Type" />
             <select
               aria-label="Task type"
-              className={`w-full h-10 px-3 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200 ${isFromOtherBranch ? 'opacity-60 cursor-not-allowed' : ''}`}
+              aria-invalid={typeUpdateError ? true : undefined}
+              aria-describedby={typeUpdateError ? "task-type-update-error" : undefined}
+              className={`w-full h-10 px-3 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200 ${isFromOtherBranch || isTypeUpdating ? 'opacity-60 cursor-not-allowed' : ''}`}
               value={typeSelectionValue}
-              onChange={(event) => void handleInlineMetaUpdate({ type: event.target.value })}
-              disabled={isFromOtherBranch}
+              onChange={(event) => void handleTaskTypeChange(event.target.value)}
+              disabled={isFromOtherBranch || isTypeUpdating}
             >
               <option value="">No type</option>
               {!canonicalTypeSelection && taskType.trim() ? (
@@ -1264,6 +1316,11 @@ export const TaskDetailsModal: React.FC<Props> = ({
                 </option>
               ))}
             </select>
+            {typeUpdateError ? (
+              <p id="task-type-update-error" role="alert" className="mt-2 text-xs text-red-600 dark:text-red-400">
+                {typeUpdateError}
+              </p>
+            ) : null}
           </div>
 
           {/* Assignee */}

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -377,11 +377,14 @@ export const TaskDetailsModal: React.FC<Props> = ({
 
   // Reset local state when task changes or modal opens
   useEffect(() => {
-    typeUpdateRequestRef.current += 1;
-    typeUpdateInFlightRef.current = false;
-    setIsTypeUpdating(false);
-    setTypeUpdateError(null);
     const nextTaskId = task?.id ?? "";
+    const modalIdentityChanged = previousTaskId.current !== nextTaskId || previousIsOpen.current !== isOpen;
+    if (modalIdentityChanged) {
+      typeUpdateRequestRef.current += 1;
+      typeUpdateInFlightRef.current = false;
+      setIsTypeUpdating(false);
+      setTypeUpdateError(null);
+    }
     const nextFormState = buildTaskDetailsFormState({
       task,
       isCreateMode,

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -10,6 +10,7 @@ import ChipInput from "./ChipInput";
 import DependencyInput from "./DependencyInput";
 import { formatStoredUtcDateForDisplay } from "../utils/date-display";
 import { getPriorityOptions } from "../../utils/priority-config";
+import { getTaskTypeValues, resolveTaskTypeValue } from "../../utils/task-type-config";
 
 interface Props {
   task?: Task; // Optional for create mode
@@ -22,6 +23,7 @@ interface Props {
   isDraftMode?: boolean; // Whether creating a draft
   availableMilestones?: string[];
   availablePriorities?: string[];
+  availableTypes?: string[];
   milestoneEntities?: Milestone[];
   archivedMilestoneEntities?: Milestone[];
   definitionOfDoneDefaults?: string[];
@@ -57,6 +59,7 @@ type TaskDetailsFormState = {
   assignee: string[];
   labels: string[];
   priority: string;
+  taskType: string;
   dependencies: string[];
   references: string[];
   milestone: string;
@@ -98,6 +101,7 @@ const buildTaskDetailsFormState = ({
   assignee: task?.assignee || [],
   labels: task?.labels || [],
   priority: task?.priority || "",
+  taskType: task?.type || "",
   dependencies: task?.dependencies || [],
   references: task?.references || [],
   milestone: task?.milestone || "",
@@ -122,6 +126,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   availableStatuses,
   availableMilestones: _availableMilestones,
   availablePriorities,
+  availableTypes,
   milestoneEntities,
   archivedMilestoneEntities,
   isDraftMode,
@@ -161,6 +166,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const initialDefinitionOfDone = task?.definitionOfDoneItems ?? (isCreateMode ? defaultDefinitionOfDone : []);
   const [definitionOfDone, setDefinitionOfDone] = useState<AcceptanceCriterion[]>(initialDefinitionOfDone);
   const priorityOptions = useMemo(() => getPriorityOptions(availablePriorities), [availablePriorities]);
+  const typeOptions = useMemo(() => getTaskTypeValues(availableTypes), [availableTypes]);
   const resolveMilestoneToId = useCallback((value?: string | null): string => {
     const normalized = (value ?? "").trim();
     if (!normalized) return "";
@@ -300,10 +306,13 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const [assignee, setAssignee] = useState<string[]>(task?.assignee || []);
   const [labels, setLabels] = useState<string[]>(task?.labels || []);
   const [priority, setPriority] = useState<string>(task?.priority || "");
+  const [taskType, setTaskType] = useState<string>(task?.type || "");
   const [dependencies, setDependencies] = useState<string[]>(task?.dependencies || []);
   const [references, setReferences] = useState<string[]>(task?.references || []);
   const [milestone, setMilestone] = useState<string>(task?.milestone || "");
   const [availableTasks, setAvailableTasks] = useState<Task[]>([]);
+  const canonicalTypeSelection = resolveTaskTypeValue(taskType, typeOptions);
+  const typeSelectionValue = canonicalTypeSelection ?? taskType;
   const milestoneSelectionValue = resolveMilestoneToId(milestone);
   const hasMilestoneSelection = (milestoneEntities ?? []).some((milestoneEntity) => milestoneEntity.id === milestoneSelectionValue);
 
@@ -412,6 +421,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
         preserveDirtyRefreshValue(current, previousFormState.labels, nextFormState.labels, areJsonEqual),
       );
       setPriority((current) => preserveDirtyRefreshValue(current, previousFormState.priority, nextFormState.priority));
+      setTaskType((current) => preserveDirtyRefreshValue(current, previousFormState.taskType, nextFormState.taskType));
       setDependencies((current) =>
         preserveDirtyRefreshValue(current, previousFormState.dependencies, nextFormState.dependencies, areJsonEqual),
       );
@@ -447,6 +457,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
     setAssignee(nextFormState.assignee);
     setLabels(nextFormState.labels);
     setPriority(nextFormState.priority);
+    setTaskType(nextFormState.taskType);
     setDependencies(nextFormState.dependencies);
     setReferences(nextFormState.references);
     setMilestone(nextFormState.milestone);
@@ -610,6 +621,10 @@ export const TaskDetailsModal: React.FC<Props> = ({
         milestone: milestone.trim().length > 0 ? milestone.trim() : undefined,
       };
 
+      if (isCreateMode) {
+        taskData.type = taskType;
+      }
+
       if (isCreateMode && onSubmit) {
         Object.assign(taskData, buildDefinitionOfDoneCreatePayload());
         // Create new task
@@ -684,6 +699,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
     if (updates.assignee !== undefined) setAssignee(updates.assignee as string[]);
     if (updates.labels !== undefined) setLabels(updates.labels as string[]);
     if (updates.priority !== undefined) setPriority(String(updates.priority));
+    if (updates.type !== undefined) setTaskType(String(updates.type));
     if (updates.dependencies !== undefined) setDependencies(updates.dependencies as string[]);
     if (updates.references !== undefined) setReferences(updates.references as string[]);
     if (updates.milestone !== undefined) setMilestone((updates.milestone ?? "") as string);
@@ -1227,6 +1243,28 @@ export const TaskDetailsModal: React.FC<Props> = ({
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
             <SectionHeader title="Status" />
             <StatusSelect current={status} onChange={(val) => handleInlineMetaUpdate({ status: val })} disabled={isFromOtherBranch} />
+          </div>
+
+          {/* Type */}
+          <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+            <SectionHeader title="Type" />
+            <select
+              aria-label="Task type"
+              className={`w-full h-10 px-3 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200 ${isFromOtherBranch ? 'opacity-60 cursor-not-allowed' : ''}`}
+              value={typeSelectionValue}
+              onChange={(event) => void handleInlineMetaUpdate({ type: event.target.value })}
+              disabled={isFromOtherBranch}
+            >
+              <option value="">No type</option>
+              {!canonicalTypeSelection && taskType.trim() ? (
+                <option value={taskType}>{taskType} (not configured)</option>
+              ) : null}
+              {typeOptions.map((typeOption) => (
+                <option key={typeOption} value={typeOption}>
+                  {typeOption}
+                </option>
+              ))}
+            </select>
           </div>
 
           {/* Assignee */}

--- a/src/web/components/TaskTypeBadge.tsx
+++ b/src/web/components/TaskTypeBadge.tsx
@@ -1,0 +1,88 @@
+import type React from "react";
+
+const TYPE_BADGE_PALETTES = [
+	"bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300",
+	"bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+	"bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300",
+	"bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200",
+	"bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+	"bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300",
+	"bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/40 dark:text-fuchsia-300",
+	"bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+] as const;
+
+const COMMON_TYPE_PALETTE_INDEX: Record<string, number> = {
+	bug: 0,
+	feature: 1,
+	enhancement: 2,
+	task: 3,
+	chore: 4,
+	docs: 5,
+	spike: 6,
+};
+
+function getPaletteIndex(taskType: string, availableTypes?: string[]): number {
+	const normalized = taskType.trim().toLowerCase();
+	const knownIndex = COMMON_TYPE_PALETTE_INDEX[normalized];
+	if (knownIndex !== undefined) {
+		return knownIndex;
+	}
+
+	if (availableTypes && availableTypes.length > 0) {
+		const usedKnownIndices = new Set<number>();
+		const configuredCustomTypes: string[] = [];
+		const seenCustomTypes = new Set<string>();
+		for (const availableType of availableTypes) {
+			const normalizedAvailableType = availableType.trim().toLowerCase();
+			if (!normalizedAvailableType) {
+				continue;
+			}
+			const availableKnownIndex = COMMON_TYPE_PALETTE_INDEX[normalizedAvailableType];
+			if (availableKnownIndex !== undefined) {
+				usedKnownIndices.add(availableKnownIndex);
+			} else if (!seenCustomTypes.has(normalizedAvailableType)) {
+				seenCustomTypes.add(normalizedAvailableType);
+				configuredCustomTypes.push(normalizedAvailableType);
+			}
+		}
+
+		const customTypeIndex = configuredCustomTypes.indexOf(normalized);
+		const availablePaletteIndices = TYPE_BADGE_PALETTES.map((_, index) => index).filter(
+			(index) => !usedKnownIndices.has(index),
+		);
+		if (customTypeIndex >= 0 && availablePaletteIndices.length > 0) {
+			return availablePaletteIndices[customTypeIndex % availablePaletteIndices.length] ?? 0;
+		}
+	}
+
+	let hash = 0;
+	for (const character of normalized) {
+		hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+	}
+	return hash % TYPE_BADGE_PALETTES.length;
+}
+
+interface TaskTypeBadgeProps {
+	type?: string;
+	availableTypes?: string[];
+	className?: string;
+}
+
+const TaskTypeBadge: React.FC<TaskTypeBadgeProps> = ({ type, availableTypes, className = "" }) => {
+	const label = type?.trim();
+	if (!label) {
+		return null;
+	}
+
+	return (
+		<span
+			data-task-type={label}
+			title={`Task type: ${label}`}
+			className={`inline-flex max-w-full items-center rounded-full px-2 py-0.5 text-[10px] font-semibold leading-4 ${TYPE_BADGE_PALETTES[getPaletteIndex(label, availableTypes)]} ${className}`}
+		>
+			<span className="truncate">{label}</span>
+		</span>
+	);
+};
+
+export default TaskTypeBadge;


### PR DESCRIPTION
Alex's Agent: Completes BACK-355.06 with the human-facing Web workflow for configured task types. The CLI remains the canonical agent workflow; this PR adds the browser surface without changing MCP into a primary workflow.

Related to #746

Summary:
- pass create, edit, and clear operations through the Web API into existing Core type validation, using the canonical server response and accessible rollback or retry errors
- show configured types in task cards with stable, distinct badges while leaving untyped cards unbadged and preserving historical values removed from config
- add configured type selectors to task detail and create flows, including No type as the create default
- add a canonical URL-backed board type filter and an intentional two-row title/action plus controls header
- use latest-request-wins loading and write locking so refreshes cannot overwrite newer task or type state
- preserve #755 cosmetic-slug routes, exact task identity, query parameters, close/Back/Forward history, focus return, stale-route rejection, and fail-closed missing or ambiguous task errors

Authoritative validation at `06f5e3ab7182f4bf4998c7d21d8af73aa01177cf`:
- focused route/type/layout tests: 37 passed, 0 failed, 314 assertions
- full `bun test`: 1,599 passed, 2 expected interactive TUI skips, 0 failed, 6,465 assertions across 1,601 tests and 185 files
- `bunx tsc --noEmit`
- `bun run check .` — 320 files checked
- `git diff --check`
- `bun run build`
- independent exact-tree review approved with no P1/P2 findings

Rendered Chrome QA:
- 1440x1000: verified the two-row header, configured/custom/untyped and historical badges, URL filtering, create/edit/clear flows, validation recovery, keyboard navigation, route history, zero overlays, and zero console warnings or errors
- 390x844 desktop-browser stress: verified best-effort narrow behavior with no document overflow; the Kanban owns horizontal scrolling and the task modal owns vertical scrolling
