### PR TITLE
BACK-633 - Scroll the task detail pane with Shift+J/K without leaving the list

### DIFF
--- a/backlog/tasks/back-633 - Scroll-the-task-detail-pane-with-ShiftJ-K-without-leaving-the-list.md
+++ b/backlog/tasks/back-633 - Scroll-the-task-detail-pane-with-ShiftJ-K-without-leaving-the-list.md
@@ -1,0 +1,64 @@
+---
+id: BACK-633
+title: Scroll the task detail pane with Shift+J/K without leaving the list
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-11 17:03'
+updated_date: '2026-08-11 17:07'
+labels:
+  - enhancement
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/769'
+  - 'https://github.com/MrLesk/Backlog.md/pull/771'
+type: enhancement
+ordinal: 269000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+In the task-list TUI view, the detail pane can only be scrolled after moving focus into it (right/l or Enter). Bind Shift+J / Shift+K as screen-level shortcuts that scroll the detail pane body from either pane, so the list keeps focus while long descriptions are read. The shortcut must stay inert while the filter bar is focused, a popup or modal is open, or there is no detail pane, and it must never trigger the boundary handoff into the search field.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Shift+J / Shift+K scroll the detail pane from the task list without moving focus
+- [x] #2 The shortcut is inert while filters are focused, a popup or modal is open, or no detail pane exists
+- [x] #3 Plain j/k navigation and the arrow-key boundary search handoff are unaffected
+- [x] #4 Helper branches are fully covered by unit tests and the help popup documents the shortcut
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Export a pure helper shouldScrollDetailPaneFromShortcut(currentFocus, modalOpen, filterPopupOpen, hasDetailPane) in src/ui/task-viewer-with-search.ts. 2. Add screen-level key bindings ['J','S-j'] / ['K','S-k'] that scroll descriptionBox by +/-1 line through the helper without moving focus. 3. Add the 'J/K - Scroll task details' entry to the task-list help popup. 4. Unit-test every helper branch in src/test/task-viewer-detail-scroll.test.ts.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Rebased onto upstream/main after BACK-584 (#866) reshaped boundary navigation. No textual conflicts; the helper composes cleanly with the new shouldMoveFromDetailBoundaryToSearch(scrollOffset, key) signature and adds no interaction with it. Originally filed as BACK-537, but upstream allocated that ID to 'Make checklist edits and serialization deterministic' on 2026-07-11; the task was recreated through the CLI allocator as BACK-633 to remove the duplicate ID from the PR.
+
+Note on scope after #866: the original motivation included 'must never trigger the boundary handoff into the search field'. BACK-584 already made k at the top of the detail pane stay put, so that clause is now satisfied upstream independently; the remaining value of this change is scrolling the detail pane while the list keeps focus.
+
+Verification evidence:
+- Unit: src/test/task-viewer-detail-scroll.test.ts covers all six helper branches (focus in list, focus in detail, filters focused, modal open, filter popup open, no detail pane).
+- Real PTY (tmux, 200x50, temp project with a 60-line description): Shift+J five times scrolled the detail body from line-1 to line-2-at-top without changing the selected task; three Shift+K scrolled back; a subsequent plain j moved the selection to TASK-2, proving focus never left the list. With the search field focused, J was inserted as a literal character ('Search: J') and the detail pane did not scroll.
+- Regression: src/test/tui-vim-boundary-navigation.test.ts and src/test/task-viewer-boundary-navigation.test.ts pass unchanged (25 tests), so BACK-584's j/k and arrow behaviour is untouched.
+- bunx tsc --noEmit clean, bun run check . clean (374 files), bun run test 2250 pass / 6 skip / 1 fail. The single failure is src/test/tui-window-title.test.ts, which fails identically on unmodified upstream/main in this environment (tmux rewrites the terminal escape sequences the test asserts on), so it is pre-existing and unrelated.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Bound Shift+J / Shift+K as screen-level shortcuts that scroll the task detail pane body while the task list keeps focus, so long descriptions can be read without bouncing focus between panes. Guarded by a pure exported helper that keeps the shortcut inert while the filter bar is focused, a modal or filter popup is open, or no detail pane exists; uppercase-only bindings follow the existing ['e','E','S-e'] idiom so plain j/k navigation is untouched. Help popup documents the shortcut. Verified with per-branch unit tests, a real-PTY tmux check of both the scroll and the focus-retention claim, the unchanged BACK-584 navigation suites, and clean tsc/biome.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/task-viewer-detail-scroll.test.ts
+++ b/src/test/task-viewer-detail-scroll.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { shouldScrollDetailPaneFromShortcut } from "../ui/task-viewer-with-search.ts";
+
+describe("task viewer detail scroll shortcut", () => {
+	it("scrolls the detail pane from the task list without moving focus", () => {
+		expect(shouldScrollDetailPaneFromShortcut("list", false, false, true)).toBe(true);
+	});
+
+	it("scrolls the detail pane while it is focused", () => {
+		expect(shouldScrollDetailPaneFromShortcut("detail", false, false, true)).toBe(true);
+	});
+
+	it("does not scroll while the filter header is focused", () => {
+		expect(shouldScrollDetailPaneFromShortcut("filters", false, false, true)).toBe(false);
+	});
+
+	it("does not scroll while a modal is open", () => {
+		expect(shouldScrollDetailPaneFromShortcut("list", true, false, true)).toBe(false);
+	});
+
+	it("does not scroll while a filter popup is open", () => {
+		expect(shouldScrollDetailPaneFromShortcut("list", false, true, true)).toBe(false);
+	});
+
+	it("does not scroll when there is no detail pane", () => {
+		expect(shouldScrollDetailPaneFromShortcut("list", false, false, false)).toBe(false);
+	});
+});

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -42,6 +42,7 @@ const TASK_LIST_SHORTCUTS: Shortcut[] = [
 	{ key: "↑↓", desc: "Navigate tasks" },
 	{ key: "←→", desc: "Switch between list and details" },
 	{ key: "Enter", desc: "Focus task details" },
+	{ key: "J/K", desc: "Scroll task details" },
 	{ key: "E", desc: "Edit task" },
 	{ key: "C", desc: "Complete task" },
 	{ key: "A", desc: "Archive task" },

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -107,6 +107,18 @@ export function shouldMoveFromDetailBoundaryToSearch(scrollOffset: number, key: 
 	return key === "arrow" && scrollOffset <= 0;
 }
 
+export function shouldScrollDetailPaneFromShortcut(
+	currentFocus: "filters" | "list" | "detail",
+	modalOpen: boolean,
+	filterPopupOpen: boolean,
+	hasDetailPane: boolean,
+): boolean {
+	if (modalOpen || filterPopupOpen || currentFocus === "filters") {
+		return false;
+	}
+	return hasDetailPane;
+}
+
 export function resolveSearchExitTargetIndex(
 	direction: "up" | "down" | "escape",
 	pendingWrap: PendingSearchWrap,
@@ -1373,6 +1385,24 @@ export async function viewTaskEnhanced(
 	screen.key(["e", "E", "S-e"], () => {
 		if (modalOpen) return;
 		void openCurrentTaskInEditor();
+	});
+
+	// Scroll the detail pane without moving focus off the task list.
+	const scrollDetailPane = (delta: number) => {
+		if (!shouldScrollDetailPaneFromShortcut(currentFocus, modalOpen, filterPopupOpen, Boolean(descriptionBox))) {
+			return;
+		}
+		const scrollable = descriptionBox as unknown as { scroll?: (offset: number) => void };
+		scrollable.scroll?.(delta);
+		screen.render();
+	};
+
+	screen.key(["J", "S-j"], () => {
+		scrollDetailPane(1);
+	});
+
+	screen.key(["K", "S-k"], () => {
+		scrollDetailPane(-1);
 	});
 
 	screen.key(["y", "Y"], async () => {


### PR DESCRIPTION
## Summary

In the task-list view the detail pane can only be scrolled after moving focus into it (`right`/`l` or `Enter`). This binds `Shift+J` / `Shift+K` as screen-level shortcuts that scroll the detail pane body from either pane, so the list keeps focus while long descriptions are read.

- inert while the filter bar is focused, a popup or modal is open, or there is no detail pane
- plain `j`/`k` list navigation is untouched (uppercase-only bindings, following the existing `['e','E','S-e']` idiom)
- the help popup documents the shortcut

## Rebased onto current main

Rebased from the July branch point onto current `main`. Two notes on how this interacts with what shipped since:

- **BACK-584 (#866)** reshaped boundary navigation after this PR was opened. The original description also claimed "never triggers the boundary handoff into the search field" — that clause is now satisfied by #866 independently, since `k` at the top of the detail pane already stays put. The remaining scope of this PR is only the scroll-without-leaving-the-list behaviour. The new helper composes with the current `shouldMoveFromDetailBoundaryToSearch(scrollOffset, key)` signature and adds no interaction with it; the existing navigation suites pass unchanged.
- **Task ID reallocated.** This was originally filed as BACK-537, but `main` allocated that ID to "Make checklist edits and serialization deterministic" on 2026-07-11. To avoid introducing a duplicate task ID, the task was recreated through the CLI allocator as **BACK-633** and the old file dropped. The branch name still says `back-537` because renaming it would close this PR.

## Related Issue or Task

Closes #769

Backlog task: BACK-633

## Task Checklist

- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Testing

- `bunx tsc --noEmit` — clean
- `bun run check .` — clean (374 files)
- `bun run test` — 2250 passed / 6 skipped / 1 failed. The single failure is `src/test/tui-window-title.test.ts`, which fails identically on unmodified `main` in my environment (I run tests inside tmux, which rewrites the terminal escape sequences that test asserts on), so it is pre-existing and unrelated to this change.
- `src/test/task-viewer-detail-scroll.test.ts` covers all six branches of the new helper.
- Real-PTY check (tmux, 200x50, temp project with a 60-line description), since `viewTaskEnhanced` is not exercised by the test suite: five `Shift+J` scrolled the detail body without changing the selected task, three `Shift+K` scrolled back, and a subsequent plain `j` moved the selection — confirming focus never left the list. With the search field focused, `J` was inserted as a literal character and the detail pane did not scroll.

Happy to add a key-event test in the style of `src/test/tui-vim-boundary-navigation.test.ts` if you'd prefer that behaviour locked down in CI rather than verified by hand.
