### PR TITLE
BACK-535.8 - Thin duplicated MCP semantic test permutations

### DIFF
--- a/backlog/tasks/back-535.8 - Thin-duplicated-MCP-semantic-test-permutations.md
+++ b/backlog/tasks/back-535.8 - Thin-duplicated-MCP-semantic-test-permutations.md
@@ -1,0 +1,86 @@
+---
+id: BACK-535.8
+title: Thin duplicated MCP semantic test permutations
+status: Done
+assignee:
+  - '@back5358-publish-finalize'
+created_date: '2026-07-11 16:41'
+updated_date: '2026-07-11 16:57'
+labels: []
+dependencies: []
+modified_files:
+  - src/test/mcp-refs-docs.test.ts
+parent_task_id: BACK-535
+priority: medium
+ordinal: 179000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Consolidate only evidence-backed duplicate MCP semantic test permutations in one focused PR. Keep MCP as a supported legacy adapter while treating the CLI workflow and shared product model as canonical. This slice changes tests only and must not change production behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 An inventory identifies duplicated MCP semantic cases and the shipped contract protected by each affected MCP test file
+- [x] #2 Shipped MCP schema, tool, resource, stdio, CLI-parity, and error-boundary contracts remain directly covered
+- [x] #3 Every removed or consolidated MCP test is mapped to retained canonical CLI coverage or shared-domain coverage
+- [x] #4 No production behavior or production source file changes
+- [x] #5 Focused MCP tests pass repeatedly, full type/lint/build/test gates pass, and Linux/macOS/Windows CI remains required before merge
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inventory all MCP tests and shipped MCP public surfaces.
+2. Classify semantic permutations against canonical CLI/shared-domain replacement coverage.
+3. Consolidate only unambiguous duplicates while retaining adapter contract tests.
+4. Run repeated focused tests and full local gates; document mappings and leave 3-OS CI as the merge gate.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Inventory reviewed all 16 MCP test files (124 retained MCP cases after this slice) plus shipped MCP tool schemas/descriptions, workflow and init-required resources, roots/workspace routing, stdio entrypoint, and README guidance. Only mcp-refs-docs.test.ts had an unambiguous bounded consolidation candidate.
+
+Coverage mapping:
+- MCP create references, create without references -> cli-refs-docs.test.ts create --ref cases plus references.test.ts present/absent/empty/persistence cases.
+- MCP create documentation, create without documentation -> cli-refs-docs.test.ts create --doc cases plus documentation.test.ts present/absent/empty/persistence cases.
+- MCP combined create and standalone persistence -> retained combined MCP create/output/persistence round-trip plus canonical CLI combined-create and markdown-persistence cases.
+- MCP reference edit set/add/remove -> retained combined MCP edit-routing case plus CLI set/multiple cases and references.test.ts set/add/remove/replace/dedupe cases.
+- MCP documentation edit set/add/remove -> retained combined MCP edit-routing case plus CLI set/multiple cases and documentation.test.ts set/add/remove/replace/dedupe cases.
+
+The retained MCP tests directly assert published create/edit schemas for references and documentation, adapter create output and persisted values, and adapter edit routing for set/add/remove. No production files changed. All MCP roots, resources, stdio, schema, parity, validation, and error-boundary suites were otherwise left intact.
+
+Validation: focused MCP file passed 20 consecutive runs (60/60 cases); canonical CLI/shared replacement set passed 37/37; complete MCP suite passed 124/124; bunx tsc --noEmit passed; bun run check . passed (323 files); bun run build passed; bun test passed 1653 with 2 intentional interactive TUI skips and 0 failures. git diff --check passed. Linux/macOS/Windows CI remains the required pre-merge remote gate.
+
+Final exact removal mapping:
+- Removed MCP "creates task with references" -> retained MCP combined create/output/persistence; cli-refs-docs "creates task with single reference" and "creates task with multiple references"; references "should create a task with references".
+- Removed MCP "creates task without references" -> references "should create a task without references" and "should handle empty references array".
+- Removed MCP "creates task with documentation" -> retained MCP combined create/output/persistence; cli-refs-docs "creates task with single documentation" and "creates task with multiple documentation entries"; documentation "should create a task with documentation".
+- Removed MCP "creates task without documentation" -> documentation "should create a task without documentation" and "should handle empty documentation array".
+- Removed MCP "creates task with both fields" -> retained MCP combined create/output/persistence and cli-refs-docs "creates task with both references and documentation".
+- Removed MCP "sets references on existing task" -> retained MCP combined edit-routing; cli-refs-docs "sets references on existing task" and "sets multiple references on existing task"; references "should set references on existing task" and "should replace references when setting directly".
+- Removed MCP "adds references to existing task" -> retained MCP combined edit-routing and references "should add references to existing task"/dedupe coverage.
+- Removed MCP "removes references from existing task" -> retained MCP combined edit-routing and references "should remove references from existing task".
+- Removed MCP "sets documentation on existing task" -> retained MCP combined edit-routing; cli-refs-docs "sets documentation on existing task" and "sets multiple documentation entries on existing task"; documentation set/replace cases.
+- Removed MCP "adds documentation to existing task" -> retained MCP combined edit-routing and documentation add/dedupe cases.
+- Removed MCP "removes documentation from existing task" -> retained MCP combined edit-routing and documentation remove case.
+- Removed MCP "persists references and documentation in task" -> retained MCP combined create/persistence; cli-refs-docs reference/documentation markdown persistence; references/documentation frontmatter persistence cases.
+Review evidence: specification review cycle 1 APPROVED; quality review cycle 1 APPROVED; zero findings; circuit-breaker count 0.
+Final local evidence: focused MCP file 20 consecutive runs = 60/60; canonical CLI/shared replacement set = 37/37; complete MCP suite = 124/124; full suite = 1653 passed, 2 intentional interactive TUI skips, 0 failed; bunx tsc --noEmit passed; bun run check . passed (323 files); bun run build passed; git diff --check passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Consolidated 12 duplicated one-field MCP reference/documentation semantic permutations into three focused adapter-contract tests for published schemas, combined create/persistence, and combined edit routing. Canonical CLI and shared-domain suites retain every removed semantic case; production behavior and source files are unchanged. Specification and quality reviews both approved in cycle 1 with zero findings. Verified locally with focused 20x (60/60), replacement coverage (37/37), all MCP tests (124/124), full suite (1653 pass, 2 intentional skips, 0 fail), TypeScript, Biome (323 files), build, and diff checks; 3-OS CI remains the merge gate.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/test/mcp-refs-docs.test.ts
+++ b/src/test/mcp-refs-docs.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { $ } from "bun";
 import { McpServer } from "../mcp/server.ts";
 import { registerTaskTools } from "../mcp/tools/tasks/index.ts";
+import type { JsonSchema } from "../mcp/validation/validators.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
 
 const getText = (content: unknown[] | undefined, index = 0): string => {
@@ -46,259 +47,78 @@ describe("MCP task references and documentation", () => {
 		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
-	describe("task_create with references", () => {
-		it("creates task with references", async () => {
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Feature with refs",
-						references: ["https://github.com/issue/123", "src/api.ts"],
-					},
-				},
-			});
+	it("publishes references and documentation in task create and edit schemas", async () => {
+		const tools = await mcpServer.testInterface.listTools();
+		const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+		const createSchema = toolByName.get("task_create")?.inputSchema as JsonSchema | undefined;
+		const editSchema = toolByName.get("task_edit")?.inputSchema as JsonSchema | undefined;
 
-			const text = getText(result.content);
-			expect(text).toContain("Task TASK-1 - Feature with refs");
-			expect(text).toContain("References: https://github.com/issue/123, src/api.ts");
-		});
-
-		it("creates task without references", async () => {
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Feature without refs",
-					},
-				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("Task TASK-1 - Feature without refs");
-			expect(text).not.toContain("References:");
-		});
+		expect(createSchema?.properties?.references?.items?.type).toBe("string");
+		expect(createSchema?.properties?.documentation?.items?.type).toBe("string");
+		for (const field of [
+			"references",
+			"addReferences",
+			"removeReferences",
+			"documentation",
+			"addDocumentation",
+			"removeDocumentation",
+		]) {
+			expect(editSchema?.properties?.[field]?.items?.type).toBe("string");
+		}
 	});
 
-	describe("task_create with documentation", () => {
-		it("creates task with documentation", async () => {
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Feature with docs",
-						documentation: ["https://design-docs.example.com", "docs/spec.md"],
-					},
+	it("creates and persists references and documentation through the MCP adapter", async () => {
+		const result = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Feature with supporting material",
+					references: ["https://github.com/issue/123", "src/api.ts"],
+					documentation: ["https://design-docs.example.com", "docs/spec.md"],
 				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("Task TASK-1 - Feature with docs");
-			expect(text).toContain("Documentation: https://design-docs.example.com, docs/spec.md");
+			},
 		});
 
-		it("creates task without documentation", async () => {
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Feature without docs",
-					},
-				},
-			});
+		const text = getText(result.content);
+		expect(text).toContain("Task TASK-1 - Feature with supporting material");
+		expect(text).toContain("References: https://github.com/issue/123, src/api.ts");
+		expect(text).toContain("Documentation: https://design-docs.example.com, docs/spec.md");
 
-			const text = getText(result.content);
-			expect(text).toContain("Task TASK-1 - Feature without docs");
-			expect(text).not.toContain("Documentation:");
-		});
+		const task = await mcpServer.getTask("task-1");
+		expect(task?.references).toEqual(["https://github.com/issue/123", "src/api.ts"]);
+		expect(task?.documentation).toEqual(["https://design-docs.example.com", "docs/spec.md"]);
 	});
 
-	describe("task_create with both references and documentation", () => {
-		it("creates task with both fields", async () => {
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Feature with both",
-						references: ["https://github.com/issue/123"],
-						documentation: ["https://design-docs.example.com"],
-					},
-				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("Task TASK-1 - Feature with both");
-			expect(text).toContain("References: https://github.com/issue/123");
-			expect(text).toContain("Documentation: https://design-docs.example.com");
-		});
-	});
-
-	describe("task_edit with references", () => {
-		it("sets references on existing task", async () => {
-			await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: { title: "Task to edit" },
-				},
-			});
-
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_edit",
-					arguments: {
-						id: "task-1",
-						references: ["https://example.com", "file.ts"],
-					},
-				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("References: https://example.com, file.ts");
+	it("routes reference and documentation set, add, and remove edits", async () => {
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Task to edit" } },
 		});
 
-		it("adds references to existing task", async () => {
-			await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Task with refs",
-						references: ["file1.ts"],
-					},
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					references: ["ref-1.ts", "ref-2.ts"],
+					documentation: ["doc-1.md", "doc-2.md"],
 				},
-			});
-
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_edit",
-					arguments: {
-						id: "task-1",
-						addReferences: ["file2.ts", "file3.ts"],
-					},
+			},
+		});
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					addReferences: ["ref-3.ts"],
+					removeReferences: ["ref-2.ts"],
+					addDocumentation: ["doc-3.md"],
+					removeDocumentation: ["doc-2.md"],
 				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("References: file1.ts, file2.ts, file3.ts");
+			},
 		});
 
-		it("removes references from existing task", async () => {
-			await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Task with refs",
-						references: ["file1.ts", "file2.ts", "file3.ts"],
-					},
-				},
-			});
-
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_edit",
-					arguments: {
-						id: "task-1",
-						removeReferences: ["file2.ts"],
-					},
-				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("References: file1.ts, file3.ts");
-			expect(text).not.toContain("file2.ts");
-		});
-	});
-
-	describe("task_edit with documentation", () => {
-		it("sets documentation on existing task", async () => {
-			await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: { title: "Task to edit" },
-				},
-			});
-
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_edit",
-					arguments: {
-						id: "task-1",
-						documentation: ["https://docs.example.com", "README.md"],
-					},
-				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("Documentation: https://docs.example.com, README.md");
-		});
-
-		it("adds documentation to existing task", async () => {
-			await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Task with docs",
-						documentation: ["doc1.md"],
-					},
-				},
-			});
-
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_edit",
-					arguments: {
-						id: "task-1",
-						addDocumentation: ["doc2.md", "doc3.md"],
-					},
-				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("Documentation: doc1.md, doc2.md, doc3.md");
-		});
-
-		it("removes documentation from existing task", async () => {
-			await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Task with docs",
-						documentation: ["doc1.md", "doc2.md", "doc3.md"],
-					},
-				},
-			});
-
-			const result = await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_edit",
-					arguments: {
-						id: "task-1",
-						removeDocumentation: ["doc2.md"],
-					},
-				},
-			});
-
-			const text = getText(result.content);
-			expect(text).toContain("Documentation: doc1.md, doc3.md");
-			expect(text).not.toContain("doc2.md");
-		});
-	});
-
-	describe("persistence verification", () => {
-		it("persists references and documentation in task", async () => {
-			await mcpServer.testInterface.callTool({
-				params: {
-					name: "task_create",
-					arguments: {
-						title: "Persistent task",
-						references: ["ref1.ts", "ref2.ts"],
-						documentation: ["doc1.md", "doc2.md"],
-					},
-				},
-			});
-
-			// Reload task to verify persistence
-			const task = await mcpServer.getTask("task-1");
-			expect(task?.references).toEqual(["ref1.ts", "ref2.ts"]);
-			expect(task?.documentation).toEqual(["doc1.md", "doc2.md"]);
-		});
+		const task = await mcpServer.getTask("task-1");
+		expect(task?.references).toEqual(["ref-1.ts", "ref-3.ts"]);
+		expect(task?.documentation).toEqual(["doc-1.md", "doc-3.md"]);
 	});
 });


### PR DESCRIPTION
## Summary
- consolidate 12 duplicated one-field MCP reference/documentation permutations into three adapter-boundary tests
- retain direct MCP schema, create/persistence, and edit-routing coverage
- map every removed case to canonical CLI or shared-domain coverage; no production changes

Task: [BACK-535.8](https://github.com/MrLesk/Backlog.md/blob/tasks/back-535-8-mcp-test-consolidation/backlog/tasks/back-535.8%20-%20Thin-duplicated-MCP-semantic-test-permutations.md)

## Verification
- focused MCP: 60/60 across 20 runs
- canonical replacement set: 37/37
- complete MCP suite: 124/124
- full suite: 1653 passed, 2 intentional skips, 0 failed
- TypeScript, Biome (323 files), build, and diff checks passed
- specification and quality review cycle 1: APPROVED, zero findings