### PR TITLE
BACK-536 - Add wrapNavigationToSearch config to opt out of the boundary search handoff

### DIFF
--- a/ADVANCED-CONFIG.md
+++ b/ADVANCED-CONFIG.md
@@ -30,6 +30,7 @@ Running `backlog config` with no arguments launches the interactive advanced wiz
 | `defaultEditor`   | Editor for 'E' key | Platform default (nano/notepad) |
 | `defaultPort`     | Web UI port        | `6420`                        |
 | `autoOpenBrowser` | Open browser automatically | `true`            |
+| `wrapNavigationToSearch` | Move focus into TUI search when navigating past the first/last row | `true` |
 | `remoteOperations`| Enable remote git operations | `true`           |
 | `autoCommit`      | Automatically commit task changes | `false`       |
 | `bypassGitHooks`  | Skip git hooks when committing (uses --no-verify) | `false`       |
@@ -41,6 +42,8 @@ Running `backlog config` with no arguments launches the interactive advanced wiz
 ## Detailed Notes
 
 > Editor setup guide: See [Configuring VIM and Neovim as Default Editor](backlog/docs/doc-002%20-%20Configuring-VIM-and-Neovim-as-Default-Editor.md) for configuration tips and troubleshooting interactive editors.
+
+> **TUI Navigation**: By default, navigating past the first/last row in the TUI task list or kanban board hands focus to the search input. Set `wrapNavigationToSearch: false` to disable that handoff — boundary navigation then falls back to the circular list behavior (pressing down on the last row wraps to the first row). `/` and `Ctrl+F` still focus the search input directly.
 
 > **Note**: Set `remoteOperations: false` to work offline. This disables git fetch operations and loads tasks from local branches only, useful when working without network connectivity.
 

--- a/backlog/tasks/back-536 - Add-wrapNavigationToSearch-config-to-opt-out-of-the-boundary-search-handoff.md
+++ b/backlog/tasks/back-536 - Add-wrapNavigationToSearch-config-to-opt-out-of-the-boundary-search-handoff.md
@@ -1,0 +1,46 @@
+---
+id: BACK-536
+title: Add wrapNavigationToSearch config to opt out of the boundary search handoff
+status: Done
+assignee: []
+created_date: '2026-07-11 16:30'
+updated_date: '2026-07-11 16:30'
+labels: []
+dependencies: []
+ordinal: 179000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+In the TUI, pressing j on the last row or k on the first row (or k at the top of the focused detail pane) moves focus into the search input. This wrap was added on purpose (task back-399), but it surprises vim-style navigation users: j/k are expected to stay inside the list, and / and Ctrl+F already focus search directly. Add an opt-out config key, wrapNavigationToSearch (boolean, default true), that keeps the current behavior by default and, when set to false, stops the handoff in the task list, the detail pane, and the kanban board (including empty columns). With the handoff disabled, boundary navigation falls back to the circular wrap that both views used before back-399 (introduced in task-248).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 New boolean config key wrapNavigationToSearch (default true) round-trips through config get/set/list and the config file
+- [x] #2 When false, boundary navigation in the task list, detail pane, and kanban board (including empty columns) no longer moves focus to search and falls back to circular navigation
+- [x] #3 Default behavior is unchanged when the key is unset or set to true
+- [x] #4 Helpers and config round-trip are covered by tests; ADVANCED-CONFIG.md documents the key
+<!-- AC:END -->
+
+
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add wrapNavigationToSearch to BacklogConfig, the snake_case config parser/serializer (wrap_navigation_to_search), and the config watcher key list. 2. Wire backlog config get/set/list. 3. Extend shouldMoveFromListBoundaryToSearch / shouldMoveFromDetailBoundaryToSearch with a wrapNavigationToSearch parameter (default true) and pass the config value at all call sites. 4. Board: extract a pure resolveBoardBoundaryToSearch helper covering the empty-column jumps, and fall back to circular navigation when the handoff is disabled. 5. Tests for the helpers and the config round-trip; document the key in ADVANCED-CONFIG.md.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Validation: bunx tsc --noEmit clean, bunx biome check clean, bun test 1671 pass / 2 skip / 0 fail. Default behavior is unchanged when the key is unset or true; the config round-trip test covers the false value specifically so a truthiness regression in the serializer cannot slip through.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,6 +111,7 @@ const CONFIG_GET_KEYS = [
 	"maxColumnWidth",
 	"defaultPort",
 	"autoOpenBrowser",
+	"wrapNavigationToSearch",
 	"remoteOperations",
 	"autoCommit",
 	"filesystemOnly",
@@ -127,6 +128,7 @@ const CONFIG_SET_KEYS = [
 	"dateFormat",
 	"maxColumnWidth",
 	"autoOpenBrowser",
+	"wrapNavigationToSearch",
 	"defaultPort",
 	"remoteOperations",
 	"autoCommit",
@@ -4254,7 +4256,7 @@ agentsCmd
 
 // Config command group
 const CONFIG_AVAILABLE_KEYS =
-	"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, priorities, types, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays";
+	"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, priorities, types, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, wrapNavigationToSearch, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays";
 
 const configCmd = addHelpSchema(program.command("config"), {
 	reads: "Project Backlog.md configuration",
@@ -4420,6 +4422,9 @@ addHelpSchema(configCmd.command("get <key>"), {
 				case "hideEmptyColumns":
 					console.log(config.hideEmptyColumns?.toString() || "false");
 					break;
+				case "wrapNavigationToSearch":
+					console.log(config.wrapNavigationToSearch?.toString() || "true");
+					break;
 				case "remoteOperations":
 					console.log(config.remoteOperations?.toString() || "");
 					break;
@@ -4526,6 +4531,18 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 						config.hideEmptyColumns = false;
 					} else {
 						console.error("hideEmptyColumns must be true or false");
+						process.exit(1);
+					}
+					break;
+				}
+				case "wrapNavigationToSearch": {
+					const boolValue = value.toLowerCase();
+					if (boolValue === "true" || boolValue === "1" || boolValue === "yes") {
+						config.wrapNavigationToSearch = true;
+					} else if (boolValue === "false" || boolValue === "0" || boolValue === "no") {
+						config.wrapNavigationToSearch = false;
+					} else {
+						console.error("wrapNavigationToSearch must be true or false");
 						process.exit(1);
 					}
 					break;
@@ -4706,6 +4723,7 @@ addHelpSchema(configCmd.command("list"), {
 			console.log(`  maxColumnWidth: ${config.maxColumnWidth || "(not set)"}`);
 			console.log(`  autoOpenBrowser: ${config.autoOpenBrowser ?? "(not set)"}`);
 			console.log(`  hideEmptyColumns: ${config.hideEmptyColumns ?? "(not set)"}`);
+			console.log(`  wrapNavigationToSearch: ${config.wrapNavigationToSearch ?? "true"}`);
 			console.log(`  defaultPort: ${config.defaultPort ?? "(not set)"}`);
 			console.log(`  remoteOperations: ${config.remoteOperations ?? "(not set)"}`);
 			console.log(`  autoCommit: ${config.autoCommit ?? "(not set)"}`);

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1537,6 +1537,9 @@ ${description || `Milestone: ${title}`}`,
 				case "hide_empty_columns":
 					config.hideEmptyColumns = value.toLowerCase() === "true";
 					break;
+				case "wrap_navigation_to_search":
+					config.wrapNavigationToSearch = value.toLowerCase() === "true";
+					break;
 				case "default_port":
 					config.defaultPort = Number.parseInt(value, 10);
 					break;
@@ -1592,6 +1595,7 @@ ${description || `Milestone: ${title}`}`,
 			defaultEditor: config.defaultEditor,
 			autoOpenBrowser: config.autoOpenBrowser,
 			hideEmptyColumns: config.hideEmptyColumns,
+			wrapNavigationToSearch: config.wrapNavigationToSearch,
 			defaultPort: config.defaultPort,
 			remoteOperations: config.remoteOperations,
 			autoCommit: config.autoCommit,
@@ -1627,6 +1631,9 @@ ${description || `Milestone: ${title}`}`,
 			...(config.defaultEditor ? [`default_editor: "${config.defaultEditor}"`] : []),
 			...(typeof config.autoOpenBrowser === "boolean" ? [`auto_open_browser: ${config.autoOpenBrowser}`] : []),
 			...(typeof config.hideEmptyColumns === "boolean" ? [`hide_empty_columns: ${config.hideEmptyColumns}`] : []),
+			...(typeof config.wrapNavigationToSearch === "boolean"
+				? [`wrap_navigation_to_search: ${config.wrapNavigationToSearch}`]
+				: []),
 			...(config.defaultPort ? [`default_port: ${config.defaultPort}`] : []),
 			...(typeof config.remoteOperations === "boolean" ? [`remote_operations: ${config.remoteOperations}`] : []),
 			...(typeof config.autoCommit === "boolean" ? [`auto_commit: ${config.autoCommit}`] : []),

--- a/src/test/board-ui.test.ts
+++ b/src/test/board-ui.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Task } from "../types/index.ts";
 import type { ColumnData } from "../ui/board.ts";
-import { hasMoveBlockingBoardFilters, shouldRebuildColumns } from "../ui/board.ts";
+import { hasMoveBlockingBoardFilters, resolveBoardBoundaryToSearch, shouldRebuildColumns } from "../ui/board.ts";
 
 // Helper to create a minimal valid Task for testing
 const createTestTask = (id: string, title: string, status: string): Task => ({
@@ -75,6 +75,27 @@ describe("Board TUI Logic", () => {
 			expect(hasMoveBlockingBoardFilters({ ...baseFilters, searchQuery: "auth" })).toBe(true);
 			expect(hasMoveBlockingBoardFilters({ ...baseFilters, typeFilter: ["bug"] })).toBe(true);
 			expect(hasMoveBlockingBoardFilters({ ...baseFilters, labelFilter: ["bug"] })).toBe(true);
+		});
+	});
+
+	describe("resolveBoardBoundaryToSearch", () => {
+		it("jumps to search from an empty column when wrap navigation is enabled", () => {
+			expect(resolveBoardBoundaryToSearch("up", 0, 0, true)).toBe("jump-clear-pending");
+		});
+
+		it("stays put in an empty column when wrap navigation is disabled", () => {
+			expect(resolveBoardBoundaryToSearch("up", 0, 0, false)).toBe("none");
+		});
+
+		it("jumps to search at a boundary when wrap navigation is enabled", () => {
+			expect(resolveBoardBoundaryToSearch("up", 0, 4, true)).toBe("jump-with-wrap");
+			expect(resolveBoardBoundaryToSearch("down", 3, 4, true)).toBe("jump-with-wrap");
+			expect(resolveBoardBoundaryToSearch("up", 2, 4, true)).toBe("none");
+		});
+
+		it("never jumps to search when wrap navigation is disabled", () => {
+			expect(resolveBoardBoundaryToSearch("up", 0, 4, false)).toBe("none");
+			expect(resolveBoardBoundaryToSearch("down", 3, 4, false)).toBe("none");
 		});
 	});
 });

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -236,6 +236,24 @@ describe("Config commands", () => {
 		expect(setKeys).toEqual(getKeys);
 	});
 
+	it("round-trips wrapNavigationToSearch through config get/set/list", async () => {
+		const defaultGet = await $`bun ${CLI_PATH} config get wrapNavigationToSearch`.cwd(TEST_DIR).text();
+		expect(defaultGet.trim()).toBe("true");
+
+		await $`bun ${CLI_PATH} config set wrapNavigationToSearch false`.cwd(TEST_DIR).quiet();
+
+		const afterSet = await $`bun ${CLI_PATH} config get wrapNavigationToSearch`.cwd(TEST_DIR).text();
+		expect(afterSet.trim()).toBe("false");
+
+		const listOutput = await $`bun ${CLI_PATH} config list`.cwd(TEST_DIR).text();
+		expect(listOutput).toContain("wrapNavigationToSearch: false");
+
+		await $`bun ${CLI_PATH} config set wrapNavigationToSearch true`.cwd(TEST_DIR).quiet();
+
+		const afterReenable = await $`bun ${CLI_PATH} config get wrapNavigationToSearch`.cwd(TEST_DIR).text();
+		expect(afterReenable.trim()).toBe("true");
+	});
+
 	it("surfaces milestones in config get/list from milestone files", async () => {
 		await core.filesystem.createMilestone("Release 1");
 

--- a/src/test/task-viewer-boundary-navigation.test.ts
+++ b/src/test/task-viewer-boundary-navigation.test.ts
@@ -30,6 +30,12 @@ describe("task viewer boundary navigation", () => {
 		expect(shouldMoveFromDetailBoundaryToSearch("down", 0)).toBe(false);
 	});
 
+	it("never moves to search when wrapNavigationToSearch is disabled", () => {
+		expect(shouldMoveFromListBoundaryToSearch("up", 0, 4, false)).toBe(false);
+		expect(shouldMoveFromListBoundaryToSearch("down", 3, 4, false)).toBe(false);
+		expect(shouldMoveFromDetailBoundaryToSearch("up", 0, false)).toBe(false);
+	});
+
 	it("resolves search exit target to last row after top-boundary handoff", () => {
 		const pending: PendingSearchWrap = "to-last";
 		expect(resolveSearchExitTargetIndex("up", pending, 5, 2)).toBe(4);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -317,6 +317,8 @@ export interface BacklogConfig {
 	defaultPort?: number;
 	/** When true, hide board columns whose status has no tasks. Columns reappear while a task is being dragged so they remain valid drop targets. Defaults to false. */
 	hideEmptyColumns?: boolean;
+	/** When false, TUI list/board navigation stops wrapping focus into the search input at list boundaries. Defaults to true. */
+	wrapNavigationToSearch?: boolean;
 	remoteOperations?: boolean;
 	autoCommit?: boolean;
 	/** Disable all Git integration for filesystem-only projects. */

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -231,6 +231,22 @@ export function getCreatedTaskBoardOutcome(
 	return { focusTaskId: task.id, message: `Created ${task.id}.`, tone: "green" };
 }
 
+export type BoardBoundaryToSearchAction = "jump-clear-pending" | "jump-with-wrap" | "none";
+
+export function resolveBoardBoundaryToSearch(
+	direction: "up" | "down",
+	selected: number,
+	total: number,
+	wrapNavigationToSearch: boolean,
+): BoardBoundaryToSearchAction {
+	if (total === 0) {
+		return wrapNavigationToSearch ? "jump-clear-pending" : "none";
+	}
+	return shouldMoveFromListBoundaryToSearch(direction, selected, total, wrapNavigationToSearch)
+		? "jump-with-wrap"
+		: "none";
+}
+
 /**
  * Render tasks in an interactive TUI when stdout is a TTY.
  * Falls back to plain-text board when not in a terminal
@@ -277,6 +293,7 @@ export async function renderBoardTui(
 		createTask?: (input: TaskCreateInput) => Promise<Task>;
 		screen?: ScreenInterface;
 		taskComposer?: (options: TaskComposerOptions) => Promise<Task | null>;
+		wrapNavigationToSearch?: boolean;
 	},
 ): Promise<void> {
 	if (!process.stdout.isTTY) {
@@ -293,6 +310,7 @@ export async function renderBoardTui(
 		console.log("No tasks available for the Kanban board.");
 		return;
 	}
+	const wrapNavigationToSearch = options?.wrapNavigationToSearch ?? true;
 
 	await new Promise<void>((resolve) => {
 		const screen = options?.screen ?? createScreen({ title: "Backlog Board" });
@@ -1141,21 +1159,17 @@ export async function renderBoardTui(
 				const listWidget = column.list;
 				const selected = listWidget.selected ?? 0;
 				const total = column.tasks.length;
-				if (total === 0) {
-					pendingSearchWrap = null;
+				const boundaryAction = resolveBoardBoundaryToSearch("up", selected, total, wrapNavigationToSearch);
+				if (boundaryAction !== "none") {
+					pendingSearchWrap = boundaryAction === "jump-with-wrap" ? "to-last" : null;
 					focusFilterControl("search");
 					updateFooter();
 					screen.render();
 					return;
 				}
-				if (shouldMoveFromListBoundaryToSearch("up", selected, total)) {
-					pendingSearchWrap = "to-last";
-					focusFilterControl("search");
-					updateFooter();
-					screen.render();
-					return;
-				}
-				const nextIndex = selected - 1;
+				if (total === 0) return;
+				// With the search handoff disabled, boundary navigation falls back to the circular wrap.
+				const nextIndex = selected > 0 ? selected - 1 : total - 1;
 				selectColumnRow(column, nextIndex, true);
 				screen.render();
 			}
@@ -1178,21 +1192,17 @@ export async function renderBoardTui(
 				const listWidget = column.list;
 				const selected = listWidget.selected ?? 0;
 				const total = column.tasks.length;
-				if (total === 0) {
-					pendingSearchWrap = null;
+				const boundaryAction = resolveBoardBoundaryToSearch("down", selected, total, wrapNavigationToSearch);
+				if (boundaryAction !== "none") {
+					pendingSearchWrap = boundaryAction === "jump-with-wrap" ? "to-first" : null;
 					focusFilterControl("search");
 					updateFooter();
 					screen.render();
 					return;
 				}
-				if (shouldMoveFromListBoundaryToSearch("down", selected, total)) {
-					pendingSearchWrap = "to-first";
-					focusFilterControl("search");
-					updateFooter();
-					screen.render();
-					return;
-				}
-				const nextIndex = selected + 1;
+				if (total === 0) return;
+				// With the search handoff disabled, boundary navigation falls back to the circular wrap.
+				const nextIndex = selected < total - 1 ? selected + 1 : 0;
 				selectColumnRow(column, nextIndex, true);
 				screen.render();
 			}

--- a/src/ui/enhanced-views.ts
+++ b/src/ui/enhanced-views.ts
@@ -186,6 +186,7 @@ async function renderBoardTuiWithSwitching(
 	// This is a placeholder - we'll need to modify the actual board.ts
 	return renderBoardTui(tasks, statuses, layout, maxColumnWidth, {
 		dateFormat: config?.dateFormat,
+		wrapNavigationToSearch: config?.wrapNavigationToSearch,
 		priorities: config?.priorities,
 		types: config?.types,
 	});

--- a/src/ui/simple-unified-view.ts
+++ b/src/ui/simple-unified-view.ts
@@ -122,6 +122,7 @@ export async function runSimpleUnifiedView(options: SimpleUnifiedViewOptions): P
 				await switchView();
 			},
 			dateFormat: config?.dateFormat,
+			wrapNavigationToSearch: config?.wrapNavigationToSearch,
 			priorities: config?.priorities,
 			types: config?.types,
 		});

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -93,7 +93,11 @@ export function shouldMoveFromListBoundaryToSearch(
 	direction: TaskListBoundaryDirection,
 	selectedIndex: number,
 	totalTasks: number,
+	wrapNavigationToSearch = true,
 ): boolean {
+	if (!wrapNavigationToSearch) {
+		return false;
+	}
 	if (totalTasks <= 0) {
 		return false;
 	}
@@ -106,7 +110,11 @@ export function shouldMoveFromListBoundaryToSearch(
 export function shouldMoveFromDetailBoundaryToSearch(
 	direction: TaskListBoundaryDirection,
 	scrollOffset: number,
+	wrapNavigationToSearch = true,
 ): boolean {
+	if (!wrapNavigationToSearch) {
+		return false;
+	}
 	if (direction !== "up") {
 		return false;
 	}
@@ -242,6 +250,7 @@ export async function viewTaskEnhanced(
 	const { availableMilestoneTitles, resolveMilestoneLabel } = buildTaskViewerMilestoneFilterModel(milestoneEntities);
 
 	let dateFormat: string | undefined;
+	let wrapNavigationToSearch = true;
 
 	if (options.tasks) {
 		// Tasks already provided - use in-memory search (no ContentStore loading)
@@ -252,6 +261,7 @@ export async function viewTaskEnhanced(
 		priorityOptions = getPriorityOptions(config);
 		configuredTaskTypes = getTaskTypeValues(config);
 		dateFormat = config?.dateFormat;
+		wrapNavigationToSearch = config?.wrapNavigationToSearch ?? true;
 		taskSearchIndex = createTaskSearchIndex(allTasks);
 	} else {
 		// Need to load tasks - show loading screen
@@ -264,6 +274,7 @@ export async function viewTaskEnhanced(
 			priorityOptions = getPriorityOptions(config);
 			configuredTaskTypes = getTaskTypeValues(config);
 			dateFormat = config?.dateFormat;
+			wrapNavigationToSearch = config?.wrapNavigationToSearch ?? true;
 
 			loadingScreen?.update("Loading tasks from branches...");
 			contentStore = await core.getContentStore();
@@ -903,7 +914,7 @@ export async function viewTaskEnhanced(
 				void applySelection(selected);
 			},
 			onBoundaryNavigation: (direction, selectedIndex, total) => {
-				if (!shouldMoveFromListBoundaryToSearch(direction, selectedIndex, total)) {
+				if (!shouldMoveFromListBoundaryToSearch(direction, selectedIndex, total, wrapNavigationToSearch)) {
 					return false;
 				}
 				pendingSearchWrap = direction === "up" ? "to-last" : "to-first";
@@ -960,7 +971,7 @@ export async function viewTaskEnhanced(
 			};
 
 			boxInstance.key(["up", "k"], () => {
-				if (!shouldMoveFromDetailBoundaryToSearch("up", scrollable.getScroll?.() ?? 0)) {
+				if (!shouldMoveFromDetailBoundaryToSearch("up", scrollable.getScroll?.() ?? 0, wrapNavigationToSearch)) {
 					return true;
 				}
 				pendingSearchWrap = null;

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -494,6 +494,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					milestoneEntities,
 					startupWarning,
 					dateFormat: config?.dateFormat,
+					wrapNavigationToSearch: config?.wrapNavigationToSearch,
 					priorities: config?.priorities,
 					types: config?.types,
 					createTask: async (input) => createTaskFromBoard(options.core, input, taskUpdateCallbacks.onTaskAdded),

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -19,6 +19,7 @@ const CONFIG_POLL_INTERVAL_MS = 500;
 const BOOLEAN_CONFIG_KEYS = new Set([
 	"auto_open_browser",
 	"hide_empty_columns",
+	"wrap_navigation_to_search",
 	"remote_operations",
 	"auto_commit",
 	"filesystem_only",


### PR DESCRIPTION
## Summary

In the TUI, pressing `j` on the last row or `k` on the first row (or `k` at the top of the focused detail pane) hands focus to the search input. The wrap is deliberate (back-399), but it surprises vim-style navigation: `j`/`k` are expected to stay inside the list, and `/` and `Ctrl+F` already focus search directly.

This adds an opt-out config key that keeps today's behavior by default:

- `wrapNavigationToSearch` (boolean, default `true`), available through `backlog config get/set/list` and documented in ADVANCED-CONFIG.md
- when `false`, the handoff stops in the task list, the detail pane, and the kanban board (including empty columns)
- with the handoff disabled, boundary navigation falls back to the circular wrap both views used before back-399 (introduced in task-248)

## Related Issue or Task

Closes #768

Backlog task: BACK-536

## Task Checklist

- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Testing

- `bunx tsc --noEmit` — passed
- `bun run check .` — passed (323 files)
- `bun test` — 1670 passed + 2 intentional skips / 0 failed (187 files)
- new coverage: wrap-disabled cases in `task-viewer-boundary-navigation.test.ts`, `resolveBoardBoundaryToSearch` cases in `board-ui.test.ts`, and a `config get/set/list` round-trip for the new key