### PR TITLE
BACK-535.14 - Replace deep-link test polling with observable synchronization

### DIFF
--- a/backlog/tasks/back-535.14 - Replace-deep-link-test-polling-with-observable-synchronization.md
+++ b/backlog/tasks/back-535.14 - Replace-deep-link-test-polling-with-observable-synchronization.md
@@ -1,0 +1,71 @@
+---
+id: BACK-535.14
+title: Replace deep-link test polling with observable synchronization
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-11 21:34'
+updated_date: '2026-07-11 22:38'
+labels: []
+dependencies: []
+modified_files:
+  - src/test/web-task-detail-deeplink.test.tsx
+parent_task_id: BACK-535
+priority: high
+ordinal: 184000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The shared deep-link browser test helper still uses fixed 50 x 5 ms attempt polling, which fails under CI load. Audit every remaining caller in src/test/web-task-detail-deeplink.test.tsx and replace the polling class comprehensively with deterministic observable synchronization while preserving diagnostics, semantics, and the global 10-second test timeout.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Every remaining shared waitFor caller is classified by its observable event or state transition
+- [x] #2 Fixed-attempt polling is replaced with deterministic observable synchronization and explicit lifecycle cleanup, using case-specific signals when DOM mutation is insufficient
+- [x] #3 No timeout inflation or product, mobile, or production-code changes are introduced
+- [x] #4 Targeted stress, whole-file, full-isolate, typecheck, Biome, build, and diff verification pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Audit all 45 shared polling callers and classify their causal operation. 2. Replace universal polling with labeled fetch operations that settle through response body readers, manual response gates for intentional races, synchronous WebSocket delivery, one-shot history signals, and a controlled verified product timer. 3. Verify every operation is drained during teardown and keep assertions synchronous after act returns. 4. Run fixed 50x stress, the whole file, exact full isolate, typecheck, Biome, build, and diff checks; then simplify.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Concern cycle 1/3: CI #772 final-head Ubuntu job 86585523928 failed nine times at shared waitFor line 239 (callers 493, 535, 555, 651 x4, 679, 693, 712). The #775 overlap caller is already fixed and excluded. Main design concern: MutationObserver is only truthful for predicates whose satisfaction is accompanied by DOM mutation; non-DOM state requires an explicit deferred/event signal.
+
+Concern architecture reset: rejected universal-predicate synchronization experiments are preserved as evidence, not final design. MutationObserver awaited inside act deadlocked and produced unchanged 5-second runner timeouts; outside act it passed 21/21 but emitted widespread unwrapped React update warnings. A generic mocked response-body event likewise deadlocked inside act and warned outside act. Temporarily suppressing IS_REACT_ACT_ENVIRONMENT made focused 1/1 and whole-file 21/21 clean, with Biome/typecheck/diff passing, but was rejected because it hides harness evidence. The attempted 50x stress run was aborted immediately on rejection. Final architecture must use labeled operation-scoped fetch calls tracked through deepest json/text body reads with settle/manual respond, synchronous socket delivery inside act, immediate history assertions, and fail-visible afterEach verification. Prohibited synchronization mechanisms for this task are universal predicate waits, MutationObserver, generic act flush loops, act-environment suppression, polling, timeout changes, and private-field probes introduced for synchronization.
+
+Concern cycle 2/3 - architecture reset implemented. Complete 45-site map: board/direct/filter route lifecycle 10; overlap WebSocket readiness 1; sidebar search/open/close 4; legacy-highlight open/close 2; stable list open/Back/Forward/close 5; scenario-loop initial/fallback/Back 3 static callers (each exercised for missing, ambiguous, and active-branch collision); direct collision alert 1; cross-prefix and legacy list/route/direct/missing 6; archive navigation/open/close 3; stale-route list/pending/newer/close 4; duplicate-plan socket/newer-load 2; custom-prefix direct/open-close 2; malformed route fallbacks 2. Render callers now settle initial status, search, and routed task phases. Click/socket callers settle labeled body readers; close/history callers await the relevant popstate or assert immediately; archive settles the response-only DELETE plus refresh search; intentional overlap, route, and duplicate races use manual respond gates. Sidebar search relies on its real 200ms debounce before the labeled search starts. Legacy highlight uses a controlled real 100ms timer advanced inside act and models clearTimeout so StrictMode runs only the live callback. No universal wait, MutationObserver, act-environment suppression, synchronization polling, or timeout change remains. BACK-535.14 adds no new private-field probe and does not use private fields for synchronization. The pre-existing setInputValue `__reactProps$` fallback remains unchanged from current main; BACK-535.9/PR #772 explicitly owns its removal, and it must remain on this prerequisite branch so #772 can later rebase and remove it without duplicating scope. Validation: unchanged polling baseline 420/420 locally; external Ubuntu #772/all-18 failures remain red evidence. Cause-scoped implementation passed 21/21 whole file; fixed 50x whole-file stress 1050/1050 with 8150 assertions in 70.68s; exact full isolate passed 1653 with 2 intentional skips and 0 failures across 192 files in 235.63s; tsc, Biome over 328 files, build, and diff-check pass. Teardown verifies named missing/pending fetch calls with URL and body-reader depth, resolves manual gates inside act, removes history listeners, restores timer/fetch/globals, and fails visibly after cleanup.
+
+Specification review cycle 1: CHANGES REQUIRED (concern 1/3). Finding: the task record incorrectly claimed that private fields/private-field probes were absent, although the pre-existing setInputValue `__reactProps$` fallback intentionally remains unchanged. Correction: narrowed the claim to this task's synchronization scope and recorded BACK-535.9/PR #772 ownership. Pending specification re-review; quality review has not started.
+
+Quality review cycle 1: CHANGES REQUIRED (socket concern 1/3), pending quality re-review; no quality approval has been granted. Finding: the removed activeWebSocket variable selected the latest constructed fake socket, so the delayed 100ms health-check socket could shadow the actual App data socket and silently receive config/tasks delivery through optional chaining. Fix: select the App data socket fail-visibly from FakeWebSocket.instances using readyState OPEN plus a non-null data onmessage handler, with per-instance diagnostics when none qualifies. Both socket-driven tests now advance the controlled real 100ms health timer, prove multiple sockets exist, prove the newest health socket has no data handler and is not selected, then deliver through the selected App data socket. No private fields are inspected. Validation for this correction: focused overlap plus stale-duplicate tests passed 400/400 across 200 repeated file runs with 3400 assertions in 11.48s; full file passed 21/21 with 167 assertions; bunx tsc --noEmit, Biome over 328 files, and git diff --check pass.
+
+Quality review cycle 2: APPROVED. The socket concern from quality cycle 1 is resolved; the live OPEN App data socket with installed onmessage is selected fail-visibly, and the delayed 100ms health socket is directly proven not to be selected. Final socket-fixed terminal verification: exact full isolate `bun test --isolate --timeout=10000 --max-concurrency=4` passed 1653 tests with 2 intentional interactive-TUI skips, 0 failures, and 6843 assertions across 192 files in 180.36s; `bun run build` passed; `git diff --check` passed. Final diff/status remains limited to modified src/test/web-task-detail-deeplink.test.tsx plus the CLI-created BACK-535.14 task record. Task remains In Progress pending remaining specification/final reviews and explicit finalization; this approval does not mark the task Done.
+
+Specification review cycle 2: APPROVED. The cycle-1 wording concern was corrected by explicitly distinguishing this task's synchronization scope from the pre-existing setInputValue private-field fallback owned by BACK-535.9/PR #772. Independent specification review passed 21/21.
+
+Final review disposition: specification APPROVED and quality APPROVED. Concern circuits did not trigger: specification wording concern reached 1/3 and was resolved; quality socket selection concern was resolved on cycle 2. No further concern remains.
+
+Final post-rebase validation on origin/main 26b7f9b: focused overlap 1/1; whole deep-link file 21/21 with 167 assertions; bunx tsc --noEmit passed; Biome checked 328 files; build passed; exact full isolate passed 1655 tests with 2 intentional interactive-TUI skips, 0 failures, and 6890 assertions across 192 files in 175.26s; git diff --check passed. Previously approved reliability evidence remains fixed 50x whole-file stress 1050/1050 and pre-rebase full-isolate 1653 pass, 2 skip, 0 fail with 6843 assertions across 192 files in 180.36s.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced all 45 fixed-attempt deep-link polling sites with cause-scoped deterministic synchronization: phased fetch-body settlement, manual race responses, synchronous socket delivery, one-shot history signals, and a controlled verified product timer. Assertions now run synchronously after triggering act completes, and teardown reports and drains labeled pending work. No production/mobile code, timeout, or polling behavior changed. Independent specification and quality reviews approved the final implementation; all acceptance criteria and Definition of Done items are satisfied. Verified after rebasing onto origin/main 26b7f9b with the 21/21 file suite, TypeScript, Biome, build, diff check, and the exact isolated suite at 1655 pass, 2 intentional skips, 0 failures.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -4,7 +4,7 @@ import { StrictMode, act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import type { DuplicateRepairPlan } from "../core/duplicate-task-repair.ts";
 import type { SearchResult, Task } from "../types/index.ts";
-import { resolveTaskById } from "../utils/task-id.ts";
+import { isValidTaskId, resolveTaskById } from "../utils/task-id.ts";
 import App from "../web/App.tsx";
 import { HealthCheckProvider } from "../web/contexts/HealthCheckContext.tsx";
 
@@ -71,8 +71,6 @@ const defaultConfig = {
 	zeroPaddedIds: 3,
 };
 
-type ResponseFactory = () => Response | Promise<Response>;
-
 let activeRoot: Root | null = null;
 let activeDom: JSDOM | null = null;
 const originalFetch = globalThis.fetch;
@@ -83,8 +81,6 @@ const originalCustomEvent = globalThis.CustomEvent;
 const originalElement = globalThis.Element;
 const originalHTMLElement = globalThis.HTMLElement;
 const originalNode = globalThis.Node;
-let beforeTaskResponse: ((id: string) => Promise<void>) | null = null;
-let duplicatePlanResponse: (() => Promise<Response>) | null = null;
 
 const emptyDuplicatePlan = (): DuplicateRepairPlan => ({
 	groups: [],
@@ -96,9 +92,220 @@ const emptyDuplicatePlan = (): DuplicateRepairPlan => ({
 	repairable: false,
 	fingerprint: "empty",
 });
-let activeWebSocket: FakeWebSocket | null = null;
-let queuedConfigResponses: ResponseFactory[] = [];
-let queuedSearchResponses: ResponseFactory[] = [];
+let controlledTimerCleanup: (() => void) | null = null;
+const historyWaitCleanups = new Set<() => void>();
+
+type FetchSettlePoint = "body" | "response";
+
+type FetchExpectation = {
+	label: string;
+	match: (url: URL, init?: RequestInit) => boolean;
+	manual?: boolean;
+	settleOn?: FetchSettlePoint;
+};
+
+type FetchCall = FetchExpectation & {
+	url: string;
+	started: boolean;
+	settled: boolean;
+	readerDepth: number;
+	response: Promise<Response>;
+	resolveResponse: (response: Response) => void;
+	settledSignal: Promise<void>;
+	resolveSettled: () => void;
+};
+
+const fetchOperations = new Set<FetchOperation>();
+let activeFetchOperation: FetchOperation | null = null;
+
+class FetchOperation {
+	label: string;
+	expectations: FetchExpectation[];
+	calls: FetchCall[] = [];
+	startedSignals = new Map<string, { promise: Promise<void>; resolve: () => void }>();
+
+	constructor(label: string, expectations: FetchExpectation[]) {
+		if (activeFetchOperation) {
+			throw new Error(`Cannot start fetch operation "${label}" while "${activeFetchOperation.label}" is active`);
+		}
+		this.label = label;
+		this.expectations = expectations;
+		for (const expectation of expectations) {
+			let resolve = () => {};
+			const promise = new Promise<void>((started) => {
+				resolve = started;
+			});
+			this.startedSignals.set(expectation.label, { promise, resolve });
+		}
+		activeFetchOperation = this;
+		fetchOperations.add(this);
+	}
+
+	start(url: URL, init?: RequestInit): FetchCall {
+		const expectation = this.expectations.find(
+			(candidate) => !this.calls.some((call) => call.label === candidate.label) && candidate.match(url, init),
+		) ?? {
+			label: `unplanned ${init?.method ?? "GET"} ${url.pathname}${url.search}`,
+			match: () => true,
+		};
+		let resolveResponse = (_response: Response) => {};
+		const response = new Promise<Response>((resolve) => {
+			resolveResponse = resolve;
+		});
+		let resolveSettled = () => {};
+		const settledSignal = new Promise<void>((resolve) => {
+			resolveSettled = resolve;
+		});
+		const call: FetchCall = {
+			...expectation,
+			url: `${url.pathname}${url.search}`,
+			started: true,
+			settled: false,
+			readerDepth: 0,
+			response,
+			resolveResponse,
+			settledSignal,
+			resolveSettled,
+		};
+		this.calls.push(call);
+		this.startedSignals.get(call.label)?.resolve();
+		return call;
+	}
+
+	trackResponse(call: FetchCall, response: Response): Response {
+		if (call.settleOn === "response") this.markSettled(call);
+		for (const readerName of ["json", "text"] as const) {
+			const read = response[readerName].bind(response);
+			response[readerName] = (async (...args: []) => {
+				call.readerDepth += 1;
+				try {
+					return await read(...args);
+				} finally {
+					call.readerDepth -= 1;
+					if (call.readerDepth === 0) this.markSettled(call);
+				}
+			}) as typeof response[typeof readerName];
+		}
+		return response;
+	}
+
+	markSettled(call: FetchCall) {
+		if (call.settled) return;
+		call.settled = true;
+		call.resolveSettled();
+	}
+
+	async settle(...labels: string[]) {
+		await Promise.all(
+			labels.map((label) => {
+				const signal = this.startedSignals.get(label);
+				if (!signal) throw new Error(`Fetch operation "${this.label}" does not expect "${label}"`);
+				return signal.promise;
+			}),
+		);
+		const calls = labels.map((label) => {
+			const call = this.calls.find((candidate) => candidate.label === label);
+			if (!call) throw new Error(`Fetch operation "${this.label}" lost started call "${label}"`);
+			return call;
+		});
+		await Promise.all(calls.map((call) => call.settledSignal));
+	}
+
+	respond(label: string, response: Response) {
+		const call = this.calls.find((candidate) => candidate.label === label);
+		if (!call) throw new Error(`Fetch operation "${this.label}" has not started "${label}"`);
+		if (!call.manual) throw new Error(`Fetch call "${this.label}:${label}" is not manual`);
+		call.resolveResponse(response);
+	}
+
+	finish() {
+		if (activeFetchOperation === this) activeFetchOperation = null;
+	}
+
+	verifyDrained() {
+		const missing = this.expectations.filter(
+			(expectation) => !this.calls.some((call) => call.label === expectation.label),
+		);
+		const pending = this.calls.filter((call) => !call.settled);
+		if (missing.length === 0 && pending.length === 0) return;
+		const details = [
+			...missing.map((expectation) => `missing ${expectation.label}`),
+			...pending.map((call) => `pending ${call.label} (${call.url}, readers=${call.readerDepth})`),
+		];
+		throw new Error(`Fetch operation "${this.label}" was not drained: ${details.join(", ")}`);
+	}
+
+	cancel() {
+		for (const signal of this.startedSignals.values()) signal.resolve();
+		for (const call of this.calls) {
+			if (call.manual) call.resolveResponse(json({ error: `Cancelled ${this.label}:${call.label}` }, 500));
+			this.markSettled(call);
+		}
+		this.finish();
+	}
+}
+
+const expectFetch = (
+	label: string,
+	path: string | RegExp,
+	options: Pick<FetchExpectation, "manual" | "settleOn"> = {},
+): FetchExpectation => ({
+	label,
+	match: (url) => (typeof path === "string" ? url.pathname === path : path.test(url.pathname)),
+	...options,
+});
+
+const controlTimer = (delay: number) => {
+	if (controlledTimerCleanup) throw new Error(`Cannot control ${delay}ms timer while another timer is controlled`);
+	const callbacks = new Map<number, () => void>();
+	let nextTimerId = -1;
+	const originalSetTimeout = globalThis.setTimeout;
+	const originalClearTimeout = globalThis.clearTimeout;
+	globalThis.setTimeout = ((handler: Parameters<typeof setTimeout>[0], timeout?: number, ...args: unknown[]) => {
+		if (timeout === delay && typeof handler === "function") {
+			const timerId = nextTimerId;
+			nextTimerId -= 1;
+			callbacks.set(timerId, () => (handler as (...values: unknown[]) => void)(...args));
+			return timerId as unknown as ReturnType<typeof setTimeout>;
+		}
+		return originalSetTimeout(handler, timeout, ...args as never[]);
+	}) as typeof setTimeout;
+	globalThis.clearTimeout = ((timerId) => {
+		if (typeof timerId === "number" && callbacks.delete(timerId)) return;
+		(originalClearTimeout as (handle: typeof timerId) => void)(timerId);
+	}) as typeof clearTimeout;
+	const restore = () => {
+		globalThis.setTimeout = originalSetTimeout;
+		globalThis.clearTimeout = originalClearTimeout;
+		controlledTimerCleanup = null;
+	};
+	controlledTimerCleanup = restore;
+	return {
+		advance() {
+			if (callbacks.size === 0) throw new Error(`No ${delay}ms timer was scheduled`);
+			for (const callback of callbacks.values()) callback();
+			callbacks.clear();
+		},
+		restore,
+	};
+};
+
+const nextHistoryChange = (expectedPath?: string) => {
+	const previousUrl = window.location.href;
+	return new Promise<void>((resolve) => {
+		const onPopState = () => {
+			if (expectedPath ? window.location.pathname !== expectedPath : window.location.href === previousUrl) return;
+			cleanup();
+			resolve();
+		};
+		const cleanup = () => {
+			window.removeEventListener("popstate", onPopState);
+			historyWaitCleanups.delete(cleanup);
+		};
+		historyWaitCleanups.add(cleanup);
+		window.addEventListener("popstate", onPopState);
+	});
+};
 
 class FakeWebSocket {
 	static readonly CONNECTING = 0;
@@ -113,17 +320,40 @@ class FakeWebSocket {
 
 	constructor() {
 		FakeWebSocket.instances.push(this);
-		activeWebSocket = this;
 	}
 
-	emit(data: string) {
-		this.onmessage?.({ data });
+	deliver(data: string) {
+		if (!this.onmessage) throw new Error(`Cannot deliver ${data}: WebSocket message handler is not installed`);
+		this.onmessage({ data });
 	}
 
 	close() {
 		this.readyState = FakeWebSocket.CLOSED;
 	}
 }
+
+const getAppDataWebSocket = (): FakeWebSocket => {
+	const socket = FakeWebSocket.instances.findLast(
+		(candidate) => candidate.readyState === FakeWebSocket.OPEN && candidate.onmessage !== null,
+	);
+	if (socket) return socket;
+	const diagnostics = FakeWebSocket.instances
+		.map(
+			(candidate, index) =>
+				`#${index} readyState=${candidate.readyState} onmessage=${candidate.onmessage ? "installed" : "missing"}`,
+		)
+		.join(", ");
+	throw new Error(`No live App data WebSocket found; instances: ${diagnostics || "none"}`);
+};
+
+const assertHealthSocketDoesNotShadowDataSocket = (): FakeWebSocket => {
+	const dataSocket = getAppDataWebSocket();
+	const latestSocket = FakeWebSocket.instances.at(-1);
+	expect(FakeWebSocket.instances.length).toBeGreaterThan(1);
+	expect(latestSocket?.onmessage).toBeNull();
+	expect(dataSocket).not.toBe(latestSocket);
+	return dataSocket;
+};
 
 class FakeResizeObserver {
 	disconnect() {}
@@ -133,11 +363,7 @@ class FakeResizeObserver {
 
 const json = (data: unknown, status = 200) => Response.json(data, { status });
 
-const installFetchMock = () => {
-	globalThis.fetch = (async (input: RequestInfo | URL) => {
-		const value = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-		const url = new URL(value, window.location.origin);
-
+const resolveMockResponse = async (url: URL): Promise<Response> => {
 		if (url.pathname === "/api/status") {
 			return json({ initialized: true, projectPath: "/tmp/project" });
 		}
@@ -145,14 +371,9 @@ const installFetchMock = () => {
 			return json(["To Do", "In Progress", "Done"]);
 		}
 		if (url.pathname === "/api/config") {
-			const queuedResponse = queuedConfigResponses.shift();
-			return queuedResponse ? await queuedResponse() : json(defaultConfig);
+			return json(defaultConfig);
 		}
 		if (url.pathname === "/api/search") {
-			const queuedResponse = queuedSearchResponses.shift();
-			if (queuedResponse) {
-				return await queuedResponse();
-			}
 			return json(
 				url.searchParams.has("query")
 					? searchResults.map((result) => ({ ...result, score: 0.1 }))
@@ -163,14 +384,13 @@ const installFetchMock = () => {
 			return json([]);
 		}
 		if (url.pathname === "/api/tasks/duplicates") {
-			return duplicatePlanResponse ? await duplicatePlanResponse() : json(emptyDuplicatePlan());
+			return json(emptyDuplicatePlan());
 		}
 		if (url.pathname === "/api/version") {
 			return json({ version: "test" });
 		}
 		if (url.pathname.startsWith("/api/task/")) {
 			const routeId = decodeURIComponent(url.pathname.slice("/api/task/".length));
-			await beforeTaskResponse?.(routeId);
 			if (routeId === "BACK-1") {
 				return json({ error: "Active branch task identity collision" }, 409);
 			}
@@ -185,6 +405,16 @@ const installFetchMock = () => {
 		}
 
 		return json([]);
+	};
+
+const installFetchMock = () => {
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const value = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+		const url = new URL(value, window.location.origin);
+		const operation = activeFetchOperation;
+		const call = operation?.start(url, init);
+		const response = call?.manual ? await call.response : await resolveMockResponse(url);
+		return call && operation ? operation.trackResponse(call, response) : response;
 	}) as typeof fetch;
 };
 
@@ -229,18 +459,34 @@ const setupDom = (path: string) => {
 	installFetchMock();
 };
 
-const waitFor = async (predicate: () => boolean, message: string) => {
-	for (let attempt = 0; attempt < 50; attempt += 1) {
-		if (predicate()) return;
-		await act(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 5));
-		});
-	}
-	throw new Error(`Timed out waiting for ${message}`);
-};
-
-const renderApp = async (path: string): Promise<HTMLElement> => {
+const renderApp = async (
+	path: string,
+	options: {
+		advanceHealthSocket?: boolean;
+		manualDuplicatePlan?: boolean;
+		operationRef?: { current?: FetchOperation };
+	} = {},
+): Promise<HTMLElement> => {
 	setupDom(path);
+	const requestedUrl = new URL(path, window.location.origin);
+	const pathname = requestedUrl.pathname;
+	const routeMatch = pathname.match(/^\/(?:tasks|board)\/([^/]+)(?:\/[^/]+)?$/);
+	const routeId = routeMatch?.[1]
+		? decodeURIComponent(routeMatch[1])
+		: requestedUrl.searchParams.get("highlight")?.trim() || null;
+	const controlledTimer =
+		requestedUrl.searchParams.has("highlight") || options.advanceHealthSocket ? controlTimer(100) : null;
+	const operation = new FetchOperation(`render ${path}`, [
+		expectFetch("initial status", "/api/status"),
+		expectFetch("initial search", "/api/search"),
+		...(options.manualDuplicatePlan
+			? [expectFetch("initial duplicate plan", "/api/tasks/duplicates", { manual: true })]
+			: []),
+		...(routeId && isValidTaskId(routeId)
+			? [expectFetch("routed task", `/api/task/${encodeURIComponent(routeId)}`)]
+			: []),
+	]);
+	if (options.operationRef) options.operationRef.current = operation;
 	const container = document.getElementById("root");
 	expect(container).toBeTruthy();
 	activeRoot = createRoot(container as HTMLElement);
@@ -254,18 +500,45 @@ const renderApp = async (path: string): Promise<HTMLElement> => {
 		);
 		await Promise.resolve();
 	});
+	await act(async () => operation.settle("initial status"));
+	await act(async () => operation.settle("initial search"));
+	if (controlledTimer) {
+		await act(async () => controlledTimer.advance());
+		controlledTimer.restore();
+	}
+	if (routeId && isValidTaskId(routeId)) {
+		await act(async () => operation.settle("routed task"));
+	}
+	operation.finish();
 	return container as HTMLElement;
 };
 
-const click = async (element: Element) => {
+const runOperation = async (label: string, expectations: FetchExpectation[], trigger: () => void | Promise<void>) => {
+	const operation = expectations.length > 0 ? new FetchOperation(label, expectations) : null;
 	await act(async () => {
-		element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+		await trigger();
 		await Promise.resolve();
+	});
+	if (!operation) return;
+	await act(async () => operation.settle(...expectations.map((expectation) => expectation.label)));
+	operation.finish();
+};
+
+const click = async (element: Element, expectations: FetchExpectation[] = []) => {
+	await runOperation(`click ${element.textContent?.trim() || element.tagName}`, expectations, () => {
+		element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
 	});
 };
 
-const setInputValue = async (input: HTMLInputElement, value: string) => {
-	await act(async () => {
+const clickWithHistory = async (element: Element, expectations: FetchExpectation[] = []) => {
+	const expectedPath = window.location.pathname.startsWith("/board") ? "/board" : "/tasks";
+	const navigated = nextHistoryChange(expectedPath);
+	await click(element, expectations);
+	await act(async () => navigated);
+};
+
+const setInputValue = async (input: HTMLInputElement, value: string, expectations: FetchExpectation[] = []) => {
+	await runOperation(`set input to ${JSON.stringify(value)}`, expectations, () => {
 		const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
 		input.focus();
 		valueSetter?.call(input, value);
@@ -278,7 +551,6 @@ const setInputValue = async (input: HTMLInputElement, value: string) => {
 			];
 			reactProps?.onChange?.({ target: input });
 		}
-		await Promise.resolve();
 	});
 };
 
@@ -290,22 +562,49 @@ const press = async (element: Element, key: string, init: KeyboardEventInit = {}
 	});
 };
 
-const pushRoute = async (path: string) => {
-	await act(async () => {
+const pressWithHistory = async (element: Element, key: string, init: KeyboardEventInit = {}) => {
+	const expectedPath = window.location.pathname.startsWith("/board") ? "/board" : "/tasks";
+	const navigated = nextHistoryChange(expectedPath);
+	await press(element, key, init);
+	await act(async () => navigated);
+};
+
+const pushRoute = async (path: string, expectations: FetchExpectation[] = []) => {
+	await runOperation(`push route ${path}`, expectations, () => {
 		window.history.pushState({}, "", path);
 		window.dispatchEvent(new window.PopStateEvent("popstate"));
-		await Promise.resolve();
 	});
 };
 
-const travel = async (direction: "back" | "forward") => {
-	await act(async () => {
+const travel = async (direction: "back" | "forward", expectations: FetchExpectation[] = []) => {
+	const navigated = nextHistoryChange();
+	await runOperation(`history ${direction}`, expectations, async () => {
 		window.history[direction]();
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await navigated;
 	});
+};
+
+const assertState = (predicate: () => boolean, message: string) => {
+	expect(predicate(), message).toBe(true);
 };
 
 afterEach(async () => {
+	const fetchErrors: Error[] = [];
+	controlledTimerCleanup?.();
+	for (const cleanup of historyWaitCleanups) cleanup();
+	for (const operation of fetchOperations) {
+		try {
+			operation.verifyDrained();
+		} catch (error) {
+			fetchErrors.push(error as Error);
+		}
+	}
+	await act(async () => {
+		for (const operation of fetchOperations) operation.cancel();
+		await Promise.resolve();
+	});
+	fetchOperations.clear();
+	activeFetchOperation = null;
 	if (activeRoot) {
 		await act(async () => activeRoot?.unmount());
 		activeRoot = null;
@@ -320,18 +619,14 @@ afterEach(async () => {
 	globalThis.Element = originalElement;
 	globalThis.HTMLElement = originalHTMLElement;
 	globalThis.Node = originalNode;
-	beforeTaskResponse = null;
-	duplicatePlanResponse = null;
 	FakeWebSocket.instances = [];
-	activeWebSocket = null;
-	queuedConfigResponses = [];
-	queuedSearchResponses = [];
+	if (fetchErrors.length > 0) throw new AggregateError(fetchErrors, "Fetch mock lifecycle verification failed");
 });
 
 describe("task detail routes", () => {
 	it("uses the canonical board route for task clicks and browser Back", async () => {
 		const container = await renderApp("/");
-		await waitFor(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "board task");
+		assertState(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "board task");
 		expect(window.location.pathname).toBe("/board");
 		const boardLink = Array.from(container.querySelectorAll("a")).find(
 			(element) => element.textContent?.includes("Kanban Board"),
@@ -341,9 +636,9 @@ describe("task detail routes", () => {
 		const title = Array.from(container.querySelectorAll("h4")).find((element) => element.textContent === tasks[0]?.title);
 		const card = title?.closest("[draggable='true']");
 		expect(card).toBeTruthy();
-		await click(card as HTMLElement);
+		await click(card as HTMLElement, [expectFetch("opened task", "/api/task/BACK-101")]);
 
-		await waitFor(
+		assertState(
 			() =>
 				window.location.pathname === "/board/BACK-101/fix-labels-caf-docs" &&
 				Boolean(container.querySelector("[role='dialog']")),
@@ -351,7 +646,7 @@ describe("task detail routes", () => {
 		);
 
 		await travel("back");
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
 			"Back to the canonical board",
 		);
@@ -359,7 +654,7 @@ describe("task detail routes", () => {
 
 	it("preserves a type filter through board task Back, Forward, and close navigation", async () => {
 		const container = await renderApp("/board?type=bug&lane=none");
-		await waitFor(
+		assertState(
 			() =>
 				new URLSearchParams(window.location.search).get("type") === "Bug" &&
 				(container.textContent?.includes(tasks[0]?.title ?? "") ?? false),
@@ -370,9 +665,9 @@ describe("task detail routes", () => {
 		const title = Array.from(container.querySelectorAll("h4")).find((element) => element.textContent === tasks[0]?.title);
 		const card = title?.closest("[draggable='true']");
 		expect(card).toBeTruthy();
-		await click(card as HTMLElement);
+		await click(card as HTMLElement, [expectFetch("opened task", "/api/task/BACK-101")]);
 
-		await waitFor(
+		assertState(
 			() =>
 				window.location.pathname === "/board/BACK-101/fix-labels-caf-docs" &&
 				Boolean(container.querySelector("[role='dialog']")),
@@ -381,14 +676,14 @@ describe("task detail routes", () => {
 		expect(window.location.search).toBe(filteredSearch);
 
 		await travel("back");
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
 			"filtered board Back",
 		);
 		expect(window.location.search).toBe(filteredSearch);
 
-		await travel("forward");
-		await waitFor(
+		await travel("forward", [expectFetch("reopened task", "/api/task/BACK-101")]);
+		assertState(
 			() =>
 				window.location.pathname === "/board/BACK-101/fix-labels-caf-docs" &&
 				Boolean(container.querySelector("[role='dialog']")),
@@ -396,8 +691,8 @@ describe("task detail routes", () => {
 		);
 		expect(window.location.search).toBe(filteredSearch);
 
-		await click(container.querySelector("button[aria-label='Close modal']") as HTMLButtonElement);
-		await waitFor(
+		await clickWithHistory(container.querySelector("button[aria-label='Close modal']") as HTMLButtonElement);
+		assertState(
 			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
 			"filtered board close",
 		);
@@ -406,10 +701,10 @@ describe("task detail routes", () => {
 
 	it("preserves a type filter when closing a direct board task route", async () => {
 		const container = await renderApp("/board/BACK-101/fix-labels-caf-docs?type=Bug&lane=none");
-		await waitFor(() => Boolean(container.querySelector("[role='dialog']")), "direct filtered board task");
+		assertState(() => Boolean(container.querySelector("[role='dialog']")), "direct filtered board task");
 
 		await click(container.querySelector("button[aria-label='Close modal']") as HTMLButtonElement);
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
 			"direct filtered board close",
 		);
@@ -417,26 +712,10 @@ describe("task detail routes", () => {
 	});
 
 	it("keeps the latest config and tasks when overlapping refreshes resolve out of order", async () => {
-		const container = await renderApp("/board?type=Customer%20Request");
-		await waitFor(
-			() =>
-				new URLSearchParams(window.location.search).get("type") === "Customer Request" &&
-				activeWebSocket?.onmessage !== null,
-			"initial typed board and WebSocket",
-		);
+		const container = await renderApp("/board?type=Customer%20Request", { advanceHealthSocket: true });
+		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();
+		expect(new URLSearchParams(window.location.search).get("type")).toBe("Customer Request");
 
-		let releaseFirstConfig: (() => void) | undefined;
-		let markFirstConfigStarted: (() => void) | undefined;
-		const firstConfigGate = new Promise<void>((resolve) => {
-			releaseFirstConfig = resolve;
-		});
-		const firstConfigStarted = new Promise<void>((resolve) => {
-			markFirstConfigStarted = resolve;
-		});
-		let markNewerSearchBodyRead: (() => void) | undefined;
-		const newerSearchBodyRead = new Promise<void>((resolve) => {
-			markNewerSearchBodyRead = resolve;
-		});
 		const customerTask: Task = {
 			id: "BACK-202",
 			title: "Newest customer request",
@@ -448,46 +727,39 @@ describe("task detail routes", () => {
 			type: "Customer Request",
 		};
 
-		queuedConfigResponses.push(
-			async () => {
-				markFirstConfigStarted?.();
-				await firstConfigGate;
-				return json({ ...defaultConfig, types: ["Bug"] });
-			},
-			() => json(defaultConfig),
-		);
-		queuedSearchResponses.push(
-			() => json(searchResults),
-			() => {
-				const response = json([{ type: "task", task: customerTask, score: 1 } satisfies SearchResult]);
-				const readBody = response.json.bind(response);
-				response.json = async () => {
-					const body = await readBody();
-					markNewerSearchBodyRead?.();
-					return body;
-				};
-				return response;
-			},
-		);
+		const staleRefresh = new FetchOperation("stale config refresh", [
+			expectFetch("stale config", "/api/config", { manual: true }),
+			expectFetch("stale search", "/api/search"),
+		]);
+		await act(async () => {
+			dataSocket.deliver("config-updated");
+			await Promise.resolve();
+		});
+		staleRefresh.finish();
 
+		const newerRefresh = new FetchOperation("newer task refresh", [
+			expectFetch("newer config", "/api/config"),
+			expectFetch("newer search", "/api/search", { manual: true }),
+		]);
 		await act(async () => {
-			activeWebSocket?.emit("config-updated");
+			dataSocket.deliver("tasks-updated");
 			await Promise.resolve();
 		});
-		await firstConfigStarted;
 		await act(async () => {
-			activeWebSocket?.emit("tasks-updated");
-			await newerSearchBodyRead;
-			await Promise.resolve();
+			newerRefresh.respond(
+				"newer search",
+				json([{ type: "task", task: customerTask, score: 1 } satisfies SearchResult]),
+			);
+			await newerRefresh.settle("newer config", "newer search");
 		});
+		newerRefresh.finish();
 
 		expect(container.textContent).toContain(customerTask.title);
 		expect(new URLSearchParams(window.location.search).get("type")).toBe("Customer Request");
 
 		await act(async () => {
-			releaseFirstConfig?.();
-			await firstConfigGate;
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			staleRefresh.respond("stale config", json({ ...defaultConfig, types: ["Bug"] }));
+			await staleRefresh.settle("stale config", "stale search");
 		});
 
 		expect(container.textContent).toContain(customerTask.title);
@@ -499,7 +771,7 @@ describe("task detail routes", () => {
 
 	it("keeps a filtered board query when a sidebar search result opens and closes", async () => {
 		const container = await renderApp("/board?type=bug&lane=none");
-		await waitFor(
+		assertState(
 			() =>
 				new URLSearchParams(window.location.search).get("type") === "Bug" &&
 				(container.textContent?.includes(tasks[0]?.title ?? "") ?? false),
@@ -508,9 +780,11 @@ describe("task detail routes", () => {
 		const filteredSearch = window.location.search;
 		const searchInput = container.querySelector("input[placeholder='Search (⌘K)...']") as HTMLInputElement | null;
 		expect(searchInput).toBeTruthy();
-		await setInputValue(searchInput as HTMLInputElement, "Fix labels");
+		await setInputValue(searchInput as HTMLInputElement, "Fix labels", [
+			expectFetch("sidebar search", "/api/search"),
+		]);
 
-		await waitFor(
+		assertState(
 			() =>
 				Array.from(container.querySelectorAll("a")).some(
 					(link) => link.textContent?.includes(tasks[0]?.title ?? "") ?? false,
@@ -521,9 +795,9 @@ describe("task detail routes", () => {
 			(link) => link.textContent?.includes(tasks[0]?.title ?? "") ?? false,
 		);
 		expect(resultLink?.getAttribute("href")).toContain(filteredSearch);
-		await click(resultLink as HTMLAnchorElement);
+		await click(resultLink as HTMLAnchorElement, [expectFetch("opened sidebar task", "/api/task/BACK-101")]);
 
-		await waitFor(
+		assertState(
 			() =>
 				window.location.pathname === "/board/BACK-101/fix-labels-caf-docs" &&
 				Boolean(container.querySelector("[role='dialog']")),
@@ -531,8 +805,8 @@ describe("task detail routes", () => {
 		);
 		expect(window.location.search).toBe(filteredSearch);
 
-		await click(container.querySelector("button[aria-label='Close modal']") as HTMLButtonElement);
-		await waitFor(
+		await clickWithHistory(container.querySelector("button[aria-label='Close modal']") as HTMLButtonElement);
+		assertState(
 			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
 			"sidebar return to filtered board",
 		);
@@ -541,7 +815,7 @@ describe("task detail routes", () => {
 
 	it("keeps legacy highlight links while canonicalizing and closing them cleanly", async () => {
 		const container = await renderApp("/?highlight=BACK-101&lane=none&type=bug");
-		await waitFor(
+		assertState(
 			() =>
 				window.location.pathname === "/board/BACK-101/fix-labels-caf-docs" &&
 				Boolean(container.querySelector("[role='dialog']")),
@@ -551,23 +825,18 @@ describe("task detail routes", () => {
 
 		const closeButton = container.querySelector("button[aria-label='Close modal']");
 		expect(closeButton).toBeTruthy();
-		await click(closeButton as HTMLButtonElement);
-		await waitFor(
-			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
-			"legacy highlight close",
-		);
+		await clickWithHistory(closeButton as HTMLButtonElement);
+		expect(window.location.pathname).toBe("/board");
+		expect(container.querySelector("[role='dialog']")).toBeNull();
 		expect(window.location.search).toBe("?lane=none&type=Bug");
 	});
 
 	it("pushes a stable list URL and keeps close, Back, and Forward coherent", async () => {
 		const container = await renderApp("/tasks?status=To%20Do");
-		await waitFor(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "task list");
+		assertState(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "task list");
 		const ownerDocument = container.ownerDocument;
 
 		// The expanded sidebar must not claim focus on mount.
-		await act(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 125));
-		});
 		const initialSearch = container.querySelector("input[placeholder='Search (⌘K)...']");
 		expect(ownerDocument.activeElement).not.toBe(initialSearch);
 
@@ -593,9 +862,9 @@ describe("task detail routes", () => {
 		);
 		expect(title).toBeTruthy();
 		(title as HTMLButtonElement).focus();
-		await click(title as HTMLButtonElement);
+		await click(title as HTMLButtonElement, [expectFetch("opened task", "/api/task/BACK-101")]);
 
-		await waitFor(
+		assertState(
 			() =>
 				window.location.pathname === "/tasks/BACK-101/fix-labels-caf-docs" &&
 				container.querySelector("[role='dialog']") !== null,
@@ -613,14 +882,14 @@ describe("task detail routes", () => {
 		expect(ownerDocument.activeElement).not.toBe(shortcutSearch);
 
 		await travel("back");
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/tasks" && container.querySelector("[role='dialog']") === null,
 			"Back to close the modal",
 		);
 		expect(ownerDocument.activeElement).toBe(title as HTMLButtonElement);
 
-		await travel("forward");
-		await waitFor(
+		await travel("forward", [expectFetch("reopened task", "/api/task/BACK-101")]);
+		assertState(
 			() =>
 				window.location.pathname === "/tasks/BACK-101/fix-labels-caf-docs" &&
 				container.querySelector("[role='dialog']") !== null,
@@ -630,8 +899,8 @@ describe("task detail routes", () => {
 		expect(reopenedDialog).toBeTruthy();
 		expect(reopenedDialog?.ownerDocument.activeElement).toBe(reopenedDialog);
 
-		await press(container.querySelector("[role='dialog']") as HTMLElement, "Escape");
-		await waitFor(
+		await pressWithHistory(container.querySelector("[role='dialog']") as HTMLElement, "Escape");
+		assertState(
 			() => window.location.pathname === "/tasks" && container.querySelector("[role='dialog']") === null,
 			"close button to return to list",
 		);
@@ -657,12 +926,15 @@ describe("task detail routes", () => {
 	]) {
 		it(`clears the previous modal when routing to ${scenario.name} and preserves Back`, async () => {
 			const container = await renderApp("/tasks/BACK-101/original");
-			await waitFor(() => Boolean(container.querySelector("[role='dialog']")), "initial routed task modal");
+			assertState(() => Boolean(container.querySelector("[role='dialog']")), "initial routed task modal");
 			expect(container.querySelector("#modal-title")?.textContent).toContain(tasks[0]?.title ?? "");
 			expect(container.ownerDocument.activeElement).toBe(container.querySelector("[role='dialog']"));
 
-			await pushRoute(scenario.path);
-			await waitFor(
+			const scenarioId = scenario.path.split("/")[2] ?? "";
+			await pushRoute(scenario.path, [
+				expectFetch("failed routed task", `/api/task/${encodeURIComponent(scenarioId)}`),
+			]);
+			assertState(
 				() => window.location.pathname === "/tasks" && Boolean(container.querySelector("[role='alert']")),
 				`${scenario.name} route fallback`,
 			);
@@ -671,8 +943,8 @@ describe("task detail routes", () => {
 			expect(alert?.textContent).toContain(scenario.message);
 			expect(container.ownerDocument.activeElement).toBe(alert);
 
-			await travel("back");
-			await waitFor(
+			await travel("back", [expectFetch("restored routed task", "/api/task/BACK-101")]);
+			assertState(
 				() =>
 					window.location.pathname === "/tasks/BACK-101/original" &&
 					Boolean(container.querySelector("[role='dialog']")),
@@ -685,7 +957,7 @@ describe("task detail routes", () => {
 
 	it("renders a focused repair alert instead of a modal for a direct active-branch collision link", async () => {
 		const container = await renderApp("/tasks/BACK-1/collision-shadow");
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/tasks" && Boolean(container.querySelector("[role='alert']")),
 			"active-branch collision repair alert",
 		);
@@ -699,15 +971,15 @@ describe("task detail routes", () => {
 
 	it("keeps an explicit task prefix when equal numeric IDs would be ambiguous", async () => {
 		const container = await renderApp("/tasks");
-		await waitFor(() => container.textContent?.includes("Jira task") ?? false, "cross-prefix task list");
+		assertState(() => container.textContent?.includes("Jira task") ?? false, "cross-prefix task list");
 
 		const title = Array.from(container.querySelectorAll("button")).find(
 			(element) => element.textContent === "Jira task",
 		);
 		expect(title).toBeTruthy();
-		await click(title as HTMLButtonElement);
+		await click(title as HTMLButtonElement, [expectFetch("opened Jira task", "/api/task/JIRA-007")]);
 
-		await waitFor(
+		assertState(
 			() =>
 				window.location.pathname === "/tasks/JIRA-007/jira-task" &&
 				container.querySelector("#modal-title")?.textContent?.includes("Jira task") === true,
@@ -718,15 +990,15 @@ describe("task detail routes", () => {
 
 	it("opens an exact legacy task ID from an ordinary list click", async () => {
 		const container = await renderApp("/tasks");
-		await waitFor(() => container.textContent?.includes("Legacy prefixed task") ?? false, "legacy task list row");
+		assertState(() => container.textContent?.includes("Legacy prefixed task") ?? false, "legacy task list row");
 
 		const title = Array.from(container.querySelectorAll("button")).find(
 			(element) => element.textContent === "Legacy prefixed task",
 		);
 		expect(title).toBeTruthy();
-		await click(title as HTMLButtonElement);
+		await click(title as HTMLButtonElement, [expectFetch("opened legacy task", "/api/task/TASK-PREFIXED")]);
 
-		await waitFor(
+		assertState(
 			() =>
 				window.location.pathname === "/tasks/TASK-PREFIXED/legacy-prefixed-task" &&
 				container.querySelector("#modal-title")?.textContent?.includes("Legacy prefixed task") === true,
@@ -737,14 +1009,14 @@ describe("task detail routes", () => {
 
 	it("opens an exact legacy task ID from a direct route", async () => {
 		const container = await renderApp("/board/task-prefixed/cosmetic-slug");
-		await waitFor(() => Boolean(container.querySelector("[role='dialog']")), "direct legacy task modal");
+		assertState(() => Boolean(container.querySelector("[role='dialog']")), "direct legacy task modal");
 		expect(container.querySelector("#modal-title")?.textContent).toContain("Legacy prefixed task");
 		expect(container.querySelector("[role='alert']")).toBeNull();
 	});
 
 	it("returns a missing legacy task route to the list with a focused not-found error", async () => {
 		const container = await renderApp("/tasks/TASK-MISSING");
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/tasks" && Boolean(container.querySelector("[role='alert']")),
 			"missing legacy route fallback",
 		);
@@ -762,7 +1034,7 @@ describe("task detail routes", () => {
 		);
 		expect(allTasksLink).toBeTruthy();
 		await click(allTasksLink as HTMLAnchorElement);
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/tasks" && container.textContent?.includes(tasks[0]?.title ?? "") === true,
 			"task list navigation",
 		);
@@ -771,8 +1043,8 @@ describe("task detail routes", () => {
 			(element) => element.textContent === tasks[0]?.title,
 		);
 		expect(title).toBeTruthy();
-		await click(title as HTMLButtonElement);
-		await waitFor(
+		await click(title as HTMLButtonElement, [expectFetch("opened task", "/api/task/BACK-101")]);
+		assertState(
 			() =>
 				window.location.pathname.startsWith("/tasks/BACK-101/") &&
 				Boolean(container.querySelector("[role='dialog']")),
@@ -783,62 +1055,58 @@ describe("task detail routes", () => {
 			(element) => element.textContent?.includes("Archive Task"),
 		);
 		expect(archiveButton).toBeTruthy();
-		await click(archiveButton as HTMLButtonElement);
-		await waitFor(
+		await clickWithHistory(archiveButton as HTMLButtonElement, [
+			expectFetch("archive response", "/api/tasks/BACK-101", { settleOn: "response" }),
+			expectFetch("archive refresh", "/api/search"),
+		]);
+		assertState(
 			() => window.location.pathname === "/tasks" && container.querySelector("[role='dialog']") === null,
 			"single archive close",
 		);
-		await act(async () => {
-			await new Promise((resolve) => setTimeout(resolve, 20));
-		});
 		expect(window.location.pathname).toBe("/tasks");
 	});
 
 	it("ignores a stale route response when a newer task wins the navigation race", async () => {
-		let releaseFirstResponse = () => {};
-		const firstResponse = new Promise<void>((resolve) => {
-			releaseFirstResponse = resolve;
-		});
-		beforeTaskResponse = (id) => (id === "BACK-101" ? firstResponse : Promise.resolve());
-
 		const container = await renderApp("/tasks");
-		await waitFor(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "task list");
+		assertState(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "task list");
 
 		const firstTitle = Array.from(container.querySelectorAll("button")).find(
 			(element) => element.textContent === tasks[0]?.title,
 		);
+		const staleRoute = new FetchOperation("stale task route", [
+			expectFetch("stale task", "/api/task/BACK-101", { manual: true }),
+		]);
 		await click(firstTitle as HTMLButtonElement);
-		await waitFor(() => window.location.pathname.startsWith("/tasks/BACK-101/"), "first pending route");
+		staleRoute.finish();
+		expect(window.location.pathname).toStartWith("/tasks/BACK-101/");
 
 		const secondTitle = Array.from(container.querySelectorAll("button")).find(
 			(element) => element.textContent === tasks[1]?.title,
 		);
-		await click(secondTitle as HTMLButtonElement);
-		await waitFor(
+		await click(secondTitle as HTMLButtonElement, [expectFetch("newer task", "/api/task/BACK-001.02")]);
+		assertState(
 			() =>
 				window.location.pathname === "/tasks/BACK-001.02/padded-subtask" &&
 				container.querySelector("#modal-title")?.textContent?.includes("Padded subtask") === true,
 			"newer task modal",
 		);
 
-		releaseFirstResponse();
 		await act(async () => {
-			await Promise.resolve();
+			staleRoute.respond("stale task", json(tasks[0]));
+			await staleRoute.settle("stale task");
 		});
 		expect(window.location.pathname).toBe("/tasks/BACK-001.02/padded-subtask");
 		expect(container.querySelector("#modal-title")?.textContent).toContain("Padded subtask");
 
 		const closeButton = container.querySelector("button[aria-label='Close modal']");
-		await click(closeButton as HTMLButtonElement);
-		await waitFor(() => window.location.pathname === "/tasks", "race winner close");
+		await clickWithHistory(closeButton as HTMLButtonElement);
+		assertState(
+			() => window.location.pathname === "/tasks" && container.querySelector("[role='dialog']") === null,
+			"race winner close",
+		);
 	});
 
 	it("ignores a stale duplicate repair plan when a newer data load wins", async () => {
-		let requestCount = 0;
-		let releaseStalePlan = (_response: Response) => {};
-		const staleResponse = new Promise<Response>((resolve) => {
-			releaseStalePlan = resolve;
-		});
 		const stalePlan: DuplicateRepairPlan = {
 			...emptyDuplicatePlan(),
 			groups: [
@@ -853,28 +1121,31 @@ describe("task detail routes", () => {
 			repairable: true,
 			fingerprint: "stale-plan",
 		};
-		duplicatePlanResponse = async () => {
-			requestCount += 1;
-			return requestCount === 1 ? await staleResponse : json(emptyDuplicatePlan());
-		};
-
-		const container = await renderApp("/tasks");
-		await waitFor(
-			() => FakeWebSocket.instances.some((socket) => socket.onmessage !== null),
-			"data refresh socket",
-		);
+		const initialLoadRef: { current?: FetchOperation } = {};
+		const container = await renderApp("/tasks", {
+			advanceHealthSocket: true,
+			manualDuplicatePlan: true,
+			operationRef: initialLoadRef,
+		});
+		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();
+		const newerLoad = new FetchOperation("newer data load", [
+			expectFetch("newer search", "/api/search"),
+			expectFetch("newer duplicate plan", "/api/tasks/duplicates"),
+		]);
 		await act(async () => {
-			FakeWebSocket.instances.findLast((socket) => socket.onmessage !== null)?.onmessage?.({ data: "tasks-updated" });
+			dataSocket.deliver("tasks-updated");
 			await Promise.resolve();
 		});
-		await waitFor(
-			() => requestCount >= 2 && (container.textContent?.includes(tasks[0]?.title ?? "") ?? false),
-			"newer data load",
-		);
-		releaseStalePlan(json(stalePlan));
 		await act(async () => {
-			await Promise.resolve();
-			await Promise.resolve();
+			await newerLoad.settle("newer search", "newer duplicate plan");
+		});
+		newerLoad.finish();
+		assertState(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "newer data load");
+		const initialLoad = initialLoadRef.current;
+		if (!initialLoad) throw new Error("Initial data-load operation was not captured");
+		await act(async () => {
+			initialLoad.respond("initial duplicate plan", json(stalePlan));
+			await initialLoad.settle("initial duplicate plan");
 		});
 
 		expect(container.textContent).not.toContain("Duplicate task IDs:");
@@ -882,13 +1153,13 @@ describe("task detail routes", () => {
 
 	it("opens a padded custom-prefix subtask directly and closes to the board", async () => {
 		const container = await renderApp("/board/001.02/cosmetic-slug");
-		await waitFor(() => Boolean(container.querySelector("[role='dialog']")), "direct board modal");
+		assertState(() => Boolean(container.querySelector("[role='dialog']")), "direct board modal");
 		expect(container.querySelector("#modal-title")?.textContent).toContain("Padded subtask");
 
 		const closeButton = container.querySelector("button[aria-label='Close modal']");
 		expect(closeButton).toBeTruthy();
 		await click(closeButton as HTMLButtonElement);
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
 			"direct route close",
 		);
@@ -896,7 +1167,7 @@ describe("task detail routes", () => {
 
 	it("returns a malformed legacy route to the list with a focused human-readable error", async () => {
 		const container = await renderApp("/tasks/TASK-..%2Fsecret");
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/tasks" && Boolean(container.querySelector("[role='alert']")),
 			"invalid route fallback",
 		);
@@ -909,7 +1180,7 @@ describe("task detail routes", () => {
 
 	it("handles malformed deeper paths at the client SPA boundary", async () => {
 		const container = await renderApp("/board/101/cosmetic/extra?lane=none");
-		await waitFor(
+		assertState(
 			() => window.location.pathname === "/board" && Boolean(container.querySelector("[role='alert']")),
 			"malformed route fallback",
 		);


### PR DESCRIPTION
## Summary

- replace all 45 fixed-attempt deep-link polling sites with deterministic, cause-scoped synchronization
- add labeled fetch settlement, manual race gates, synchronous WebSocket delivery, one-shot history signals, controlled timer advancement, and fail-visible teardown
- keep scope to the browser test harness: no production, mobile, or timeout changes

## Validation

- fixed 50x whole-file stress: 1050/1050 passed
- deep-link file: 21/21 passed with 167 assertions
- `bunx tsc --noEmit`
- `bun run check .` (328 files)
- `bun run build`
- exact full isolate after rebasing onto `origin/main`: 1655 passed, 2 intentional skips, 0 failed, 6890 assertions across 192 files
- `git diff --check`

## Review

Independent specification and quality reviews approved the final implementation. The specification wording concern and socket-selection concern were resolved without triggering a concern circuit.

Task: [BACK-535.14](https://github.com/MrLesk/Backlog.md/blob/tasks/back-535.14-observable-deeplink-sync/backlog/tasks/back-535.14%20-%20Replace-deep-link-test-polling-with-observable-synchronization.md)