### PR TITLE
BACK-540 - Parse block-style YAML lists in config and fix config set guidance for list keys

### DIFF
--- a/backlog/tasks/back-540 - Parse-block-style-YAML-lists-in-config-and-fix-config-set-guidance-for-list-keys.md
+++ b/backlog/tasks/back-540 - Parse-block-style-YAML-lists-in-config-and-fix-config-set-guidance-for-list-keys.md
@@ -1,0 +1,56 @@
+---
+id: BACK-540
+title: >-
+  Parse block-style YAML lists in config and fix config set guidance for list
+  keys
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-07-12 14:59'
+updated_date: '2026-07-12 15:14'
+labels: []
+dependencies: []
+priority: high
+type: bug
+ordinal: 188000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+parseConfig is a hand-rolled line parser that only accepts inline flow arrays ([a, b]) for statuses, labels, types, priorities and milestones; block-style YAML sequences (- item lines) are silently dropped, so users hand-editing config.yml (the intended path for user-defined priorities BACK-530 and task types BACK-355) get defaults back with no error and task create --priority fails. Related guidance copy is wrong: config set priorities/statuses/labels points at a nonexistent backlog config list-<key> command, config set types answers Unknown config key even though types is a valid readable key, and the available-keys lists shown by config get and config set disagree.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 config set for every non-settable list key (including types) explains it cannot be set directly and references only commands that exist
+- [x] #2 config get and config set report the same available-keys list
+- [x] #3 Block-style YAML sequences for statuses, labels, types and priorities parse identically to inline arrays (covered by tests)
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Parse statuses/labels/types/priorities from the whole config document with the same gray-matter YAML approach parseDefinitionOfDone already uses; prefer the YAML result and keep the inline-bracket line parse only as fallback for legacy not-quite-YAML files. Block sequences, quoted values, and commas inside quoted items then parse correctly.
+2. Fix config set guidance: array keys (including types) get the same 'cannot be set directly, edit config.yml; view with backlog config get <key>' message referencing only real commands; reconcile the available-keys lists between config get and config set.
+3. Tests: parseConfig block-style vs inline equivalence for all four keys, quoted-comma items, legacy fallback; CLI-level test for config set guidance copy. Verify live with a throwaway project (block-style priorities then task create --priority).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+parseConfig now resolves statuses/labels/types/priorities via the same gray-matter YAML pass parseDefinitionOfDone already uses (block sequences, quoted values, and commas inside quoted items all work); the inline-bracket line parse remains as fallback for legacy not-quite-YAML configs. config set: types added to the array-key case, guidance now points to 'backlog config get <key>' and the config file (the old copy referenced a nonexistent list-<key> command), and both unknown-key errors share one CONFIG_AVAILABLE_KEYS constant. Verified via 4 new tests incl. end-to-end block-style priorities through config get and task create --priority; 52 tests across 6 config-adjacent suites pass, tsc and biome clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Hand-edited config.yml with block-style YAML lists was silently ignored for statuses/labels/types/priorities, breaking the intended human path for user-defined priorities and task types, and config set gave wrong guidance (nonexistent command, types reported as unknown, mismatched key lists). List keys now parse through the real YAML parser with the legacy line parse as fallback, and the guidance copy references only real commands with one shared available-keys list. Verified with parser-equivalence and end-to-end CLI tests.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4163,6 +4163,9 @@ agentsCmd
 	});
 
 // Config command group
+const CONFIG_AVAILABLE_KEYS =
+	"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, priorities, types, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays";
+
 const configCmd = addHelpSchema(program.command("config"), {
 	reads: "Project Backlog.md configuration",
 	required: [],
@@ -4350,9 +4353,7 @@ addHelpSchema(configCmd.command("get <key>"), {
 					break;
 				default:
 					console.error(`Unknown config key: ${key}`);
-					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, statuses, labels, priorities, types, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
-					);
+					console.error(CONFIG_AVAILABLE_KEYS);
 					process.exit(1);
 			}
 		} catch (err) {
@@ -4533,6 +4534,7 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 				}
 				case "statuses":
 				case "labels":
+				case "types":
 				case "priorities":
 				case "milestones":
 				case "definitionOfDone":
@@ -4547,8 +4549,10 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 							"Use `backlog config` for interactive editing, update the project config file (`backlog/config.yml`, `.backlog/config.yml`, or `backlog.config.yml`), or use Web UI Settings.",
 						);
 					} else {
-						console.error(`${key} cannot be set directly. Use 'backlog config list-${key}' to view current values.`);
-						console.error("Array values should be edited in the config file directly.");
+						console.error(`${key} cannot be set directly. View current values with 'backlog config get ${key}'.`);
+						console.error(
+							"Edit the list in the project config file (`backlog/config.yml`, `.backlog/config.yml`, or `backlog.config.yml`) directly.",
+						);
 					}
 					process.exit(1);
 					break;
@@ -4562,9 +4566,7 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 					break;
 				default:
 					console.error(`Unknown config key: ${key}`);
-					console.error(
-						"Available keys: defaultEditor, projectName, defaultStatus, dateFormat, maxColumnWidth, autoOpenBrowser, hideEmptyColumns, defaultPort, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays",
-					);
+					console.error(CONFIG_AVAILABLE_KEYS);
 					process.exit(1);
 			}
 

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1467,6 +1467,7 @@ ${description || `Milestone: ${title}`}`,
 	parseConfig(content: string): BacklogConfig {
 		const config: Partial<BacklogConfig> = {};
 		const parsedDefinitionOfDone = this.parseDefinitionOfDone(content);
+		const parsedListValues = this.parseConfigListValues(content);
 		const lines = content.split("\n");
 
 		for (const line of lines) {
@@ -1495,8 +1496,11 @@ ${description || `Milestone: ${title}`}`,
 				case "statuses":
 				case "labels":
 				case "types":
-				case "priorities":
-					if (value.startsWith("[") && value.endsWith("]")) {
+				case "priorities": {
+					const parsedList = parsedListValues[key];
+					if (parsedList) {
+						config[key] = parsedList;
+					} else if (value.startsWith("[") && value.endsWith("]")) {
 						const arrayContent = value.slice(1, -1);
 						config[key] = arrayContent
 							.split(",")
@@ -1504,6 +1508,7 @@ ${description || `Milestone: ${title}`}`,
 							.filter(Boolean);
 					}
 					break;
+				}
 				case "definition_of_done":
 					if (parsedDefinitionOfDone !== undefined) {
 						config.definitionOfDone = parsedDefinitionOfDone;
@@ -1630,6 +1635,30 @@ ${description || `Milestone: ${title}`}`,
 		];
 
 		return `${lines.join("\n")}\n`;
+	}
+
+	/**
+	 * Parse the list-valued config keys with a real YAML parser so block-style
+	 * sequences and quoted values work like inline arrays. Returns nothing for a
+	 * key when the document is not valid YAML, so the legacy inline-bracket line
+	 * parse stays the fallback.
+	 */
+	private parseConfigListValues(
+		content: string,
+	): Partial<Record<"statuses" | "labels" | "types" | "priorities", string[]>> {
+		const result: Partial<Record<"statuses" | "labels" | "types" | "priorities", string[]>> = {};
+		try {
+			const data = matter(`---\n${content.trimEnd()}\n---\n`).data as Record<string, unknown>;
+			for (const key of ["statuses", "labels", "types", "priorities"] as const) {
+				const value = data[key];
+				if (Array.isArray(value)) {
+					result[key] = value.map((item) => String(item).trim()).filter((item) => item.length > 0);
+				}
+			}
+		} catch {
+			// Not valid YAML; the caller falls back to the line-based parse.
+		}
+		return result;
 	}
 
 	private parseDefinitionOfDone(content: string): string[] | undefined {

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -180,6 +180,62 @@ describe("Config commands", () => {
 		expect(listOutput).toContain("hideEmptyColumns: true");
 	});
 
+	it("parses block-style YAML sequences identically to inline arrays for list keys", () => {
+		const inline = core.filesystem.parseConfig(
+			'project_name: "P"\nstatuses: ["To Do", "Done"]\nlabels: ["a", "b"]\ntypes: ["bug", "epic"]\npriorities: ["Critical", "Low"]\n',
+		);
+		const block = core.filesystem.parseConfig(
+			'project_name: "P"\nstatuses:\n  - To Do\n  - Done\nlabels:\n  - a\n  - b\ntypes:\n  - bug\n  - epic\npriorities:\n  - Critical\n  - Low\n',
+		);
+
+		expect(block.statuses).toEqual(inline.statuses);
+		expect(block.labels).toEqual(inline.labels);
+		expect(block.types).toEqual(inline.types);
+		expect(block.priorities).toEqual(inline.priorities);
+		expect(block.priorities).toEqual(["Critical", "Low"]);
+	});
+
+	it("preserves commas inside quoted list values", () => {
+		const config = core.filesystem.parseConfig('project_name: "P"\npriorities: ["Very High, Almost", "Low"]\n');
+		expect(config.priorities).toEqual(["Very High, Almost", "Low"]);
+	});
+
+	it("honors block-style priorities end-to-end through config get and task create", async () => {
+		const configPath = core.filesystem.configFilePath;
+		const existing = await Bun.file(configPath).text();
+		await Bun.write(configPath, `${existing.trimEnd()}\npriorities:\n  - Critical\n  - Normal\n`);
+
+		const priorities = await $`bun ${CLI_PATH} config get priorities`.cwd(TEST_DIR).text();
+		expect(priorities.trim()).toBe("Critical, Normal");
+
+		const created = await $`bun ${CLI_PATH} task create "Block priority task" --priority Critical --plain`
+			.cwd(TEST_DIR)
+			.text();
+		expect(created).toContain("Priority: Critical");
+	});
+
+	it("gives accurate guidance when setting list keys and consistent unknown-key lists", async () => {
+		const priorities = await $`bun ${CLI_PATH} config set priorities High`.cwd(TEST_DIR).nothrow().quiet();
+		const prioritiesError = priorities.stderr.toString();
+		expect(priorities.exitCode).not.toBe(0);
+		expect(prioritiesError).toContain("priorities cannot be set directly");
+		expect(prioritiesError).toContain("backlog config get priorities");
+		expect(prioritiesError).not.toContain("list-priorities");
+
+		const types = await $`bun ${CLI_PATH} config set types bug`.cwd(TEST_DIR).nothrow().quiet();
+		const typesError = types.stderr.toString();
+		expect(types.exitCode).not.toBe(0);
+		expect(typesError).toContain("types cannot be set directly");
+		expect(typesError).not.toContain("Unknown config key");
+
+		const unknownGet = await $`bun ${CLI_PATH} config get nosuchkey`.cwd(TEST_DIR).nothrow().quiet();
+		const unknownSet = await $`bun ${CLI_PATH} config set nosuchkey value`.cwd(TEST_DIR).nothrow().quiet();
+		const getKeys = unknownGet.stderr.toString().match(/Available keys: .*/)?.[0];
+		const setKeys = unknownSet.stderr.toString().match(/Available keys: .*/)?.[0];
+		expect(getKeys).toBeDefined();
+		expect(setKeys).toEqual(getKeys);
+	});
+
 	it("surfaces milestones in config get/list from milestone files", async () => {
 		await core.filesystem.createMilestone("Release 1");
 


### PR DESCRIPTION
## What changed
- `parseConfig` resolves `statuses`/`labels`/`types`/`priorities` with the same gray-matter YAML pass that `definition_of_done` already uses; the inline-bracket line parse remains as a fallback for legacy not-quite-YAML configs.
- `config set` guidance for list keys now references commands that exist (`backlog config get <key>` + editing the config file), `types` joins the array-key case instead of falling through to "Unknown config key", and `config get`/`config set` share one available-keys list.

## Why
Hand-editing `config.yml` is the intended human path for user-defined priorities (BACK-530) and task types (BACK-355), but block-style YAML lists — the most common YAML idiom — were silently dropped: `config get priorities` returned defaults with no error and `task create --priority` failed. The set-side copy pointed at a nonexistent `backlog config list-<key>` command.

## Verification
- New tests: block-vs-inline parser equivalence for all four keys, quoted-comma preservation, end-to-end block-style priorities through `config get` and `task create --priority`, and guidance-copy/key-list consistency assertions.
- 52 tests across 6 config-adjacent suites pass; `bunx tsc --noEmit`; `bun run check`.

Task: BACK-540