### PR TITLE
BACK-547 - Make TUI live refresh resilient to atomic writes

### DIFF
--- a/backlog/tasks/back-547 - Make-TUI-live-refresh-resilient-to-atomic-writes.md
+++ b/backlog/tasks/back-547 - Make-TUI-live-refresh-resilient-to-atomic-writes.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-547
 title: Make TUI live refresh resilient to atomic writes
-status: In Progress
+status: Done
 assignee:
   - '@back547-agent'
 created_date: '2026-07-14 19:59'
-updated_date: '2026-07-14 22:00'
+updated_date: '2026-07-14 22:03'
 labels: []
 dependencies: []
 references:
@@ -30,20 +30,20 @@ The v1.48.0 packaged TUI can miss the single filesystem event emitted during CLI
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 CLI and atomic external create, edit, status, archive, and delete operations refresh the open board and list reliably without restart.
-- [ ] #2 The watcher retries, debounces, or reconciles create and change events until the file parses stably or absence is confirmed, without infinite retries or duplicate updates.
-- [ ] #3 Selection remains valid when the selected task changes, moves status, archives, or deletes, and active filters reflect reconciled state.
-- [ ] #4 Configuration and status updates continue refreshing correctly.
-- [ ] #5 Cross-branch and separate-worktree changes are explicitly out of scope.
-- [ ] #6 Real filesystem tests cover single-event partial create, edit, archive or delete, and recovery and error bounds. Integration tests cover unified-view callback behavior.
-- [ ] #7 A compiled-binary PTY smoke test verifies that a packaged CLI mutation becomes visible in the open TUI within a bounded time on supported CI platforms.
+- [x] #1 CLI and atomic external create, edit, status, archive, and delete operations refresh the open board and list reliably without restart.
+- [x] #2 The watcher retries, debounces, or reconciles create and change events until the file parses stably or absence is confirmed, without infinite retries or duplicate updates.
+- [x] #3 Selection remains valid when the selected task changes, moves status, archives, or deletes, and active filters reflect reconciled state.
+- [x] #4 Configuration and status updates continue refreshing correctly.
+- [x] #5 Cross-branch and separate-worktree changes are explicitly out of scope.
+- [x] #6 Real filesystem tests cover single-event partial create, edit, archive or delete, and recovery and error bounds. Integration tests cover unified-view callback behavior.
+- [x] #7 A compiled-binary PTY smoke test verifies that a packaged CLI mutation becomes visible in the open TUI within a bounded time on supported CI platforms.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -74,4 +74,12 @@ Validation:
 - full suite: 1701 passed, 3 interactive skips, 0 failed
 
 Review fixes: task-list live updates now carry the unified selected task, preserving the next neighbor after the selected task is removed. Task watcher removals now require an independent active-task filename snapshot, so malformed or persistently unreadable files are retained during direct and directory reconciliation while true absence is still published. Validation: 10 watcher tests passed; source PTY suite passed 4 of 4, including selected B removal choosing C in 549 ms; bunx tsc --noEmit passed; Biome checked 332 files; full bun test passed 1705 tests with 4 opt-in PTY skips and 0 failures.
+
+Independent specification and code-quality reviews approved the implementation and review fixes for publication.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made TUI live refresh resilient to single-event atomic task writes with bounded stable reconciliation, confirmed file absence, deduplicated updates, unified board and task-list state, and valid neighboring selection after removal. Verified by deterministic watcher and unified-state tests, source and compiled PTY smoke tests, TypeScript, Biome, and the full 1705-test suite with zero failures.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-547 - Make-TUI-live-refresh-resilient-to-atomic-writes.md
+++ b/backlog/tasks/back-547 - Make-TUI-live-refresh-resilient-to-atomic-writes.md
@@ -1,14 +1,22 @@
 ---
 id: BACK-547
 title: Make TUI live refresh resilient to atomic writes
-status: To Do
+status: In Progress
 assignee:
-  - '@alex-agent'
+  - '@back547-agent'
 created_date: '2026-07-14 19:59'
+updated_date: '2026-07-14 21:36'
 labels: []
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/786'
+modified_files:
+  - src/utils/task-watcher.ts
+  - src/ui/unified-view.ts
+  - src/ui/task-viewer-with-search.ts
+  - src/test/task-watcher.test.ts
+  - src/test/unified-view-loading.test.ts
+  - src/test/tui-interactive-editor-handoff.test.ts
 priority: high
 type: bug
 ordinal: 194000
@@ -37,3 +45,31 @@ The v1.48.0 packaged TUI can miss the single filesystem event emitted during CLI
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add bounded per-task reconciliation to the task watcher so one create, change, rename, archive, or delete event is debounced, retried until usable stable content or confirmed absence, deduplicated, and cancelled cleanly on stop.
+2. Route watcher changes through one unified-view task-state updater, keep selected task identity current, and add a live-update subscription to the active task list so its filters and selection recompute from reconciled tasks while preserving existing board and config refresh behavior.
+3. Add deterministic watcher tests with real filesystem reads and controlled single events for partial create, edit, archive/delete, retry recovery, callback deduplication, and bounded failure, plus unified-view callback integration coverage.
+4. Extend the supported compiled-binary PTY suite with a bounded CLI-mutation live-refresh smoke scenario, then run focused tests, typecheck, Biome, the compiled binary PTY smoke, and self-review against BACK-547.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented bounded task watcher reconciliation for the current checkout. Task events now debounce by normalized ID, require two stable usable reads, retry transient partial or missing content within a finite budget, suppress duplicate publications, cancel stale generations, and reconcile the directory when atomic writes expose only a temporary-file event. Branch-only tasks are excluded from current-checkout reconciliation.
+
+Unified view now applies add, change, archive, and delete callbacks through one state transition, keeps selected task objects valid, and publishes refreshed task and configuration snapshots to both the board and active task list. The task list rebuilds its search index and filters from the reconciled state.
+
+Coverage added for controlled single-event partial create and edit, temporary-file atomic create, archive and delete absence, duplicate suppression, bounded incomplete content, branch-only scope, real fs.watch plus child CLI atomic edit, unified callback selection behavior, and a bounded source or compiled-binary PTY live-refresh smoke.
+
+Validation:
+- bunx tsc --noEmit
+- bun run check .
+- final focused watcher, unified, filter, and board tests: 34 passed
+- source PTY suite: 3 passed
+- compiled build smoke: passed
+- compiled-binary PTY suite: 3 passed
+- full suite: 1701 passed, 3 interactive skips, 0 failed
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-547 - Make-TUI-live-refresh-resilient-to-atomic-writes.md
+++ b/backlog/tasks/back-547 - Make-TUI-live-refresh-resilient-to-atomic-writes.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@back547-agent'
 created_date: '2026-07-14 19:59'
-updated_date: '2026-07-14 21:36'
+updated_date: '2026-07-14 22:00'
 labels: []
 dependencies: []
 references:
@@ -72,4 +72,6 @@ Validation:
 - compiled build smoke: passed
 - compiled-binary PTY suite: 3 passed
 - full suite: 1701 passed, 3 interactive skips, 0 failed
+
+Review fixes: task-list live updates now carry the unified selected task, preserving the next neighbor after the selected task is removed. Task watcher removals now require an independent active-task filename snapshot, so malformed or persistently unreadable files are retained during direct and directory reconciliation while true absence is still published. Validation: 10 watcher tests passed; source PTY suite passed 4 of 4, including selected B removal choosing C in 549 ms; bunx tsc --noEmit passed; Biome checked 332 files; full bun test passed 1705 tests with 4 opt-in PTY skips and 0 failures.
 <!-- SECTION:NOTES:END -->

--- a/src/test/task-watcher.test.ts
+++ b/src/test/task-watcher.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { EventEmitter } from "node:events";
+import * as nodeFs from "node:fs";
+import { mkdir, rename, unlink } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { serializeTask } from "../markdown/serializer.ts";
+import type { Task } from "../types/index.ts";
+import { watchTasks } from "../utils/task-watcher.ts";
+import {
+	createUniqueTestDir,
+	getPlatformTimeout,
+	initializeTestProject,
+	safeCleanup,
+	sleep,
+	withTimeout,
+} from "./test-utils.ts";
+
+type WatchCallback = (eventType: string, filename: string | Buffer | null) => void;
+
+function sampleTask(id: string, title: string, status = "To Do"): Task {
+	return {
+		id,
+		title,
+		status,
+		assignee: [],
+		createdDate: "2026-07-14 00:00",
+		labels: [],
+		dependencies: [],
+		rawContent: "## Description\n\nWatcher fixture",
+	};
+}
+
+describe("task watcher reconciliation", () => {
+	let testDir: string;
+	let core: Core;
+	let watcherCallback: WatchCallback;
+	let watchSpy: ReturnType<typeof spyOn>;
+	let stopWatcher: (() => void) | undefined;
+
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("task-watcher");
+		core = new Core(testDir);
+		await core.filesystem.ensureBacklogStructure();
+		watchSpy = spyOn(nodeFs, "watch").mockImplementation(((
+			_path: Parameters<typeof nodeFs.watch>[0],
+			...args: unknown[]
+		) => {
+			const callback = args.findLast((argument) => typeof argument === "function");
+			if (typeof callback !== "function") throw new Error("Expected task watcher callback");
+			watcherCallback = callback as WatchCallback;
+			const watcher = new EventEmitter() as EventEmitter & { close(): void };
+			watcher.close = () => {};
+			return watcher as unknown as nodeFs.FSWatcher;
+		}) as typeof nodeFs.watch);
+	});
+
+	afterEach(async () => {
+		stopWatcher?.();
+		watchSpy.mockRestore();
+		await safeCleanup(testDir);
+	});
+
+	it("recovers a partial create after one filesystem event and publishes it once", async () => {
+		const fileName = "task-1 - Partial-create.md";
+		const filePath = join(core.filesystem.tasksDir, fileName);
+		const added: Task[] = [];
+		let resolveAdded: (() => void) | undefined;
+		const published = new Promise<void>((resolve) => {
+			resolveAdded = resolve;
+		});
+		const handle = watchTasks(core, {
+			onTaskAdded(task) {
+				added.push(task);
+				resolveAdded?.();
+			},
+		});
+		stopWatcher = handle.stop;
+
+		await Bun.write(filePath, "---\nid: task-1\n");
+		watcherCallback("rename", fileName);
+		setTimeout(() => void Bun.write(filePath, serializeTask(sampleTask("task-1", "Recovered create"))), 90);
+
+		await withTimeout(published, "partial task create publication", getPlatformTimeout(1200));
+		expect(added.map((task) => task.title)).toEqual(["Recovered create"]);
+
+		watcherCallback("change", fileName);
+		await sleep(150);
+		expect(added).toHaveLength(1);
+	});
+
+	it("discovers a partial atomic create from one temporary-file event", async () => {
+		const fileName = "task-7 - Atomic-create.md";
+		const filePath = join(core.filesystem.tasksDir, fileName);
+		let resolveAdded: ((task: Task) => void) | undefined;
+		const added = new Promise<Task>((resolve) => {
+			resolveAdded = resolve;
+		});
+		const handle = watchTasks(core, {
+			onTaskAdded(task) {
+				resolveAdded?.(task);
+			},
+		});
+		stopWatcher = handle.stop;
+
+		await Bun.write(filePath, "---\nid: task-7\n");
+		watcherCallback("rename", ".task-7.atomic-write");
+		setTimeout(() => void Bun.write(filePath, serializeTask(sampleTask("task-7", "Atomic create"))), 90);
+
+		const task = await withTimeout(added, "temporary-file task create publication", getPlatformTimeout(1200));
+		expect(task.title).toBe("Atomic create");
+	});
+
+	it("recovers a partial edit after one filesystem event", async () => {
+		const original = sampleTask("task-2", "Original title");
+		const fileName = "task-2 - Original-title.md";
+		const filePath = join(core.filesystem.tasksDir, fileName);
+		await Bun.write(filePath, serializeTask(original));
+		const initial = await core.filesystem.loadTask(original.id);
+		if (!initial) throw new Error("Expected initial task");
+
+		let resolveChanged: ((task: Task) => void) | undefined;
+		const changed = new Promise<Task>((resolve) => {
+			resolveChanged = resolve;
+		});
+		const handle = watchTasks(
+			core,
+			{
+				onTaskChanged(task) {
+					resolveChanged?.(task);
+				},
+			},
+			[initial],
+		);
+		stopWatcher = handle.stop;
+
+		await Bun.write(filePath, "---\nid: task-2\ntitle: Original title\n");
+		watcherCallback("change", fileName);
+		setTimeout(() => void Bun.write(filePath, serializeTask(sampleTask("task-2", "Edited title", "In Progress"))), 90);
+
+		const task = await withTimeout(changed, "partial task edit publication", getPlatformTimeout(1200));
+		expect(task.title).toBe("Edited title");
+		expect(task.status).toBe("In Progress");
+	});
+
+	it("confirms archive and delete absence from one event without duplicate removals", async () => {
+		const archiveDir = join(testDir, "backlog", "archive", "tasks");
+		await mkdir(archiveDir, { recursive: true });
+		const tasks = [sampleTask("task-3", "Archived"), sampleTask("task-4", "Deleted")];
+		const paths = tasks.map((task) => join(core.filesystem.tasksDir, `${task.id} - ${task.title}.md`));
+		await Promise.all(paths.map((path, index) => Bun.write(path, serializeTask(tasks[index] as Task))));
+		const initialTasks = await core.filesystem.listTasks();
+		const removed: string[] = [];
+		let resolveRemoved: (() => void) | undefined;
+		const bothRemoved = new Promise<void>((resolve) => {
+			resolveRemoved = resolve;
+		});
+		const handle = watchTasks(
+			core,
+			{
+				onTaskRemoved(taskId) {
+					removed.push(taskId);
+					if (removed.length === 2) resolveRemoved?.();
+				},
+			},
+			initialTasks,
+		);
+		stopWatcher = handle.stop;
+
+		await rename(paths[0] as string, join(archiveDir, basename(paths[0] as string)));
+		watcherCallback("rename", basename(paths[0] as string));
+		await unlink(paths[1] as string);
+		watcherCallback("rename", basename(paths[1] as string));
+
+		await withTimeout(bothRemoved, "archive and delete publication", getPlatformTimeout(1500));
+		watcherCallback("rename", basename(paths[0] as string));
+		watcherCallback("rename", basename(paths[1] as string));
+		await sleep(400);
+		expect(removed.sort()).toEqual(["TASK-3", "TASK-4"]);
+	});
+
+	it("bounds retries for permanently incomplete content and stops pending work", async () => {
+		const fileName = "task-5 - Incomplete.md";
+		const filePath = join(core.filesystem.tasksDir, fileName);
+		await Bun.write(filePath, "---\nid: task-5\n");
+		const publications: string[] = [];
+		const handle = watchTasks(core, {
+			onTaskAdded: (task) => {
+				publications.push(task.id);
+			},
+			onTaskChanged: (task) => {
+				publications.push(task.id);
+			},
+			onTaskRemoved: (taskId) => {
+				publications.push(taskId);
+			},
+		});
+		stopWatcher = handle.stop;
+
+		watcherCallback("rename", fileName);
+		await sleep(500);
+		expect(publications).toEqual([]);
+
+		watcherCallback("change", fileName);
+		handle.stop();
+		await Bun.write(filePath, serializeTask(sampleTask("task-5", "Too late")));
+		await sleep(150);
+		expect(publications).toEqual([]);
+	});
+
+	it("does not reconcile branch-only tasks from the current checkout watcher", async () => {
+		const removed: string[] = [];
+		const branchTask = { ...sampleTask("task-8", "Other branch"), branch: "feature/other-worktree" };
+		const handle = watchTasks(
+			core,
+			{
+				onTaskRemoved(taskId) {
+					removed.push(taskId);
+				},
+			},
+			[branchTask],
+		);
+		stopWatcher = handle.stop;
+
+		watcherCallback("rename", ".unrelated-atomic-write");
+		await sleep(400);
+		expect(removed).toEqual([]);
+	});
+
+	it("reconciles an atomic CLI edit through a real filesystem watcher", async () => {
+		watchSpy.mockRestore();
+		await initializeTestProject(core, "Real task watcher");
+		const original = sampleTask("task-6", "Real watcher");
+		const filePath = join(core.filesystem.tasksDir, "task-6 - Real-watcher.md");
+		await Bun.write(filePath, serializeTask(original));
+		const initial = await core.filesystem.loadTask(original.id);
+		if (!initial) throw new Error("Expected real watcher task");
+
+		let resolveChanged: ((task: Task) => void) | undefined;
+		const changed = new Promise<Task>((resolve) => {
+			resolveChanged = resolve;
+		});
+		const handle = watchTasks(
+			core,
+			{
+				onTaskChanged(task) {
+					resolveChanged?.(task);
+				},
+			},
+			[initial],
+		);
+		stopWatcher = handle.stop;
+
+		const cliPath = join(process.cwd(), "src", "cli.ts");
+		await $`bun ${cliPath} task edit task-6 --status ${"In Progress"} --plain`.cwd(testDir).quiet();
+		const task = await withTimeout(changed, "real atomic CLI edit", getPlatformTimeout(2000));
+		expect(task.status).toBe("In Progress");
+	});
+});

--- a/src/test/task-watcher.test.ts
+++ b/src/test/task-watcher.test.ts
@@ -209,6 +209,94 @@ describe("task watcher reconciliation", () => {
 		expect(publications).toEqual([]);
 	});
 
+	it("does not remove an existing task when its content is malformed", async () => {
+		const task = sampleTask("task-9", "Malformed content");
+		const fileName = "task-9 - Malformed-content.md";
+		const filePath = join(core.filesystem.tasksDir, fileName);
+		await Bun.write(filePath, serializeTask(task));
+		const initial = await core.filesystem.loadTask(task.id);
+		if (!initial) throw new Error("Expected initial task");
+
+		const removed: string[] = [];
+		const handle = watchTasks(
+			core,
+			{
+				onTaskRemoved(taskId) {
+					removed.push(taskId);
+				},
+			},
+			[initial],
+		);
+		stopWatcher = handle.stop;
+
+		await Bun.write(filePath, "---\nid: task-9\ntitle: [unterminated\n---\n");
+		watcherCallback("change", fileName);
+		await sleep(500);
+
+		expect(removed).toEqual([]);
+	});
+
+	it("does not remove an existing task after persistent read failures", async () => {
+		const task = sampleTask("task-10", "Unreadable content");
+		const fileName = "task-10 - Unreadable-content.md";
+		await Bun.write(join(core.filesystem.tasksDir, fileName), serializeTask(task));
+		const initial = await core.filesystem.loadTask(task.id);
+		if (!initial) throw new Error("Expected initial task");
+		const loadTaskSpy = spyOn(core.filesystem, "loadTask").mockResolvedValue(null);
+		const removed: string[] = [];
+		const handle = watchTasks(
+			core,
+			{
+				onTaskRemoved(taskId) {
+					removed.push(taskId);
+				},
+			},
+			[initial],
+		);
+		stopWatcher = handle.stop;
+
+		watcherCallback("change", fileName);
+		await sleep(500);
+		loadTaskSpy.mockRestore();
+
+		expect(removed).toEqual([]);
+	});
+
+	it("preserves malformed files during directory reconciliation and removes true absence", async () => {
+		const task = sampleTask("task-11", "Directory reconciliation");
+		const fileName = "task-11 - Directory-reconciliation.md";
+		const filePath = join(core.filesystem.tasksDir, fileName);
+		await Bun.write(filePath, serializeTask(task));
+		const initial = await core.filesystem.loadTask(task.id);
+		if (!initial) throw new Error("Expected initial task");
+		const removed: string[] = [];
+		let resolveRemoved: (() => void) | undefined;
+		const published = new Promise<void>((resolve) => {
+			resolveRemoved = resolve;
+		});
+		const handle = watchTasks(
+			core,
+			{
+				onTaskRemoved(taskId) {
+					removed.push(taskId);
+					resolveRemoved?.();
+				},
+			},
+			[initial],
+		);
+		stopWatcher = handle.stop;
+
+		await Bun.write(filePath, "---\nid: task-11\ntitle: [unterminated\n---\n");
+		watcherCallback("rename", ".atomic-write");
+		await sleep(500);
+		expect(removed).toEqual([]);
+
+		await unlink(filePath);
+		watcherCallback("rename", ".atomic-write");
+		await withTimeout(published, "directory reconciliation removal", getPlatformTimeout(1500));
+		expect(removed).toEqual(["TASK-11"]);
+	});
+
 	it("does not reconcile branch-only tasks from the current checkout watcher", async () => {
 		const removed: string[] = [];
 		const branchTask = { ...sampleTask("task-8", "Other branch"), branch: "feature/other-worktree" };

--- a/src/test/tui-interactive-editor-handoff.test.ts
+++ b/src/test/tui-interactive-editor-handoff.test.ts
@@ -53,6 +53,11 @@ function buildSpawnCommand(cliArgs: string[]): string {
 	return `spawn {${CLI_RUNTIME}} {${CLI_PATH}} ${argsSegment}`;
 }
 
+function buildExecCommand(cliArgs: string[]): string {
+	const command = CLI_RUNTIME.length === 0 ? [CLI_PATH, ...cliArgs] : [CLI_RUNTIME, CLI_PATH, ...cliArgs];
+	return `exec ${command.map((part) => `{${part}}`).join(" ")}`;
+}
+
 async function runInteractiveEditScenario(options: InteractiveEditRunOptions): Promise<InteractiveEditRunResult> {
 	const testDir = createUniqueTestDir(`test-tui-interactive-${options.scenario}`);
 	await mkdir(testDir, { recursive: true });
@@ -213,7 +218,96 @@ exit $exit_code
 	};
 }
 
+async function runLiveRefreshScenario(): Promise<{ title: string; transcriptPath: string }> {
+	const scenario = "live-refresh";
+	const testDir = createUniqueTestDir(`test-tui-interactive-${scenario}`);
+	await mkdir(testDir, { recursive: true });
+	await mkdir(TRANSCRIPT_DIR, { recursive: true });
+	const transcriptPath = join(TRANSCRIPT_DIR, `${scenario}-${Date.now()}.log`);
+	const expectScriptPath = join(testDir, `${scenario}.expect`);
+
+	await $`git init -b main`.cwd(testDir).quiet();
+	await $`git config user.email test@example.com`.cwd(testDir).quiet();
+	await $`git config user.name "Test User"`.cwd(testDir).quiet();
+	const core = new Core(testDir);
+	await initializeTestProject(core, "Interactive live refresh");
+	const config = await core.filesystem.loadConfig();
+	if (!config) throw new Error("Failed to load live refresh config");
+	await core.filesystem.saveConfig({ ...config, remoteOperations: false, checkActiveBranches: false });
+	await core.createTask(
+		{
+			id: "task-1",
+			title: "before-refresh",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-07-14 00:00",
+			labels: [],
+			dependencies: [],
+			description: "Compiled TUI live refresh test",
+		},
+		false,
+	);
+
+	await writeFile(
+		expectScriptPath,
+		`#!/usr/bin/expect -f
+set timeout 20
+log_user 0
+log_file -a {${transcriptPath}}
+set env(TERM) {xterm-256color}
+set env(COLUMNS) {120}
+set env(LINES) {40}
+set env(NO_COLOR) {1}
+set stty_init {rows 40 columns 120}
+${buildSpawnCommand(["board"])}
+expect {
+	-re {before-refresh} {}
+	timeout { exit 91 }
+}
+set mutation_code [catch {${buildExecCommand(["task", "edit", "task-1", "--title", "LIVE_REFRESHED", "--plain"])} } mutation_output]
+if {$mutation_code != 0} { exit 92 }
+expect {
+	-re {LIVE_REFRESHED} {}
+	timeout { exit 93 }
+}
+send -- "q"
+expect eof
+set wait_status [wait]
+set exit_code [lindex $wait_status 3]
+exit $exit_code
+`,
+	);
+
+	const child = Bun.spawn(["expect", "-f", expectScriptPath], {
+		cwd: testDir,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const stdoutPromise = child.stdout ? new Response(child.stdout).text() : Promise.resolve("");
+	const stderrPromise = child.stderr ? new Response(child.stderr).text() : Promise.resolve("");
+	const exitCode = await child.exited;
+	const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+	const transcript = await Bun.file(transcriptPath)
+		.text()
+		.catch(() => "(no transcript captured)");
+	const finalTask = await core.filesystem.loadTask("task-1");
+	await safeCleanup(testDir);
+
+	if (![0, 130].includes(exitCode)) {
+		throw new Error(
+			`Interactive CLI live refresh failed.\nExit code: ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}\nTranscript: ${transcriptPath}\nTranscript contents:\n${transcript}\n`,
+		);
+	}
+	return { title: finalTask?.title ?? "missing", transcriptPath };
+}
+
 describe("interactive TUI editor handoff", () => {
+	itInteractive("shows a CLI mutation in the open board within a bounded time", async () => {
+		const result = await runLiveRefreshScenario();
+		expect(result.title).toBe("LIVE_REFRESHED");
+		expect(result.transcriptPath).toContain("tui-interactive-transcripts");
+	});
+
 	itInteractive("launches terminal editor from board view and marks task updated", async () => {
 		const result = await runInteractiveEditScenario({
 			scenario: "board",

--- a/src/test/tui-interactive-editor-handoff.test.ts
+++ b/src/test/tui-interactive-editor-handoff.test.ts
@@ -301,12 +301,110 @@ exit $exit_code
 	return { title: finalTask?.title ?? "missing", transcriptPath };
 }
 
+async function runSelectedTaskRemovalScenario(): Promise<{ transcriptPath: string }> {
+	const scenario = "selected-task-removal";
+	const testDir = createUniqueTestDir(`test-tui-interactive-${scenario}`);
+	await mkdir(testDir, { recursive: true });
+	await mkdir(TRANSCRIPT_DIR, { recursive: true });
+	const transcriptPath = join(TRANSCRIPT_DIR, `${scenario}-${Date.now()}.log`);
+	const expectScriptPath = join(testDir, `${scenario}.expect`);
+
+	await $`git init -b main`.cwd(testDir).quiet();
+	await $`git config user.email test@example.com`.cwd(testDir).quiet();
+	await $`git config user.name "Test User"`.cwd(testDir).quiet();
+	const core = new Core(testDir);
+	await initializeTestProject(core, "Interactive selected task removal");
+	const config = await core.filesystem.loadConfig();
+	if (!config) throw new Error("Failed to load selected task removal config");
+	await core.filesystem.saveConfig({ ...config, remoteOperations: false, checkActiveBranches: false });
+	for (const [id, title, description] of [
+		["task-1", "Alpha neighbor", "ALPHA_DETAIL_MARKER"],
+		["task-2", "Selected middle", "SELECTED_DETAIL_MARKER"],
+		["task-3", "Next neighbor", "NEXT_DETAIL_MARKER"],
+	] as const) {
+		await core.createTask(
+			{
+				id,
+				title,
+				status: "To Do",
+				assignee: [],
+				createdDate: "2026-07-14 00:00",
+				labels: [],
+				dependencies: [],
+				description,
+			},
+			false,
+		);
+	}
+	const selectedTaskPath = (await core.filesystem.loadTask("task-2"))?.filePath;
+	if (!selectedTaskPath) throw new Error("Failed to resolve selected task path");
+
+	await writeFile(
+		expectScriptPath,
+		`#!/usr/bin/expect -f
+set timeout 20
+log_user 0
+log_file -a {${transcriptPath}}
+set env(TERM) {xterm-256color}
+set env(COLUMNS) {120}
+set env(LINES) {40}
+set env(NO_COLOR) {1}
+set stty_init {rows 40 columns 120}
+${buildSpawnCommand(["task", "task-2"])}
+expect {
+	-re {SELECTED_DETAIL_MARKER} {}
+	timeout { exit 91 }
+}
+file delete -force {${selectedTaskPath}}
+expect {
+	-re {Task TASK-3 - Next neighbor} {}
+	timeout { exit 93 }
+}
+send -- "q"
+expect eof
+set wait_status [wait]
+set exit_code [lindex $wait_status 3]
+exit $exit_code
+`,
+	);
+
+	const child = Bun.spawn(["expect", "-f", expectScriptPath], {
+		cwd: testDir,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const stdoutPromise = child.stdout ? new Response(child.stdout).text() : Promise.resolve("");
+	const stderrPromise = child.stderr ? new Response(child.stderr).text() : Promise.resolve("");
+	const exitCode = await child.exited;
+	const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+	const transcript = await Bun.file(transcriptPath)
+		.text()
+		.catch(() => "(no transcript captured)");
+	await safeCleanup(testDir);
+
+	if (![0, 130].includes(exitCode)) {
+		throw new Error(
+			`Interactive selected task removal failed.\nExit code: ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}\nTranscript: ${transcriptPath}\nTranscript contents:\n${transcript}\n`,
+		);
+	}
+	return { transcriptPath };
+}
+
 describe("interactive TUI editor handoff", () => {
 	itInteractive("shows a CLI mutation in the open board within a bounded time", async () => {
 		const result = await runLiveRefreshScenario();
 		expect(result.title).toBe("LIVE_REFRESHED");
 		expect(result.transcriptPath).toContain("tui-interactive-transcripts");
 	});
+
+	itInteractive(
+		"selects the next neighbor when the open task is removed",
+		async () => {
+			const result = await runSelectedTaskRemovalScenario();
+			expect(result.transcriptPath).toContain("tui-interactive-transcripts");
+		},
+		10_000,
+	);
 
 	itInteractive("launches terminal editor from board view and marks task updated", async () => {
 		const result = await runInteractiveEditScenario({

--- a/src/test/unified-view-loading.test.ts
+++ b/src/test/unified-view-loading.test.ts
@@ -3,7 +3,12 @@ import { join } from "node:path";
 import { Core } from "../core/backlog.ts";
 import { serializeTask } from "../markdown/serializer.ts";
 import type { Task } from "../types/index.ts";
-import { getDuplicateTaskStartupWarning, loadTasksForUnifiedView } from "../ui/unified-view.ts";
+import {
+	createUnifiedTaskUpdateCallbacks,
+	getDuplicateTaskStartupWarning,
+	loadTasksForUnifiedView,
+	type UnifiedTaskState,
+} from "../ui/unified-view.ts";
 import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
 
 describe("loadTasksForUnifiedView", () => {
@@ -64,5 +69,42 @@ describe("loadTasksForUnifiedView", () => {
 		expect(await getDuplicateTaskStartupWarning(core)).toBe(
 			"Duplicate task IDs detected: TASK-1. Run 'backlog doctor' to preview a safe repair.",
 		);
+	});
+
+	it("reconciles watcher callbacks and keeps selection valid", async () => {
+		const makeTask = (id: string, title: string, status = "To Do"): Task => ({
+			id,
+			title,
+			status,
+			assignee: [],
+			createdDate: "2026-07-14",
+			labels: [],
+			dependencies: [],
+		});
+		const first = makeTask("task-1", "First");
+		const selected = makeTask("task-2", "Selected");
+		let state: UnifiedTaskState = { tasks: [first, selected], selectedTask: selected };
+		const published: UnifiedTaskState[] = [];
+		const callbacks = createUnifiedTaskUpdateCallbacks(
+			() => state,
+			(next) => {
+				state = next;
+				published.push(next);
+			},
+		);
+
+		const moved = makeTask("task-2", "Selected edited", "In Progress");
+		await callbacks.onTaskChanged?.(moved);
+		expect(state.tasks).toEqual([first, moved]);
+		expect(state.selectedTask).toBe(moved);
+
+		const added = makeTask("task-3", "Added");
+		await callbacks.onTaskAdded?.(added);
+		expect(state.tasks).toEqual([first, moved, added]);
+
+		await callbacks.onTaskRemoved?.("task-2");
+		expect(state.tasks).toEqual([first, added]);
+		expect(state.selectedTask).toBe(added);
+		expect(published).toHaveLength(3);
 	});
 });

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -201,7 +201,9 @@ export async function viewTaskEnhanced(
 		startWithSearchFocus?: boolean;
 		startupWarning?: string;
 		viewSwitcher?: import("./view-switcher.ts").ViewSwitcher;
-		subscribeUpdates?: (update: (nextTasks: Task[], nextStatuses: string[], nextLabels: string[]) => void) => void;
+		subscribeUpdates?: (
+			update: (nextTasks: Task[], nextStatuses: string[], nextLabels: string[], nextSelectedTask?: Task) => void,
+		) => void;
 		onTaskChange?: (task: Task) => void;
 		onTabPress?: () => Promise<void>;
 		onFilterChange?: (filters: {
@@ -1415,7 +1417,7 @@ export async function viewTaskEnhanced(
 	} else {
 		taskList = createTaskList();
 	}
-	options.subscribeUpdates?.((nextTasks, nextStatuses, nextLabels) => {
+	options.subscribeUpdates?.((nextTasks, nextStatuses, nextLabels, nextSelectedTask) => {
 		allTasks = nextTasks;
 		statuses = nextStatuses;
 		labels = nextLabels;
@@ -1423,7 +1425,10 @@ export async function viewTaskEnhanced(
 		if (taskSearchIndex) taskSearchIndex = createTaskSearchIndex(allTasks);
 
 		const previousTaskId = currentSelectedTask.id;
-		const currentTask = allTasks.find((candidate) => candidate.id === currentSelectedTask.id) ?? allTasks[0];
+		const currentTask =
+			allTasks.find((candidate) => candidate.id === nextSelectedTask?.id) ??
+			allTasks.find((candidate) => candidate.id === currentSelectedTask.id) ??
+			allTasks[0];
 		if (currentTask) {
 			currentSelectedTask = enrichTask(currentTask) ?? currentTask;
 			if (currentSelectedTask.id !== previousTaskId) options.onTaskChange?.(currentSelectedTask);

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -201,6 +201,7 @@ export async function viewTaskEnhanced(
 		startWithSearchFocus?: boolean;
 		startupWarning?: string;
 		viewSwitcher?: import("./view-switcher.ts").ViewSwitcher;
+		subscribeUpdates?: (update: (nextTasks: Task[], nextStatuses: string[], nextLabels: string[]) => void) => void;
 		onTaskChange?: (task: Task) => void;
 		onTabPress?: () => Promise<void>;
 		onFilterChange?: (filters: {
@@ -1414,6 +1415,21 @@ export async function viewTaskEnhanced(
 	} else {
 		taskList = createTaskList();
 	}
+	options.subscribeUpdates?.((nextTasks, nextStatuses, nextLabels) => {
+		allTasks = nextTasks;
+		statuses = nextStatuses;
+		labels = nextLabels;
+		availableLabels = collectAvailableLabels(allTasks, labels);
+		if (taskSearchIndex) taskSearchIndex = createTaskSearchIndex(allTasks);
+
+		const previousTaskId = currentSelectedTask.id;
+		const currentTask = allTasks.find((candidate) => candidate.id === currentSelectedTask.id) ?? allTasks[0];
+		if (currentTask) {
+			currentSelectedTask = enrichTask(currentTask) ?? currentTask;
+			if (currentSelectedTask.id !== previousTaskId) options.onTaskChange?.(currentSelectedTask);
+		}
+		applyFilters();
+	});
 	refreshDetailPane();
 
 	if (options.startWithSearchFocus) {

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -301,7 +301,9 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 		let tasks = baseTasks;
 		let kanbanStatuses = loadedStatuses ?? [];
 		let boardUpdater: ((nextTasks: Task[], nextStatuses: string[]) => void) | null = null;
-		let taskListUpdater: ((nextTasks: Task[], nextStatuses: string[], nextLabels: string[]) => void) | null = null;
+		let taskListUpdater:
+			| ((nextTasks: Task[], nextStatuses: string[], nextLabels: string[], nextSelectedTask?: Task) => void)
+			| null = null;
 
 		const getRenderableTasks = () => tasks.filter((task) => task.id && task.id.trim() !== "" && hasAnyPrefix(task.id));
 		const getBoardAvailableLabels = () => collectAvailableLabels(getRenderableTasks(), configuredLabels);
@@ -313,7 +315,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 		};
 		const emitTaskListUpdate = () => {
 			if (!taskListUpdater) return;
-			taskListUpdater(getRenderableTasks(), kanbanStatuses, configuredLabels);
+			taskListUpdater(getRenderableTasks(), kanbanStatuses, configuredLabels, selectedTask);
 		};
 		const taskUpdateCallbacks = createUnifiedTaskUpdateCallbacks(
 			() => ({ tasks, selectedTask }),

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -10,7 +10,7 @@ import { formatDuplicateTaskIdSummary } from "../utils/duplicate-detection.ts";
 import { collectAvailableLabels } from "../utils/label-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
 import { applySharedTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
-import { watchTasks } from "../utils/task-watcher.ts";
+import { type TaskWatcherCallbacks, watchTasks } from "../utils/task-watcher.ts";
 import { renderBoardTui } from "./board.ts";
 import { createLoadingScreen } from "./loading.ts";
 import { buildTaskViewerMilestoneFilterModel, viewTaskEnhanced } from "./task-viewer-with-search.ts";
@@ -56,6 +56,47 @@ type LoadingScreen = {
 export interface UnifiedViewLoadResult {
 	tasks: Task[];
 	statuses: string[];
+}
+
+export type UnifiedTaskUpdate = { type: "upsert"; task: Task } | { type: "remove"; taskId: string };
+
+export interface UnifiedTaskState {
+	tasks: Task[];
+	selectedTask?: Task;
+}
+
+export function applyUnifiedTaskUpdate(state: UnifiedTaskState, update: UnifiedTaskUpdate): UnifiedTaskState {
+	if (update.type === "upsert") {
+		const index = state.tasks.findIndex((task) => task.id === update.task.id);
+		const tasks = [...state.tasks];
+		if (index === -1) tasks.push(update.task);
+		else tasks[index] = update.task;
+		return {
+			tasks,
+			selectedTask: state.selectedTask?.id === update.task.id ? update.task : state.selectedTask,
+		};
+	}
+
+	const removedIndex = state.tasks.findIndex((task) => task.id === update.taskId);
+	if (removedIndex === -1) return state;
+	const tasks = state.tasks.filter((task) => task.id !== update.taskId);
+	const selectedTask =
+		state.selectedTask?.id === update.taskId
+			? tasks[Math.min(removedIndex, Math.max(tasks.length - 1, 0))]
+			: state.selectedTask;
+	return { tasks, selectedTask };
+}
+
+export function createUnifiedTaskUpdateCallbacks(
+	getState: () => UnifiedTaskState,
+	onStateChanged: (state: UnifiedTaskState) => void,
+): TaskWatcherCallbacks {
+	const publish = (update: UnifiedTaskUpdate) => onStateChanged(applyUnifiedTaskUpdate(getState(), update));
+	return {
+		onTaskAdded: (task) => publish({ type: "upsert", task }),
+		onTaskChanged: (task) => publish({ type: "upsert", task }),
+		onTaskRemoved: (taskId) => publish({ type: "remove", taskId }),
+	};
 }
 
 export interface UnifiedViewFilters {
@@ -260,6 +301,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 		let tasks = baseTasks;
 		let kanbanStatuses = loadedStatuses ?? [];
 		let boardUpdater: ((nextTasks: Task[], nextStatuses: string[]) => void) | null = null;
+		let taskListUpdater: ((nextTasks: Task[], nextStatuses: string[], nextLabels: string[]) => void) | null = null;
 
 		const getRenderableTasks = () => tasks.filter((task) => task.id && task.id.trim() !== "" && hasAnyPrefix(task.id));
 		const getBoardAvailableLabels = () => collectAvailableLabels(getRenderableTasks(), configuredLabels);
@@ -269,6 +311,25 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 			if (!boardUpdater) return;
 			boardUpdater(getRenderableTasks(), kanbanStatuses);
 		};
+		const emitTaskListUpdate = () => {
+			if (!taskListUpdater) return;
+			taskListUpdater(getRenderableTasks(), kanbanStatuses, configuredLabels);
+		};
+		const taskUpdateCallbacks = createUnifiedTaskUpdateCallbacks(
+			() => ({ tasks, selectedTask }),
+			(next) => {
+				tasks = next.tasks;
+				selectedTask = next.selectedTask;
+				const state = viewSwitcher?.getState();
+				viewSwitcher?.updateState({
+					tasks,
+					selectedTask,
+					kanbanData: state?.kanbanData ? { ...state.kanbanData, tasks } : undefined,
+				});
+				emitBoardUpdate();
+				emitTaskListUpdate();
+			},
+		);
 		let isInitialLoad = true; // Track if this is the first view load
 
 		// Create view switcher (without problematic onViewChange callback)
@@ -276,43 +337,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 			core: options.core,
 			initialState,
 		});
-		const watcher = watchTasks(options.core, {
-			onTaskAdded(task) {
-				tasks.push(task);
-				const state = viewSwitcher?.getState();
-				viewSwitcher?.updateState({
-					tasks,
-					kanbanData: state?.kanbanData ? { ...state.kanbanData, tasks } : undefined,
-				});
-				emitBoardUpdate();
-			},
-			onTaskChanged(task) {
-				const idx = tasks.findIndex((t) => t.id === task.id);
-				if (idx >= 0) {
-					tasks[idx] = task;
-				} else {
-					tasks.push(task);
-				}
-				const state = viewSwitcher?.getState();
-				viewSwitcher?.updateState({
-					tasks,
-					kanbanData: state?.kanbanData ? { ...state.kanbanData, tasks } : undefined,
-				});
-				emitBoardUpdate();
-			},
-			onTaskRemoved(taskId) {
-				tasks = tasks.filter((t) => t.id !== taskId);
-				if (selectedTask?.id === taskId) {
-					selectedTask = tasks[0];
-				}
-				const state = viewSwitcher?.getState();
-				viewSwitcher?.updateState({
-					tasks,
-					kanbanData: state?.kanbanData ? { ...state.kanbanData, tasks } : undefined,
-				});
-				emitBoardUpdate();
-			},
-		});
+		const watcher = watchTasks(options.core, taskUpdateCallbacks, baseTasks);
 		process.on("exit", () => watcher.stop());
 
 		const configWatcher = watchConfig(options.core, {
@@ -320,6 +345,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 				kanbanStatuses = config?.statuses ?? [];
 				configuredLabels = config?.labels ?? [];
 				emitBoardUpdate();
+				emitTaskListUpdate();
 			},
 		});
 
@@ -380,6 +406,10 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					startWithDetailFocus: currentView === "task-detail",
 					startWithSearchFocus: shouldFocusSearch,
 					startupWarning,
+					subscribeUpdates: (updater) => {
+						taskListUpdater = updater;
+						emitTaskListUpdate();
+					},
 					onTaskChange: (newTask) => {
 						selectedTask = newTask;
 						currentView = "task-detail";
@@ -393,6 +423,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					if (result === "exit") {
 						process.exit(0);
 					}
+					taskListUpdater = null;
 					resolve(result);
 				});
 			});

--- a/src/utils/task-watcher.ts
+++ b/src/utils/task-watcher.ts
@@ -1,8 +1,8 @@
 import { type FSWatcher, watch } from "node:fs";
-import { join } from "node:path";
 import type { Core } from "../core/backlog.ts";
 import type { Task } from "../types/index.ts";
 import { hasAnyPrefix } from "./prefix-config.ts";
+import { normalizeTaskId, normalizeTaskIdentity, taskIdsEqual } from "./task-path.ts";
 
 export interface TaskWatcherCallbacks {
 	/** Called when a new task file is created */
@@ -13,59 +13,189 @@ export interface TaskWatcherCallbacks {
 	onTaskRemoved?: (taskId: string) => void | Promise<void>;
 }
 
-/**
- * Watch the backlog/tasks directory for changes and emit incremental updates.
- * Uses node:fs.watch as implemented by Bun runtime.
- */
-export function watchTasks(core: Core, callbacks: TaskWatcherCallbacks): { stop: () => void } {
-	const tasksDir = core.filesystem.tasksDir;
+interface TaskReconciliation {
+	generation: number;
+	processing: boolean;
+	pending: boolean;
+	hasPublishedState: boolean;
+	lastPublishedSignature: string | null;
+}
 
-	const watcher: FSWatcher = watch(tasksDir, { recursive: false }, async (eventType, filename) => {
-		// Normalize filename to a string when available
-		let fileName: string | undefined;
-		if (typeof filename === "string") {
-			fileName = filename;
-		} else if (filename != null) {
-			fileName = String(filename);
+const TASK_SETTLE_DELAY_MS = 50;
+const TASK_RETRY_DELAY_MS = 35;
+const TASK_READ_ATTEMPTS = 8;
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isUsableTask(task: Task | null, taskId: string): task is Task {
+	return Boolean(task && taskIdsEqual(task.id, taskId) && task.title.trim() && task.status.trim());
+}
+
+function taskSignature(task: Task): string {
+	const { branch: _branch, filePath: _filePath, lastModified: _lastModified, source: _source, ...content } = task;
+	return JSON.stringify(content);
+}
+
+function createReconciliation(initialTask?: Task): TaskReconciliation {
+	return {
+		generation: 0,
+		processing: false,
+		pending: false,
+		hasPublishedState: initialTask !== undefined,
+		lastPublishedSignature: initialTask ? taskSignature(initialTask) : null,
+	};
+}
+
+/**
+ * Watch the current checkout's backlog/tasks directory and emit incremental updates.
+ * A single filesystem event is reconciled until task content is stable or absence is
+ * confirmed, because atomic writes can make the event visible before the file is.
+ */
+export function watchTasks(
+	core: Core,
+	callbacks: TaskWatcherCallbacks,
+	initialTasks: readonly Task[] = [],
+): { stop: () => void } {
+	const tasksDir = core.filesystem.tasksDir;
+	const reconciliations = new Map(
+		initialTasks.filter((task) => !task.branch).map((task) => [normalizeTaskId(task.id), createReconciliation(task)]),
+	);
+	let stopped = false;
+	let directoryGeneration = 0;
+
+	const reconcile = async (taskId: string, state: TaskReconciliation, eventGeneration: number): Promise<void> => {
+		let previousCandidateSignature: string | null | undefined;
+
+		for (let attempt = 0; attempt < TASK_READ_ATTEMPTS; attempt++) {
+			await delay(attempt === 0 ? TASK_SETTLE_DELAY_MS : TASK_RETRY_DELAY_MS);
+			if (stopped || eventGeneration !== state.generation) return;
+
+			let task: Task | null = null;
+			try {
+				task = await core.filesystem.loadTask(taskId);
+			} catch {
+				continue;
+			}
+
+			if (!isUsableTask(task, taskId)) {
+				previousCandidateSignature = task === null ? null : undefined;
+				if (attempt < TASK_READ_ATTEMPTS - 1) continue;
+
+				if (task === null && (!state.hasPublishedState || state.lastPublishedSignature !== null)) {
+					try {
+						await callbacks.onTaskRemoved?.(taskId);
+						state.hasPublishedState = true;
+						state.lastPublishedSignature = null;
+					} catch {
+						// Callback failures are bounded by the same finite reconciliation budget.
+					}
+				}
+				return;
+			}
+
+			const signature = taskSignature(task);
+			if (signature !== previousCandidateSignature) {
+				previousCandidateSignature = signature;
+				continue;
+			}
+			if (state.hasPublishedState && state.lastPublishedSignature === signature) return;
+
+			try {
+				if (!state.hasPublishedState || state.lastPublishedSignature === null) {
+					await callbacks.onTaskAdded?.(normalizeTaskIdentity(task));
+				} else {
+					await callbacks.onTaskChanged?.(normalizeTaskIdentity(task));
+				}
+				state.hasPublishedState = true;
+				state.lastPublishedSignature = signature;
+				return;
+			} catch {
+				// Retry callback delivery while this event remains current.
+			}
 		}
-		// Accept any prefix pattern (task-, draft-, JIRA-, etc.) for task files
+	};
+
+	const drain = async (taskId: string, state: TaskReconciliation): Promise<void> => {
+		if (state.processing) return;
+		state.processing = true;
+		try {
+			do {
+				state.pending = false;
+				await reconcile(taskId, state, state.generation);
+			} while (!stopped && state.pending);
+		} finally {
+			state.processing = false;
+			if (!stopped && state.pending) void drain(taskId, state).catch(() => {});
+		}
+	};
+
+	const schedule = (taskId: string) => {
+		const normalizedTaskId = normalizeTaskId(taskId);
+		const state = reconciliations.get(normalizedTaskId) ?? createReconciliation();
+		reconciliations.set(normalizedTaskId, state);
+		state.generation += 1;
+		state.pending = true;
+		void drain(normalizedTaskId, state).catch(() => {});
+	};
+	const scheduleDirectoryReconciliation = () => {
+		const eventGeneration = ++directoryGeneration;
+		void (async () => {
+			const visibleTaskIds = new Set<string>();
+			for (let attempt = 0; attempt < TASK_READ_ATTEMPTS; attempt++) {
+				await delay(attempt === 0 ? TASK_SETTLE_DELAY_MS : TASK_RETRY_DELAY_MS);
+				if (stopped || eventGeneration !== directoryGeneration) return;
+
+				let tasks: Task[];
+				try {
+					tasks = await core.filesystem.listTasks();
+				} catch {
+					continue;
+				}
+				visibleTaskIds.clear();
+				for (const task of tasks) {
+					if (!isUsableTask(task, task.id)) continue;
+					const taskId = normalizeTaskId(task.id);
+					visibleTaskIds.add(taskId);
+					const state = reconciliations.get(taskId);
+					if (!state?.hasPublishedState || state.lastPublishedSignature !== taskSignature(task)) schedule(taskId);
+				}
+			}
+
+			if (stopped || eventGeneration !== directoryGeneration) return;
+			for (const taskId of reconciliations.keys()) {
+				if (!visibleTaskIds.has(taskId)) schedule(taskId);
+			}
+		})().catch(() => {});
+	};
+
+	const watcher: FSWatcher = watch(tasksDir, { recursive: false }, (eventType, filename) => {
+		if (eventType !== "change" && eventType !== "rename") return;
+
+		const rawFilename: unknown = filename;
+		const fileName =
+			typeof rawFilename === "string" ? rawFilename : rawFilename != null ? String(rawFilename) : undefined;
 		const [taskId] = fileName?.split(" ") ?? [];
 		if (!fileName || !taskId || !hasAnyPrefix(taskId) || !fileName.endsWith(".md")) {
+			scheduleDirectoryReconciliation();
 			return;
 		}
 
-		if (eventType === "change") {
-			const task = await core.filesystem.loadTask(taskId);
-			if (task) {
-				await callbacks.onTaskChanged?.(task);
-			}
-			return;
-		}
-
-		if (eventType === "rename") {
-			// "rename" can be create, delete, or rename. Check if file exists.
-			try {
-				const fullPath = join(tasksDir, fileName);
-				const exists = await Bun.file(fullPath).exists();
-
-				if (!exists) {
-					await callbacks.onTaskRemoved?.(taskId);
-					return;
-				}
-
-				const task = await core.filesystem.loadTask(taskId);
-				if (task) {
-					// Treat as a change; handlers may add if not present
-					await callbacks.onTaskChanged?.(task);
-				}
-			} catch {
-				// Ignore transient errors
-			}
-		}
+		schedule(taskId);
+	});
+	watcher.on("error", (error) => {
+		if (process.env.DEBUG) console.warn("Task watcher error", error);
 	});
 
 	return {
 		stop() {
+			stopped = true;
+			directoryGeneration += 1;
+			for (const state of reconciliations.values()) {
+				state.generation += 1;
+				state.pending = false;
+			}
 			try {
 				watcher.close();
 			} catch {}

--- a/src/utils/task-watcher.ts
+++ b/src/utils/task-watcher.ts
@@ -1,8 +1,9 @@
 import { type FSWatcher, watch } from "node:fs";
+import { stat } from "node:fs/promises";
 import type { Core } from "../core/backlog.ts";
 import type { Task } from "../types/index.ts";
 import { hasAnyPrefix } from "./prefix-config.ts";
-import { normalizeTaskId, normalizeTaskIdentity, taskIdsEqual } from "./task-path.ts";
+import { extractTaskIdFromFilename, normalizeTaskId, normalizeTaskIdentity, taskIdsEqual } from "./task-path.ts";
 
 export interface TaskWatcherCallbacks {
 	/** Called when a new task file is created */
@@ -20,6 +21,8 @@ interface TaskReconciliation {
 	hasPublishedState: boolean;
 	lastPublishedSignature: string | null;
 }
+
+type TaskFileSnapshot = { state: "complete"; taskIds: Set<string> } | { state: "incomplete" };
 
 const TASK_SETTLE_DELAY_MS = 50;
 const TASK_RETRY_DELAY_MS = 35;
@@ -46,6 +49,23 @@ function createReconciliation(initialTask?: Task): TaskReconciliation {
 		hasPublishedState: initialTask !== undefined,
 		lastPublishedSignature: initialTask ? taskSignature(initialTask) : null,
 	};
+}
+
+async function readTaskFileSnapshot(tasksDir: string): Promise<TaskFileSnapshot> {
+	try {
+		const directory = await stat(tasksDir);
+		if (!directory.isDirectory()) return { state: "incomplete" };
+		const files = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: tasksDir, followSymlinks: true }));
+		await stat(tasksDir);
+		const taskIds = new Set<string>();
+		for (const file of files) {
+			const taskId = extractTaskIdFromFilename(file);
+			if (taskId) taskIds.add(normalizeTaskId(taskId));
+		}
+		return { state: "complete", taskIds };
+	} catch {
+		return { state: "incomplete" };
+	}
 }
 
 /**
@@ -83,7 +103,10 @@ export function watchTasks(
 				previousCandidateSignature = task === null ? null : undefined;
 				if (attempt < TASK_READ_ATTEMPTS - 1) continue;
 
-				if (task === null && (!state.hasPublishedState || state.lastPublishedSignature !== null)) {
+				const fileSnapshot = await readTaskFileSnapshot(tasksDir);
+				const isConfirmedAbsent =
+					task === null && fileSnapshot.state === "complete" && !fileSnapshot.taskIds.has(normalizeTaskId(taskId));
+				if (isConfirmedAbsent && (!state.hasPublishedState || state.lastPublishedSignature !== null)) {
 					try {
 						await callbacks.onTaskRemoved?.(taskId);
 						state.hasPublishedState = true;
@@ -143,16 +166,20 @@ export function watchTasks(
 		const eventGeneration = ++directoryGeneration;
 		void (async () => {
 			const visibleTaskIds = new Set<string>();
+			let taskFileIds: Set<string> | null = null;
 			for (let attempt = 0; attempt < TASK_READ_ATTEMPTS; attempt++) {
 				await delay(attempt === 0 ? TASK_SETTLE_DELAY_MS : TASK_RETRY_DELAY_MS);
 				if (stopped || eventGeneration !== directoryGeneration) return;
 
+				const fileSnapshot = await readTaskFileSnapshot(tasksDir);
+				if (fileSnapshot.state === "incomplete") continue;
 				let tasks: Task[];
 				try {
 					tasks = await core.filesystem.listTasks();
 				} catch {
 					continue;
 				}
+				taskFileIds = fileSnapshot.taskIds;
 				visibleTaskIds.clear();
 				for (const task of tasks) {
 					if (!isUsableTask(task, task.id)) continue;
@@ -163,9 +190,9 @@ export function watchTasks(
 				}
 			}
 
-			if (stopped || eventGeneration !== directoryGeneration) return;
+			if (stopped || eventGeneration !== directoryGeneration || !taskFileIds) return;
 			for (const taskId of reconciliations.keys()) {
-				if (!visibleTaskIds.has(taskId)) schedule(taskId);
+				if (!visibleTaskIds.has(taskId) && !taskFileIds.has(taskId)) schedule(taskId);
 			}
 		})().catch(() => {});
 	};


### PR DESCRIPTION
## Summary

- reconcile task filesystem events until content is stable or active-file absence is confirmed
- publish one unified task state to the board and task list while preserving valid neighboring selection
- add deterministic watcher, unified-state, and source or compiled PTY coverage for atomic writes and removals

## Root cause

The TUI watcher could consume the single event from an atomic CLI write before the task file was readable, then remain stale because no later event arrived. A failed read could also be mistaken for confirmed removal.

## Verification

- `bunx tsc --noEmit`
- `bun run check .`
- `bun test`: 1705 passed, 4 opt-in PTY skips, 0 failed
- source PTY suite: 4 passed
- compiled binary PTY suite: 3 passed

Closes #786