### PR TITLE
BACK-536 - Enforce just-in-time implementation planning in workflow guidance

### DIFF
--- a/backlog/tasks/back-536 - Enforce-just-in-time-implementation-planning-in-workflow-guidance.md
+++ b/backlog/tasks/back-536 - Enforce-just-in-time-implementation-planning-in-workflow-guidance.md
@@ -1,0 +1,73 @@
+---
+id: BACK-536
+title: Enforce just-in-time implementation planning in workflow guidance
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-11 21:18'
+updated_date: '2026-07-11 21:51'
+labels:
+  - workflow
+  - instructions
+  - documentation
+dependencies: []
+priority: high
+ordinal: 184000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent task creators from freezing an implementation approach before work starts. Creation records durable intent, scope, acceptance criteria, references, and dependencies; the worker researches the current system and records the plan only after taking the task into an active status.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The canonical CLI task-creation guide explicitly excludes implementation plans and explains that plans become stale before pickup
+- [x] #2 The task-execution guide requires moving and assigning the task before current-state research and plan recording
+- [x] #3 Plan approval is required before implementation when the plan contains material product, architecture, or workflow decisions
+- [x] #4 Legacy MCP workflow guidance matches the canonical lifecycle without becoming the primary workflow
+- [x] #5 Instruction tests cover the creation-versus-execution phase boundary
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update the canonical CLI creation guide to capture only durable intent/scope and explicitly defer plans until task pickup.
+2. Update the execution guide so the worker first activates and owns the task, researches the current system, records a current plan, and pauses only for material product, architecture, or workflow approval.
+3. Align the legacy MCP adapter guidance and the shipped full agent guidance with the same lifecycle while keeping CLI canonical.
+4. Add focused instruction contract tests, run the relevant test/type/lint checks, and finalize the task record.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Groma evidence: all 11 To Do tasks GROM-8 through GROM-18 already had implementation plans; GROM-18 was created and updated within one minute while still To Do and unassigned. Updated canonical CLI guidance, legacy MCP parity guidance, and the shipped full agent guide so planning happens only after pickup and current-state research, with proportional approval for material decisions.
+
+Verification: bun test src/test/cli-guidance.test.ts src/test/mcp-server.test.ts (27 pass, 0 fail); bunx tsc --noEmit passed; bun run check . passed across 328 files; git diff --check passed; rendered CLI guides show the intended phase order.
+
+Review repair: removed the remaining unconditional MCP approval and confirmation rules, made routine plan adjustments non-blocking within confirmed scope, and corrected the full agent example to order pickup, task read, fresh research, plan recording, conditional review, then implementation. Added negative assertions for the contradictory phrases and an explicit lifecycle-order test.
+
+Exact repair verification: 46 focused tests passed; full suite 1655 passed, 2 intentional interactive skips, 0 failed with 6808 assertions across 192 files in 248.46s; bunx tsc --noEmit, bun run check . across 328 files, and git diff --check passed.
+
+Consolidated five-comment repair: restored read-and-eligibility review before status/assignee mutation; kept fresh research and plan after activation; limited MCP creation to durable intent/scope/criteria/references/dependencies; removed blanket MCP reapproval; preserved proportional review; documented the direct-active exception for --plan in task create option help and its schema. Added positive, negative, lifecycle-order, and help contract assertions.
+
+Old-head Windows failure classification: the sole failure was this change own MCP test matching a literal LF across a Markdown blockquote; Windows imported CRLF. The corrected assertion is line-ending independent. No old-head rerun. Final local verification: 46 focused tests passed; full suite 1655 passed, 2 intentional interactive skips, 0 failed, 6827 assertions across 192 files in 241.18s; tsc, Biome 328 files, rendered help/guides, and diff hygiene passed.
+
+Third instruction-contradiction review repair: replaced the legacy MCP creation guide Additional Context Gathering section that still encouraged code/test/external research for a plan. Creation now gathers only durable work-order context, explicitly defers implementation research until active execution, and preserves only the already-started/direct-active exception based on research already completed. Regression tests require the new wording and forbid both contradictory phrases.
+
+Final verification after this repair: focused instruction suite 46 passed, 0 failed; full suite 1655 passed, 2 intentional interactive skips, 0 failed, 6833 assertions across 192 files in 204.38s; tsc, Biome 328 files, and diff hygiene passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Established just-in-time task planning across canonical CLI, full agent, and legacy MCP guidance. Creation captures durable work-order context and never triggers implementation research for future work; current-system research and planning happen after eligible work is activated. The narrow already-started/direct-active exception preserves research already completed. Proportional approval, lifecycle order, help wording, and contradictory legacy phrases are protected by cross-platform contract tests; focused and full gates pass.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1662,6 +1662,12 @@ addHelpSchema(taskCmd.command("create [title]"), {
 		{ name: "acceptanceCriteria", type: "Markdown list item text", description: "Repeat --ac for multiple criteria" },
 		{ name: "ordinal", type: "Integer", description: "Non-negative manual ordering value" },
 		{ name: "parent", type: "Task ID", description: "Existing parent task for subtasks; not a milestone ID" },
+		{
+			name: "plan",
+			type: "Markdown",
+			description:
+				"Only for already-started work created directly in a configured active status (for example, In Progress)",
+		},
 	],
 	writes: "Creates a task or draft markdown file through Backlog.md",
 	output: "Created task details; use --plain for text output",
@@ -1687,7 +1693,10 @@ addHelpSchema(taskCmd.command("create [title]"), {
 	)
 	.option("--dod <item>", "add Definition of Done item (can be used multiple times)", createMultiValueAccumulator())
 	.option("--no-dod-defaults", "disable Definition of Done defaults")
-	.option("--plan <text>", "add implementation plan")
+	.option(
+		"--plan <text>",
+		"add a plan only for already-started work created directly in an active status (for example, In Progress)",
+	)
 	.option("--notes <text>", "add implementation notes")
 	.option("--final-summary <text>", "add final summary")
 	.option("--ordinal <number>", "set task ordinal for custom ordering")

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -301,9 +301,16 @@ Bad Example (Implementation Step):
 
 ## 5. Implementing Tasks
 
-### 5.1. First step when implementing a task
+### 5.1. Inspect before pickup, then start eligible work
 
-The very first things you must do when you take over a task are:
+Before mutating a task, read its current record and confirm its status, scope, acceptance criteria, and dependencies make
+it eligible to start:
+
+```bash
+backlog task 42 --plain
+```
+
+Only then take over the task:
 
 * set the task in progress
 * assign it to yourself
@@ -320,6 +327,9 @@ Before planning, check if the task has any attached `references` or `documentati
 - **Documentation**: Design docs, API specs, or other materials for understanding context
 
 These are visible in the task view output. Review them to understand the full context before drafting your plan.
+
+After the task is In Progress and assigned to you, research the current system: inspect relevant code, tests, conventions,
+and recent changes. Do not rely on an implementation approach proposed when the task was created.
 
 ### 5.3. Create an Implementation Plan (The "how")
 
@@ -373,8 +383,10 @@ implementation.
 - Creation phase: provide Title, Description, Acceptance Criteria, and optionally labels/priority/assignee.
 - When you begin work, switch to edit, set the task in progress and assign to yourself
   `backlog task edit <id> -s "In Progress" -a "..."`.
-- Think about how you would solve the task and add the plan: `backlog task edit <id> --plan "..."`.
-- After updating the plan, share it with the user and ask for confirmation. Do not begin coding until the user approves the plan or explicitly tells you to skip the review.
+- Research the current code, tests, conventions, and recent changes, then add the current plan: `backlog task edit <id> --plan "..."`.
+- If the plan contains a material product, architecture, or workflow decision, or the project or user requires review,
+  share it and wait for explicit approval before implementation. Routine plans can proceed when no review was requested
+  and they stay within confirmed scope.
 - Append Implementation Notes during implementation using `--append-notes` as progress is made.
 - Add Final Summary only after completing the work: `backlog task edit <id> --final-summary "..."` (replace) or append using `--append-final-summary`.
 
@@ -397,30 +409,33 @@ implementation.
 # 1. Identify work
 backlog task list -s "To Do" --plain
 
-# 2. Read task details
+# 2. Read task details and confirm status, scope, acceptance criteria, and dependencies
 backlog task 42 --plain
 
-# 3. Start work: assign yourself & change status
+# 3. Start eligible work: assign yourself & change status
 backlog task edit 42 -s "In Progress" -a @myself
 
-# 4. Add implementation plan
+# 4. Research the current code, tests, conventions, and recent changes after activation
+
+# 5. Add the current implementation plan
 backlog task edit 42 --plan "1. Analyze\n2. Refactor\n3. Test"
 
-# 5. Share the plan with the user and wait for approval (do not write code yet)
+# 6. If the plan contains a material product, architecture, or workflow decision,
+#    or the project or user requires review, share it and wait for approval
 
-# 6. Work on the task (write code, test, etc.)
+# 7. Work on the task (write code, test, etc.)
 
-# 7. Mark acceptance criteria as complete (supports multiple in one command)
+# 8. Mark acceptance criteria as complete (supports multiple in one command)
 backlog task edit 42 --check-ac 1 --check-ac 2 --check-ac 3  # Check all at once
 # Or check them individually if preferred:
 # backlog task edit 42 --check-ac 1
 # backlog task edit 42 --check-ac 2
 # backlog task edit 42 --check-ac 3
 
-# 8. Add Final Summary (PR Description)
+# 9. Add Final Summary (PR Description)
 backlog task edit 42 --final-summary "Refactored using strategy pattern, updated tests"
 
-# 9. Mark task as done
+# 10. Mark task as done
 backlog task edit 42 -s Done
 ```
 

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -65,6 +65,12 @@ Include:
 - References or documentation when they are needed for implementation.
 - Dependencies when work must happen in order.
 
+For future work, do **not** add an implementation plan or speculative code approach during task creation. Creation
+captures the durable intent, context, scope, acceptance criteria, references, and dependencies. The worker researches
+the current system and records the plan after picking up and activating the task, because the codebase or constraints may
+change before then. The narrow exception is already-started work being created directly in a configured active status
+(for example, In Progress); its current researched plan may be supplied at creation.
+
 Examples:
 
 ```bash

--- a/src/guidelines/cli-instructions/task-execution.md
+++ b/src/guidelines/cli-instructions/task-execution.md
@@ -6,17 +6,21 @@ Use this guide when you are working on an existing Backlog task.
 
 Before writing code for non-trivial work:
 
-1. Read the task:
+1. Read the task before mutating it:
    - `backlog task view {{TASK_ID:123}} --plain`
-2. Mark it in progress and assign yourself:
+2. Review its current status, description, acceptance criteria, dependencies, references, and documentation. Confirm the
+   task is eligible to start and remains within the requested scope.
+3. Mark it in progress and assign yourself:
    - Inspect accepted statuses if needed: `backlog task edit {{TASK_ID:123}} --help`
    - `backlog task edit {{TASK_ID:123}} -s "<active status>" -a @your-name`
-3. Review description, acceptance criteria, dependencies, references, and documentation.
-4. Inspect relevant code and tests.
+4. Research the current system, including relevant code, tests, conventions, and recent changes. Do not rely on an
+   implementation approach proposed when the task was created.
 5. Draft an implementation plan.
-6. Present the plan to the user when approval is expected.
-7. Record the approved plan:
+6. Record the current plan in the task before implementation:
    - `backlog task edit {{TASK_ID:123}} --plan "1. ..."`
+7. If the plan contains a material product, architecture, or workflow decision, or the project or user requires plan
+   review, present it and wait for explicit approval before implementation. Routine plans need not block when no review
+   was requested and they stay within confirmed scope.
 
 Keep the Backlog task as the plan of record. If the approach changes, update the plan through `backlog task edit` before continuing.
 

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -93,6 +93,11 @@ Create all tasks in the same session to maintain consistency and context.
 
 **Ask for clarification** if requirements are ambiguous
 
+**Do not add implementation research, an implementation plan, or a speculative code approach during creation.** MCP task
+creation records only durable intent, context, scope, acceptance criteria, references, and dependencies. The future
+worker researches the then-current system and records the plan after taking the task into progress. CLI instructions
+remain the canonical workflow; this legacy MCP guide mirrors the same task lifecycle for adapter users.
+
 **Drafts (exceptional):** Default to creating regular tasks (e.g., To Do) for any work you are committing to track. Only create a Draft when the user explicitly requests a draft, or when there is clear uncertainty that makes a commitment inappropriate (e.g., missing requirements and the user wants a placeholder). Use `task_create` with status `Draft` to create a draft, `task_edit` to promote/demote by changing status, and pass status `Draft` to `task_list`/`task_search` to include drafts. Drafts are excluded unless explicitly filtered.
 
 ### Step 6: Report created tasks
@@ -116,8 +121,13 @@ Then create the tasks and report what was created.
 
 **Standalone task example (includes tests/docs):** "Add API endpoint for bulk updates" with acceptance criteria that include required tests and documentation updates in the same task.
 
-### Additional Context Gathering
+### Durable Context at Creation
 
-- Use `task_view` to read the description, acceptance criteria, dependencies, current plan, and notes before acting
-- Inspect relevant code/docs/tests in the repository to ground your understanding
-- When permitted, consult up-to-date external references (design docs, service manuals, API specs) so your plan reflects current reality
+- Use `task_view` on related work only to avoid duplicates and recover durable product decisions, scope, acceptance
+  criteria, dependencies, and references.
+- Gather the intended outcome, confirmed constraints, acceptance criteria, dependencies, and reference material needed to
+  understand the work order. Do not inspect implementation code or tests, or perform external implementation research,
+  to draft a plan for future work.
+- The execution worker performs current-system research after the task is active and records the plan then. The narrow
+  exception is already-started work created directly in an active status: it may preserve a current plan based on
+  research already completed, but task creation itself does not trigger that research.

--- a/src/guidelines/mcp/task-execution.md
+++ b/src/guidelines/mcp/task-execution.md
@@ -2,22 +2,24 @@
 
 ### Planning Workflow
 
-> **Non-negotiable:** Capture an implementation plan in the Backlog task _before_ writing any code or running commands. The plan must live in the task record prior to implementation and remain up to date when you close the task.
+> **Non-negotiable:** Capture an implementation plan in the Backlog task _after_ taking the task into progress and
+> researching the current system, but before implementation. The plan must live in the task record prior to implementation
+> and remain up to date when you close the task. CLI instructions are canonical; this legacy MCP guide preserves parity.
 
-1. **Mark task as In Progress** via `task_edit` with status "In Progress"
-2. **Assign to yourself** via `task_edit` with assignee field
-3. **Review task description, acceptance criteria, references, and documentation** - Check the description for outcome and any local code context, review acceptance criteria to confirm scope and success conditions, check `references` for external links/issues, and check `documentation` for design docs or API specs before planning
-4. **Draft the implementation plan** - Think through the approach, review code, identify key files
-5. **Present plan to user** - Show your proposed implementation approach
-6. **Wait for explicit approval** - Do not start coding until user confirms or asks you to skip review
-7. **Record approved plan** - Use `task_edit` with planSet or planAppend to capture the agreed approach in the task
-8. **Document the agreed breakdown** - In the parent task's plan, capture the final list of subtasks, owners, and sequencing so a replacement agent can resume with the approved structure
+1. **Read before mutating** - Use `task_view` to inspect the current status, description, acceptance criteria, dependencies, references, and documentation
+2. **Confirm eligibility and scope** - Verify the task is eligible to start, its dependencies permit work, and it remains within the requested scope
+3. **Mark task as In Progress** via `task_edit` with status "In Progress"
+4. **Assign to yourself** via `task_edit` with assignee field
+5. **Research the current system** - Inspect relevant code, tests, conventions, and recent changes rather than relying on an approach proposed when the task was created
+6. **Draft and record the implementation plan** - Use `task_edit` with planSet or planAppend to capture the current approach in the task
+7. **Apply proportional review** - If the plan contains a material product, architecture, or workflow decision, or the project or user requires plan review, present it and wait for explicit approval before implementation. Routine plans can proceed when no review was requested and they stay within confirmed scope
+8. **Document the agreed breakdown** - In the parent task's plan, capture any approved list of subtasks, owners, and sequencing so a replacement agent can resume with the current structure
 
 **IMPORTANT:** Use tasks as permanent storage for everything related to the work. You may be interrupted or replaced at any point, so the task record must contain everything needed for a clean handoff.
 
 ### Planning Guidelines
 
-- Keep the Backlog task as the single plan of record: capture the agreed approach with `task_edit` (planSet field) before writing code
+- Keep the Backlog task as the single plan of record: capture the current approach with `task_edit` (planSet field) before writing code
 - Use `task_edit` (planAppend field) to refine the plan when you learn more during implementation
 - Verify prerequisites before committing to a plan: confirm required tools, access, data, and environment support are in place
 - Keep plans structured and actionable: list concrete steps, highlight key files, call out risks, and note any checkpoints or validations
@@ -34,8 +36,8 @@
 
 ### Execution Workflow
 
-- **IMPORTANT**: Do not touch the codebase until the implementation plan is approved _and_ recorded in the task via `task_edit`
-- The recorded plan must stay accurate; if the approach shifts, update it first and get confirmation before continuing
+- **IMPORTANT**: Do not start implementation until the current implementation plan is recorded in the task via `task_edit` and any review required by the proportional-review rule above is complete
+- The recorded plan must stay accurate. Update routine plan adjustments in the task and continue without mandatory human confirmation when they stay within confirmed scope and introduce no material decision
 - If feedback requires changes, revise the plan first via `task_edit` (planSet or planAppend fields)
 - Work in short loops: implement, run the relevant tests, and record progress. Do not check acceptance criteria, write the final summary, or move the task to Done from this guide alone; first follow the Task Finalization Guide and verify each acceptance criterion with objective evidence.
 - Log progress with `task_edit` (notesAppend field) to document decisions, blockers, or learnings
@@ -60,8 +62,8 @@ If new work appears during implementation that wasn't in the original acceptance
 ### Staying on Track
 
 - Stay within the scope defined by the plan and acceptance criteria
-- Update the plan first if direction changes, then get user approval for the revised approach
-- If you need to deviate from the plan, explain why and wait for confirmation
+- Update the plan before following a changed approach
+- If a deviation introduces a material product, architecture, or workflow decision, or the project explicitly requires review, explain it and wait for approval. Otherwise record the routine adjustment and continue within confirmed scope
 
 ### Working with Subtasks (Execution)
 

--- a/src/test/agent-instructions.test.ts
+++ b/src/test/agent-instructions.test.ts
@@ -143,6 +143,31 @@ describe("addAgentInstructions", () => {
 		expect(content).toContain("# Instructions for the usage of Backlog.md CLI Tool");
 	});
 
+	it("full agent workflow plans only after pickup and current-state research", async () => {
+		const guideline = await _loadAgentGuideline(AGENT_GUIDELINES);
+		const workflow = guideline.match(/## 6\. Typical Workflow[\s\S]*?(?=\n---)/)?.[0] ?? "";
+		const readIndex = workflow.indexOf(
+			"Read task details and confirm status, scope, acceptance criteria, and dependencies",
+		);
+		const pickupIndex = workflow.indexOf("Start eligible work: assign yourself & change status");
+		const researchIndex = workflow.indexOf(
+			"Research the current code, tests, conventions, and recent changes after activation",
+		);
+		const planIndex = workflow.indexOf("Add the current implementation plan");
+		const conditionalReviewIndex = workflow.indexOf(
+			"If the plan contains a material product, architecture, or workflow decision",
+		);
+		const implementationIndex = workflow.indexOf("Work on the task");
+
+		expect(readIndex).toBeGreaterThan(-1);
+		expect(pickupIndex).toBeGreaterThan(readIndex);
+		expect(researchIndex).toBeGreaterThan(pickupIndex);
+		expect(planIndex).toBeGreaterThan(researchIndex);
+		expect(conditionalReviewIndex).toBeGreaterThan(planIndex);
+		expect(implementationIndex).toBeGreaterThan(conditionalReviewIndex);
+		expect(workflow).not.toContain("Share the plan with the user and wait for approval");
+	});
+
 	it("does not duplicate content when run multiple times (idempotent)", async () => {
 		// First run
 		await addAgentInstructions(TEST_DIR);

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -130,11 +130,40 @@ describe("CLI Integration", () => {
 			expect(taskCreation).toContain(
 				"If you will continue from task creation into implementation in the same session, stop and read `backlog instructions task-execution` before viewing, assigning, planning, editing, or implementing a task.",
 			);
+			expect(taskCreation).toContain(
+				"For future work, do **not** add an implementation plan or speculative code approach",
+			);
+			expect(taskCreation).toContain(
+				"The narrow exception is already-started work being created directly in a configured active status",
+			);
 			expect(taskExecution).toContain(
 				'backlog task list --status "<active status>" --assignee @your-name --labels backend --search "auth" --limit 20 --plain',
 			);
 			expect(taskExecution).toContain('backlog task edit BACK-123 -s "<active status>" -a @your-name');
 			expect(taskExecution).not.toContain('backlog task edit BACK-123 -s "In Progress" -a @your-name');
+			expect(taskExecution).toContain(
+				"Research the current system, including relevant code, tests, conventions, and recent changes",
+			);
+			expect(taskExecution).toContain("Record the current plan in the task before implementation");
+			expect(taskExecution).toContain(
+				"If the plan contains a material product, architecture, or workflow decision, or the project or user requires plan",
+			);
+			const viewIndex = taskExecution.indexOf("backlog task view BACK-123 --plain");
+			const eligibilityIndex = taskExecution.indexOf("Review its current status");
+			const activateIndex = taskExecution.indexOf('backlog task edit BACK-123 -s "<active status>" -a @your-name');
+			const researchIndex = taskExecution.indexOf("Research the current system");
+			const planIndex = taskExecution.indexOf("Record the current plan in the task");
+			const conditionalReviewIndex = taskExecution.indexOf(
+				"If the plan contains a material product, architecture, or workflow decision",
+			);
+			const implementIndex = taskExecution.indexOf("### Execution Workflow");
+			expect(viewIndex).toBeGreaterThan(-1);
+			expect(eligibilityIndex).toBeGreaterThan(viewIndex);
+			expect(activateIndex).toBeGreaterThan(eligibilityIndex);
+			expect(researchIndex).toBeGreaterThan(activateIndex);
+			expect(planIndex).toBeGreaterThan(researchIndex);
+			expect(conditionalReviewIndex).toBeGreaterThan(planIndex);
+			expect(implementIndex).toBeGreaterThan(conditionalReviewIndex);
 			expect(taskExecution).toContain(
 				"Do not check acceptance criteria, write the final summary, or move the task to the terminal status from this guide alone.",
 			);
@@ -272,6 +301,7 @@ describe("CLI Integration", () => {
 			const createHelp = await $`bun ${CLI_PATH} task create --help`.cwd(TEST_DIR).text();
 			const listHelp = await $`bun ${CLI_PATH} task list --help`.cwd(TEST_DIR).text();
 			const editHelp = await $`bun ${CLI_PATH} task edit --help`.cwd(TEST_DIR).text();
+			const createHelpCompact = createHelp.replace(/\s+/g, " ");
 			const editHelpCompact = editHelp.replace(/\s+/g, " ");
 			const completeHelp = await $`bun ${CLI_PATH} task complete --help`.cwd(TEST_DIR).text();
 
@@ -280,6 +310,12 @@ describe("CLI Integration", () => {
 			expect(createHelp).toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
 			expect(createHelp).toContain("priority: one of configured priorities: High, Medium, Low");
 			expect(createHelp).toContain("ordinal: Integer");
+			expect(createHelpCompact).toContain(
+				"--plan <text> add a plan only for already-started work created directly in an active status (for example, In Progress)",
+			);
+			expect(createHelp).toContain(
+				"plan: Markdown - Only for already-started work created directly in a configured active status (for example, In Progress)",
+			);
 			expect(listHelp).toContain("status: one of configured statuses: To Do, In Progress, Done");
 			expect(listHelp).not.toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
 			expect(listHelp).toContain("priority: one of configured priorities: High, Medium, Low");

--- a/src/test/mcp-server.test.ts
+++ b/src/test/mcp-server.test.ts
@@ -176,6 +176,59 @@ describe("McpServer bootstrap", () => {
 		);
 	});
 
+	it("legacy MCP guides preserve just-in-time planning parity with the canonical CLI lifecycle", () => {
+		TEST_DIR = createUniqueTestDir("mcp-server-guides");
+
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Do not add implementation research, an implementation plan, or a speculative code approach during creation.",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"creation records only durable intent, context, scope, acceptance criteria, references, and dependencies",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("CLI instructions");
+		expect(MCP_TASK_CREATION_GUIDE).toContain("canonical workflow");
+		expect(MCP_TASK_CREATION_GUIDE).toContain("### Durable Context at Creation");
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Do not inspect implementation code or tests, or perform external implementation research",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"The execution worker performs current-system research after the task is active and records the plan then",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("already-started work created directly in an active status");
+		expect(MCP_TASK_CREATION_GUIDE).not.toContain("Inspect relevant code/docs/tests in the repository");
+		expect(MCP_TASK_CREATION_GUIDE).not.toContain("so your plan reflects current reality");
+		expect(MCP_TASK_EXECUTION_GUIDE).toContain("_after_ taking the task into progress");
+		expect(MCP_TASK_EXECUTION_GUIDE).toContain("researching the current system, but before implementation");
+		expect(MCP_TASK_EXECUTION_GUIDE).toContain(
+			"If the plan contains a material product, architecture, or workflow decision",
+		);
+		expect(MCP_TASK_EXECUTION_GUIDE).toContain("Routine plans can proceed when no review was requested");
+		expect(MCP_TASK_EXECUTION_GUIDE).toContain(
+			"Update routine plan adjustments in the task and continue without mandatory human confirmation",
+		);
+		expect(MCP_TASK_EXECUTION_GUIDE).not.toContain(
+			"Do not touch the codebase until the implementation plan is approved _and_ recorded",
+		);
+		expect(MCP_TASK_EXECUTION_GUIDE).not.toContain("update it first and get confirmation before continuing");
+		expect(MCP_TASK_EXECUTION_GUIDE).not.toContain("then get user approval for the revised approach");
+		expect(MCP_TASK_EXECUTION_GUIDE).not.toContain("explain why and wait for confirmation");
+
+		const viewIndex = MCP_TASK_EXECUTION_GUIDE.indexOf("Use `task_view` to inspect");
+		const eligibilityIndex = MCP_TASK_EXECUTION_GUIDE.indexOf("Confirm eligibility and scope");
+		const activateIndex = MCP_TASK_EXECUTION_GUIDE.indexOf("Mark task as In Progress");
+		const researchIndex = MCP_TASK_EXECUTION_GUIDE.indexOf("Research the current system");
+		const planIndex = MCP_TASK_EXECUTION_GUIDE.indexOf("Draft and record the implementation plan");
+		const conditionalReviewIndex = MCP_TASK_EXECUTION_GUIDE.indexOf("Apply proportional review");
+		const implementIndex = MCP_TASK_EXECUTION_GUIDE.indexOf("### Execution Workflow");
+		expect(viewIndex).toBeGreaterThan(-1);
+		expect(eligibilityIndex).toBeGreaterThan(viewIndex);
+		expect(activateIndex).toBeGreaterThan(eligibilityIndex);
+		expect(researchIndex).toBeGreaterThan(activateIndex);
+		expect(planIndex).toBeGreaterThan(researchIndex);
+		expect(conditionalReviewIndex).toBeGreaterThan(planIndex);
+		expect(implementIndex).toBeGreaterThan(conditionalReviewIndex);
+	});
+
 	it("workflow tool returns overview by default and selected guide content when requested", async () => {
 		const server = await bootstrapServer();
 


### PR DESCRIPTION
## Summary

- make the canonical CLI task-creation guide explicitly defer implementation plans until task pickup
- require the worker to activate and own the task, research the current system, then record the plan before implementation
- make plan approval proportional to material product, architecture, or workflow decisions and explicit review requirements
- keep the legacy MCP adapter and full agent guidance aligned with the CLI-canonical lifecycle
- add focused CLI and MCP instruction contract tests

## Why

Implementation plans written while creating future tasks can become stale before a worker starts them. Task creation should preserve durable intent and scope; the current worker should own the researched implementation approach.

## Validation

- `bun test src/test/cli-guidance.test.ts src/test/mcp-server.test.ts` — 27 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run check .` — 328 files checked
- `git diff --check`

Related task: BACK-536
