### PR TITLE
BACK-535.4 - Make server and process test teardown deterministic

### DIFF
--- a/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
+++ b/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@test-hygiene-resources'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 15:28'
+updated_date: '2026-07-11 15:36'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -56,6 +56,10 @@ Final local lifecycle candidate passed focused shared-helper/build/stdio coverag
 Post-BACK-535.6/BACK-535.7 reconciliation (supersedes earlier build-inclusive counts): BACK-535.6 removed src/test/build.test.ts and its four assigned cleanup sites as part of the accepted compiled-smoke consolidation. BACK-535.4 therefore owns the remaining 20 original resource-cleanup sites plus config-watcher lifecycle verification across 16 original test files, with src/test/test-utils.ts as the single shared close/error/kill helper file (17 changed test files total). Current catch inventory is 35: 24 baseline sites (20 legitimate explicit catches and four BACK-535.5 vacuous assertions) plus 11 new fail-visible error-preservation sites (mcp-stdio-exit 4, mcp-tasks 4, worktree-refresh 2, shared child-close helper 1). No production, CI, or BACK-535.5 files changed.
 
 Final rebase verification on unified-main 1f617b6: integrated lifecycle set passed 172/172 twice (30.72s and 30.01s); exact shared full command `bun test --isolate --timeout=10000 --max-concurrency=4` passed 1,665 with two intentional interactive-TUI skips across 188 files in 182.07s; bunx tsc --noEmit, Biome over 324 files, bun run build, and git diff --check passed. AC4 remains open pending this exact repair head in unified Linux/macOS/Windows CI.
+
+Final stage-1 review found and corrected one shutdown-observation race: the raw MCP stdio test had attached the shared close helper at spawn, which also started its one-second graceful timer before shutdown was requested. The shared helper now observes close/error immediately but exposes an idempotent startTimeout operation; the raw test activates it only after stdin closes or cleanup begins, while the transport test activates it immediately before client.close. This preserves the existing four-second startup allowance and keeps bounded shutdown diagnostics separate from tested process lifetime.
+
+Post-correction exact verification: focused stdio/helper tests passed 5/5; integrated lifecycle set passed 172/172 twice (27.44s and 27.16s); shared full command passed 1,665 with two intentional skips across 188 files in 170.39s; typecheck, Biome over 324 files, build, and diff checks passed. Unified-main operational baseline is green in CI run 29157797520 and CodeQL run 29157797240. AC4 remains open for this repair head.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
+++ b/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@test-hygiene-resources'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 12:05'
+updated_date: '2026-07-11 12:53'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -25,21 +25,38 @@ Stop servers and watchers, close clients, streams, content stores, and search se
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every owned server, watcher, client, stream, subscription, and child process is deterministically released
-- [ ] #2 Shutdown failures remain visible and primary assertion failures remain diagnosable
-- [ ] #3 No arbitrary sleeps or timeout increases are used as lifecycle fixes
+- [x] #1 Every owned server, watcher, client, stream, subscription, and child process is deterministically released
+- [x] #2 Shutdown failures remain visible and primary assertion failures remain diagnosable
+- [x] #3 No arbitrary sleeps or timeout increases are used as lifecycle fixes
 - [ ] #4 Focused repeated stress and full cross-platform CI pass
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Audit the 17 owned resource-bearing test files and classify the 24 assigned swallowed cleanup sites.
+2. Release resources in reverse acquisition order, await terminal process state, preserve primary failures, and remove arbitrary lifecycle sleeps without production changes.
+3. Run repeated focused stress, full static/build/test gates, and independent specification and quality reviews.
+4. Publish the bounded test-only PR and require exact-head Linux, macOS, and Windows CI before finalization.
+<!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Context Hunter L2 brief: this is test-only lifecycle work across MCP servers/clients, stdio processes, browser processes, config watchers, ContentStore/SearchService, board background operations, and Git worktrees. Follow resource acquisition in each file and release in reverse order before filesystem cleanup. Reuse existing stop/close/dispose/kill/exited/cancel APIs; attach rejection handlers immediately, await terminal state, and preserve a primary test failure when shutdown also fails. Do not add sleeps/timeouts as fixes, change production code, touch BACK-535.5 vacuous sites, or broaden the 17 owned files. Risks: stop methods may not be idempotent, abort may not drain an in-flight promise, process kill without exited can leak, worktree removal can race Git, and a teardown failure can mask an assertion. No new identifiers should be introduced without following local resource names.
+
+Integrated audit after implementation: all 24 owned swallowed cleanup/pre-clean sites were removed. The remaining test catch inventory is 39 sites: 22 previously classified legitimate catches, four vacuous assertions reserved for BACK-535.5, and 13 new fail-visible catches used only to preserve or aggregate primary and cleanup failures (build 3, mcp-stdio-exit 4, mcp-tasks 4, worktree-refresh 2). No production files changed.
+
+Independent spec review found and corrected two lifecycle gaps before freeze: board fixtures now guard Core disposal when setup fails before construction, and the compiled MCP smoke test captures and awaits the transport-owned child terminal event alongside client.close(). Corrected-head validation: two integrated runs passed 170/170 each; focused corrected paths passed 9/9; full suite passed 1666 with two intentional interactive-TUI skips; bunx tsc --noEmit, Biome over 323 files, bun run build, and git diff --check passed. Exact-head cross-platform CI remains required before AC4/finalization.
+
+Scope/evidence correction (supersedes the earlier 17-file/39-catch statement): the two process-close implementations converged, so src/test/test-utils.ts is an intentional 18th test-infrastructure file used to keep close/error/kill/listener semantics single-sourced. The current catch inventory is 40 sites: 26 baseline sites (22 legitimate plus four reserved for BACK-535.5) and 14 new fail-visible error-preservation sites, including the shared helper kill-error capture.
+
+Final local lifecycle candidate passed focused shared-helper/build/stdio coverage 6/6, integrated coverage 173/173 twice, typecheck, Biome over 323 files, build, and diff-check. The exact full suite then reported 1665 pass, two intentional interactive-TUI skips, and one failure: the unchanged monolithic CLI packaging test hit Bun’s 5000ms outer timeout under full-suite contention for the second time. Isolated packaging passed repeatedly around 2-3.3s. Per maintainer coordination, do not alter packaging/workflows or mark AC4 complete in BACK-535.4; BACK-535.6 owns that repeated build/CI duplication and timeout. Rebase this frozen lifecycle commit after BACK-535.6 merges, then rerun exact integrated/full/static and independent reviews before PR/finalization.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->

--- a/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
+++ b/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-535.4
 title: Make server and process test teardown deterministic
-status: In Progress
+status: Done
 assignee:
   - '@test-hygiene-resources'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 15:36'
+updated_date: '2026-07-11 15:51'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -28,7 +28,7 @@ Stop servers and watchers, close clients, streams, content stores, and search se
 - [x] #1 Every owned server, watcher, client, stream, subscription, and child process is deterministically released
 - [x] #2 Shutdown failures remain visible and primary assertion failures remain diagnosable
 - [x] #3 No arbitrary sleeps or timeout increases are used as lifecycle fixes
-- [ ] #4 Focused repeated stress and full cross-platform CI pass
+- [x] #4 Focused repeated stress and full cross-platform CI pass
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -60,7 +60,15 @@ Final rebase verification on unified-main 1f617b6: integrated lifecycle set pass
 Final stage-1 review found and corrected one shutdown-observation race: the raw MCP stdio test had attached the shared close helper at spawn, which also started its one-second graceful timer before shutdown was requested. The shared helper now observes close/error immediately but exposes an idempotent startTimeout operation; the raw test activates it only after stdin closes or cleanup begins, while the transport test activates it immediately before client.close. This preserves the existing four-second startup allowance and keeps bounded shutdown diagnostics separate from tested process lifetime.
 
 Post-correction exact verification: focused stdio/helper tests passed 5/5; integrated lifecycle set passed 172/172 twice (27.44s and 27.16s); shared full command passed 1,665 with two intentional skips across 188 files in 170.39s; typecheck, Biome over 324 files, build, and diff checks passed. Unified-main operational baseline is green in CI run 29157797520 and CodeQL run 29157797240. AC4 remains open for this repair head.
+
+Exact implementation-head PR verification at 446e47d: CI run 29158369735 passed full unit jobs on Ubuntu (3m53s), macOS (3m53s), and Windows (9m49s), plus compiled build/smoke on Ubuntu (20s), macOS (29s), and Windows (1m32s). JUnit artifacts were non-empty: Ubuntu 66,166 bytes, macOS 66,955 bytes, Windows 65,505 bytes. CodeQL run 29158369248 passed both JavaScript/TypeScript and Actions analyses. Both independent final reviews approved the exact diff with no blockers.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made resource-owning tests deterministic and fail-visible: MCP servers/clients, watchers, stores, child processes, and Git worktrees now release before fixture deletion; cleanup failures aggregate without hiding primary assertions. Shared child-close observation captures events immediately while bounded shutdown timers begin only when cleanup starts. Verified with repeated 172-test lifecycle stress, the 1,665-test full suite, static/build gates, independent specification and quality reviews, and unified Linux/macOS/Windows CI, compiled smoke, JUnit artifacts, and CodeQL.
+<!-- SECTION:FINAL_SUMMARY:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
+++ b/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@test-hygiene-resources'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 12:53'
+updated_date: '2026-07-11 15:28'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -52,6 +52,10 @@ Independent spec review found and corrected two lifecycle gaps before freeze: bo
 Scope/evidence correction (supersedes the earlier 17-file/39-catch statement): the two process-close implementations converged, so src/test/test-utils.ts is an intentional 18th test-infrastructure file used to keep close/error/kill/listener semantics single-sourced. The current catch inventory is 40 sites: 26 baseline sites (22 legitimate plus four reserved for BACK-535.5) and 14 new fail-visible error-preservation sites, including the shared helper kill-error capture.
 
 Final local lifecycle candidate passed focused shared-helper/build/stdio coverage 6/6, integrated coverage 173/173 twice, typecheck, Biome over 323 files, build, and diff-check. The exact full suite then reported 1665 pass, two intentional interactive-TUI skips, and one failure: the unchanged monolithic CLI packaging test hit Bun’s 5000ms outer timeout under full-suite contention for the second time. Isolated packaging passed repeatedly around 2-3.3s. Per maintainer coordination, do not alter packaging/workflows or mark AC4 complete in BACK-535.4; BACK-535.6 owns that repeated build/CI duplication and timeout. Rebase this frozen lifecycle commit after BACK-535.6 merges, then rerun exact integrated/full/static and independent reviews before PR/finalization.
+
+Post-BACK-535.6/BACK-535.7 reconciliation (supersedes earlier build-inclusive counts): BACK-535.6 removed src/test/build.test.ts and its four assigned cleanup sites as part of the accepted compiled-smoke consolidation. BACK-535.4 therefore owns the remaining 20 original resource-cleanup sites plus config-watcher lifecycle verification across 16 original test files, with src/test/test-utils.ts as the single shared close/error/kill helper file (17 changed test files total). Current catch inventory is 35: 24 baseline sites (20 legitimate explicit catches and four BACK-535.5 vacuous assertions) plus 11 new fail-visible error-preservation sites (mcp-stdio-exit 4, mcp-tasks 4, worktree-refresh 2, shared child-close helper 1). No production, CI, or BACK-535.5 files changed.
+
+Final rebase verification on unified-main 1f617b6: integrated lifecycle set passed 172/172 twice (30.72s and 30.01s); exact shared full command `bun test --isolate --timeout=10000 --max-concurrency=4` passed 1,665 with two intentional interactive-TUI skips across 188 files in 182.07s; bunx tsc --noEmit, Biome over 324 files, bun run build, and git diff --check passed. AC4 remains open pending this exact repair head in unified Linux/macOS/Windows CI.
 <!-- SECTION:NOTES:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
+++ b/backlog/tasks/back-535.4 - Make-server-and-process-test-teardown-deterministic.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-535.4
 title: Make server and process test teardown deterministic
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@test-hygiene-resources'
 created_date: '2026-07-11 09:21'
-updated_date: '2026-07-11 10:58'
+updated_date: '2026-07-11 12:05'
 labels: []
 dependencies: []
 parent_task_id: BACK-535
@@ -29,6 +30,12 @@ Stop servers and watchers, close clients, streams, content stores, and search se
 - [ ] #3 No arbitrary sleeps or timeout increases are used as lifecycle fixes
 - [ ] #4 Focused repeated stress and full cross-platform CI pass
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Context Hunter L2 brief: this is test-only lifecycle work across MCP servers/clients, stdio processes, browser processes, config watchers, ContentStore/SearchService, board background operations, and Git worktrees. Follow resource acquisition in each file and release in reverse order before filesystem cleanup. Reuse existing stop/close/dispose/kill/exited/cancel APIs; attach rejection handlers immediately, await terminal state, and preserve a primary test failure when shutdown also fails. Do not add sleeps/timeouts as fixes, change production code, touch BACK-535.5 vacuous sites, or broaden the 17 owned files. Risks: stop methods may not be idempotent, abort may not drain an in-flight promise, process kill without exited can leak, worktree removal can race Git, and a teardown failure can mask an assertion. No new identifiers should be introduced without following local resource names.
+<!-- SECTION:NOTES:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/src/test/board-command.test.ts
+++ b/src/test/board-command.test.ts
@@ -9,10 +9,11 @@ let TEST_DIR: string;
 
 describe("Board command integration", () => {
 	let core: Core;
+	let coreInitialized = false;
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-board-command");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
+		coreInitialized = false;
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Configure git for tests - required for CI
@@ -21,6 +22,7 @@ describe("Board command integration", () => {
 		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
 
 		core = new Core(TEST_DIR);
+		coreInitialized = true;
 		await initializeTestProject(core, "Test Board Project");
 
 		// Disable remote operations for tests to prevent background git fetches
@@ -68,13 +70,8 @@ This is another test task for board testing.`,
 	});
 
 	afterEach(async () => {
-		// Wait a bit to ensure any background operations complete
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		if (coreInitialized) core.disposeContentStore();
+		await safeCleanup(TEST_DIR);
 	});
 
 	describe("Board loading", () => {
@@ -104,8 +101,8 @@ This is another test task for board testing.`,
 		it("should handle empty task list gracefully", async () => {
 			// Remove test tasks
 			const tasksDir = core.filesystem.tasksDir;
-			await rm(join(tasksDir, "task-1 - Test Task One.md")).catch(() => {});
-			await rm(join(tasksDir, "task-2 - Test Task Two.md")).catch(() => {});
+			await rm(join(tasksDir, "task-1 - Test Task One.md"));
+			await rm(join(tasksDir, "task-2 - Test Task Two.md"));
 
 			const tasks = await core.filesystem.listTasks();
 			expect(tasks.length).toBe(0);

--- a/src/test/cli-board-integration.test.ts
+++ b/src/test/cli-board-integration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -9,10 +9,11 @@ let TEST_DIR: string;
 
 describe("CLI Board Integration", () => {
 	let core: Core;
+	let coreInitialized = false;
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-board-integration");
-		await rm(TEST_DIR, { recursive: true, force: true }).catch(() => {});
+		coreInitialized = false;
 		await mkdir(TEST_DIR, { recursive: true });
 
 		// Configure git for tests - required for CI
@@ -21,6 +22,7 @@ describe("CLI Board Integration", () => {
 		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
 
 		core = new Core(TEST_DIR);
+		coreInitialized = true;
 		await initializeTestProject(core, "Test CLI Board Project");
 
 		// Disable remote operations for tests to prevent background git fetches
@@ -51,13 +53,8 @@ Test task for board CLI integration.`,
 	});
 
 	afterEach(async () => {
-		// Wait a bit to ensure any background operations from listTasksWithMetadata complete
-		await new Promise((resolve) => setTimeout(resolve, 100));
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - the unique directory names prevent conflicts
-		}
+		if (coreInitialized) core.disposeContentStore();
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("should handle board command logic without crashing", async () => {

--- a/src/test/config-watcher.test.ts
+++ b/src/test/config-watcher.test.ts
@@ -10,6 +10,7 @@ import { createUniqueTestDir, getPlatformTimeout, safeCleanup } from "./test-uti
 
 let testDir: string;
 let core: Core;
+let watcherChild: Bun.Subprocess<"ignore", "ignore", "pipe"> | undefined;
 
 const initialConfig: BacklogConfig = {
 	projectName: "Config watcher",
@@ -47,12 +48,18 @@ async function replaceConfigFile(content: string): Promise<void> {
 describe("config watcher", () => {
 	beforeEach(async () => {
 		testDir = createUniqueTestDir("config-watcher");
+		watcherChild = undefined;
 		core = new Core(testDir);
 		await core.filesystem.ensureBacklogStructure();
 		await core.filesystem.saveConfig(initialConfig);
 	});
 
 	afterEach(async () => {
+		if (watcherChild) {
+			watcherChild.kill();
+			await watcherChild.exited;
+			watcherChild = undefined;
+		}
 		core.disposeContentStore();
 		await safeCleanup(testDir);
 	});
@@ -560,22 +567,18 @@ describe("config watcher", () => {
 			import { watchConfigFile } from "./src/utils/config-watcher.ts";
 			watchConfigFile(new FileSystem(${JSON.stringify(missingProjectRoot)}), {});
 		`;
-		const child = Bun.spawn(["bun", "-e", script], {
+		watcherChild = Bun.spawn(["bun", "-e", script], {
 			cwd: process.cwd(),
 			stdin: "ignore",
 			stdout: "ignore",
 			stderr: "pipe",
 		});
 
-		try {
-			const exitCode = await withTimeout(child.exited, "unrefed config watcher child exit");
-			if (exitCode !== 0) {
-				const stderr = child.stderr ? await new Response(child.stderr).text() : "";
-				throw new Error(`Watcher child exited with ${exitCode}: ${stderr}`);
-			}
-			expect(exitCode).toBe(0);
-		} finally {
-			child.kill();
+		const exitCode = await withTimeout(watcherChild.exited, "unrefed config watcher child exit");
+		if (exitCode !== 0) {
+			const stderr = watcherChild.stderr ? await new Response(watcherChild.stderr).text() : "";
+			throw new Error(`Watcher child exited with ${exitCode}: ${stderr}`);
 		}
+		expect(exitCode).toBe(0);
 	});
 });

--- a/src/test/content-store.test.ts
+++ b/src/test/content-store.test.ts
@@ -57,11 +57,7 @@ describe("ContentStore", () => {
 
 	afterEach(async () => {
 		store?.dispose();
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("loads tasks, documents, and decisions during initialization", async () => {

--- a/src/test/mcp-definition-of-done-defaults.test.ts
+++ b/src/test/mcp-definition-of-done-defaults.test.ts
@@ -39,12 +39,13 @@ describe("MCP Definition of Done default tools", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await server.stop();
-		} catch {
-			// ignore
-		}
-		await safeCleanup(testDir);
+		const stopResult = await Promise.allSettled([server.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(testDir)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	it("gets and upserts project Definition of Done defaults", async () => {

--- a/src/test/mcp-documents.test.ts
+++ b/src/test/mcp-documents.test.ts
@@ -39,12 +39,13 @@ describe("MCP document tools", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await mcpServer.stop();
-		} catch {
-			// ignore shutdown issues in tests
-		}
-		await safeCleanup(TEST_DIR);
+		const stopResult = await Promise.allSettled([mcpServer.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(TEST_DIR)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	it("creates and lists documents", async () => {

--- a/src/test/mcp-drafts.test.ts
+++ b/src/test/mcp-drafts.test.ts
@@ -39,12 +39,13 @@ describe("MCP draft support via task tools", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await mcpServer.stop();
-		} catch {
-			// ignore
-		}
-		await safeCleanup(TEST_DIR);
+		const stopResult = await Promise.allSettled([mcpServer.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(TEST_DIR)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	it("creates, lists, and views drafts while excluding them by default", async () => {

--- a/src/test/mcp-final-summary.test.ts
+++ b/src/test/mcp-final-summary.test.ts
@@ -37,12 +37,13 @@ describe("MCP final summary", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await mcpServer.stop();
-		} catch {
-			// ignore
-		}
-		await safeCleanup(TEST_DIR);
+		const stopResult = await Promise.allSettled([mcpServer.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(TEST_DIR)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	it("supports finalSummary on task_create and task_view output", async () => {

--- a/src/test/mcp-milestones.test.ts
+++ b/src/test/mcp-milestones.test.ts
@@ -64,12 +64,13 @@ describe("MCP milestone tools", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await server.stop();
-		} catch {
-			// ignore
-		}
-		await safeCleanup(TEST_DIR);
+		const stopResult = await Promise.allSettled([server.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(TEST_DIR)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	it("assigns and clears a milestone without blocking the content store", async () => {

--- a/src/test/mcp-refs-docs.test.ts
+++ b/src/test/mcp-refs-docs.test.ts
@@ -37,12 +37,13 @@ describe("MCP task references and documentation", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await mcpServer.stop();
-		} catch {
-			// ignore
-		}
-		await safeCleanup(TEST_DIR);
+		const stopResult = await Promise.allSettled([mcpServer.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(TEST_DIR)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	describe("task_create with references", () => {

--- a/src/test/mcp-stdio-exit.test.ts
+++ b/src/test/mcp-stdio-exit.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Core } from "../core/backlog.ts";
 import { initializeProject } from "../core/init.ts";
-import { createUniqueTestDir, getPlatformTimeout, isWindows, safeCleanup, waitForChildClose } from "./test-utils.ts";
+import { createUniqueTestDir, getPlatformTimeout, isWindows, observeChildClose, safeCleanup } from "./test-utils.ts";
 
 const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 const START_MESSAGE = "Backlog.md MCP server started (stdio transport)";
@@ -103,7 +103,8 @@ describe("MCP stdio shutdown", () => {
 			cwd: TEST_DIR,
 			stdio: ["pipe", "pipe", "pipe"],
 		});
-		const childClose = waitForChildClose(child, "MCP process", Math.min(timeout, 2000)).then(
+		const childClose = observeChildClose(child, "MCP process", Math.min(timeout, 2000));
+		const closeOutcome = childClose.result.then(
 			(result) => ({ ok: true as const, result }),
 			(error: unknown) => ({ ok: false as const, error }),
 		);
@@ -116,27 +117,32 @@ describe("MCP stdio shutdown", () => {
 
 			await waitForSubstring(child.stderr, START_MESSAGE, timeout);
 			child.stdin.end();
+			childClose.startTimeout();
 
-			const closeOutcome = await childClose;
-			if (!closeOutcome.ok) throw closeOutcome.error;
-			expect(closeOutcome.result.code).toBe(0);
-			expect(closeOutcome.result.signal).toBeNull();
+			const primaryCloseOutcome = await closeOutcome;
+			if (!primaryCloseOutcome.ok) throw primaryCloseOutcome.error;
+			expect(primaryCloseOutcome.result.code).toBe(0);
+			expect(primaryCloseOutcome.result.signal).toBeNull();
 		} catch (error) {
 			primaryError = error;
 		}
 
+		childClose.startTimeout();
 		let cleanupError: unknown;
 		try {
 			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
 		} catch (error) {
 			cleanupError = error;
 		}
-		const closeOutcome = await childClose;
-		if (!closeOutcome.ok && closeOutcome.error !== primaryError) {
+		const cleanupCloseOutcome = await closeOutcome;
+		if (!cleanupCloseOutcome.ok && cleanupCloseOutcome.error !== primaryError) {
 			cleanupError =
 				cleanupError === undefined
-					? closeOutcome.error
-					: new AggregateError([cleanupError, closeOutcome.error], "MCP process kill and close wait both failed");
+					? cleanupCloseOutcome.error
+					: new AggregateError(
+							[cleanupError, cleanupCloseOutcome.error],
+							"MCP process kill and close wait both failed",
+						);
 		}
 
 		if (primaryError !== undefined && cleanupError !== undefined) {
@@ -198,8 +204,10 @@ describe("MCP stdio shutdown", () => {
 		}
 
 		const child = (transport as unknown as { _process?: ReturnType<typeof spawn> })._process;
-		const exitOutcome = child
-			? waitForChildClose(child, "MCP transport process", Math.min(timeout, 2000)).then(
+		const childClose = child ? observeChildClose(child, "MCP transport process", Math.min(timeout, 2000)) : undefined;
+		childClose?.startTimeout();
+		const exitOutcome = childClose
+			? childClose.result.then(
 					() => ({ error: undefined }),
 					(error: unknown) => ({ error }),
 				)

--- a/src/test/mcp-stdio-exit.test.ts
+++ b/src/test/mcp-stdio-exit.test.ts
@@ -6,14 +6,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Core } from "../core/backlog.ts";
 import { initializeProject } from "../core/init.ts";
-import { createUniqueTestDir, getPlatformTimeout, isWindows, safeCleanup, sleep } from "./test-utils.ts";
+import { createUniqueTestDir, getPlatformTimeout, isWindows, safeCleanup, waitForChildClose } from "./test-utils.ts";
 
 const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 const START_MESSAGE = "Backlog.md MCP server started (stdio transport)";
 
 let TEST_DIR: string;
-
-type ExitResult = { code: number | null; signal: NodeJS.Signals | null };
 
 function waitForSubstring(stream: NodeJS.ReadableStream, substring: string, timeoutMs: number): Promise<void> {
 	return new Promise((resolve, reject) => {
@@ -51,20 +49,6 @@ function waitForSubstring(stream: NodeJS.ReadableStream, substring: string, time
 		stream.on("data", onData);
 		stream.on("error", onError);
 		stream.on("end", onEnd);
-	});
-}
-
-function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<ExitResult> {
-	return new Promise((resolve, reject) => {
-		const timer = setTimeout(() => {
-			child.kill("SIGKILL");
-			reject(new Error("Timed out waiting for MCP process to exit"));
-		}, timeoutMs);
-
-		child.once("exit", (code, signal) => {
-			clearTimeout(timer);
-			resolve({ code, signal });
-		});
 	});
 }
 
@@ -119,19 +103,47 @@ describe("MCP stdio shutdown", () => {
 			cwd: TEST_DIR,
 			stdio: ["pipe", "pipe", "pipe"],
 		});
+		const childClose = waitForChildClose(child, "MCP process", Math.min(timeout, 2000)).then(
+			(result) => ({ ok: true as const, result }),
+			(error: unknown) => ({ ok: false as const, error }),
+		);
 
-		if (!child.stderr || !child.stdin) {
-			child.kill("SIGKILL");
-			throw new Error("Failed to spawn MCP process with stdio pipes");
+		let primaryError: unknown;
+		try {
+			if (!child.stderr || !child.stdin) {
+				throw new Error("Failed to spawn MCP process with stdio pipes");
+			}
+
+			await waitForSubstring(child.stderr, START_MESSAGE, timeout);
+			child.stdin.end();
+
+			const closeOutcome = await childClose;
+			if (!closeOutcome.ok) throw closeOutcome.error;
+			expect(closeOutcome.result.code).toBe(0);
+			expect(closeOutcome.result.signal).toBeNull();
+		} catch (error) {
+			primaryError = error;
 		}
 
-		await waitForSubstring(child.stderr, START_MESSAGE, timeout);
-		await sleep(50);
-		child.stdin.end();
+		let cleanupError: unknown;
+		try {
+			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+		} catch (error) {
+			cleanupError = error;
+		}
+		const closeOutcome = await childClose;
+		if (!closeOutcome.ok && closeOutcome.error !== primaryError) {
+			cleanupError =
+				cleanupError === undefined
+					? closeOutcome.error
+					: new AggregateError([cleanupError, closeOutcome.error], "MCP process kill and close wait both failed");
+		}
 
-		const result = await waitForExit(child, timeout);
-		expect(result.code).toBe(0);
-		expect(result.signal).toBeNull();
+		if (primaryError !== undefined && cleanupError !== undefined) {
+			throw new AggregateError([primaryError, cleanupError], "Test and MCP process cleanup both failed");
+		}
+		if (primaryError !== undefined) throw primaryError;
+		if (cleanupError !== undefined) throw cleanupError;
 	});
 
 	it("keeps stdio sessions alive after listing tools so document calls can respond", async () => {
@@ -158,6 +170,7 @@ describe("MCP stdio shutdown", () => {
 
 		const client = new Client({ name: "MCP Stdio Document Test", version: "1.0.0" }, { capabilities: {} });
 
+		let primaryError: unknown;
 		try {
 			await withTimeout(client.connect(transport), "connect", timeout, () => ` stderr:\n${stderr}`);
 
@@ -180,8 +193,35 @@ describe("MCP stdio shutdown", () => {
 			const text = getText(result.content);
 			expect(text).toContain("Document created successfully.");
 			expect(text).toContain("Document doc-1 - Stdio Repro Doc");
-		} finally {
-			await client.close().catch(() => {});
+		} catch (error) {
+			primaryError = error;
 		}
+
+		const child = (transport as unknown as { _process?: ReturnType<typeof spawn> })._process;
+		const exitOutcome = child
+			? waitForChildClose(child, "MCP transport process", Math.min(timeout, 2000)).then(
+					() => ({ error: undefined }),
+					(error: unknown) => ({ error }),
+				)
+			: Promise.resolve({ error: undefined });
+		let cleanupError: unknown;
+		try {
+			await client.close();
+		} catch (error) {
+			cleanupError = error;
+		}
+		const { error: exitError } = await exitOutcome;
+		if (exitError !== undefined) {
+			cleanupError =
+				cleanupError === undefined
+					? exitError
+					: new AggregateError([cleanupError, exitError], "MCP client and process cleanup both failed");
+		}
+
+		if (primaryError !== undefined && cleanupError !== undefined) {
+			throw new AggregateError([primaryError, cleanupError], "Test and MCP client cleanup both failed");
+		}
+		if (primaryError !== undefined) throw primaryError;
+		if (cleanupError !== undefined) throw cleanupError;
 	});
 });

--- a/src/test/mcp-task-complete.test.ts
+++ b/src/test/mcp-task-complete.test.ts
@@ -37,12 +37,13 @@ describe("MCP task_complete", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await server.stop();
-		} catch {
-			// ignore
-		}
-		await safeCleanup(TEST_DIR);
+		const stopResult = await Promise.allSettled([server.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(TEST_DIR)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	it("moves Done tasks to the completed folder", async () => {

--- a/src/test/mcp-task-type-filtering.test.ts
+++ b/src/test/mcp-task-type-filtering.test.ts
@@ -44,12 +44,13 @@ describe("MCP task type filtering adapter", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await server.stop();
-		} catch {
-			// ignore cleanup errors
-		}
-		await safeCleanup(testDir);
+		const stopResult = await Promise.allSettled([server.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(testDir)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	it("exposes configured type arrays in list and search schemas", async () => {

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -43,12 +43,13 @@ describe("MCP task tools (MVP)", () => {
 	});
 
 	afterEach(async () => {
-		try {
-			await mcpServer.stop();
-		} catch {
-			// ignore
-		}
-		await safeCleanup(TEST_DIR);
+		const stopResult = await Promise.allSettled([mcpServer.stop()]);
+		const cleanupResult = await Promise.allSettled([safeCleanup(TEST_DIR)]);
+		const errors = [...stopResult, ...cleanupResult]
+			.filter((result): result is PromiseRejectedResult => result.status === "rejected")
+			.map((result) => result.reason);
+		if (errors.length === 1) throw errors[0];
+		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
 	it("creates and lists tasks", async () => {
@@ -519,6 +520,7 @@ describe("MCP task tools (MVP)", () => {
 		await mcpServer.filesystem.saveConfig(config);
 
 		const customServer = new McpServer(TEST_DIR, "Test instructions");
+		let primaryError: unknown;
 		try {
 			registerTaskTools(customServer, config);
 			const tools = await customServer.testInterface.listTools();
@@ -551,9 +553,22 @@ describe("MCP task tools (MVP)", () => {
 			expect(createResult.isError).not.toBe(true);
 			const task = await customServer.getTask("task-1");
 			expect(task?.priority).toBe("very high");
-		} finally {
-			await customServer.stop();
+		} catch (error) {
+			primaryError = error;
 		}
+
+		let cleanupError: unknown;
+		try {
+			await customServer.stop();
+		} catch (error) {
+			cleanupError = error;
+		}
+
+		if (primaryError !== undefined && cleanupError !== undefined) {
+			throw new AggregateError([primaryError, cleanupError], "Test and MCP server cleanup both failed");
+		}
+		if (primaryError !== undefined) throw primaryError;
+		if (cleanupError !== undefined) throw cleanupError;
 	});
 
 	it("describes Definition of Done fields as task-level in schemas", async () => {
@@ -1160,6 +1175,7 @@ describe("MCP task tools (MVP)", () => {
 		await mcpServer.filesystem.saveConfig(config);
 
 		const customServer = new McpServer(TEST_DIR, "Test instructions");
+		let primaryError: unknown;
 		try {
 			registerTaskTools(customServer, await loadConfig(customServer));
 
@@ -1191,8 +1207,21 @@ describe("MCP task tools (MVP)", () => {
 			});
 			expect(invalidResult.isError).toBe(true);
 			expect(getText(invalidResult.content)).toContain("must be one of: Bug, Epic");
-		} finally {
-			await customServer.stop().catch(() => {});
+		} catch (error) {
+			primaryError = error;
 		}
+
+		let cleanupError: unknown;
+		try {
+			await customServer.stop();
+		} catch (error) {
+			cleanupError = error;
+		}
+
+		if (primaryError !== undefined && cleanupError !== undefined) {
+			throw new AggregateError([primaryError, cleanupError], "Test and MCP server cleanup both failed");
+		}
+		if (primaryError !== undefined) throw primaryError;
+		if (cleanupError !== undefined) throw cleanupError;
 	});
 });

--- a/src/test/search-service.test.ts
+++ b/src/test/search-service.test.ts
@@ -65,11 +65,7 @@ describe("SearchService", () => {
 	afterEach(async () => {
 		search?.dispose();
 		store?.dispose();
-		try {
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// ignore cleanup errors between tests
-		}
+		await safeCleanup(TEST_DIR);
 	});
 
 	it("indexes tasks, documents, and decisions and returns combined results", async () => {

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -3,6 +3,7 @@
  * Designed to handle Windows-specific file system quirks and prevent parallel test interference
  */
 
+import type { ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { rm } from "node:fs/promises";
 import net from "node:net";
@@ -49,6 +50,67 @@ export function withTimeout<T>(operation: Promise<T>, label: string, timeoutMs: 
 				reject(error);
 			},
 		);
+	});
+}
+
+export type ChildCloseResult = { code: number | null; signal: NodeJS.Signals | null };
+
+/**
+ * Waits for a child process to close so its stdio streams are drained. Process
+ * errors are retained as diagnostics, while closure remains the terminal event.
+ */
+export function waitForChildClose(child: ChildProcess, label: string, timeoutMs: number): Promise<ChildCloseResult> {
+	return new Promise((resolve, reject) => {
+		const gracefulTimeoutMs = Math.max(1, Math.floor(timeoutMs / 2));
+		const forcedTimeoutMs = Math.max(1, timeoutMs - gracefulTimeoutMs);
+		let timeoutError: Error | undefined;
+		let processError: Error | undefined;
+		let terminalTimer: ReturnType<typeof setTimeout> | undefined;
+		let timeoutTimer: ReturnType<typeof setTimeout>;
+
+		const cleanup = () => {
+			clearTimeout(timeoutTimer);
+			if (terminalTimer) clearTimeout(terminalTimer);
+			child.off("error", onError);
+			child.off("close", onClose);
+		};
+		const rejectErrors = (errors: Error[]) => {
+			cleanup();
+			reject(errors.length === 1 ? errors[0] : new AggregateError(errors, `${label} cleanup failed`));
+		};
+		const onError = (error: Error) => {
+			child.off("error", onError);
+			processError = error;
+		};
+		const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+			const errors = [timeoutError, processError].filter((error): error is Error => error !== undefined);
+			if (errors.length > 0) {
+				rejectErrors(errors);
+				return;
+			}
+			cleanup();
+			resolve({ code, signal });
+		};
+
+		child.once("error", onError);
+		child.once("close", onClose);
+		timeoutTimer = setTimeout(() => {
+			timeoutError = new Error(`Timed out waiting for ${label} to close`);
+			terminalTimer = setTimeout(
+				() =>
+					rejectErrors(
+						[timeoutError as Error, processError, new Error(`${label} did not close after SIGKILL`)].filter(
+							(error): error is Error => error !== undefined,
+						),
+					),
+				forcedTimeoutMs,
+			);
+			try {
+				child.kill("SIGKILL");
+			} catch (error) {
+				onError(error as Error);
+			}
+		}, gracefulTimeoutMs);
 	});
 }
 

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -56,20 +56,24 @@ export function withTimeout<T>(operation: Promise<T>, label: string, timeoutMs: 
 export type ChildCloseResult = { code: number | null; signal: NodeJS.Signals | null };
 
 /**
- * Waits for a child process to close so its stdio streams are drained. Process
- * errors are retained as diagnostics, while closure remains the terminal event.
+ * Observes a child process immediately so close/error events cannot be missed,
+ * while letting callers start the bounded shutdown timer only when cleanup begins.
  */
-export function waitForChildClose(child: ChildProcess, label: string, timeoutMs: number): Promise<ChildCloseResult> {
-	return new Promise((resolve, reject) => {
+export function observeChildClose(child: ChildProcess, label: string, timeoutMs: number) {
+	let startTimeout = () => {};
+	const result = new Promise<ChildCloseResult>((resolve, reject) => {
 		const gracefulTimeoutMs = Math.max(1, Math.floor(timeoutMs / 2));
 		const forcedTimeoutMs = Math.max(1, timeoutMs - gracefulTimeoutMs);
+		let settled = false;
+		let timeoutStarted = false;
 		let timeoutError: Error | undefined;
 		let processError: Error | undefined;
 		let terminalTimer: ReturnType<typeof setTimeout> | undefined;
-		let timeoutTimer: ReturnType<typeof setTimeout>;
+		let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
 
 		const cleanup = () => {
-			clearTimeout(timeoutTimer);
+			settled = true;
+			if (timeoutTimer) clearTimeout(timeoutTimer);
 			if (terminalTimer) clearTimeout(terminalTimer);
 			child.off("error", onError);
 			child.off("close", onClose);
@@ -94,24 +98,29 @@ export function waitForChildClose(child: ChildProcess, label: string, timeoutMs:
 
 		child.once("error", onError);
 		child.once("close", onClose);
-		timeoutTimer = setTimeout(() => {
-			timeoutError = new Error(`Timed out waiting for ${label} to close`);
-			terminalTimer = setTimeout(
-				() =>
-					rejectErrors(
-						[timeoutError as Error, processError, new Error(`${label} did not close after SIGKILL`)].filter(
-							(error): error is Error => error !== undefined,
+		startTimeout = () => {
+			if (settled || timeoutStarted) return;
+			timeoutStarted = true;
+			timeoutTimer = setTimeout(() => {
+				timeoutError = new Error(`Timed out waiting for ${label} to close`);
+				terminalTimer = setTimeout(
+					() =>
+						rejectErrors(
+							[timeoutError as Error, processError, new Error(`${label} did not close after SIGKILL`)].filter(
+								(error): error is Error => error !== undefined,
+							),
 						),
-					),
-				forcedTimeoutMs,
-			);
-			try {
-				child.kill("SIGKILL");
-			} catch (error) {
-				onError(error as Error);
-			}
-		}, gracefulTimeoutMs);
+					forcedTimeoutMs,
+				);
+				try {
+					child.kill("SIGKILL");
+				} catch (error) {
+					onError(error as Error);
+				}
+			}, gracefulTimeoutMs);
+		};
 	});
+	return { result, startTimeout: () => startTimeout() };
 }
 
 /**

--- a/src/test/worktree-refresh.test.ts
+++ b/src/test/worktree-refresh.test.ts
@@ -8,11 +8,14 @@ import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-
 let TEST_DIR: string;
 let WORKTREE_DIR: string;
 let mainCore: Core | undefined;
+let featureCore: Core | undefined;
+let worktreeAdded = false;
 
 describe("worktree task refresh", () => {
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-worktree-refresh");
 		WORKTREE_DIR = `${TEST_DIR}-feature`;
+		worktreeAdded = false;
 		await mkdir(TEST_DIR, { recursive: true });
 		await $`git init -b main`.cwd(TEST_DIR).quiet();
 		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
@@ -21,12 +24,31 @@ describe("worktree task refresh", () => {
 
 	afterEach(async () => {
 		mainCore?.disposeContentStore();
+		featureCore?.disposeContentStore();
 		mainCore = undefined;
-		try {
-			await safeCleanup(WORKTREE_DIR);
-			await safeCleanup(TEST_DIR);
-		} catch {
-			// Ignore cleanup errors - unique directory names prevent conflicts.
+		featureCore = undefined;
+
+		const cleanupErrors: unknown[] = [];
+		if (worktreeAdded) {
+			try {
+				await $`git worktree remove --force ${WORKTREE_DIR}`.cwd(TEST_DIR).quiet();
+			} catch (error) {
+				cleanupErrors.push(error);
+			}
+			worktreeAdded = false;
+		}
+		for (const directory of [WORKTREE_DIR, TEST_DIR]) {
+			try {
+				await safeCleanup(directory);
+			} catch (error) {
+				cleanupErrors.push(error);
+			}
+		}
+		if (cleanupErrors.length === 1) {
+			throw cleanupErrors[0];
+		}
+		if (cleanupErrors.length > 1) {
+			throw new AggregateError(cleanupErrors, "Worktree teardown failed");
 		}
 	});
 
@@ -50,7 +72,8 @@ describe("worktree task refresh", () => {
 		expect(await mainCore.queryTasks({ query: "Created elsewhere" })).toEqual([]);
 
 		await $`git worktree add ${WORKTREE_DIR} -b feature`.cwd(TEST_DIR).quiet();
-		const featureCore = new Core(WORKTREE_DIR);
+		worktreeAdded = true;
+		featureCore = new Core(WORKTREE_DIR);
 		const worktreeTask: Task = {
 			id: "task-1",
 			title: "Created elsewhere",


### PR DESCRIPTION
Backlog task: `BACK-535.4`

## Summary
- release MCP servers, clients, watchers, stores, child processes, and Git worktrees deterministically
- preserve primary failures while surfacing and aggregating teardown failures
- observe child close/error events immediately while activating bounded shutdown timers only when cleanup begins

## Verification
- focused lifecycle tests: 172/172 twice
- full suite: 1,665 passed, 2 intentional skips
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- independent specification and quality reviews approved