### PR TITLE
BACK-537 - Make checklist editing deterministic

### DIFF
--- a/backlog/tasks/back-537 - Make-checklist-edits-and-serialization-deterministic.md
+++ b/backlog/tasks/back-537 - Make-checklist-edits-and-serialization-deterministic.md
@@ -1,0 +1,61 @@
+---
+id: BACK-537
+title: Make checklist edits and serialization deterministic
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-07-11 23:02'
+updated_date: '2026-07-12 12:16'
+labels: []
+dependencies: []
+priority: high
+ordinal: 185000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Acceptance-criteria replacement currently appends only the final repeated value, and repeated checklist edits can reorder structured sections or accumulate blank lines. Make the canonical CLI contract and shared Markdown checklist serialization deterministic for acceptance criteria and Definition of Done while preserving line endings and unrelated sections.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `--ac` remains additive and repeatable, while repeated `--acceptance-criteria` values atomically replace the complete acceptance-criteria checklist without splitting commas.
+- [x] #2 The CLI provides an explicit clear-all acceptance-criteria operation and rejects ambiguous combinations of replacement or clearing with incremental checklist mutations.
+- [x] #3 Removing and re-adding a checklist preserves canonical structured-section order with exactly one blank line between sections and no orphan whitespace.
+- [x] #4 Repeated checklist set, add, remove, check, uncheck, and clear cycles are byte-stable aside from the intended semantic change, including files with custom sections and CRLF line endings.
+- [x] #5 Shared checklist serialization provides analogous deterministic behavior for Definition of Done where the same mutation path applies.
+- [x] #6 Regression tests cover replacement, commas, additive edits, clear-all, canonical reinsertion, whitespace stability, surrounding sections, Definition of Done, and CRLF preservation.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Keep --ac additive; wire repeated --acceptance-criteria to atomic replacement, add --clear-ac, preserve commas, and reject ambiguous replacement/clear combinations with incremental mutations.
+2. Normalize to LF once, tokenize known Backlog sentinel families, mask balanced foreign ranges, and strictly resolve visible AC/DoD target markers.
+3. Route checklist parse, discovery, replacement, composition, anchors, and migration through the shared resolver while preserving masked foreign bytes.
+4. Unify zero-item and nonzero rewrites: compose the existing body with an empty queue, remove visible checkbox rows, preserve all non-checkbox residual content in place, retain a canonical marked shell when residual content remains, and remove only whitespace-only shells.
+5. Canonicalize only section-boundary blank lines, preserve residual interior bytes and CRLF, keep duplicate consolidation, and prove deterministic AC/DoD clear and re-add cycles with cross-target isolation.
+6. Run exact focused and adjacent regression suites, the full suite on final bytes, TypeScript, Biome, build, diff checks, and simplification review before fresh independent review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented strict shared AC/DoD marker resolution with actionable failures for malformed or ambiguous structures; wired repeatable atomic acceptance-criteria replacement and explicit clear-all while retaining additive --ac semantics; canonicalized checklist placement and boundary whitespace without altering custom content or line endings.
+
+Verification on the reviewed implementation: focused acceptance-criteria and Markdown serializer regressions, full Bun test suite, TypeScript, Biome, production build, and independent specification and quality reviews passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made acceptance-criteria editing deterministic: replacement, additive, clear, and conflict behavior now have explicit CLI semantics, while shared AC/DoD serialization preserves canonical section order, custom content, stable whitespace, and CRLF. Malformed or ambiguous checklist markers fail without writing and explain how to repair the task. Verified with focused and full tests, type checking, Biome, build, and independent reviews.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->

--- a/backlog/tasks/back-537 - Make-checklist-edits-and-serialization-deterministic.md
+++ b/backlog/tasks/back-537 - Make-checklist-edits-and-serialization-deterministic.md
@@ -3,9 +3,9 @@ id: BACK-537
 title: Make checklist edits and serialization deterministic
 status: Done
 assignee:
-  - '@codex'
+  - '@claude'
 created_date: '2026-07-11 23:02'
-updated_date: '2026-07-12 12:16'
+updated_date: '2026-07-12 13:49'
 labels: []
 dependencies: []
 priority: high
@@ -45,6 +45,8 @@ Acceptance-criteria replacement currently appends only the final repeated value,
 Implemented strict shared AC/DoD marker resolution with actionable failures for malformed or ambiguous structures; wired repeatable atomic acceptance-criteria replacement and explicit clear-all while retaining additive --ac semantics; canonicalized checklist placement and boundary whitespace without altering custom content or line endings.
 
 Verification on the reviewed implementation: focused acceptance-criteria and Markdown serializer regressions, full Bun test suite, TypeScript, Biome, production build, and independent specification and quality reviews passed.
+
+Review fix: balanced AC/DoD marker pairs with no attached section header (e.g. a pair mentioned in description prose) made findChecklistSectionRanges skip the legacy-heading scan, so reads returned no criteria while edits still stripped the legacy section — an incremental --ac dropped existing legacy items. The early return now requires an actual header-attached marked range before skipping legacy scanning. Regression test added for both AC and DoD. Codex review claims about lowercase markers and equality-skip on replacement were verified as not actionable (lowercase markers were already unsupported on the read path before this change; the no-op equality skip is the intended byte-stability behavior and stale duplicates are consolidated on the next real mutation).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -245,6 +245,12 @@ function parsePositiveIntegerOption(value: unknown, optionName: string, helpComm
 
 function formatTaskEditError(error: unknown, taskId: string): string {
 	const message = error instanceof Error ? error.message : String(error);
+	if (
+		message.startsWith("Malformed Acceptance Criteria markers:") ||
+		message.startsWith("Malformed Definition of Done markers:")
+	) {
+		return `${message}\nThe edit was not applied. Run 'backlog task view ${taskId} --plain' to locate the task file, repair or remove the malformed marker block in that Markdown file, then rerun the edit.`;
+	}
 	if (message.startsWith("Invalid index:")) {
 		return `${message} Try 'backlog task edit ${taskId} --help' for index options.`;
 	}
@@ -446,6 +452,7 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.addLabel !== undefined ||
 			options.removeLabel !== undefined ||
 			options.ac !== undefined ||
+			options.clearAc ||
 			options.dod !== undefined ||
 			options.removeAc !== undefined ||
 			options.removeDod !== undefined ||
@@ -2700,7 +2707,12 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		"uncheck Definition of Done item by index (1-based, can be used multiple times)",
 		createMultiValueAccumulator(),
 	)
-	.option("--acceptance-criteria <criteria>", "set acceptance criteria (comma-separated or use multiple times)")
+	.option(
+		"--acceptance-criteria <criteria>",
+		"replace all acceptance criteria (can be used multiple times; commas are preserved)",
+		createMultiValueAccumulator(),
+	)
+	.option("--clear-ac", "remove all acceptance criteria (cannot combine with acceptance criteria mutation options)")
 	.option("--plan <text>", "set implementation plan")
 	.option("--notes <text>", "set implementation notes (replaces existing)")
 	.option(
@@ -2921,11 +2933,34 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			return;
 		}
 
+		const hasIncrementalAcceptanceCriteriaMutation =
+			options.ac !== undefined ||
+			options.removeAc !== undefined ||
+			options.checkAc !== undefined ||
+			options.uncheckAc !== undefined;
+		if (options.clearAc && (options.acceptanceCriteria !== undefined || hasIncrementalAcceptanceCriteriaMutation)) {
+			console.error(
+				"Cannot combine --clear-ac with --acceptance-criteria, --ac, --remove-ac, --check-ac, or --uncheck-ac. Use --clear-ac by itself.",
+			);
+			process.exitCode = 1;
+			return;
+		}
+		if (options.acceptanceCriteria !== undefined && hasIncrementalAcceptanceCriteriaMutation) {
+			console.error(
+				"Cannot combine --acceptance-criteria with --ac, --remove-ac, --check-ac, or --uncheck-ac. Use replacement by itself, or use only incremental operations.",
+			);
+			process.exitCode = 1;
+			return;
+		}
+
 		const labelValues = parseDelimitedStringList(options.label) ?? [];
 		const addLabelValues = parseDelimitedStringList(options.addLabel) ?? [];
 		const removeLabelValues = parseDelimitedStringList(options.removeLabel) ?? [];
 		const assigneeValues = parseDelimitedStringList(options.assignee) ?? [];
-		const acceptanceAdditions = processAcceptanceCriteriaOptions(options);
+		const acceptanceAdditions = processAcceptanceCriteriaOptions({ ac: options.ac });
+		const acceptanceReplacement = processAcceptanceCriteriaOptions({
+			acceptanceCriteria: options.acceptanceCriteria,
+		});
 		const definitionOfDoneAdditions = toStringArray(options.dod)
 			.map((value) => String(value).trim())
 			.filter((value) => value.length > 0);
@@ -3013,6 +3048,11 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		}
 		if (options.clearFinalSummary) {
 			editArgs.finalSummaryClear = true;
+		}
+		if (options.clearAc) {
+			editArgs.acceptanceCriteriaSet = [];
+		} else if (options.acceptanceCriteria !== undefined) {
+			editArgs.acceptanceCriteriaSet = acceptanceReplacement;
 		}
 		if (acceptanceAdditions.length > 0) {
 			editArgs.acceptanceCriteriaAdd = acceptanceAdditions;

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -81,9 +81,8 @@ export function serializeTask(task: Task): string {
 	}
 	if (Array.isArray(task.acceptanceCriteriaItems)) {
 		const existingCriteria = AcceptanceCriteriaManager.parseAllCriteria(task.rawContent ?? "");
-		const hasExistingStructuredCriteria = existingCriteria.length > 0;
 		if (
-			(task.acceptanceCriteriaItems.length > 0 || hasExistingStructuredCriteria) &&
+			task.acceptanceCriteriaItems.length === 0 ||
 			!checklistItemsEqual(existingCriteria, task.acceptanceCriteriaItems)
 		) {
 			contentBody = AcceptanceCriteriaManager.updateContent(contentBody, task.acceptanceCriteriaItems);
@@ -91,9 +90,8 @@ export function serializeTask(task: Task): string {
 	}
 	if (Array.isArray(task.definitionOfDoneItems)) {
 		const existingDefinitionOfDone = DefinitionOfDoneManager.parseAllCriteria(task.rawContent ?? "");
-		const hasExistingDefinitionOfDone = existingDefinitionOfDone.length > 0;
 		if (
-			(task.definitionOfDoneItems.length > 0 || hasExistingDefinitionOfDone) &&
+			task.definitionOfDoneItems.length === 0 ||
 			!checklistItemsEqual(existingDefinitionOfDone, task.definitionOfDoneItems)
 		) {
 			contentBody = DefinitionOfDoneManager.updateContent(contentBody, task.definitionOfDoneItems);

--- a/src/markdown/structured-sections.ts
+++ b/src/markdown/structured-sections.ts
@@ -53,6 +53,7 @@ const KNOWN_SECTION_TITLES = new Set<string>([
 interface ChecklistSectionDefinition {
 	sectionHeader: string;
 	title: string;
+	markerId: string;
 	beginMarker: string;
 	endMarker: string;
 }
@@ -60,6 +61,7 @@ interface ChecklistSectionDefinition {
 const ACCEPTANCE_CRITERIA_DEFINITION: ChecklistSectionDefinition = {
 	sectionHeader: ACCEPTANCE_CRITERIA_SECTION_HEADER,
 	title: ACCEPTANCE_CRITERIA_TITLE,
+	markerId: "AC",
 	beginMarker: ACCEPTANCE_CRITERIA_BEGIN_MARKER,
 	endMarker: ACCEPTANCE_CRITERIA_END_MARKER,
 };
@@ -67,6 +69,7 @@ const ACCEPTANCE_CRITERIA_DEFINITION: ChecklistSectionDefinition = {
 const DEFINITION_OF_DONE_DEFINITION: ChecklistSectionDefinition = {
 	sectionHeader: DEFINITION_OF_DONE_SECTION_HEADER,
 	title: DEFINITION_OF_DONE_TITLE,
+	markerId: "DOD",
 	beginMarker: DEFINITION_OF_DONE_BEGIN_MARKER,
 	endMarker: DEFINITION_OF_DONE_END_MARKER,
 };
@@ -119,20 +122,6 @@ function sectionHeaderRegex(key: StructuredSectionKey): RegExp {
 	return new RegExp(`## ${escapeForRegex(title)}\\s*\\n([\\s\\S]*?)${structuredSectionLookahead(title)}`, "i");
 }
 
-function checklistSentinelRegex(definition: ChecklistSectionDefinition, flags = "i"): RegExp {
-	const header = escapeForRegex(definition.sectionHeader);
-	const begin = escapeForRegex(definition.beginMarker);
-	const end = escapeForRegex(definition.endMarker);
-	return new RegExp(`(\\n|^)${header}\\s*\\n${begin}\\s*\\n([\\s\\S]*?)${end}`, flags);
-}
-
-function checklistLegacyRegex(definition: ChecklistSectionDefinition, flags: string): RegExp {
-	return new RegExp(
-		`(\\n|^)${escapeForRegex(definition.sectionHeader)}\\s*\\n([\\s\\S]*?)${structuredSectionLookahead(definition.title)}`,
-		flags,
-	);
-}
-
 function commentsSentinelRegex(flags = "i"): RegExp {
 	const header = escapeForRegex(COMMENTS_SECTION_HEADER);
 	const begin = escapeForRegex(COMMENTS_BEGIN_MARKER);
@@ -147,33 +136,164 @@ function commentsLegacyRegex(flags: string): RegExp {
 	);
 }
 
-function acceptanceCriteriaSentinelRegex(flags = "i"): RegExp {
-	return checklistSentinelRegex(ACCEPTANCE_CRITERIA_DEFINITION, flags);
-}
-
 function legacySectionRegex(title: string, flags: string): RegExp {
 	return new RegExp(`(\\n|^)## ${escapeForRegex(title)}\\s*\\n([\\s\\S]*?)${structuredSectionLookahead(title)}`, flags);
 }
 
+type SentinelKind = "BEGIN" | "END";
+
+interface SentinelToken {
+	family: string;
+	kind: SentinelKind;
+	start: number;
+	end: number;
+}
+
+interface TextRange {
+	start: number;
+	end: number;
+}
+
+interface ChecklistSentinelPair extends TextRange {
+	begin: SentinelToken;
+	endToken: SentinelToken;
+}
+
+interface ChecklistSentinelResolution {
+	foreignRanges: TextRange[];
+	targetPairs: ChecklistSentinelPair[];
+	targetState: "none" | "balanced" | "ambiguous";
+	targetIssue?: "unexpected-end" | "repeated-begin" | "unclosed-begin";
+}
+
+function tokenizeKnownSentinels(content: string): SentinelToken[] {
+	const markerRegex = /<!-- (SECTION:[A-Z][A-Z0-9_]*|COMMENTS|COMMENT|AC|DOD):(BEGIN|END) -->/g;
+	const tokens: SentinelToken[] = [];
+	for (const match of content.matchAll(markerRegex)) {
+		const start = match.index ?? 0;
+		tokens.push({
+			family: String(match[1]),
+			kind: match[2] as SentinelKind,
+			start,
+			end: start + match[0].length,
+		});
+	}
+	return tokens;
+}
+
+function mergeRanges(ranges: TextRange[]): TextRange[] {
+	const merged: TextRange[] = [];
+	for (const range of [...ranges].sort((left, right) => left.start - right.start || left.end - right.end)) {
+		const previous = merged[merged.length - 1];
+		if (previous && range.start <= previous.end) {
+			previous.end = Math.max(previous.end, range.end);
+		} else {
+			merged.push({ ...range });
+		}
+	}
+	return merged;
+}
+
+function pairForeignFamily(tokens: SentinelToken[]): TextRange[] {
+	const pending: SentinelToken[] = [];
+	const ranges: TextRange[] = [];
+	for (const token of tokens) {
+		if (token.kind === "BEGIN") {
+			pending.push(token);
+			continue;
+		}
+		const begin = pending.pop();
+		if (begin) ranges.push({ start: begin.start, end: token.end });
+	}
+	return ranges;
+}
+
+function resolveKnownSentinelRanges(tokens: SentinelToken[]): TextRange[] {
+	const families = new Set(tokens.map((token) => token.family));
+	const ranges: TextRange[] = [];
+	for (const family of families) {
+		ranges.push(...pairForeignFamily(tokens.filter((token) => token.family === family)));
+	}
+	return mergeRanges(ranges);
+}
+
+function resolveChecklistSentinels(
+	content: string,
+	definition: ChecklistSectionDefinition,
+): ChecklistSentinelResolution {
+	const tokens = tokenizeKnownSentinels(content);
+	const foreignRanges = resolveKnownSentinelRanges(tokens.filter((token) => token.family !== definition.markerId));
+	const targetTokens = tokens.filter(
+		(token) => token.family === definition.markerId && !isIndexWithinRanges(token.start, foreignRanges),
+	);
+	if (targetTokens.length === 0) {
+		return { foreignRanges, targetPairs: [], targetState: "none" };
+	}
+
+	const targetPairs: ChecklistSentinelPair[] = [];
+	let begin: SentinelToken | undefined;
+	for (const token of targetTokens) {
+		if (token.kind === "BEGIN") {
+			if (begin) {
+				return { foreignRanges, targetPairs: [], targetState: "ambiguous", targetIssue: "repeated-begin" };
+			}
+			begin = token;
+			continue;
+		}
+		if (!begin) {
+			return { foreignRanges, targetPairs: [], targetState: "ambiguous", targetIssue: "unexpected-end" };
+		}
+		targetPairs.push({ start: begin.start, end: token.end, begin, endToken: token });
+		begin = undefined;
+	}
+
+	return begin
+		? { foreignRanges, targetPairs: [], targetState: "ambiguous", targetIssue: "unclosed-begin" }
+		: { foreignRanges, targetPairs, targetState: "balanced" };
+}
+
+function assertUnambiguousChecklistSentinels(
+	resolution: ChecklistSentinelResolution,
+	definition: ChecklistSectionDefinition,
+): void {
+	if (resolution.targetState !== "ambiguous") return;
+
+	const detail =
+		resolution.targetIssue === "unexpected-end"
+			? `found ${definition.endMarker} without a preceding ${definition.beginMarker}`
+			: resolution.targetIssue === "repeated-begin"
+				? `found a second ${definition.beginMarker} before the matching ${definition.endMarker}`
+				: `found ${definition.beginMarker} without a following ${definition.endMarker}`;
+	throw new Error(`Malformed ${definition.title} markers: ${detail}.`);
+}
+
 function findSectionEndIndex(content: string, title: string): number | undefined {
 	const normalizedTitle = title.trim();
-	let sentinelMatch: RegExpExecArray | null = null;
 	if (normalizedTitle.toLowerCase() === ACCEPTANCE_CRITERIA_TITLE.toLowerCase()) {
-		sentinelMatch = acceptanceCriteriaSentinelRegex().exec(content);
-	} else if (normalizedTitle.toLowerCase() === DEFINITION_OF_DONE_TITLE.toLowerCase()) {
-		sentinelMatch = checklistSentinelRegex(DEFINITION_OF_DONE_DEFINITION).exec(content);
-	} else if (normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()) {
-		sentinelMatch = commentsSentinelRegex().exec(content);
+		return findChecklistSectionRanges(content, ACCEPTANCE_CRITERIA_DEFINITION)[0]?.end;
+	}
+	if (normalizedTitle.toLowerCase() === DEFINITION_OF_DONE_TITLE.toLowerCase()) {
+		return findChecklistSectionRanges(content, DEFINITION_OF_DONE_DEFINITION)[0]?.end;
+	}
+	const sentinelRanges = resolveKnownSentinelRanges(tokenizeKnownSentinels(content));
+	let sentinelMatch: RegExpExecArray | null = null;
+	if (normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()) {
+		sentinelMatch = findMatchOutsideRanges(commentsSentinelRegex(), content, sentinelRanges) ?? null;
 	} else {
 		const keyEntry = Object.entries(SECTION_CONFIG).find(
 			([, config]) => config.title.toLowerCase() === normalizedTitle.toLowerCase(),
 		);
 		if (keyEntry) {
 			const key = keyEntry[0] as StructuredSectionKey;
-			sentinelMatch = new RegExp(
-				`## ${escapeForRegex(getConfig(key).title)}\\s*\\n${escapeForRegex(getBeginMarker(key))}\\s*\\n([\\s\\S]*?)${escapeForRegex(getEndMarker(key))}`,
-				"i",
-			).exec(content);
+			sentinelMatch =
+				findMatchOutsideRanges(
+					new RegExp(
+						`## ${escapeForRegex(getConfig(key).title)}\\s*\\n${escapeForRegex(getBeginMarker(key))}\\s*\\n([\\s\\S]*?)${escapeForRegex(getEndMarker(key))}`,
+						"i",
+					),
+					content,
+					sentinelRanges,
+				) ?? null;
 		}
 	}
 
@@ -181,12 +301,11 @@ function findSectionEndIndex(content: string, title: string): number | undefined
 		return sentinelMatch.index + sentinelMatch[0].length;
 	}
 
-	const legacyMatch =
-		normalizedTitle.toLowerCase() === DEFINITION_OF_DONE_TITLE.toLowerCase()
-			? checklistLegacyRegex(DEFINITION_OF_DONE_DEFINITION, "i").exec(content)
-			: normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()
-				? commentsLegacyRegex("i").exec(content)
-				: legacySectionRegex(normalizedTitle, "i").exec(content);
+	const legacyRegex =
+		normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()
+			? commentsLegacyRegex("i")
+			: legacySectionRegex(normalizedTitle, "i");
+	const legacyMatch = findMatchOutsideRanges(legacyRegex, content, sentinelRanges);
 	if (legacyMatch) {
 		return legacyMatch.index + legacyMatch[0].length;
 	}
@@ -195,23 +314,31 @@ function findSectionEndIndex(content: string, title: string): number | undefined
 
 function findSectionStartIndex(content: string, title: string): number | undefined {
 	const normalizedTitle = title.trim();
-	let sentinelMatch: RegExpExecArray | null = null;
 	if (normalizedTitle.toLowerCase() === ACCEPTANCE_CRITERIA_TITLE.toLowerCase()) {
-		sentinelMatch = acceptanceCriteriaSentinelRegex().exec(content);
-	} else if (normalizedTitle.toLowerCase() === DEFINITION_OF_DONE_TITLE.toLowerCase()) {
-		sentinelMatch = checklistSentinelRegex(DEFINITION_OF_DONE_DEFINITION).exec(content);
-	} else if (normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()) {
-		sentinelMatch = commentsSentinelRegex().exec(content);
+		return findChecklistSectionRanges(content, ACCEPTANCE_CRITERIA_DEFINITION)[0]?.start;
+	}
+	if (normalizedTitle.toLowerCase() === DEFINITION_OF_DONE_TITLE.toLowerCase()) {
+		return findChecklistSectionRanges(content, DEFINITION_OF_DONE_DEFINITION)[0]?.start;
+	}
+	const sentinelRanges = resolveKnownSentinelRanges(tokenizeKnownSentinels(content));
+	let sentinelMatch: RegExpExecArray | null = null;
+	if (normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()) {
+		sentinelMatch = findMatchOutsideRanges(commentsSentinelRegex(), content, sentinelRanges) ?? null;
 	} else {
 		const keyEntry = Object.entries(SECTION_CONFIG).find(
 			([, config]) => config.title.toLowerCase() === normalizedTitle.toLowerCase(),
 		);
 		if (keyEntry) {
 			const key = keyEntry[0] as StructuredSectionKey;
-			sentinelMatch = new RegExp(
-				`(\\n|^)## ${escapeForRegex(getConfig(key).title)}\\s*\\n${escapeForRegex(getBeginMarker(key))}\\s*\\n([\\s\\S]*?)${escapeForRegex(getEndMarker(key))}`,
-				"i",
-			).exec(content);
+			sentinelMatch =
+				findMatchOutsideRanges(
+					new RegExp(
+						`(\\n|^)## ${escapeForRegex(getConfig(key).title)}\\s*\\n${escapeForRegex(getBeginMarker(key))}\\s*\\n([\\s\\S]*?)${escapeForRegex(getEndMarker(key))}`,
+						"i",
+					),
+					content,
+					sentinelRanges,
+				) ?? null;
 		}
 	}
 
@@ -219,12 +346,11 @@ function findSectionStartIndex(content: string, title: string): number | undefin
 		return sentinelMatch.index;
 	}
 
-	const legacyMatch =
-		normalizedTitle.toLowerCase() === DEFINITION_OF_DONE_TITLE.toLowerCase()
-			? checklistLegacyRegex(DEFINITION_OF_DONE_DEFINITION, "i").exec(content)
-			: normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()
-				? commentsLegacyRegex("i").exec(content)
-				: legacySectionRegex(normalizedTitle, "i").exec(content);
+	const legacyRegex =
+		normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()
+			? commentsLegacyRegex("i")
+			: legacySectionRegex(normalizedTitle, "i");
+	const legacyMatch = findMatchOutsideRanges(legacyRegex, content, sentinelRanges);
 	return legacyMatch?.index;
 }
 
@@ -242,15 +368,28 @@ interface SectionRange {
 	kind: "sentinel" | "legacy";
 }
 
+interface ChecklistSectionRange {
+	start: number;
+	end: number;
+	body: string;
+	maskedRanges: TextRange[];
+	marked: boolean;
+	hasChecklistItems: boolean;
+}
+
 function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
 	return aStart < bEnd && bStart < aEnd;
 }
 
-function isIndexWithinRanges(index: number, ranges: SectionRange[]): boolean {
+function isIndexWithinRanges(index: number, ranges: Array<{ start: number; end: number }>): boolean {
 	return ranges.some((range) => index >= range.start && index < range.end);
 }
 
-function findMatchOutsideRanges(regex: RegExp, content: string, ranges: SectionRange[]): RegExpExecArray | undefined {
+function findMatchOutsideRanges(
+	regex: RegExp,
+	content: string,
+	ranges: Array<{ start: number; end: number }>,
+): RegExpExecArray | undefined {
 	const flags = regex.flags.includes("g") ? regex.flags : `${regex.flags}g`;
 	const globalRegex = new RegExp(regex.source, flags);
 	for (const match of content.matchAll(globalRegex)) {
@@ -278,6 +417,103 @@ function getStructuredSectionRanges(content: string): SectionRange[] {
 		}
 	}
 	return ranges;
+}
+
+function parseChecklistBody(body: string, marked: boolean, maskedRanges: TextRange[]): AcceptanceCriterion[] {
+	const lineRegex = marked ? /^- \[([ x])\] (?:#\d+ )?(.+)$/gm : /^- \[([ x])\] (.+)$/gm;
+	const items: AcceptanceCriterion[] = [];
+	for (const match of body.matchAll(lineRegex)) {
+		const start = match.index ?? 0;
+		if (isIndexWithinRanges(start, maskedRanges)) continue;
+		items.push({ checked: match[1] === "x", text: String(match[2] ?? ""), index: items.length + 1 });
+	}
+	return items;
+}
+
+function findChecklistHeaderStart(
+	content: string,
+	markerStart: number,
+	definition: ChecklistSectionDefinition,
+): number | undefined {
+	const prefix = content.slice(0, markerStart);
+	const headerRegex = new RegExp(
+		`(?:^|\\n)(${escapeForRegex(definition.sectionHeader)})[\\t ]*\\n(?:[\\t ]*\\n)*[\\t ]*$`,
+		"i",
+	);
+	const match = headerRegex.exec(prefix);
+	if (!match?.[1] || match.index === undefined) return undefined;
+	return match.index + match[0].indexOf(match[1]);
+}
+
+function findTopLevelHeadings(content: string, sentinelRanges: TextRange[]) {
+	const headings: Array<{ start: number; bodyStart: number; title: string }> = [];
+	for (const match of content.matchAll(/^##[\t ]+(.+?)[\t ]*$/gm)) {
+		const start = match.index ?? 0;
+		if (isIndexWithinRanges(start, sentinelRanges)) continue;
+		const lineEnd = start + match[0].length;
+		headings.push({
+			start,
+			bodyStart: content[lineEnd] === "\n" ? lineEnd + 1 : lineEnd,
+			title: String(match[1] ?? "").trim(),
+		});
+	}
+	return headings;
+}
+
+function rangesRelativeToBody(ranges: TextRange[], bodyStart: number, bodyEnd: number): TextRange[] {
+	return ranges
+		.filter((range) => rangesOverlap(range.start, range.end, bodyStart, bodyEnd))
+		.map((range) => ({
+			start: Math.max(range.start, bodyStart) - bodyStart,
+			end: Math.min(range.end, bodyEnd) - bodyStart,
+		}));
+}
+
+function findChecklistSectionRanges(
+	content: string,
+	definition: ChecklistSectionDefinition,
+	resolution = resolveChecklistSentinels(content, definition),
+	includeLegacyWithMarked = false,
+): ChecklistSectionRange[] {
+	if (resolution.targetState === "ambiguous") return [];
+	const ranges: ChecklistSectionRange[] = [];
+
+	for (const pair of resolution.targetPairs) {
+		const start = findChecklistHeaderStart(content, pair.begin.start, definition);
+		if (start === undefined || isIndexWithinRanges(start, resolution.foreignRanges)) continue;
+		const rawBody = content.slice(pair.begin.end, pair.endToken.start);
+		const leadingWhitespace = rawBody.match(/^[\t ]*\n/)?.[0].length ?? 0;
+		const bodyStart = pair.begin.end + leadingWhitespace;
+		const bodyEnd = pair.endToken.start;
+		const body = content.slice(bodyStart, bodyEnd);
+		const maskedRanges = rangesRelativeToBody(resolution.foreignRanges, bodyStart, bodyEnd);
+		ranges.push({
+			start,
+			end: pair.end,
+			body,
+			maskedRanges,
+			marked: true,
+			hasChecklistItems: parseChecklistBody(body, true, maskedRanges).length > 0,
+		});
+	}
+
+	if (resolution.targetState !== "none" && !includeLegacyWithMarked) {
+		return ranges.sort((left, right) => left.start - right.start);
+	}
+
+	const headings = findTopLevelHeadings(content, resolution.foreignRanges);
+	for (let index = 0; index < headings.length; index += 1) {
+		const heading = headings[index];
+		if (!heading || heading.title.toLowerCase() !== definition.title.toLowerCase()) continue;
+		const end = headings[index + 1]?.start ?? content.length;
+		if (ranges.some((range) => rangesOverlap(range.start, range.end, heading.start, end))) continue;
+		const body = content.slice(heading.bodyStart, end);
+		const maskedRanges = rangesRelativeToBody(resolution.foreignRanges, heading.bodyStart, end);
+		const hasChecklistItems = parseChecklistBody(body, false, maskedRanges).length > 0;
+		ranges.push({ start: heading.start, end, body, maskedRanges, marked: false, hasChecklistItems });
+	}
+
+	return ranges.sort((left, right) => left.start - right.start);
 }
 
 function stripSectionInstances(content: string, key: StructuredSectionKey): string {
@@ -372,7 +608,10 @@ export function updateStructuredSections(content: string, sections: SectionValue
 
 	if (plan) {
 		const planBlock = buildSectionBlock("implementationPlan", plan);
-		let res = insertAfterSection(tail, ACCEPTANCE_CRITERIA_TITLE, planBlock);
+		let res = insertAfterSection(tail, DEFINITION_OF_DONE_TITLE, planBlock);
+		if (!res.inserted) {
+			res = insertAfterSection(tail, ACCEPTANCE_CRITERIA_TITLE, planBlock);
+		}
 		if (!res.inserted) {
 			res = insertAfterSection(tail, getConfig("description").title, planBlock);
 		}
@@ -386,6 +625,9 @@ export function updateStructuredSections(content: string, sections: SectionValue
 	if (notes) {
 		const notesBlock = buildSectionBlock("implementationNotes", notes);
 		let res = insertAfterSection(tail, getConfig("implementationPlan").title, notesBlock);
+		if (!res.inserted) {
+			res = insertAfterSection(tail, DEFINITION_OF_DONE_TITLE, notesBlock);
+		}
 		if (!res.inserted) {
 			res = insertAfterSection(tail, ACCEPTANCE_CRITERIA_TITLE, notesBlock);
 		}
@@ -410,6 +652,9 @@ export function updateStructuredSections(content: string, sections: SectionValue
 		}
 		if (!res.inserted) {
 			res = insertAfterSection(tail, getConfig("implementationPlan").title, finalBlock);
+		}
+		if (!res.inserted) {
+			res = insertAfterSection(tail, DEFINITION_OF_DONE_TITLE, finalBlock);
 		}
 		if (!res.inserted) {
 			res = insertAfterSection(tail, ACCEPTANCE_CRITERIA_TITLE, finalBlock);
@@ -440,83 +685,48 @@ export function getStructuredSections(content: string): StructuredSectionValues 
 	};
 }
 
-function extractExistingChecklistBody(
-	content: string,
-	definition: ChecklistSectionDefinition,
-): { body: string; hasMarkers: boolean } | undefined {
-	const src = content.replace(/\r\n/g, "\n");
-	const sentinelMatch = checklistSentinelRegex(definition, "i").exec(src);
-	if (sentinelMatch?.[2] !== undefined) {
-		return { body: sentinelMatch[2], hasMarkers: true };
-	}
-	const legacyMatch = checklistLegacyRegex(definition, "i").exec(src);
-	if (legacyMatch?.[2] !== undefined) {
-		return { body: legacyMatch[2], hasMarkers: false };
-	}
-	return undefined;
-}
-
-function parseOldChecklistFormat(content: string, definition: ChecklistSectionDefinition): AcceptanceCriterion[] {
-	const src = content.replace(/\r\n/g, "\n");
-	const criteriaRegex = new RegExp(`${escapeForRegex(definition.sectionHeader)}\\s*\\n([\\s\\S]*?)(?=\\n## |$)`, "i");
-	const match = src.match(criteriaRegex);
-	if (!match?.[1]) {
-		return [];
-	}
-	const lines = match[1].split("\n").filter((line) => line.trim());
-	const criteria: AcceptanceCriterion[] = [];
-	let index = 1;
-	for (const line of lines) {
-		const checkboxMatch = line.match(/^- \[([ x])\] (.+)$/);
-		if (checkboxMatch?.[1] && checkboxMatch?.[2]) {
-			criteria.push({
-				checked: checkboxMatch[1] === "x",
-				text: checkboxMatch[2],
-				index: index++,
-			});
-		}
-	}
-	return criteria;
-}
-
 function parseChecklist(content: string, definition: ChecklistSectionDefinition): AcceptanceCriterion[] {
 	const src = content.replace(/\r\n/g, "\n");
-	const beginIndex = src.indexOf(definition.beginMarker);
-	const endIndex = src.indexOf(definition.endMarker);
-	if (beginIndex === -1 || endIndex === -1) {
-		return parseOldChecklistFormat(src, definition);
-	}
-	const checklistContent = src.substring(beginIndex + definition.beginMarker.length, endIndex);
-	const lines = checklistContent.split("\n").filter((line) => line.trim());
+	const resolution = resolveChecklistSentinels(src, definition);
+	if (resolution.targetState === "ambiguous") return [];
+	const ranges = findChecklistSectionRanges(src, definition, resolution);
+	const range = ranges.find((candidate) => candidate.marked) ?? ranges.find((candidate) => !candidate.marked);
+	if (!range) return [];
+	if (!range.marked) return parseChecklistBody(range.body, false, range.maskedRanges);
+
 	const criteria: AcceptanceCriterion[] = [];
-	for (const line of lines) {
-		const match = line.match(/^- \[([ x])\] #(\d+) (.+)$/);
-		if (match?.[1] && match?.[2] && match?.[3]) {
-			criteria.push({
-				checked: match[1] === "x",
-				text: match[3],
-				index: Number.parseInt(match[2], 10),
-			});
-		}
+	for (const match of range.body.matchAll(/^- \[([ x])\] #(\d+) (.+)$/gm)) {
+		const start = match.index ?? 0;
+		if (isIndexWithinRanges(start, range.maskedRanges)) continue;
+		criteria.push({
+			checked: match[1] === "x",
+			text: String(match[3] ?? ""),
+			index: Number.parseInt(String(match[2]), 10),
+		});
 	}
 	return criteria;
 }
 
-function composeChecklistBody(criteria: AcceptanceCriterion[], existingBody?: string): string {
+function composeChecklistBody(
+	criteria: AcceptanceCriterion[],
+	existingBody?: string,
+	maskedRanges: TextRange[] = [],
+): string {
 	const sorted = [...criteria].sort((a, b) => a.index - b.index);
-	if (sorted.length === 0) {
-		return "";
-	}
 	const queue = [...sorted];
 	const lines: string[] = [];
 	let nextNumber = 1;
-	// trimEnd() removes trailing newlines from regex capture that would create empty sourceLines entries
-	const sourceLines = existingBody ? existingBody.replace(/\r\n/g, "\n").trimEnd().split("\n") : [];
+	const sourceLines = existingBody ? existingBody.replace(/\r\n/g, "\n").split("\n") : [];
+	let sourceOffset = 0;
 
 	if (sourceLines.length > 0) {
 		for (const line of sourceLines) {
+			const lineStart = sourceOffset;
+			sourceOffset += line.length + 1;
 			const trimmed = line.trim();
-			const checkboxMatch = trimmed.match(/^- \[([ x])\] (?:#\d+ )?(.*)$/);
+			const checkboxMatch = isIndexWithinRanges(lineStart, maskedRanges)
+				? null
+				: trimmed.match(/^- \[([ x])\] (?:#\d+ )?(.*)$/);
 			if (checkboxMatch) {
 				const criterion = queue.shift();
 				if (!criterion) {
@@ -531,6 +741,13 @@ function composeChecklistBody(criteria: AcceptanceCriterion[], existingBody?: st
 		}
 	}
 
+	while (lines.length > 0 && lines[0]?.trim() === "") {
+		lines.shift();
+	}
+	while (lines.length > 0 && lines[lines.length - 1]?.trim() === "") {
+		lines.pop();
+	}
+
 	while (queue.length > 0) {
 		const criterion = queue.shift();
 		if (!criterion) continue;
@@ -541,15 +758,6 @@ function composeChecklistBody(criteria: AcceptanceCriterion[], existingBody?: st
 		lines.push(`- [${criterion.checked ? "x" : " "}] #${nextNumber++} ${criterion.text}`);
 	}
 
-	while (lines.length > 0) {
-		const tail = lines[lines.length - 1];
-		if (!tail || tail.trim() === "") {
-			lines.pop();
-		} else {
-			break;
-		}
-	}
-
 	return lines.join("\n");
 }
 
@@ -557,15 +765,16 @@ function formatChecklistSection(
 	criteria: AcceptanceCriterion[],
 	definition: ChecklistSectionDefinition,
 	existingBody?: string,
+	maskedRanges?: TextRange[],
 ): string {
-	if (criteria.length === 0) {
+	const effectiveMasks =
+		maskedRanges ?? (existingBody ? resolveChecklistSentinels(existingBody, definition).foreignRanges : []);
+	const body = composeChecklistBody(criteria, existingBody, effectiveMasks);
+	if (body.trim() === "") {
 		return "";
 	}
-	const body = composeChecklistBody(criteria, existingBody);
 	const lines = [definition.sectionHeader, definition.beginMarker];
-	if (body.trim() !== "") {
-		lines.push(...body.split("\n"));
-	}
+	lines.push(...body.split("\n"));
 	lines.push(definition.endMarker);
 	return lines.join("\n");
 }
@@ -575,89 +784,85 @@ function updateChecklistContent(
 	criteria: AcceptanceCriterion[],
 	definition: ChecklistSectionDefinition,
 ): string {
-	// Normalize to LF while computing, preserve original EOL at return
-	const useCRLF = /\r\n/.test(content);
-	const src = content.replace(/\r\n/g, "\n");
-	const existingBodyInfo = extractExistingChecklistBody(src, definition);
-	const newSection = formatChecklistSection(criteria, definition, existingBodyInfo?.body);
-
-	// Remove ALL existing checklist sections (legacy header blocks)
-	const legacyBlockRegex = checklistLegacyRegex(definition, "gi");
-	const matches = Array.from(src.matchAll(legacyBlockRegex));
-	let insertionIndex: number | null = null;
-	const firstMatch = matches[0];
-	if (firstMatch && firstMatch.index !== undefined) {
-		insertionIndex = firstMatch.index;
+	const { text: src, useCRLF } = normalizeToLF(content);
+	const resolution = resolveChecklistSentinels(src, definition);
+	assertUnambiguousChecklistSentinels(resolution, definition);
+	const existingRanges = findChecklistSectionRanges(src, definition, resolution, true);
+	const mutableRanges = existingRanges.filter((range) => range.marked || range.hasChecklistItems);
+	if (criteria.length === 0 && mutableRanges.length === 0) {
+		return content;
 	}
-
-	let stripped = src.replace(legacyBlockRegex, "").trimEnd();
-	// Also remove any stray marker-only blocks (defensive)
-	const markerBlockRegex = new RegExp(
-		`${escapeForRegex(definition.beginMarker)}[\\s\\S]*?${escapeForRegex(definition.endMarker)}`,
-		"gi",
-	);
-	stripped = stripped.replace(markerBlockRegex, "").trimEnd();
+	const existingRange = mutableRanges[0];
+	const newSection = formatChecklistSection(criteria, definition, existingRange?.body, existingRange?.maskedRanges);
+	let stripped = src;
+	for (const range of mutableRanges.sort((left, right) => right.start - left.start)) {
+		const before = stripped.slice(0, range.start).trimEnd();
+		const after = stripped.slice(range.end).replace(/^\s+/, "");
+		stripped = before && after ? `${before}\n\n${after}` : `${before}${after}`;
+	}
+	stripped = stripped.trim();
 
 	if (!newSection) {
-		// If criteria is empty, return stripped content (all checklist sections removed)
-		return stripped;
+		return restoreLineEndings(stripped, useCRLF);
 	}
 
-	// Insert the single consolidated section
-	if (insertionIndex !== null) {
-		const before = stripped.slice(0, insertionIndex).trimEnd();
-		const after = stripped.slice(insertionIndex);
-		const out = `${before}${before ? "\n\n" : ""}${newSection}${after ? `\n\n${after}` : ""}`;
-		return useCRLF ? out.replace(/\n/g, "\r\n") : out;
+	const precedingTitles =
+		definition === ACCEPTANCE_CRITERIA_DEFINITION
+			? [getConfig("description").title]
+			: [ACCEPTANCE_CRITERIA_TITLE, getConfig("description").title];
+	for (const title of precedingTitles) {
+		const result = insertAfterSection(stripped, title, newSection);
+		if (result.inserted) {
+			return restoreLineEndings(result.content.trim(), useCRLF);
+		}
 	}
 
-	// No existing section found: append at end
-	{
-		const out = `${stripped}${stripped ? "\n\n" : ""}${newSection}`;
-		return useCRLF ? out.replace(/\n/g, "\r\n") : out;
+	const followingTitles =
+		definition === ACCEPTANCE_CRITERIA_DEFINITION
+			? [
+					DEFINITION_OF_DONE_TITLE,
+					getConfig("implementationPlan").title,
+					getConfig("implementationNotes").title,
+					COMMENTS_TITLE,
+					getConfig("finalSummary").title,
+				]
+			: [
+					getConfig("implementationPlan").title,
+					getConfig("implementationNotes").title,
+					COMMENTS_TITLE,
+					getConfig("finalSummary").title,
+				];
+	for (const title of followingTitles) {
+		const result = insertBeforeSection(stripped, title, newSection);
+		if (result.inserted) {
+			return restoreLineEndings(result.content.trim(), useCRLF);
+		}
 	}
+
+	return restoreLineEndings(appendBlock(stripped, newSection).trim(), useCRLF);
 }
 
 function parseAllChecklistItems(content: string, definition: ChecklistSectionDefinition): AcceptanceCriterion[] {
 	const marked: AcceptanceCriterion[] = [];
 	const legacy: AcceptanceCriterion[] = [];
-	// Normalize to LF to make matching platform-agnostic
 	const src = content.replace(/\r\n/g, "\n");
-	// Find all checklist blocks (legacy header blocks)
-	const blockRegex = checklistLegacyRegex(definition, "gi");
-	let m: RegExpExecArray | null = blockRegex.exec(src);
-	while (m !== null) {
-		const block = m[2] || "";
-		if (block.includes(definition.beginMarker) && block.includes(definition.endMarker)) {
-			// Capture lines within each marked pair
-			const markedBlockRegex = new RegExp(
-				`${escapeForRegex(definition.beginMarker)}([\\s\\S]*?)${escapeForRegex(definition.endMarker)}`,
-				"gi",
-			);
-			let mm: RegExpExecArray | null = markedBlockRegex.exec(block);
-			while (mm !== null) {
-				const inside = mm[1] || "";
-				const lineRegex = /^- \[([ x])\] (?:#\d+ )?(.+)$/gm;
-				let lm: RegExpExecArray | null = lineRegex.exec(inside);
-				while (lm !== null) {
-					marked.push({ checked: lm[1] === "x", text: String(lm?.[2] ?? ""), index: marked.length + 1 });
-					lm = lineRegex.exec(inside);
-				}
-				mm = markedBlockRegex.exec(block);
-			}
-		} else {
-			// Legacy: parse checkbox lines without markers
-			const lineRegex = /^- \[([ x])\] (.+)$/gm;
-			let lm: RegExpExecArray | null = lineRegex.exec(block);
-			while (lm !== null) {
-				legacy.push({ checked: lm[1] === "x", text: String(lm?.[2] ?? ""), index: legacy.length + 1 });
-				lm = lineRegex.exec(block);
-			}
+	const resolution = resolveChecklistSentinels(src, definition);
+	if (resolution.targetState === "ambiguous") return [];
+	for (const range of findChecklistSectionRanges(src, definition, resolution)) {
+		const target = range.marked ? marked : legacy;
+		for (const item of parseChecklistBody(range.body, range.marked, range.maskedRanges)) {
+			target.push({ ...item, index: target.length + 1 });
 		}
-		m = blockRegex.exec(src);
 	}
-	// Prefer marked content when present; otherwise fall back to legacy
 	return marked.length > 0 ? marked : legacy;
+}
+
+function migrateChecklistToStableFormat(content: string, definition: ChecklistSectionDefinition): string {
+	const { text: src } = normalizeToLF(content);
+	const resolution = resolveChecklistSentinels(src, definition);
+	if (resolution.targetState !== "none") return content;
+	const criteria = parseAllChecklistItems(src, definition);
+	return criteria.length > 0 ? updateChecklistContent(content, criteria, definition) : content;
 }
 
 function normalizeCommentMetadata(value: string | undefined): string | undefined {
@@ -980,17 +1185,7 @@ export class AcceptanceCriteriaManager {
 	}
 
 	static migrateToStableFormat(content: string): string {
-		const criteria = AcceptanceCriteriaManager.parseAllCriteria(content);
-		if (criteria.length === 0) {
-			return content;
-		}
-		if (
-			content.includes(AcceptanceCriteriaManager.BEGIN_MARKER) &&
-			content.includes(AcceptanceCriteriaManager.END_MARKER)
-		) {
-			return content;
-		}
-		return AcceptanceCriteriaManager.updateContent(content, criteria);
+		return migrateChecklistToStableFormat(content, ACCEPTANCE_CRITERIA_DEFINITION);
 	}
 }
 
@@ -1047,16 +1242,6 @@ export class DefinitionOfDoneManager {
 	}
 
 	static migrateToStableFormat(content: string): string {
-		const criteria = DefinitionOfDoneManager.parseAllCriteria(content);
-		if (criteria.length === 0) {
-			return content;
-		}
-		if (
-			content.includes(DefinitionOfDoneManager.BEGIN_MARKER) &&
-			content.includes(DefinitionOfDoneManager.END_MARKER)
-		) {
-			return content;
-		}
-		return DefinitionOfDoneManager.updateContent(content, criteria);
+		return migrateChecklistToStableFormat(content, DEFINITION_OF_DONE_DEFINITION);
 	}
 }

--- a/src/markdown/structured-sections.ts
+++ b/src/markdown/structured-sections.ts
@@ -497,7 +497,9 @@ function findChecklistSectionRanges(
 		});
 	}
 
-	if (resolution.targetState !== "none" && !includeLegacyWithMarked) {
+	// Balanced markers with no attached section header (e.g. a stray pair in prose)
+	// must not hide legacy sections, or reads would miss criteria that writes still strip.
+	if (ranges.length > 0 && !includeLegacyWithMarked) {
 		return ranges.sort((left, right) => left.start - right.start);
 	}
 

--- a/src/test/acceptance-criteria-manager.test.ts
+++ b/src/test/acceptance-criteria-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { AcceptanceCriteriaManager } from "../markdown/structured-sections.ts";
+import { AcceptanceCriteriaManager, DefinitionOfDoneManager } from "../markdown/structured-sections.ts";
 
 describe("AcceptanceCriteriaManager", () => {
 	it("does not insert blank lines when adding new criteria (BACK-365)", () => {
@@ -53,5 +53,657 @@ Some description
 		const base = AcceptanceCriteriaManager.formatAcceptanceCriteria([{ checked: false, text: "Only", index: 1 }]);
 		const updated = AcceptanceCriteriaManager.checkCriterionByIndex(base, 1, true);
 		expect(updated).toContain("- [x] #1 Only");
+	});
+
+	it("removes and re-adds acceptance criteria in canonical order with stable spacing", () => {
+		const initial = [
+			"## Description",
+			"",
+			"<!-- SECTION:DESCRIPTION:BEGIN -->",
+			"Something",
+			"<!-- SECTION:DESCRIPTION:END -->",
+			"",
+			"## Acceptance Criteria",
+			"<!-- AC:BEGIN -->",
+			"- [ ] #1 Original",
+			"<!-- AC:END -->",
+			"",
+			"## Implementation Plan",
+			"",
+			"<!-- SECTION:PLAN:BEGIN -->",
+			"Plan",
+			"<!-- SECTION:PLAN:END -->",
+			"",
+			"## Implementation Notes",
+			"",
+			"<!-- SECTION:NOTES:BEGIN -->",
+			"Notes",
+			"<!-- SECTION:NOTES:END -->",
+			"",
+			"## Comments",
+			"",
+			"<!-- COMMENTS:BEGIN -->",
+			"created: 2026-07-11 12:00",
+			"---",
+			"Comment",
+			"---",
+			"<!-- COMMENTS:END -->",
+			"",
+			"## Final Summary",
+			"",
+			"<!-- SECTION:FINAL_SUMMARY:BEGIN -->",
+			"Summary",
+			"<!-- SECTION:FINAL_SUMMARY:END -->",
+		].join("\n");
+
+		const cleared = AcceptanceCriteriaManager.updateContent(initial, []);
+		expect(cleared).not.toContain("## Acceptance Criteria");
+		expect(cleared).not.toMatch(/\n{3,}/);
+
+		const readded = AcceptanceCriteriaManager.updateContent(cleared, [
+			{ checked: false, text: "Replacement", index: 1 },
+		]);
+		const headings = [
+			"## Description",
+			"## Acceptance Criteria",
+			"## Implementation Plan",
+			"## Implementation Notes",
+			"## Comments",
+			"## Final Summary",
+		].map((heading) => readded.indexOf(heading));
+		expect(headings).toEqual([...headings].sort((left, right) => left - right));
+		expect(readded).not.toMatch(/\n{3,}/);
+		expect(readded).toContain("<!-- AC:END -->\n\n## Implementation Plan");
+	});
+
+	it("preserves adjacent custom sections while replacing a checklist", () => {
+		const content = [
+			"## Description",
+			"",
+			"Something",
+			"",
+			"## Acceptance Criteria",
+			"<!-- AC:BEGIN -->",
+			"- [ ] #1 Original",
+			"<!-- AC:END -->",
+			"",
+			"## Custom Details",
+			"",
+			"Keep this exactly.",
+			"",
+			"## Implementation Plan",
+			"",
+			"Plan",
+		].join("\n");
+
+		const updated = AcceptanceCriteriaManager.updateContent(content, [
+			{ checked: false, text: "Replacement", index: 1 },
+		]);
+		expect(updated).toContain("## Custom Details\n\nKeep this exactly.");
+		expect(updated).toContain("- [ ] #1 Replacement");
+		expect(updated).not.toContain("Original");
+		expect(updated).not.toMatch(/\n{3,}/);
+	});
+
+	it("is byte-stable across repeated acceptance criteria edit cycles", () => {
+		const base = "## Description\n\nSomething\n\n## Implementation Plan\n\nPlan";
+		const criteria = [
+			{ checked: false, text: "First", index: 1 },
+			{ checked: false, text: "Second", index: 2 },
+		];
+		const expected = AcceptanceCriteriaManager.updateContent(base, criteria);
+
+		let cycled = expected;
+		for (let index = 0; index < 3; index += 1) {
+			cycled = AcceptanceCriteriaManager.addCriteria(cycled, ["Temporary"]);
+			cycled = AcceptanceCriteriaManager.removeCriterionByIndex(cycled, 3);
+			cycled = AcceptanceCriteriaManager.checkCriterionByIndex(cycled, 1, true);
+			cycled = AcceptanceCriteriaManager.checkCriterionByIndex(cycled, 1, false);
+			cycled = AcceptanceCriteriaManager.updateContent(cycled, []);
+			cycled = AcceptanceCriteriaManager.updateContent(cycled, criteria);
+		}
+
+		expect(cycled).toBe(expected);
+		expect(cycled).not.toMatch(/\n{3,}/);
+	});
+
+	it("applies canonical placement and stable spacing to Definition of Done", () => {
+		const base = [
+			"## Description",
+			"",
+			"Something",
+			"",
+			"## Acceptance Criteria",
+			"<!-- AC:BEGIN -->",
+			"- [ ] #1 Criterion",
+			"<!-- AC:END -->",
+			"",
+			"## Implementation Plan",
+			"",
+			"Plan",
+		].join("\n");
+		const items = [{ checked: false, text: "Validate", index: 1 }];
+		const expected = DefinitionOfDoneManager.updateContent(base, items);
+		expect(expected.indexOf("## Definition of Done")).toBeGreaterThan(expected.indexOf("## Acceptance Criteria"));
+		expect(expected.indexOf("## Definition of Done")).toBeLessThan(expected.indexOf("## Implementation Plan"));
+		expect(expected).not.toMatch(/\n{3,}/);
+
+		const cleared = DefinitionOfDoneManager.updateContent(expected, []);
+		expect(cleared).not.toContain("## Definition of Done");
+		expect(cleared).not.toMatch(/\n{3,}/);
+		expect(DefinitionOfDoneManager.updateContent(cleared, items)).toBe(expected);
+	});
+
+	it("preserves CRLF through checklist removal and canonical reinsertion", () => {
+		const base = "## Description\r\n\r\nSomething\r\n\r\n## Implementation Plan\r\n\r\nPlan";
+		const cases = [
+			{ manager: AcceptanceCriteriaManager, endMarker: "<!-- AC:END -->", text: "Criterion" },
+			{ manager: DefinitionOfDoneManager, endMarker: "<!-- DOD:END -->", text: "DoD item" },
+		];
+
+		for (const { manager, endMarker, text } of cases) {
+			const items = [{ checked: false, text, index: 1 }];
+			const added = manager.updateContent(base, items);
+			expect(added).not.toMatch(/(?<!\r)\n/);
+			expect(added).toContain(`${endMarker}\r\n\r\n## Implementation Plan`);
+
+			const cleared = manager.updateContent(added, []);
+			expect(cleared).not.toMatch(/(?<!\r)\n/);
+			const readded = manager.updateContent(cleared, items);
+			expect(readded).toBe(added);
+			expect(manager.updateContent(readded, items)).toBe(added);
+		}
+	});
+
+	it("leaves content byte-for-byte unchanged when an empty checklist section is absent", () => {
+		const content = "## Description\r\n\r\nSomething\r\n\r\n## Custom Details\r\n\r\nKeep this.\r\n";
+
+		expect(AcceptanceCriteriaManager.updateContent(content, [])).toBe(content);
+		expect(DefinitionOfDoneManager.updateContent(content, [])).toBe(content);
+	});
+
+	it("treats checklist-looking content inside foreign sentinel blocks as opaque", () => {
+		const comments = [
+			"## Comments",
+			"",
+			"<!-- COMMENTS:BEGIN -->",
+			"## Acceptance Criteria",
+			"- [ ] Comment checkbox",
+			"<!-- AC:BEGIN -->",
+			"- [ ] #1 Fake marked criterion",
+			"<!-- AC:END -->",
+			"## Definition of Done",
+			"- [ ] Comment DoD checkbox",
+			"<!-- DOD:BEGIN -->",
+			"- [ ] #1 Fake marked DoD item",
+			"<!-- DOD:END -->",
+			"## Implementation Plan",
+			"- [ ] Comment plan checkbox",
+			"<!-- COMMENTS:END -->",
+		].join("\n");
+
+		expect(AcceptanceCriteriaManager.parseAllCriteria(comments)).toEqual([]);
+		expect(DefinitionOfDoneManager.parseAllCriteria(comments)).toEqual([]);
+		expect(AcceptanceCriteriaManager.updateContent(comments, [])).toBe(comments);
+		expect(DefinitionOfDoneManager.updateContent(comments, [])).toBe(comments);
+
+		const withAcceptanceCriteria = AcceptanceCriteriaManager.updateContent(comments, [
+			{ checked: false, text: "Real criterion", index: 1 },
+		]);
+		expect(withAcceptanceCriteria).toContain(comments);
+		expect(withAcceptanceCriteria.indexOf("- [ ] #1 Real criterion")).toBeLessThan(
+			withAcceptanceCriteria.indexOf("<!-- COMMENTS:BEGIN -->"),
+		);
+		expect(withAcceptanceCriteria).toContain("- [ ] #1 Real criterion");
+
+		const withDefinitionOfDone = DefinitionOfDoneManager.updateContent(comments, [
+			{ checked: false, text: "Real DoD item", index: 1 },
+		]);
+		expect(withDefinitionOfDone).toContain(comments);
+		expect(withDefinitionOfDone.indexOf("- [ ] #1 Real DoD item")).toBeLessThan(
+			withDefinitionOfDone.indexOf("<!-- COMMENTS:BEGIN -->"),
+		);
+		expect(withDefinitionOfDone).toContain("- [ ] #1 Real DoD item");
+	});
+
+	it("resolves target markers only after masking nested known foreign families", () => {
+		const cases = [
+			{
+				manager: AcceptanceCriteriaManager,
+				header: "Acceptance Criteria",
+				target: "AC",
+				crossFamily: "DOD",
+				text: "Real criterion",
+			},
+			{
+				manager: DefinitionOfDoneManager,
+				header: "Definition of Done",
+				target: "DOD",
+				crossFamily: "AC",
+				text: "Real DoD item",
+			},
+		];
+
+		for (const { manager, header, target, crossFamily, text } of cases) {
+			const content = [
+				"## Comments",
+				"",
+				"<!-- COMMENTS:BEGIN -->",
+				`<!-- ${target}:END -->`,
+				`<!-- ${target}:BEGIN -->`,
+				"<!-- COMMENT:BEGIN -->",
+				`<!-- ${target}:BEGIN -->`,
+				"- [ ] #1 Fake nested item",
+				`<!-- ${target}:END -->`,
+				"<!-- COMMENT:END -->",
+				"<!-- COMMENTS:END -->",
+				`## ${crossFamily === "AC" ? "Acceptance Criteria" : "Definition of Done"}`,
+				`<!-- ${crossFamily}:BEGIN -->`,
+				`<!-- ${target}:BEGIN -->`,
+				"- [ ] #1 Fake cross-family item",
+				`<!-- ${target}:END -->`,
+				`<!-- ${crossFamily}:END -->`,
+				`## ${header}`,
+				`<!-- ${target}:BEGIN -->`,
+				`- [ ] #1 ${text}`,
+				"<!-- SECTION:CUSTOM:BEGIN -->",
+				"- [ ] #9 Opaque checkbox",
+				`<!-- ${target}:END -->`,
+				"<!-- SECTION:CUSTOM:END -->",
+				`<!-- ${target}:END -->`,
+				"<!-- COMMENT:BEGIN -->",
+				`<!-- ${target}:END -->`,
+				`<!-- ${target}:BEGIN -->`,
+				"fake unmatched target markers after the real section",
+				"<!-- COMMENT:END -->",
+				"## Implementation Plan",
+				"Plan",
+			].join("\n");
+
+			expect(manager.parseAllCriteria(content)).toEqual([{ checked: false, text, index: 1 }]);
+			const replaced = manager.updateContent(content, [{ checked: false, text: `Replacement ${text}`, index: 1 }]);
+			expect(replaced).toContain("- [ ] #9 Opaque checkbox");
+			expect(replaced).toContain(`- [ ] #1 Replacement ${text}`);
+			expect(manager.parseAllCriteria(replaced)).toEqual([{ checked: false, text: `Replacement ${text}`, index: 1 }]);
+		}
+	});
+
+	it("keeps balanced inner foreign blocks opaque when an outer foreign marker is unclosed", () => {
+		const cases = [
+			{ manager: AcceptanceCriteriaManager, header: "Acceptance Criteria", target: "AC", text: "Real criterion" },
+			{ manager: DefinitionOfDoneManager, header: "Definition of Done", target: "DOD", text: "Real DoD item" },
+		];
+
+		for (const { manager, header, target, text } of cases) {
+			const content = [
+				"<!-- COMMENTS:BEGIN -->",
+				"outer marker intentionally unclosed",
+				"<!-- COMMENTS:BEGIN -->",
+				`<!-- ${target}:BEGIN -->`,
+				"- [ ] #1 Fake inner item",
+				`<!-- ${target}:END -->`,
+				"<!-- COMMENTS:END -->",
+				`## ${header}`,
+				`<!-- ${target}:BEGIN -->`,
+				`- [ ] #1 ${text}`,
+				`<!-- ${target}:END -->`,
+			].join("\n");
+
+			expect(manager.parseAllCriteria(content)).toEqual([{ checked: false, text, index: 1 }]);
+		}
+	});
+
+	it("does not let an unclosed foreign marker hide visible malformed target markers", () => {
+		const cases = [
+			{ manager: AcceptanceCriteriaManager, header: "Acceptance Criteria", target: "AC" },
+			{ manager: DefinitionOfDoneManager, header: "Definition of Done", target: "DOD" },
+		];
+
+		for (const { manager, header, target } of cases) {
+			const content = [
+				"<!-- COMMENTS:BEGIN -->",
+				"outer marker intentionally unclosed",
+				`<!-- ${target}:END -->`,
+				"<!-- COMMENTS:BEGIN -->",
+				`<!-- ${target}:BEGIN -->`,
+				"- [ ] #1 Fake inner item",
+				`<!-- ${target}:END -->`,
+				"<!-- COMMENTS:END -->",
+				`## ${header}`,
+				`<!-- ${target}:BEGIN -->`,
+				"- [ ] #1 Real item",
+				`<!-- ${target}:END -->`,
+			].join("\n");
+
+			expect(manager.parseAllCriteria(content)).toEqual([]);
+			expect(() => manager.updateContent(content, [{ checked: false, text: "Replacement", index: 1 }])).toThrow(
+				`Malformed ${header} markers`,
+			);
+		}
+	});
+
+	it("fails with a specific diagnostic for ambiguous visible target markers", () => {
+		const cases = [
+			{ manager: AcceptanceCriteriaManager, header: "Acceptance Criteria", target: "AC" },
+			{ manager: DefinitionOfDoneManager, header: "Definition of Done", target: "DOD" },
+		];
+		const sequences = [
+			{
+				lines: (marker: string) => [
+					`<!-- ${marker}:END -->`,
+					`<!-- ${marker}:BEGIN -->`,
+					"- [ ] #1 Existing",
+					`<!-- ${marker}:END -->`,
+				],
+				detail: "without a preceding",
+			},
+			{
+				lines: (marker: string) => [`<!-- ${marker}:BEGIN -->`, "- [ ] #1 Existing"],
+				detail: "without a following",
+			},
+			{
+				lines: (marker: string) => [
+					`<!-- ${marker}:BEGIN -->`,
+					`<!-- ${marker}:BEGIN -->`,
+					"- [ ] #1 Existing",
+					`<!-- ${marker}:END -->`,
+					`<!-- ${marker}:END -->`,
+				],
+				detail: "found a second",
+			},
+		];
+
+		for (const { manager, header, target } of cases) {
+			for (const sequence of sequences) {
+				const content = [`## ${header}`, ...sequence.lines(target), "", "## Implementation Plan", "Plan"].join("\n");
+				expect(manager.parseAllCriteria(content)).toEqual([]);
+				for (const replacement of [[], [{ checked: false, text: "Replacement", index: 1 }]]) {
+					expect(() => manager.updateContent(content, replacement)).toThrow(`Malformed ${header} markers`);
+					expect(() => manager.updateContent(content, replacement)).toThrow(sequence.detail);
+				}
+			}
+		}
+	});
+
+	it("migrates legacy checklists when target-looking markers exist only inside COMMENT or COMMENTS", () => {
+		const cases = [
+			{ manager: AcceptanceCriteriaManager, header: "Acceptance Criteria", target: "AC", text: "Legacy criterion" },
+			{ manager: DefinitionOfDoneManager, header: "Definition of Done", target: "DOD", text: "Legacy DoD item" },
+		];
+
+		for (const { manager, header, target, text } of cases) {
+			const content = [
+				"## Comments",
+				"<!-- COMMENTS:BEGIN -->",
+				`<!-- ${target}:BEGIN -->`,
+				"- [ ] #1 Fake comments item",
+				`<!-- ${target}:END -->`,
+				"<!-- COMMENTS:END -->",
+				"<!-- COMMENT:BEGIN -->",
+				`<!-- ${target}:BEGIN -->`,
+				"- [ ] #1 Fake comment item",
+				`<!-- ${target}:END -->`,
+				"<!-- COMMENT:END -->",
+				`## ${header}`,
+				`- [ ] ${text}`,
+			].join("\n");
+
+			expect(manager.parseAllCriteria(content)).toEqual([{ checked: false, text, index: 1 }]);
+			const migrated = manager.migrateToStableFormat(content);
+			expect(migrated).not.toBe(content);
+			expect(migrated).toContain(`## ${header}\n<!-- ${target}:BEGIN -->\n- [ ] #1 ${text}\n<!-- ${target}:END -->`);
+			expect(manager.migrateToStableFormat(migrated)).toBe(migrated);
+		}
+	});
+
+	it("clears top-level legacy checklists but preserves prose-only namesake sections", () => {
+		const cases = [
+			{
+				manager: AcceptanceCriteriaManager,
+				header: "Acceptance Criteria",
+				item: "Legacy criterion",
+			},
+			{
+				manager: DefinitionOfDoneManager,
+				header: "Definition of Done",
+				item: "Legacy DoD item",
+			},
+		];
+
+		for (const { manager, header, item } of cases) {
+			const legacy = `## Description\n\nDetails\n\n## ${header}\n- [ ] ${item}\n\n## Custom Details\n\nKeep this.`;
+			const cleared = manager.updateContent(legacy, []);
+			expect(cleared).toBe("## Description\n\nDetails\n\n## Custom Details\n\nKeep this.");
+			expect(manager.parseAllCriteria(legacy)).toEqual([{ checked: false, text: item, index: 1 }]);
+
+			const prose = `## Description\r\n\r\nDetails\r\n\r\n## ${header}\r\nThis heading is ordinary prose, not a checklist.\r\n`;
+			expect(manager.parseAllCriteria(prose)).toEqual([]);
+			expect(manager.updateContent(prose, [])).toBe(prose);
+		}
+	});
+
+	it("preserves foreign sentinel blocks nested in a real checklist body", () => {
+		const content = [
+			"## Acceptance Criteria",
+			"<!-- AC:BEGIN -->",
+			"- [ ] #1 Original",
+			"<!-- SECTION:CUSTOM:BEGIN -->",
+			"- [ ] This checkbox is opaque",
+			"<!-- SECTION:CUSTOM:END -->",
+			"<!-- AC:END -->",
+		].join("\n");
+		const foreignBlock = [
+			"<!-- SECTION:CUSTOM:BEGIN -->",
+			"- [ ] This checkbox is opaque",
+			"<!-- SECTION:CUSTOM:END -->",
+		].join("\n");
+
+		expect(AcceptanceCriteriaManager.parseAllCriteria(content)).toEqual([
+			{ checked: false, text: "Original", index: 1 },
+		]);
+		const replaced = AcceptanceCriteriaManager.updateContent(content, [
+			{ checked: false, text: "Replacement", index: 1 },
+		]);
+		expect(replaced).toContain(foreignBlock);
+		expect(replaced).toContain("- [ ] #1 Replacement");
+		expect(AcceptanceCriteriaManager.updateContent(replaced, [{ checked: false, text: "Replacement", index: 1 }])).toBe(
+			replaced,
+		);
+
+		const formatted = AcceptanceCriteriaManager.formatAcceptanceCriteria(
+			[{ checked: false, text: "Formatted replacement", index: 1 }],
+			["- [ ] #1 Original", foreignBlock].join("\n"),
+		);
+		expect(formatted).toContain(foreignBlock);
+		expect(formatted).toContain("- [ ] #1 Formatted replacement");
+	});
+});
+
+describe("deterministic empty checklist rewrites", () => {
+	const cases = [
+		{
+			name: "acceptance criteria",
+			manager: AcceptanceCriteriaManager,
+			header: "Acceptance Criteria",
+			beginMarker: "<!-- AC:BEGIN -->",
+			endMarker: "<!-- AC:END -->",
+			otherManager: DefinitionOfDoneManager,
+			otherHeader: "Definition of Done",
+			otherBeginMarker: "<!-- DOD:BEGIN -->",
+			otherEndMarker: "<!-- DOD:END -->",
+		},
+		{
+			name: "definition of done",
+			manager: DefinitionOfDoneManager,
+			header: "Definition of Done",
+			beginMarker: "<!-- DOD:BEGIN -->",
+			endMarker: "<!-- DOD:END -->",
+			otherManager: AcceptanceCriteriaManager,
+			otherHeader: "Acceptance Criteria",
+			otherBeginMarker: "<!-- AC:BEGIN -->",
+			otherEndMarker: "<!-- AC:END -->",
+		},
+	];
+
+	it("retains one marked shell and every non-checkbox residual line when clearing", () => {
+		for (const { manager, header, beginMarker, endMarker } of cases) {
+			const content = [
+				"## Description",
+				"",
+				"Details",
+				"",
+				`## ${header}`,
+				beginMarker,
+				"- [ ] #1 First row",
+				"Keep this prose exactly.",
+				"<!-- SECTION:CUSTOM:BEGIN -->",
+				"- [ ] Opaque foreign checkbox",
+				"",
+				"",
+				"Opaque tail.",
+				"<!-- SECTION:CUSTOM:END -->",
+				"Tail prose.",
+				"- [x] #2 Second row",
+				endMarker,
+				"",
+				"## Implementation Plan",
+				"",
+				"Plan",
+			].join("\n");
+			const residual = [
+				`## ${header}`,
+				beginMarker,
+				"Keep this prose exactly.",
+				"<!-- SECTION:CUSTOM:BEGIN -->",
+				"- [ ] Opaque foreign checkbox",
+				"",
+				"",
+				"Opaque tail.",
+				"<!-- SECTION:CUSTOM:END -->",
+				"Tail prose.",
+				endMarker,
+			].join("\n");
+
+			const cleared = manager.updateContent(content, []);
+			expect(cleared).toContain(residual);
+			expect(cleared.match(new RegExp(beginMarker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))).toHaveLength(1);
+			expect(cleared).not.toContain("First row");
+			expect(cleared).not.toContain("Second row");
+			expect(manager.parseAllCriteria(cleared)).toEqual([]);
+			expect(manager.updateContent(cleared, [])).toBe(cleared);
+		}
+	});
+
+	it("removes a rows-and-blanks-only shell with one blank line between neighbors", () => {
+		for (const { manager, header, beginMarker, endMarker } of cases) {
+			const content = [
+				"## Description",
+				"",
+				"Details",
+				"",
+				`## ${header}`,
+				beginMarker,
+				"",
+				"- [ ] #1 First row",
+				"",
+				"- [x] #2 Second row",
+				"",
+				endMarker,
+				"",
+				"## Implementation Plan",
+				"",
+				"Plan",
+			].join("\n");
+
+			expect(manager.updateContent(content, [])).toBe("## Description\n\nDetails\n\n## Implementation Plan\n\nPlan");
+		}
+	});
+
+	it("re-adds deterministically after a residual-preserving clear", () => {
+		for (const { manager, header, beginMarker, endMarker } of cases) {
+			const content = [`## ${header}`, beginMarker, "- [ ] #1 Old row", "Keep this prose.", endMarker].join("\n");
+			const cleared = manager.updateContent(content, []);
+			const replacement = [{ checked: false, text: "Replacement", index: 1 }];
+			const readded = manager.updateContent(cleared, replacement);
+
+			expect(readded).toContain(`Keep this prose.\n\n- [ ] #1 Replacement\n${endMarker}`);
+			expect(manager.updateContent(readded, replacement)).toBe(readded);
+			expect(manager.updateContent(readded, [])).toBe(cleared);
+		}
+	});
+
+	it("preserves CRLF while retaining residual shells", () => {
+		for (const { manager, header, beginMarker, endMarker } of cases) {
+			const content = [
+				`## ${header}`,
+				beginMarker,
+				"- [ ] #1 Old row",
+				"Residual prose.",
+				endMarker,
+				"",
+				"## Implementation Plan",
+				"",
+				"Plan",
+			].join("\r\n");
+
+			const cleared = manager.updateContent(content, []);
+			expect(cleared).not.toMatch(/(?<!\r)\n/);
+			expect(cleared).toContain(`${beginMarker}\r\nResidual prose.\r\n${endMarker}`);
+			expect(manager.updateContent(cleared, [])).toBe(cleared);
+		}
+	});
+
+	it("does not change the other checklist family when clearing a residual shell", () => {
+		for (const {
+			manager,
+			header,
+			beginMarker,
+			endMarker,
+			otherManager,
+			otherHeader,
+			otherBeginMarker,
+			otherEndMarker,
+		} of cases) {
+			const otherSection = [`## ${otherHeader}`, otherBeginMarker, "- [ ] #1 Other family row", otherEndMarker].join(
+				"\n",
+			);
+			const content = [
+				`## ${header}`,
+				beginMarker,
+				"- [ ] #1 Target row",
+				"Target residual.",
+				endMarker,
+				"",
+				otherSection,
+			].join("\n");
+
+			const cleared = manager.updateContent(content, []);
+			expect(cleared).toContain(otherSection);
+			expect(otherManager.parseAllCriteria(cleared)).toEqual([{ checked: false, text: "Other family row", index: 1 }]);
+		}
+	});
+
+	it("converts a legacy checklist with residual prose to one stable marked shell", () => {
+		for (const { manager, header, beginMarker, endMarker } of cases) {
+			const legacy = [
+				"## Description",
+				"",
+				"Details",
+				"",
+				`## ${header}`,
+				"- [ ] Legacy row",
+				"Keep legacy prose.",
+				"",
+				"## Implementation Plan",
+				"",
+				"Plan",
+			].join("\n");
+
+			const cleared = manager.updateContent(legacy, []);
+			expect(cleared).toContain(`## ${header}\n${beginMarker}\nKeep legacy prose.\n${endMarker}`);
+			expect(cleared).not.toContain("Legacy row");
+			expect(manager.parseAllCriteria(cleared)).toEqual([]);
+			expect(manager.updateContent(cleared, [])).toBe(cleared);
+		}
 	});
 });

--- a/src/test/acceptance-criteria-manager.test.ts
+++ b/src/test/acceptance-criteria-manager.test.ts
@@ -456,6 +456,29 @@ Some description
 		}
 	});
 
+	it("still parses legacy checklists when a balanced marker pair sits in prose without a header", () => {
+		const cases = [
+			{ manager: AcceptanceCriteriaManager, header: "Acceptance Criteria", target: "AC", text: "Legacy criterion" },
+			{ manager: DefinitionOfDoneManager, header: "Definition of Done", target: "DOD", text: "Legacy DoD item" },
+		];
+
+		for (const { manager, header, target, text } of cases) {
+			const proseMention = `Wrap items between <!-- ${target}:BEGIN --> and <!-- ${target}:END --> markers.`;
+			const content = ["## Description", "", proseMention, "", `## ${header}`, "", `- [ ] ${text}`].join("\n");
+
+			expect(manager.parseAllCriteria(content)).toEqual([{ checked: false, text, index: 1 }]);
+
+			const added = manager.addCriteria(content, ["New item"]);
+			expect(added).toContain(proseMention);
+			expect(added).toContain(`- [ ] #1 ${text}`);
+			expect(added).toContain("- [ ] #2 New item");
+			expect(manager.parseAllCriteria(added)).toEqual([
+				{ checked: false, text, index: 1 },
+				{ checked: false, text: "New item", index: 2 },
+			]);
+		}
+	});
+
 	it("clears top-level legacy checklists but preserves prose-only namesake sections", () => {
 		const cases = [
 			{

--- a/src/test/acceptance-criteria.test.ts
+++ b/src/test/acceptance-criteria.test.ts
@@ -136,6 +136,147 @@ describe("Acceptance Criteria CLI", () => {
 			expect(task?.rawContent).toContain("- [ ] #2 New criterion 2");
 		});
 
+		it("replaces all acceptance criteria with repeated --acceptance-criteria values", async () => {
+			await $`bun ${CLI_PATH} task edit 1 --ac "Old criterion 1" --ac "Old criterion 2" --ac "Old criterion 3"`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			const result =
+				await $`bun ${CLI_PATH} task edit 1 --acceptance-criteria "Replacement A, with comma" --acceptance-criteria "Replacement B"`
+					.cwd(TEST_DIR)
+					.quiet();
+			expect(result.exitCode).toBe(0);
+
+			const core = new Core(TEST_DIR);
+			const task = await core.filesystem.loadTask("task-1");
+			const body = task?.rawContent ?? "";
+			expect(body).not.toContain("Old criterion");
+			expect(body).toContain("- [ ] #1 Replacement A, with comma");
+			expect(body).toContain("- [ ] #2 Replacement B");
+			expect(body).not.toContain("- [ ] #3");
+		});
+
+		it("clears all acceptance criteria atomically with --clear-ac", async () => {
+			await $`bun ${CLI_PATH} task edit 1 --ac "First" --ac "Second"`.cwd(TEST_DIR).quiet();
+
+			const result = await $`bun ${CLI_PATH} task edit 1 --clear-ac`.cwd(TEST_DIR).quiet();
+			expect(result.exitCode).toBe(0);
+
+			const core = new Core(TEST_DIR);
+			const task = await core.filesystem.loadTask("task-1");
+			const body = task?.rawContent ?? "";
+			expect(body).not.toContain("## Acceptance Criteria");
+			expect(body).not.toContain("<!-- AC:");
+			expect(body).not.toMatch(/\n{3,}/);
+		});
+
+		it("rejects replacement or clear combined with incremental acceptance criteria edits", async () => {
+			await $`bun ${CLI_PATH} task edit 1 --ac "Existing"`.cwd(TEST_DIR).quiet();
+			const core = new Core(TEST_DIR);
+			const before = await core.getTaskContent("task-1");
+
+			const replaceAndAdd = await $`bun ${CLI_PATH} task edit 1 --acceptance-criteria "Replacement" --ac "Addition"`
+				.cwd(TEST_DIR)
+				.nothrow()
+				.quiet();
+			expect(replaceAndAdd.exitCode).toBe(1);
+			expect(replaceAndAdd.stderr.toString()).toContain("Cannot combine --acceptance-criteria");
+
+			const clearAndCheck = await $`bun ${CLI_PATH} task edit 1 --clear-ac --check-ac 1`
+				.cwd(TEST_DIR)
+				.nothrow()
+				.quiet();
+			expect(clearAndCheck.exitCode).toBe(1);
+			expect(clearAndCheck.stderr.toString()).toContain("Cannot combine --clear-ac");
+			expect(await core.getTaskContent("task-1")).toBe(before);
+		});
+
+		it("rejects malformed Acceptance Criteria and Definition of Done markers without changing task bytes", async () => {
+			const core = new Core(TEST_DIR);
+			const task = await core.filesystem.loadTask("task-1");
+			if (!task?.filePath) throw new Error("Expected task file path");
+			const persisted = await Bun.file(task.filePath).text();
+			const cases = [
+				{
+					title: "Acceptance Criteria",
+					marker: "AC",
+					editArgs: ["--ac", "Replacement"],
+				},
+				{
+					title: "Definition of Done",
+					marker: "DOD",
+					editArgs: ["--dod", "Replacement"],
+				},
+			];
+			const malformed = [
+				{
+					body: (marker: string) => `<!-- ${marker}:END -->`,
+					detail: "without a preceding",
+				},
+				{
+					body: (marker: string) => `<!-- ${marker}:BEGIN -->\n- [ ] #1 Existing`,
+					detail: "without a following",
+				},
+				{
+					body: (marker: string) =>
+						`<!-- ${marker}:BEGIN -->\n<!-- ${marker}:BEGIN -->\n- [ ] #1 Existing\n<!-- ${marker}:END -->\n<!-- ${marker}:END -->`,
+					detail: "found a second",
+				},
+			];
+
+			for (const target of cases) {
+				for (const invalid of malformed) {
+					const before = `${persisted.trimEnd()}\n\n## ${target.title}\n${invalid.body(target.marker)}\n`;
+					await Bun.write(task.filePath, before);
+					const child = Bun.spawn(["bun", CLI_PATH, "task", "edit", "1", ...target.editArgs], {
+						cwd: TEST_DIR,
+						stdout: "pipe",
+						stderr: "pipe",
+					});
+					const [exitCode, stdout, stderr] = await Promise.all([
+						child.exited,
+						new Response(child.stdout).text(),
+						new Response(child.stderr).text(),
+					]);
+
+					expect(exitCode).not.toBe(0);
+					expect(stdout).not.toContain("Updated task");
+					expect(stderr).toContain(`Malformed ${target.title} markers:`);
+					expect(stderr).toContain(invalid.detail);
+					expect(stderr).toContain("The edit was not applied.");
+					expect(stderr).toContain("backlog task view TASK-1 --plain");
+					expect(stderr).toContain("repair or remove the malformed marker block");
+					expect(await Bun.file(task.filePath).text()).toBe(before);
+				}
+			}
+		});
+
+		it("ignores target-looking markers inside a balanced foreign block during CLI edits", async () => {
+			const core = new Core(TEST_DIR);
+			const task = await core.filesystem.loadTask("task-1");
+			if (!task?.filePath) throw new Error("Expected task file path");
+			const persisted = await Bun.file(task.filePath).text();
+			const body = `${persisted.trimEnd()}\n\n## Acceptance Criteria\n<!-- AC:BEGIN -->\n- [ ] #1 Existing\n<!-- AC:END -->\n\n## Comments\n<!-- COMMENTS:BEGIN -->\n<!-- AC:END -->\n<!-- DOD:BEGIN -->\n<!-- COMMENTS:END -->\n`;
+			await Bun.write(task.filePath, body);
+
+			const result = await $`bun ${CLI_PATH} task edit 1 --ac "Added" --dod "DoD added"`.cwd(TEST_DIR).quiet();
+			expect(result.exitCode).toBe(0);
+			const after = await Bun.file(task.filePath).text();
+			expect(after).toContain("- [ ] #1 Existing");
+			expect(after).toContain("- [ ] #2 Added");
+			expect(after).toContain("- [ ] #1 DoD added");
+			expect(after).toContain("<!-- COMMENTS:BEGIN -->\n<!-- AC:END -->\n<!-- DOD:BEGIN -->\n<!-- COMMENTS:END -->");
+		});
+
+		it("documents replacement as repeatable without comma splitting", async () => {
+			const result = await $`bun ${CLI_PATH} task edit --help`.cwd(TEST_DIR).quiet();
+			const output = result.stdout.toString();
+			expect(output).toContain("--acceptance-criteria <criteria>");
+			expect(output).toContain("replace all acceptance criteria (can be used");
+			expect(output).not.toContain("set acceptance criteria (comma-separated");
+			expect(output).toContain("--clear-ac");
+		});
+
 		it("consolidates duplicate Acceptance Criteria sections with markers into one", async () => {
 			const core = new Core(TEST_DIR);
 			await core.createTask(

--- a/src/test/markdown.test.ts
+++ b/src/test/markdown.test.ts
@@ -6,6 +6,7 @@ import {
 	serializeTask,
 	updateTaskAcceptanceCriteria,
 } from "../markdown/serializer.ts";
+import { updateStructuredSections } from "../markdown/structured-sections.ts";
 import type { Decision, Document, Task } from "../types/index.ts";
 
 describe("Markdown Parser", () => {
@@ -481,6 +482,236 @@ describe("Markdown Serializer", () => {
 			expect(result).not.toContain("<!-- AC:BEGIN -->");
 			expect(result).toContain("## Description");
 			expect(result).toContain("Some details");
+		});
+
+		it("removes an empty marked acceptance criteria section without disturbing surrounding sections", () => {
+			const rawContent = [
+				"## Description",
+				"",
+				"<!-- SECTION:DESCRIPTION:BEGIN -->",
+				"Some details",
+				"<!-- SECTION:DESCRIPTION:END -->",
+				"",
+				"## Acceptance Criteria",
+				"<!-- AC:BEGIN -->",
+				"<!-- AC:END -->",
+				"",
+				"## Implementation Plan",
+				"",
+				"<!-- SECTION:PLAN:BEGIN -->",
+				"Implement carefully",
+				"<!-- SECTION:PLAN:END -->",
+				"",
+				"## Custom Details",
+				"",
+				"Keep this exactly.",
+			].join("\n");
+			const task: Task = {
+				id: "task-empty-ac",
+				title: "Empty Acceptance Criteria",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2026-07-12",
+				labels: [],
+				dependencies: [],
+				description: "Some details",
+				acceptanceCriteriaItems: [],
+				implementationPlan: "Implement carefully",
+				rawContent,
+			};
+
+			const result = serializeTask(task);
+
+			expect(result).not.toContain("## Acceptance Criteria");
+			expect(result).not.toContain("<!-- AC:BEGIN -->");
+			expect(result).toContain("<!-- SECTION:DESCRIPTION:END -->\n\n## Implementation Plan");
+			expect(result).toContain("## Custom Details\n\nKeep this exactly.");
+			expect(result).not.toMatch(/\n{3,}/);
+		});
+
+		it("removes an empty marked definition of done section without disturbing surrounding sections", () => {
+			const rawContent = [
+				"## Description",
+				"",
+				"<!-- SECTION:DESCRIPTION:BEGIN -->",
+				"Some details",
+				"<!-- SECTION:DESCRIPTION:END -->",
+				"",
+				"## Acceptance Criteria",
+				"<!-- AC:BEGIN -->",
+				"- [ ] #1 Existing criterion",
+				"<!-- AC:END -->",
+				"",
+				"## Definition of Done",
+				"<!-- DOD:BEGIN -->",
+				"<!-- DOD:END -->",
+				"",
+				"## Implementation Plan",
+				"",
+				"<!-- SECTION:PLAN:BEGIN -->",
+				"Implement carefully",
+				"<!-- SECTION:PLAN:END -->",
+				"",
+				"## Custom Details",
+				"",
+				"Keep this exactly.",
+			].join("\n");
+			const task: Task = {
+				id: "task-empty-dod",
+				title: "Empty Definition of Done",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2026-07-12",
+				labels: [],
+				dependencies: [],
+				description: "Some details",
+				acceptanceCriteriaItems: [{ index: 1, text: "Existing criterion", checked: false }],
+				definitionOfDoneItems: [],
+				implementationPlan: "Implement carefully",
+				rawContent,
+			};
+
+			const result = serializeTask(task);
+
+			expect(result).not.toContain("## Definition of Done");
+			expect(result).not.toContain("<!-- DOD:BEGIN -->");
+			expect(result).toContain("<!-- AC:END -->\n\n## Implementation Plan");
+			expect(result).toContain("## Custom Details\n\nKeep this exactly.");
+			expect(result).not.toMatch(/\n{3,}/);
+		});
+
+		it("keeps all structured sections in canonical order when the plan changes", () => {
+			const rawContent = [
+				"## Description",
+				"",
+				"<!-- SECTION:DESCRIPTION:BEGIN -->",
+				"Details",
+				"<!-- SECTION:DESCRIPTION:END -->",
+				"",
+				"## Acceptance Criteria",
+				"<!-- AC:BEGIN -->",
+				"- [ ] #1 Accepted",
+				"<!-- AC:END -->",
+				"",
+				"## Definition of Done",
+				"<!-- DOD:BEGIN -->",
+				"- [ ] #1 Verified",
+				"<!-- DOD:END -->",
+				"",
+				"## Implementation Plan",
+				"",
+				"<!-- SECTION:PLAN:BEGIN -->",
+				"Old plan",
+				"<!-- SECTION:PLAN:END -->",
+				"",
+				"## Implementation Notes",
+				"",
+				"<!-- SECTION:NOTES:BEGIN -->",
+				"Notes",
+				"<!-- SECTION:NOTES:END -->",
+				"",
+				"## Comments",
+				"",
+				"<!-- COMMENTS:BEGIN -->",
+				"created: 2026-07-12 12:00",
+				"---",
+				"Comment",
+				"---",
+				"<!-- COMMENTS:END -->",
+				"",
+				"## Final Summary",
+				"",
+				"<!-- SECTION:FINAL_SUMMARY:BEGIN -->",
+				"Summary",
+				"<!-- SECTION:FINAL_SUMMARY:END -->",
+			].join("\n");
+			const task: Task = {
+				id: "task-plan-order",
+				title: "Plan Order",
+				status: "In Progress",
+				assignee: [],
+				createdDate: "2026-07-12",
+				labels: [],
+				dependencies: [],
+				description: "Details",
+				acceptanceCriteriaItems: [{ index: 1, text: "Accepted", checked: false }],
+				definitionOfDoneItems: [{ index: 1, text: "Verified", checked: false }],
+				implementationPlan: "New plan",
+				implementationNotes: "Notes",
+				finalSummary: "Summary",
+				rawContent,
+			};
+
+			const result = serializeTask(task);
+			const headings = [
+				"## Description",
+				"## Acceptance Criteria",
+				"## Definition of Done",
+				"## Implementation Plan",
+				"## Implementation Notes",
+				"## Comments",
+				"## Final Summary",
+			].map((heading) => result.indexOf(heading));
+
+			expect(headings).toEqual([...headings].sort((left, right) => left - right));
+			expect(result).toContain("New plan");
+			expect(result).not.toContain("Old plan");
+			expect(result).not.toMatch(/\n{3,}/);
+		});
+
+		it("uses Definition of Done in structured-section fallback ordering without changing no-DoD ordering", () => {
+			const acceptanceCriteria = [
+				"## Acceptance Criteria",
+				"<!-- AC:BEGIN -->",
+				"- [ ] #1 Accepted",
+				"<!-- AC:END -->",
+			].join("\n");
+			const definitionOfDone = [
+				"## Definition of Done",
+				"<!-- DOD:BEGIN -->",
+				"- [ ] #1 Verified",
+				"<!-- DOD:END -->",
+			].join("\n");
+			const comments = [
+				"## Comments",
+				"",
+				"<!-- COMMENTS:BEGIN -->",
+				"created: 2026-07-12 12:00",
+				"---",
+				"Comment",
+				"---",
+				"<!-- COMMENTS:END -->",
+			].join("\n");
+			const withDod = updateStructuredSections(`${acceptanceCriteria}\n\n${definitionOfDone}\n\n${comments}`, {
+				implementationNotes: "Notes",
+				finalSummary: "Summary",
+			});
+			const withDodHeadings = [
+				"## Acceptance Criteria",
+				"## Definition of Done",
+				"## Implementation Notes",
+				"## Comments",
+				"## Final Summary",
+			].map((heading) => withDod.indexOf(heading));
+			expect(withDodHeadings).toEqual([...withDodHeadings].sort((left, right) => left - right));
+
+			const finalAfterDod = updateStructuredSections(`${acceptanceCriteria}\n\n${definitionOfDone}`, {
+				finalSummary: "Summary",
+			});
+			expect(finalAfterDod.indexOf("## Final Summary")).toBeGreaterThan(finalAfterDod.indexOf("## Definition of Done"));
+
+			const withoutDod = updateStructuredSections(`${acceptanceCriteria}\n\n${comments}`, {
+				implementationNotes: "Notes",
+				finalSummary: "Summary",
+			});
+			const withoutDodHeadings = [
+				"## Acceptance Criteria",
+				"## Implementation Notes",
+				"## Comments",
+				"## Final Summary",
+			].map((heading) => withoutDod.indexOf(heading));
+			expect(withoutDodHeadings).toEqual([...withoutDodHeadings].sort((left, right) => left - right));
+			expect(withoutDod).not.toContain("## Definition of Done");
 		});
 
 		it("serializes acceptance criteria when structured items exist", () => {

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -17,11 +17,8 @@ function sanitizeAppend(values: string[] | undefined): string[] | undefined {
 }
 
 function toAcceptanceCriteriaEntries(values: string[] | undefined) {
-	if (!values) return undefined;
+	if (values === undefined) return undefined;
 	const trimmed = values.map((value) => String(value).trim()).filter((value) => value.length > 0);
-	if (trimmed.length === 0) {
-		return undefined;
-	}
 	return trimmed.map((text, index) => ({ text, checked: false, index: index + 1 }));
 }
 


### PR DESCRIPTION
## What changed

- Keeps `--ac` additive and repeatable.
- Makes repeatable `--acceptance-criteria` replace the complete checklist while preserving commas inside criterion text.
- Adds `--clear-ac` for atomic clear-all edits.
- Rejects replacement or clearing when combined with incremental acceptance-criteria mutations.
- Applies one deterministic checklist serializer to Acceptance Criteria and Definition of Done.

## Why

Acceptance-criteria replacement previously appended only the final repeated value. Repeated remove and re-add cycles could also accumulate blank lines and move the checklist below later structured sections. The edit contract and Markdown output now make semantic changes explicit and keep task diffs stable.

## CLI contract

- `--ac` adds one or more criteria.
- `--acceptance-criteria` replaces all criteria and may be repeated.
- Commas are preserved as criterion content rather than treated as separators.
- `--clear-ac` removes all acceptance criteria atomically.
- Replacement and clearing fail before writing when combined with add, remove, check, or uncheck operations.

## Serialization and recovery

- Checklist sections return to canonical structured-section order when removed and re-added.
- Section boundaries use one blank line, empty checklist shells are removed cleanly, and repeated edits are byte-stable outside the intended change.
- Custom and foreign sentinel sections remain opaque, and CRLF line endings are preserved.
- The shared behavior also covers Definition of Done.
- Malformed or ambiguous visible AC/DoD marker structures fail without changing the task. The CLI identifies the marker problem and tells the user how to locate and repair the task Markdown before retrying.

## Verification

- Focused checklist and serializer suite: 96 passed, 0 failed (521 assertions).
- Full suite: 1,687 passed, 2 expected interactive skips, 0 failed (7,132 assertions across 193 files).
- `bunx tsc --noEmit`
- `bun run check .` (330 files, no fixes)
- `bun run build`
- `git diff --check`

Task: BACK-537
