### PR TITLE
BACK-539 - Surface duplicate task ID warning in TUI task list and detail views

### DIFF
--- a/backlog/tasks/back-539 - Surface-duplicate-task-ID-warning-in-TUI-task-list-and-detail-views.md
+++ b/backlog/tasks/back-539 - Surface-duplicate-task-ID-warning-in-TUI-task-list-and-detail-views.md
@@ -1,0 +1,55 @@
+---
+id: BACK-539
+title: Surface duplicate task ID warning in TUI task list and detail views
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-07-12 14:59'
+updated_date: '2026-07-12 15:09'
+labels: []
+dependencies: []
+priority: high
+type: bug
+ordinal: 187000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+BACK-516 computes a duplicate-task-ID startup warning in the unified TUI view but only wires it into the Kanban board, where it renders as a 15-second transient footer. The default interactive entry (backlog task list / overview, initialView task-list) shows nothing: the stderr warning is wiped by the TUI screen takeover while duplicate tasks render side by side with identical IDs. A human browsing the primary interactive surface never learns the project has a data-integrity problem, below the manifesto bar that important information must be legible.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 When duplicate task IDs exist, the interactive task-list view shows the duplicate warning with the same copy as the board (pointing to backlog doctor)
+- [x] #2 The warning is legible for a data-integrity alert (not lost on entry or hidden behind a transient timeout the user can miss)
+- [x] #3 Tests cover warning propagation to the task-list view
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add startupWarning option to viewTaskEnhanced and render it as a persistent one-line warning bar directly above the help bar (yellow, blessed tags), sized into the pane layout via syncPaneLayout so it cannot be missed or timed out.
+2. Extract the warning-bar creation as an exported helper so it is unit-testable with the repo's existing createScreen blessed test pattern.
+3. Pass the already-computed startupWarning from runUnifiedView's showTaskView into viewTaskEnhanced (board path already receives it).
+4. Tests: blessed component test asserting the warning renders with the doctor guidance; keep existing getDuplicateTaskStartupWarning coverage. Manual PTY verification in a throwaway project with forged duplicate IDs for the rendered task-list view.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added createStartupWarningBar (persistent one-line yellow bar above the help bar, no timeout) and a startupWarning option on viewTaskEnhanced; runUnifiedView now passes the same formatDuplicateTaskIdSummary string the board receives, and syncPaneLayout sizes panes around the bar. Verified rendered behavior under a real PTY in a throwaway project with a forged TASK-1 duplicate: the interactive task-list screen shows 'Duplicate task IDs detected: TASK-1. Run backlog doctor to preview a safe repair.' (the bar copy, distinct from the pre-TUI stderr text). Component test asserts content and height via the repo's blessed screen test pattern. 27 TUI-adjacent tests pass, tsc and biome clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+The duplicate-task-ID startup warning was only wired into the Kanban board as a 15s transient footer, so the default interactive task-list view showed nothing when duplicates existed. viewTaskEnhanced now renders the same warning as a persistent bar above the help bar in both list and detail focus. Verified with a blessed component test and a live PTY capture of the rendered task-list view in a project with forged duplicates.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/tui-startup-warning.test.ts
+++ b/src/test/tui-startup-warning.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { box } from "neo-neo-bblessed";
+import { createStartupWarningBar } from "../ui/task-viewer-with-search.ts";
+import { createScreen } from "../ui/tui.ts";
+
+describe("TUI startup warning bar", () => {
+	it("renders the duplicate-ID warning persistently with doctor guidance", () => {
+		const screen = createScreen({ smartCSR: false });
+		try {
+			const container = box({ parent: screen, width: "100%", height: "100%" });
+			const message = "Duplicate task IDs detected: TASK-1. Run 'backlog doctor' to preview a safe repair.";
+			const bar = createStartupWarningBar(container, message);
+
+			const barContent = bar as { getContent?: () => string; content?: string };
+			const content = String(barContent.getContent ? barContent.getContent() : (barContent.content ?? ""));
+			expect(content).toContain("Duplicate task IDs detected: TASK-1");
+			expect(content).toContain("backlog doctor");
+			expect(bar.height).toBe(1);
+		} finally {
+			screen.destroy();
+		}
+	});
+});

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -163,6 +163,24 @@ export function resolveTaskListSelection<T>(
 /**
  * Display task details with search/filter header UI
  */
+/**
+ * Persistent one-line warning bar rendered above the help bar. Used for
+ * data-integrity alerts (e.g. duplicate task IDs) that must stay visible
+ * instead of expiring like transient help messages.
+ */
+export function createStartupWarningBar(parent: BoxInterface, message: string): BoxInterface {
+	return box({
+		parent,
+		bottom: 1,
+		left: 0,
+		width: "100%",
+		height: 1,
+		tags: true,
+		wrap: false,
+		content: ` {yellow-fg}${message}{/}`,
+	});
+}
+
 export async function viewTaskEnhanced(
 	task: Task,
 	options: {
@@ -181,6 +199,7 @@ export async function viewTaskEnhanced(
 		limit?: number;
 		startWithDetailFocus?: boolean;
 		startWithSearchFocus?: boolean;
+		startupWarning?: string;
 		viewSwitcher?: import("./view-switcher.ts").ViewSwitcher;
 		onTaskChange?: (task: Task) => void;
 		onTabPress?: () => Promise<void>;
@@ -545,6 +564,7 @@ export async function viewTaskEnhanced(
 		wrap: true,
 		content: "",
 	});
+	const warningBar = options.startupWarning ? createStartupWarningBar(container, options.startupWarning) : null;
 	let transientHelpContent: string | null = null;
 	let helpRestoreTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -568,7 +588,12 @@ export async function viewTaskEnhanced(
 
 	function syncPaneLayout() {
 		const headerHeight = filterHeader.getHeight();
-		const footerHeight = typeof helpBar.height === "number" ? helpBar.height : 1;
+		const helpHeight = typeof helpBar.height === "number" ? helpBar.height : 1;
+		let footerHeight = helpHeight;
+		if (warningBar) {
+			warningBar.bottom = helpHeight;
+			footerHeight += 1;
+		}
 		taskListPane.top = headerHeight;
 		taskListPane.height = `100%-${headerHeight + footerHeight}`;
 		detailPane.top = headerHeight;

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -379,6 +379,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					limit: currentFilters.limit,
 					startWithDetailFocus: currentView === "task-detail",
 					startWithSearchFocus: shouldFocusSearch,
+					startupWarning,
 					onTaskChange: (newTask) => {
 						selectedTask = newTask;
 						currentView = "task-detail";


### PR DESCRIPTION
## What changed
- `viewTaskEnhanced` accepts a `startupWarning` and renders it as a persistent one-line warning bar above the help bar (no auto-dismiss), in both task-list and detail focus.
- `runUnifiedView` passes the duplicate-ID summary it already computes (previously only the board received it).
- Pane layout accounts for the bar; component test follows the existing blessed screen test pattern.

## Why
BACK-516's duplicate-ID warning rendered only in the Kanban board, as a 15-second transient footer. The default interactive entry (`backlog task list`) showed nothing: the stderr warning is wiped by the TUI takeover while duplicate tasks render side by side with identical IDs — below the manifesto bar that important information must be legible.

## Verification
- Live PTY capture of the rendered task-list view in a throwaway project with a forged TASK-1 duplicate shows the persistent bar with the doctor guidance.
- `bun test` on 6 TUI-adjacent suites (27 pass), `bunx tsc --noEmit`, `bun run check`.

Task: BACK-539