### PR TITLE
BACK-535.3 - Make filesystem fixture cleanup fail visible

### DIFF
--- a/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
+++ b/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-535.3
 title: Make filesystem fixture cleanup fail visible
-status: In Progress
+status: Done
 assignee:
   - '@test-hygiene-filesystem'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 11:50'
+updated_date: '2026-07-11 11:59'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -27,7 +27,7 @@ Every site is identified by the current-main line captured in the audit; impleme
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Focused stress and the full local gate pass, and the exact PR head passes the actual GitHub Actions Windows test matrix; Windows-equivalent local evidence is insufficient
+- [x] #1 Focused stress and the full local gate pass, and the exact PR head passes the actual GitHub Actions Windows test matrix; Windows-equivalent local evidence is insufficient
 - [x] #2 All 37 enumerated redundant pre-clean sites are removed from unique fixture paths
 - [x] #3 All 59 enumerated filesystem-only teardown failures are fail-visible without changing test behavior
 - [x] #4 No BACK-535.4 resource-owning site, BACK-535.5 vacuous assertion site, or legitimate explicit catch site is changed
@@ -54,7 +54,15 @@ Specification review found acceptance-criteria-structured retained a fixed, unus
 Independent specification review approved the corrected exact diff after removal of the unused fixed TEMP_DIR fixture. Fresh quality review approved with no actionable findings after independently reconciling 146 baseline catches minus 96 owned removals to 50 documented exclusions, running the changed suite 617/617, and verifying TypeScript/Biome. AC1 remains intentionally unchecked until the published exact head passes the real GitHub Actions Windows matrix.
 
 First exact-head Windows CI exposed two failures. Shard 2 produced an unhandled ViewSwitcher BackgroundLoader error after afterEach removed its Git working directory; two updateState tests started background loads without awaiting them. Attached to each existing load, drained it with Promise.allSettled in finally so assertion failures remain primary, and asserted successful completion afterward. No production change, sleep, or timeout increase. ViewSwitcher passed 50/50 stress. The first full rerun hit an unrelated unchanged server SPA 5-second timeout; that exact test passed 10/10 in isolation, and a captured full rerun then passed 1,666 tests with 2 intentional skips, 0 failures, and 6,806 assertions across 189 files in 169.45s. TypeScript, Biome over 323 files, build, diff checks, and catch count 50 pass. Windows shard 1 also timed out in excluded build.test at its existing 30-second limit; no change is justified without recurrence after the actionable fix.
+
+Published reviewed head 3fd31f3 passed all 12 GitHub checks: CodeQL, Ubuntu/macOS/Windows compile and smoke, Ubuntu/macOS full tests, and Windows shards 1/3, 2/3, and 3/3. The excluded build.test timeout did not recur; the actionable ViewSwitcher shard-2 error is resolved. Specification spot-check and fresh quality re-review approved the exact Windows fix with no findings.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Removed 37 redundant pre-clean catches and made 59 filesystem teardown failures visible across 56 test files without production changes. Eliminated one dead fixed-path fixture and made ViewSwitcher tests drain background loading before deleting their Git fixture, preserving primary assertion errors. Reconciled the catch inventory from 146 to the expected 50 exclusions. Verified repeated 617-test changed-suite runs, a full 1,666-test local suite, 50/50 ViewSwitcher stress, TypeScript, Biome, build, sequential specification/quality approval, and all three GitHub Actions Windows shards.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
+++ b/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@test-hygiene-filesystem'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 11:32'
+updated_date: '2026-07-11 11:36'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -50,6 +50,8 @@ Context Hunter L2 brief: this is a wide mechanical test-only slice spanning 59 t
 Implemented all 96 owned sites across 56 test files: removed 37 redundant unique-path pre-clean catches and made 59 filesystem teardowns fail-visible. The A-L delegated batch repaired 78 sites and passed 512 focused tests; the M-Z batch repaired 18 sites and passed 105 focused tests. Integrated scan fell from 146 to exactly 50 remaining catches, matching 24 BACK-535.4 resource sites, 22 legitimate sites, and 4 BACK-535.5 sites; no excluded file changed. Moved cli-agents auxiliary directory cleanup into afterEach so assertion failures cannot skip it. Two integrated changed-suite runs each passed 617 tests across 56 files with 2,257 assertions and 0 failures in 95.89s and 91.73s. Full suite passed 1,666 with 2 intentional interactive-TUI skips, 0 failures, and 6,804 assertions across 189 files in 174.59s. bunx tsc --noEmit, Biome over 323 files, bun run build, and diff checks passed. Actual Windows CI remains required before AC1 and finalization.
 
 Specification review found acceptance-criteria-structured retained a fixed, unused repository temp directory after its catch removal. Removed the dead TEMP_DIR constant, beforeAll/afterAll hooks, and fs/path imports rather than replacing an unused fixture. Focused test passed 1/1; the integrated changed-suite rerun passed 617 tests across 56 files with 2,257 assertions and 0 failures in 89.18s. TypeScript, Biome over 323 files, build, diff checks, and the exact remaining-catch count of 50 passed.
+
+Independent specification review approved the corrected exact diff after removal of the unused fixed TEMP_DIR fixture. Fresh quality review approved with no actionable findings after independently reconciling 146 baseline catches minus 96 owned removals to 50 documented exclusions, running the changed suite 617/617, and verifying TypeScript/Biome. AC1 remains intentionally unchecked until the published exact head passes the real GitHub Actions Windows matrix.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
+++ b/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@test-hygiene-filesystem'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 11:27'
+updated_date: '2026-07-11 11:32'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -48,6 +48,8 @@ Every site is identified by the current-main line captured in the audit; impleme
 Context Hunter L2 brief: this is a wide mechanical test-only slice spanning 59 teardown and 37 redundant pre-clean sites. Follow the direct afterEach safeCleanup/rm pattern established by BACK-535.2; remove pre-clean only when createUniqueTestDir or mkdtemp already guarantees uniqueness; preserve primary errors for any in-test resource via a hook or drained finally. Reuse safeCleanup, remove only imports made unused, and do not touch BACK-535.4 resource files, BACK-535.5 vacuous sites, production code, or legitimate catches. Primary risks are overlapping setup/teardown edits, stale line numbers after rewrites, Windows file-handle cleanup, and accidentally changing fixture behavior.
 
 Implemented all 96 owned sites across 56 test files: removed 37 redundant unique-path pre-clean catches and made 59 filesystem teardowns fail-visible. The A-L delegated batch repaired 78 sites and passed 512 focused tests; the M-Z batch repaired 18 sites and passed 105 focused tests. Integrated scan fell from 146 to exactly 50 remaining catches, matching 24 BACK-535.4 resource sites, 22 legitimate sites, and 4 BACK-535.5 sites; no excluded file changed. Moved cli-agents auxiliary directory cleanup into afterEach so assertion failures cannot skip it. Two integrated changed-suite runs each passed 617 tests across 56 files with 2,257 assertions and 0 failures in 95.89s and 91.73s. Full suite passed 1,666 with 2 intentional interactive-TUI skips, 0 failures, and 6,804 assertions across 189 files in 174.59s. bunx tsc --noEmit, Biome over 323 files, bun run build, and diff checks passed. Actual Windows CI remains required before AC1 and finalization.
+
+Specification review found acceptance-criteria-structured retained a fixed, unused repository temp directory after its catch removal. Removed the dead TEMP_DIR constant, beforeAll/afterAll hooks, and fs/path imports rather than replacing an unused fixture. Focused test passed 1/1; the integrated changed-suite rerun passed 617 tests across 56 files with 2,257 assertions and 0 failures in 89.18s. TypeScript, Biome over 323 files, build, diff checks, and the exact remaining-catch count of 50 passed.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
+++ b/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@test-hygiene-filesystem'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 11:13'
+updated_date: '2026-07-11 11:27'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -28,9 +28,9 @@ Every site is identified by the current-main line captured in the audit; impleme
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 Focused stress and the full local gate pass, and the exact PR head passes the actual GitHub Actions Windows test matrix; Windows-equivalent local evidence is insufficient
-- [ ] #2 All 37 enumerated redundant pre-clean sites are removed from unique fixture paths
-- [ ] #3 All 59 enumerated filesystem-only teardown failures are fail-visible without changing test behavior
-- [ ] #4 No BACK-535.4 resource-owning site, BACK-535.5 vacuous assertion site, or legitimate explicit catch site is changed
+- [x] #2 All 37 enumerated redundant pre-clean sites are removed from unique fixture paths
+- [x] #3 All 59 enumerated filesystem-only teardown failures are fail-visible without changing test behavior
+- [x] #4 No BACK-535.4 resource-owning site, BACK-535.5 vacuous assertion site, or legitimate explicit catch site is changed
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -46,11 +46,13 @@ Every site is identified by the current-main line captured in the audit; impleme
 
 <!-- SECTION:NOTES:BEGIN -->
 Context Hunter L2 brief: this is a wide mechanical test-only slice spanning 59 teardown and 37 redundant pre-clean sites. Follow the direct afterEach safeCleanup/rm pattern established by BACK-535.2; remove pre-clean only when createUniqueTestDir or mkdtemp already guarantees uniqueness; preserve primary errors for any in-test resource via a hook or drained finally. Reuse safeCleanup, remove only imports made unused, and do not touch BACK-535.4 resource files, BACK-535.5 vacuous sites, production code, or legitimate catches. Primary risks are overlapping setup/teardown edits, stale line numbers after rewrites, Windows file-handle cleanup, and accidentally changing fixture behavior.
+
+Implemented all 96 owned sites across 56 test files: removed 37 redundant unique-path pre-clean catches and made 59 filesystem teardowns fail-visible. The A-L delegated batch repaired 78 sites and passed 512 focused tests; the M-Z batch repaired 18 sites and passed 105 focused tests. Integrated scan fell from 146 to exactly 50 remaining catches, matching 24 BACK-535.4 resource sites, 22 legitimate sites, and 4 BACK-535.5 sites; no excluded file changed. Moved cli-agents auxiliary directory cleanup into afterEach so assertion failures cannot skip it. Two integrated changed-suite runs each passed 617 tests across 56 files with 2,257 assertions and 0 failures in 95.89s and 91.73s. Full suite passed 1,666 with 2 intentional interactive-TUI skips, 0 failures, and 6,804 assertions across 189 files in 174.59s. bunx tsc --noEmit, Biome over 323 files, bun run build, and diff checks passed. Actual Windows CI remains required before AC1 and finalization.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
+++ b/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@test-hygiene-filesystem'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 11:36'
+updated_date: '2026-07-11 11:50'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -52,6 +52,8 @@ Implemented all 96 owned sites across 56 test files: removed 37 redundant unique
 Specification review found acceptance-criteria-structured retained a fixed, unused repository temp directory after its catch removal. Removed the dead TEMP_DIR constant, beforeAll/afterAll hooks, and fs/path imports rather than replacing an unused fixture. Focused test passed 1/1; the integrated changed-suite rerun passed 617 tests across 56 files with 2,257 assertions and 0 failures in 89.18s. TypeScript, Biome over 323 files, build, diff checks, and the exact remaining-catch count of 50 passed.
 
 Independent specification review approved the corrected exact diff after removal of the unused fixed TEMP_DIR fixture. Fresh quality review approved with no actionable findings after independently reconciling 146 baseline catches minus 96 owned removals to 50 documented exclusions, running the changed suite 617/617, and verifying TypeScript/Biome. AC1 remains intentionally unchecked until the published exact head passes the real GitHub Actions Windows matrix.
+
+First exact-head Windows CI exposed two failures. Shard 2 produced an unhandled ViewSwitcher BackgroundLoader error after afterEach removed its Git working directory; two updateState tests started background loads without awaiting them. Attached to each existing load, drained it with Promise.allSettled in finally so assertion failures remain primary, and asserted successful completion afterward. No production change, sleep, or timeout increase. ViewSwitcher passed 50/50 stress. The first full rerun hit an unrelated unchanged server SPA 5-second timeout; that exact test passed 10/10 in isolation, and a captured full rerun then passed 1,666 tests with 2 intentional skips, 0 failures, and 6,806 assertions across 189 files in 169.45s. TypeScript, Biome over 323 files, build, diff checks, and catch count 50 pass. Windows shard 1 also timed out in excluded build.test at its existing 30-second limit; no change is justified without recurrence after the actionable fix.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
+++ b/backlog/tasks/back-535.3 - Make-filesystem-fixture-cleanup-fail-visible.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-535.3
 title: Make filesystem fixture cleanup fail visible
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@test-hygiene-filesystem'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 10:58'
+updated_date: '2026-07-11 11:13'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -40,6 +41,12 @@ Every site is identified by the current-main line captured in the audit; impleme
 3. Confirm no BACK-535.4 resource-owning site and no justified/expected catch site changed.
 4. Run repeated focused batches locally, full static/build/test gates, then obtain successful GitHub Actions evidence from the actual Windows test matrix.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Context Hunter L2 brief: this is a wide mechanical test-only slice spanning 59 teardown and 37 redundant pre-clean sites. Follow the direct afterEach safeCleanup/rm pattern established by BACK-535.2; remove pre-clean only when createUniqueTestDir or mkdtemp already guarantees uniqueness; preserve primary errors for any in-test resource via a hook or drained finally. Reuse safeCleanup, remove only imports made unused, and do not touch BACK-535.4 resource files, BACK-535.5 vacuous sites, production code, or legitimate catches. Primary risks are overlapping setup/teardown edits, stale line numbers after rewrites, Windows file-handle cleanup, and accidentally changing fixture behavior.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/src/test/acceptance-criteria-structured.test.ts
+++ b/src/test/acceptance-criteria-structured.test.ts
@@ -1,19 +1,7 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { mkdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
 import { parseTask } from "../markdown/parser.ts";
 
-const TEMP_DIR = join(process.cwd(), ".tmp-structured-ac-test");
-
 describe("Structured Acceptance Criteria parsing", () => {
-	beforeAll(() => {
-		mkdirSync(TEMP_DIR, { recursive: true });
-	});
-
-	afterAll(() => {
-		rmSync(TEMP_DIR, { recursive: true, force: true });
-	});
-
 	it("parses acceptance criteria items with checked state and index", () => {
 		const content = `---
 id: task-999

--- a/src/test/acceptance-criteria-structured.test.ts
+++ b/src/test/acceptance-criteria-structured.test.ts
@@ -7,16 +7,11 @@ const TEMP_DIR = join(process.cwd(), ".tmp-structured-ac-test");
 
 describe("Structured Acceptance Criteria parsing", () => {
 	beforeAll(() => {
-		try {
-			rmSync(TEMP_DIR, { recursive: true, force: true });
-		} catch {}
 		mkdirSync(TEMP_DIR, { recursive: true });
 	});
 
 	afterAll(() => {
-		try {
-			rmSync(TEMP_DIR, { recursive: true, force: true });
-		} catch {}
+		rmSync(TEMP_DIR, { recursive: true, force: true });
 	});
 
 	it("parses acceptance criteria items with checked state and index", () => {

--- a/src/test/acceptance-criteria.test.ts
+++ b/src/test/acceptance-criteria.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -12,7 +12,6 @@ const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 describe("Acceptance Criteria CLI", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-acceptance-criteria");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
 		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
@@ -23,11 +22,7 @@ describe("Acceptance Criteria CLI", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("task create with acceptance criteria", () => {
@@ -468,7 +463,6 @@ describe("AcceptanceCriteriaManager unit tests", () => {
 
 	beforeEach(async () => {
 		TEST_DIR_UNIT = createUniqueTestDir("test-acceptance-criteria-unit");
-		await rm(TEST_DIR_UNIT, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR_UNIT, { recursive: true });
 		await $`git init -b main`.cwd(TEST_DIR_UNIT).quiet();
 		await $`git config user.name "Test User"`.cwd(TEST_DIR_UNIT).quiet();
@@ -479,11 +473,7 @@ describe("AcceptanceCriteriaManager unit tests", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR_UNIT);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR_UNIT);
 	});
 
 	test("should parse criteria with stable markers", () => {

--- a/src/test/agent-instructions.test.ts
+++ b/src/test/agent-instructions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import {
 	_loadAgentGuideline,
@@ -16,16 +16,11 @@ let TEST_DIR: string;
 describe("addAgentInstructions", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-agent-instructions");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("creates guideline files when none exist", async () => {

--- a/src/test/append-implementation-notes.test.ts
+++ b/src/test/append-implementation-notes.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -12,7 +12,6 @@ const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 describe("Append Implementation Notes via task edit --append-notes", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-append-notes");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
@@ -24,11 +23,7 @@ describe("Append Implementation Notes via task edit --append-notes", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// ignore
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("appends to existing Implementation Notes with single blank line separation", async () => {

--- a/src/test/auto-commit.test.ts
+++ b/src/test/auto-commit.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -13,7 +13,6 @@ describe("Auto-commit configuration", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-auto-commit");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Configure git for tests
@@ -26,11 +25,7 @@ describe("Auto-commit configuration", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("Config migration", () => {

--- a/src/test/board-loading.test.ts
+++ b/src/test/board-loading.test.ts
@@ -24,11 +24,7 @@ describe("Board Loading with checkActiveBranches", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	const createTestTask = (id: string, status = "To Do"): Task => ({

--- a/src/test/claude-agent-install.test.ts
+++ b/src/test/claude-agent-install.test.ts
@@ -11,12 +11,11 @@ describe("installClaudeAgent", () => {
 
 	beforeEach(async () => {
 		TEST_PROJECT = createUniqueTestDir("test-claude-agent");
-		await rm(TEST_PROJECT, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_PROJECT, { recursive: true });
 	});
 
 	afterEach(async () => {
-		await rm(TEST_PROJECT, { recursive: true, force: true }).catch(() => {});
+		await rm(TEST_PROJECT, { recursive: true, force: true });
 	});
 
 	it("creates .claude/agents directory in project root if it doesn't exist", async () => {

--- a/src/test/cleanup.test.ts
+++ b/src/test/cleanup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -25,11 +25,6 @@ describe("Cleanup functionality", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cleanup");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git repo
@@ -43,11 +38,7 @@ describe("Cleanup functionality", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("Core functionality", () => {

--- a/src/test/cli-agents.test.ts
+++ b/src/test/cli-agents.test.ts
@@ -6,13 +6,14 @@ import { Core } from "../index.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
 
 let TEST_DIR: string;
+let NON_BACKLOG_DIR: string | undefined;
 
 describe("CLI agents command", () => {
 	const cliPath = join(process.cwd(), "src", "cli.ts");
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-agents-cli");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
+		NON_BACKLOG_DIR = undefined;
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git repo first
@@ -26,11 +27,10 @@ describe("CLI agents command", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await Promise.all([
+			...(NON_BACKLOG_DIR ? [rm(NON_BACKLOG_DIR, { recursive: true, force: true })] : []),
+			safeCleanup(TEST_DIR),
+		]);
 	});
 
 	it("should show help when no options are provided", async () => {
@@ -93,25 +93,19 @@ describe("CLI agents command", () => {
 	it("should fail when not in a backlog project", async () => {
 		// Use OS temp directory to ensure complete isolation from project
 		const tempDir = await import("node:os").then((os) => os.tmpdir());
-		const nonBacklogDir = join(tempDir, `test-non-backlog-${Date.now()}-${Math.random().toString(36).substring(7)}`);
-
-		// Ensure clean state first
-		await rm(nonBacklogDir, { recursive: true, force: true }).catch(() => {});
+		NON_BACKLOG_DIR = join(tempDir, `test-non-backlog-${Date.now()}-${Math.random().toString(36).substring(7)}`);
 
 		// Create a temporary directory that's not a backlog project
-		await mkdir(nonBacklogDir, { recursive: true });
+		await mkdir(NON_BACKLOG_DIR, { recursive: true });
 
 		// Initialize git repo
-		await $`git init`.cwd(nonBacklogDir).quiet();
-		await $`git config user.name "Test User"`.cwd(nonBacklogDir).quiet();
-		await $`git config user.email test@example.com`.cwd(nonBacklogDir).quiet();
+		await $`git init`.cwd(NON_BACKLOG_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(NON_BACKLOG_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(NON_BACKLOG_DIR).quiet();
 
-		const result = await $`bun ${cliPath} agents --update-instructions`.cwd(nonBacklogDir).nothrow().quiet();
+		const result = await $`bun ${cliPath} agents --update-instructions`.cwd(NON_BACKLOG_DIR).nothrow().quiet();
 
 		expect(result.exitCode).toBe(1);
-
-		// Cleanup
-		await rm(nonBacklogDir, { recursive: true, force: true }).catch(() => {});
 	});
 
 	it("should update multiple selected files", async () => {

--- a/src/test/cli-auto-plain-non-tty.test.ts
+++ b/src/test/cli-auto-plain-non-tty.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -14,7 +14,6 @@ let core: Core;
 describe("CLI auto-plain behavior in non-TTY runs", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-auto-plain-non-tty");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
@@ -38,11 +37,7 @@ describe("CLI auto-plain behavior in non-TTY runs", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	test("task list falls back to plain output without --plain", async () => {

--- a/src/test/cli-commit-behaviour.test.ts
+++ b/src/test/cli-commit-behaviour.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -20,7 +20,6 @@ describe("CLI Auto-Commit Behavior with autoCommit: false", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-commit-false");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git repository first to avoid interactive prompts and ensure consistency
@@ -49,11 +48,7 @@ describe("CLI Auto-Commit Behavior with autoCommit: false", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	test("should not commit when creating a task if autoCommit is false", async () => {
@@ -101,7 +96,6 @@ describe("CLI Auto-Commit Behavior with autoCommit: true", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-commit-true");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
@@ -128,11 +122,7 @@ describe("CLI Auto-Commit Behavior with autoCommit: true", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	test("should commit when creating a task if autoCommit is true", async () => {

--- a/src/test/cli-final-summary.test.ts
+++ b/src/test/cli-final-summary.test.ts
@@ -23,7 +23,7 @@ describe("Final Summary CLI", () => {
 	});
 
 	afterEach(async () => {
-		await safeCleanup(TEST_DIR).catch(() => {});
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("supports --final-summary on task create", async () => {

--- a/src/test/cli-incrementing-ids.test.ts
+++ b/src/test/cli-incrementing-ids.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -15,7 +15,6 @@ describe("CLI ID Incrementing Behavior", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-incrementing-ids");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 		core = new Core(TEST_DIR);
 		// Initialize git repository first to avoid interactive prompts and ensure consistency
@@ -27,11 +26,7 @@ describe("CLI ID Incrementing Behavior", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	test("should increment task IDs correctly", async () => {

--- a/src/test/cli-init-no-git.test.ts
+++ b/src/test/cli-init-no-git.test.ts
@@ -34,11 +34,7 @@ describe("CLI init without Git", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	test("initializes a filesystem-only project without creating a Git repository", async () => {

--- a/src/test/cli-milestone-filter.test.ts
+++ b/src/test/cli-milestone-filter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -12,11 +12,6 @@ describe("CLI milestone filtering", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-milestone-filter");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
@@ -118,11 +113,7 @@ describe("CLI milestone filtering", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("filters by milestone with case-insensitive matching", async () => {

--- a/src/test/cli-parent-filter.test.ts
+++ b/src/test/cli-parent-filter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -12,11 +12,6 @@ describe("CLI parent task filtering", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-parent-filter");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git repo first using shell API (same pattern as other tests)
@@ -91,11 +86,7 @@ describe("CLI parent task filtering", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("should filter tasks by parent with full task ID", async () => {

--- a/src/test/cli-plain-create-edit.test.ts
+++ b/src/test/cli-plain-create-edit.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -12,9 +12,6 @@ describe("CLI --plain for task create/edit", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-plain-create-edit");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git repo first using shell API (same as other tests)
@@ -28,9 +25,7 @@ describe("CLI --plain for task create/edit", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("prints plain details after task create --plain", async () => {

--- a/src/test/cli-plain-output.test.ts
+++ b/src/test/cli-plain-output.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -13,11 +13,6 @@ describe("CLI plain output for AI agents", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-plain-output");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git repo first using shell API (same pattern as other tests)
@@ -90,11 +85,7 @@ describe("CLI plain output for AI agents", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("should output plain text with task view --plain", async () => {

--- a/src/test/cli-refs-docs.test.ts
+++ b/src/test/cli-refs-docs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -12,9 +12,6 @@ describe("CLI --ref and --doc flags", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-refs-docs");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
@@ -26,9 +23,7 @@ describe("CLI --ref and --doc flags", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("task create with --ref flag", () => {

--- a/src/test/cli-root-entry.test.ts
+++ b/src/test/cli-root-entry.test.ts
@@ -16,7 +16,7 @@ describe("CLI root entry (bare run)", () => {
 	});
 
 	afterEach(async () => {
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
+		await rm(TEST_DIR, { recursive: true, force: true });
 	});
 
 	it("can colorize the plain root entry when color is enabled", () => {

--- a/src/test/cli-task-milestone.test.ts
+++ b/src/test/cli-task-milestone.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -12,11 +12,6 @@ describe("CLI task milestone assignment", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-task-milestone");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
@@ -28,11 +23,7 @@ describe("CLI task milestone assignment", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("creates tasks with milestone titles resolved to canonical milestone IDs", async () => {

--- a/src/test/cli-task-type.test.ts
+++ b/src/test/cli-task-type.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -12,7 +12,6 @@ let core: Core;
 describe("CLI task types", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-task-type");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
 		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
@@ -27,7 +26,7 @@ describe("CLI task types", () => {
 	});
 
 	afterEach(async () => {
-		await safeCleanup(TEST_DIR).catch(() => {});
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("creates and edits typed tasks with configured canonical casing", async () => {

--- a/src/test/cli-task-wizard.test.ts
+++ b/src/test/cli-task-wizard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -11,7 +11,6 @@ const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 describe("CLI task wizard integration compatibility", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-task-wizard");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
 		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
@@ -22,11 +21,7 @@ describe("CLI task wizard integration compatibility", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors in tests
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("preserves non-interactive missing title error for task create", async () => {

--- a/src/test/cli-zero-padded-ids.test.ts
+++ b/src/test/cli-zero-padded-ids.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -12,11 +12,6 @@ let TEST_DIR: string;
 describe("CLI Zero Padded IDs Feature", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-zero-padded-ids");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git and backlog project
@@ -37,11 +32,7 @@ describe("CLI Zero Padded IDs Feature", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	test("should create a task with a zero-padded ID", async () => {

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm, stat } from "node:fs/promises";
+import { mkdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { CLI_AGENT_NUDGE, Core, isGitRepository } from "../index.ts";
@@ -17,20 +17,11 @@ const normalizeCliOutput = (output: string) => output.replace(/\r\n/g, "\n").rep
 describe("CLI Integration", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("root command", () => {

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -24,7 +24,7 @@ describe("Task comments", () => {
 	});
 
 	afterEach(async () => {
-		await safeCleanup(TEST_DIR).catch(() => {});
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("persists ordered comments and preserves markdown headings inside comment bodies", async () => {

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import type { PromptRunner } from "../commands/advanced-config-wizard.ts";
@@ -15,7 +15,6 @@ describe("Config commands", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-config-commands");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Configure git for tests - required for CI
@@ -188,11 +187,7 @@ describe("Config commands", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("should save and load defaultEditor config", async () => {

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -26,11 +26,7 @@ describe("Core", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("initialization", () => {

--- a/src/test/definition-of-done-cli.test.ts
+++ b/src/test/definition-of-done-cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -11,7 +11,6 @@ const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 describe("Definition of Done CLI", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-definition-of-done-cli");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
 		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
@@ -27,11 +26,7 @@ describe("Definition of Done CLI", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("creates task with Definition of Done defaults", async () => {

--- a/src/test/definition-of-done.test.ts
+++ b/src/test/definition-of-done.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -20,7 +20,6 @@ const writeConfigFile = async (root: string, content: string): Promise<void> => 
 describe("Definition of Done", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-definition-of-done");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
 		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
@@ -31,11 +30,7 @@ describe("Definition of Done", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("loads and saves definition_of_done in config", async () => {

--- a/src/test/dependency.test.ts
+++ b/src/test/dependency.test.ts
@@ -23,11 +23,7 @@ describe("Task Dependencies", () => {
 	});
 
 	afterEach(() => {
-		try {
-			rmSync(tempDir, { recursive: true, force: true });
-		} catch (error) {
-			console.warn(`Failed to clean up temp directory: ${error}`);
-		}
+		rmSync(tempDir, { recursive: true, force: true });
 	});
 
 	test("should create task with dependencies", async () => {

--- a/src/test/desc-alias.test.ts
+++ b/src/test/desc-alias.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -12,11 +12,6 @@ describe("--desc alias functionality", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-desc-alias");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git repo first
@@ -30,11 +25,7 @@ describe("--desc alias functionality", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("should create task with --desc alias", async () => {

--- a/src/test/description-newlines.test.ts
+++ b/src/test/description-newlines.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -12,9 +12,6 @@ describe("CLI description newline handling", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-desc-newlines");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init`.cwd(TEST_DIR).quiet();
@@ -26,9 +23,7 @@ describe("CLI description newline handling", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("should preserve literal newlines when creating task", async () => {

--- a/src/test/documentation.test.ts
+++ b/src/test/documentation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
@@ -11,7 +11,6 @@ describe("Task Documentation", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-documentation");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init`.cwd(TEST_DIR).quiet();
@@ -23,11 +22,7 @@ describe("Task Documentation", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("Create task with documentation", () => {

--- a/src/test/draft-create-consistency.test.ts
+++ b/src/test/draft-create-consistency.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -11,11 +11,6 @@ const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 describe("Draft creation consistency", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-draft-create-consistency");
-		try {
-			await rm(TEST_DIR, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
@@ -27,11 +22,7 @@ describe("Draft creation consistency", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("keeps IDs and filenames consistent between draft create and task create --draft", async () => {

--- a/src/test/editor.test.ts
+++ b/src/test/editor.test.ts
@@ -124,11 +124,7 @@ describe("Editor utilities", () => {
 		});
 
 		afterEach(async () => {
-			try {
-				await safeCleanup(TEST_DIR);
-			} catch {
-				// Ignore cleanup errors
-			}
+			await safeCleanup(TEST_DIR);
 		});
 
 		it("should open file with echo command for testing", async () => {

--- a/src/test/enhanced-init.test.ts
+++ b/src/test/enhanced-init.test.ts
@@ -13,11 +13,7 @@ describe("Enhanced init command", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(tmpDir);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(tmpDir);
 	});
 
 	test("should detect existing project and preserve config during re-initialization", async () => {

--- a/src/test/filesystem.test.ts
+++ b/src/test/filesystem.test.ts
@@ -19,11 +19,7 @@ describe("FileSystem", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("ensureBacklogStructure", () => {

--- a/src/test/final-summary.test.ts
+++ b/src/test/final-summary.test.ts
@@ -21,7 +21,7 @@ describe("Final Summary", () => {
 	});
 
 	afterEach(async () => {
-		await safeCleanup(TEST_DIR).catch(() => {});
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("creates tasks with Final Summary and persists section markers", async () => {

--- a/src/test/find-backlog-root.test.ts
+++ b/src/test/find-backlog-root.test.ts
@@ -16,11 +16,7 @@ describe("findBacklogRoot", () => {
 
 	afterEach(async () => {
 		clearProjectRootCache();
-		try {
-			await rm(testDir, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
+		await rm(testDir, { recursive: true, force: true });
 	});
 
 	it("should find root when backlog/ directory with config exists at start dir", async () => {

--- a/src/test/id-generation.test.ts
+++ b/src/test/id-generation.test.ts
@@ -19,11 +19,7 @@ describe("Task ID Generation with Archives", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await rm(testDir, { recursive: true, force: true });
-		} catch {
-			// Ignore cleanup errors
-		}
+		await rm(testDir, { recursive: true, force: true });
 	});
 
 	it("should reuse IDs from archived tasks (soft delete behavior)", async () => {

--- a/src/test/implementation-notes-append.test.ts
+++ b/src/test/implementation-notes-append.test.ts
@@ -23,7 +23,7 @@ describe("Implementation Notes - append", () => {
 	});
 
 	afterEach(async () => {
-		await safeCleanup(TEST_DIR).catch(() => {});
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("appends to existing Implementation Notes with single blank line", async () => {

--- a/src/test/implementation-notes.test.ts
+++ b/src/test/implementation-notes.test.ts
@@ -34,11 +34,7 @@ describe("Implementation Notes CLI", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("task create with implementation notes", () => {

--- a/src/test/implementation-plan.test.ts
+++ b/src/test/implementation-plan.test.ts
@@ -21,11 +21,7 @@ describe("Implementation Plan CLI", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("task create with implementation plan", () => {

--- a/src/test/parent-id-normalization.test.ts
+++ b/src/test/parent-id-normalization.test.ts
@@ -23,11 +23,7 @@ describe("CLI parent task id normalization", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("should normalize parent task id when creating subtasks", async () => {

--- a/src/test/prefix-migration.test.ts
+++ b/src/test/prefix-migration.test.ts
@@ -19,11 +19,7 @@ describe("Draft Prefix Migration", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("needsDraftPrefixMigration", () => {

--- a/src/test/references.test.ts
+++ b/src/test/references.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
@@ -11,7 +11,6 @@ describe("Task References", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-references");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		await $`git init`.cwd(TEST_DIR).quiet();
@@ -23,11 +22,7 @@ describe("Task References", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("Create task with references", () => {

--- a/src/test/remote-id-conflict.test.ts
+++ b/src/test/remote-id-conflict.test.ts
@@ -52,11 +52,7 @@ describe("next id across remote branches", () => {
 	});
 
 	afterAll(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("uses id after highest remote task", async () => {

--- a/src/test/start-id.test.ts
+++ b/src/test/start-id.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -17,7 +17,6 @@ async function initGitRepo(dir: string) {
 describe("task id generation", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-start-id");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 		await initGitRepo(TEST_DIR);
 		const core = new Core(TEST_DIR);
@@ -25,11 +24,7 @@ describe("task id generation", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("starts numbering tasks at 1", async () => {

--- a/src/test/status-callback.test.ts
+++ b/src/test/status-callback.test.ts
@@ -101,11 +101,7 @@ describe("Status Change Callbacks", () => {
 		});
 
 		afterEach(async () => {
-			try {
-				await rm(testDir, { recursive: true, force: true });
-			} catch {
-				// Ignore cleanup errors
-			}
+			await rm(testDir, { recursive: true, force: true });
 		});
 
 		test("triggers global callback on status change", async () => {

--- a/src/test/tab-switching.test.ts
+++ b/src/test/tab-switching.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -12,7 +12,6 @@ describe("Tab switching functionality", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-tab-switching");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Configure git for tests - required for CI
@@ -44,11 +43,7 @@ Test task for tab switching.`,
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("Unified Task domain", () => {

--- a/src/test/task-edit-preservation.test.ts
+++ b/src/test/task-edit-preservation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, readdir, rm } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
@@ -12,7 +12,6 @@ describe("Task edit section preservation", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-task-edit-preservation");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Initialize git repo first
@@ -26,11 +25,7 @@ describe("Task edit section preservation", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("preserves legacy task file identity and body when editing only labels", async () => {

--- a/src/test/task-path.test.ts
+++ b/src/test/task-path.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -19,7 +19,6 @@ describe("Task path utilities", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-task-path");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Configure git for tests - required for CI
@@ -41,11 +40,7 @@ describe("Task path utilities", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("normalizeTaskId", () => {

--- a/src/test/task-type.test.ts
+++ b/src/test/task-type.test.ts
@@ -23,11 +23,7 @@ describe("task type field", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("persistence round-trip", () => {

--- a/src/test/unified-view-loading.test.ts
+++ b/src/test/unified-view-loading.test.ts
@@ -16,11 +16,7 @@ describe("loadTasksForUnifiedView", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(testDir);
-		} catch {
-			// Ignore cleanup failures in tests
-		}
+		await safeCleanup(testDir);
 	});
 
 	it("uses provided loader progress and closes the loading screen", async () => {

--- a/src/test/view-switcher.test.ts
+++ b/src/test/view-switcher.test.ts
@@ -100,7 +100,7 @@ describe("View Switcher", () => {
 	});
 
 	describe("State updates", () => {
-		it("should update state correctly", () => {
+		it("should update state correctly", async () => {
 			const initialState: ViewState = {
 				type: "task-list",
 				tasks: [],
@@ -126,9 +126,15 @@ describe("View Switcher", () => {
 				selectedTask: newTask,
 				type: "task-detail",
 			});
+			const backgroundLoad = switcher.getKanbanData();
 
-			expect(updatedState.type).toBe("task-detail");
-			expect(updatedState.selectedTask).toEqual(newTask);
+			try {
+				expect(updatedState.type).toBe("task-detail");
+				expect(updatedState.selectedTask).toEqual(newTask);
+			} finally {
+				await Promise.allSettled([backgroundLoad]);
+			}
+			await expect(backgroundLoad).resolves.toBeDefined();
 		});
 	});
 
@@ -168,7 +174,7 @@ describe("View Switcher", () => {
 	});
 
 	describe("View change callback", () => {
-		it("should call onViewChange when state updates", () => {
+		it("should call onViewChange when state updates", async () => {
 			let callbackState: ViewState | null = null;
 
 			const initialState: ViewState = {
@@ -199,14 +205,20 @@ describe("View Switcher", () => {
 				selectedTask: newTask,
 				type: "task-detail",
 			});
+			const backgroundLoad = switcher.getKanbanData();
 
-			expect(callbackState).toBeTruthy();
-			if (!callbackState) {
-				throw new Error("callbackState should not be null");
+			try {
+				expect(callbackState).toBeTruthy();
+				if (!callbackState) {
+					throw new Error("callbackState should not be null");
+				}
+				const state = callbackState as unknown as ViewState;
+				expect(state.type).toBe("task-detail");
+				expect(state.selectedTask).toEqual(newTask);
+			} finally {
+				await Promise.allSettled([backgroundLoad]);
 			}
-			const state = callbackState as unknown as ViewState;
-			expect(state.type).toBe("task-detail");
-			expect(state.selectedTask).toEqual(newTask);
+			await expect(backgroundLoad).resolves.toBeDefined();
 		});
 	});
 });

--- a/src/test/view-switcher.test.ts
+++ b/src/test/view-switcher.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
 import { type ViewState, ViewSwitcher } from "../ui/view-switcher.ts";
@@ -11,7 +11,6 @@ describe("View Switcher", () => {
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-view-switcher");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Configure git for tests - required for CI
@@ -31,11 +30,7 @@ describe("View Switcher", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("ViewSwitcher initialization", () => {


### PR DESCRIPTION
## Summary
- remove 37 redundant pre-clean catches from isolated test fixtures
- make 59 filesystem teardown failures visible through framework hooks
- remove one dead fixed-path fixture and keep all 50 resource/legitimate/vacuous sites in their assigned follow-up scope

## Verification
- two integrated changed-suite runs: 617 passed across 56 files, 0 failed
- full suite: 1,666 passed, 2 intentional interactive-TUI skips, 0 failed
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- sequential independent specification and quality approval

No production behavior changes. BACK-535.4 and BACK-535.5 remain open. BACK-535.3 will be finalized only after this PR head passes the actual Windows matrix.