### PR TITLE
BACK-538 - Fix port availability probe so browser port congestion handling works on macOS

### DIFF
--- a/backlog/tasks/back-538 - Fix-port-availability-probe-so-browser-port-congestion-handling-works-on-macOS.md
+++ b/backlog/tasks/back-538 - Fix-port-availability-probe-so-browser-port-congestion-handling-works-on-macOS.md
@@ -1,0 +1,55 @@
+---
+id: BACK-538
+title: Fix port availability probe so browser port congestion handling works on macOS
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-07-12 14:58'
+updated_date: '2026-07-12 15:02'
+labels: []
+dependencies: []
+priority: high
+type: bug
+ordinal: 186000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+isPortAvailable probes 127.0.0.1 while Bun.serve binds the wildcard interface. On macOS a loopback-specific bind does not collide with a wildcard bind, so the probe returns true even when the port is held by a running server (verified live on main f73ddc0). The BACK-473 congestion flow (warning + next-free-port prompt) therefore never triggers, and two backlog browser instances can silently share a port. The port tests only pass because the test fixture binds 127.0.0.1 as well, mirroring the buggy probe instead of the production server.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 isPortAvailable returns false for a port held by a real production-style server (regression test starts an actual Bun.serve/BacklogServer and asserts the probe fails)
+- [x] #2 Port congestion handling (warning and next-free-port flow) triggers on macOS when the default port is occupied
+- [x] #3 Test fixtures probe/bind the same interface as the production server so this defect class cannot pass CI silently
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Bind the isPortAvailable probe to the same wildcard interface Bun.serve uses (drop the 127.0.0.1 argument) so specific-vs-wildcard bind semantics on macOS cannot make the probe pass on an occupied port.
+2. Update listenOnEphemeralPort test fixture to bind the wildcard default, mirroring production instead of the old buggy probe.
+3. Add a regression test that starts a real Bun.serve (production-style, default hostname) and asserts isPortAvailable returns false while it runs and true after it stops; this test fails on macOS before the fix.
+4. Re-verify the non-TTY congestion flow test (cli-browser-port.test.ts) and the server-port suite; run tsc + biome.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Probe now binds the wildcard interface (dropped 127.0.0.1 from isPortAvailable and the listenOnEphemeralPort fixture). Regression test starts a real Bun.serve and asserts the probe returns false while running and true after stop; this fails against the old probe on macOS. End-to-end verified live: two 'backlog browser --port 6431 --no-open' instances on macOS, second printed 'Port 6431 is already in use. Using port 6432 instead.' bun test server-port + cli-browser-port: 9 pass, tsc clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+isPortAvailable probed 127.0.0.1 while Bun.serve binds the wildcard interface, so on macOS the BACK-473 port-congestion flow never triggered and two browser instances silently shared a port. The probe and the test fixture now bind the same wildcard interface as production, with a Bun.serve-based regression test. Verified by unit tests and a live two-instance run that relocated to the next free port.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -160,7 +160,10 @@ export async function isPortAvailable(port: number): Promise<boolean> {
 	if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) return false;
 	return new Promise((resolve) => {
 		const srv = net.createServer();
-		srv.listen(port, "127.0.0.1", () => srv.close(() => resolve(true)));
+		// Probe the wildcard interface that Bun.serve binds: on macOS a loopback-specific
+		// bind does not collide with a wildcard bind, so probing 127.0.0.1 would report
+		// a port as free while the browser server already holds it.
+		srv.listen(port, () => srv.close(() => resolve(true)));
 		srv.on("error", () => resolve(false));
 	});
 }

--- a/src/test/server-port.test.ts
+++ b/src/test/server-port.test.ts
@@ -25,6 +25,20 @@ describe("isPortAvailable", () => {
 		const result = await isPortAvailable(0);
 		expect(result).toBe(false);
 	});
+
+	it("detects a port held by a production-style Bun.serve on its default interface", async () => {
+		// Regression for BACK-538: the probe used to bind 127.0.0.1 while Bun.serve
+		// binds the wildcard interface, so on macOS an occupied port looked free.
+		const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+		const port = server.port;
+		if (port === undefined) throw new Error("Expected Bun.serve to expose its port");
+		try {
+			expect(await isPortAvailable(port)).toBe(false);
+		} finally {
+			await server.stop(true);
+		}
+		expect(await isPortAvailable(port)).toBe(true);
+	});
 });
 
 describe("findNextAvailablePort", () => {

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -185,7 +185,9 @@ export async function listenOnEphemeralPort(): Promise<{ server: net.Server; por
 	const server = net.createServer();
 	await new Promise<void>((resolve, reject) => {
 		server.once("error", reject);
-		server.listen(0, "127.0.0.1", () => {
+		// Bind the wildcard interface like the production Bun.serve does, so port
+		// fixtures collide with the same binds the real browser server would.
+		server.listen(0, () => {
 			server.off("error", reject);
 			resolve();
 		});


### PR DESCRIPTION
## What changed
- `isPortAvailable` now probes the same wildcard interface that `Bun.serve` binds, instead of 127.0.0.1.
- The `listenOnEphemeralPort` test fixture binds the wildcard interface to mirror production.
- Added a regression test that starts a real `Bun.serve` and asserts the probe reports the port as taken.

## Why
On macOS a loopback-specific bind does not collide with a wildcard bind, so the probe always reported ports as free: the BACK-473 congestion flow (warning + next-free-port) never triggered and two `backlog browser` instances silently shared a port. The old tests passed only because the fixture bound the same loopback interface as the buggy probe.

## Verification
- New regression test fails against the old probe on macOS, passes now.
- Live two-instance check on macOS: second instance prints `Port 6431 is already in use. Using port 6432 instead.`
- `bun test server-port cli-browser-port` (9 pass), `bunx tsc --noEmit`, `bun run check`.

Task: BACK-538