### PR TITLE
BACK-545 - Add stable JSON output to read commands

### DIFF
--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -57,9 +57,11 @@ Humans and agents can run `backlog instructions` for workflow guides and `backlo
 | Create (all options) | `backlog task create "Feature" -d "Description" -a @sara -s "To Do" -l auth --priority high --ac "Must work" --notes "Initial setup done" --dep task-1 --ref src/api.ts --doc docs/spec.md -p 14` |
 | List tasks  | `backlog task list [-s <status>] [-a <assignee>] [-p <parent>] [--labels <labels>] [--search <query>] [--limit <n>]` |
 | List filtered | `backlog task list --labels frontend,bug --search "login" --limit 10 --plain` |
+| List as JSON | `backlog task list --status "To Do" --json` |
 | List by parent | `backlog task list --parent 42` or `backlog task list -p task-42` |
 | View detail | `backlog task 7` (interactive UI, press 'E' to edit in editor) |
 | View (AI mode) | `backlog task 7 --plain`                           |
+| View as JSON | `backlog task 7 --json` |
 | Edit        | `backlog task edit 7 -a @sara -l auth,backend`       |
 | Add plan    | `backlog task edit 7 --plan "Implementation approach"`    |
 | Add AC      | `backlog task edit 7 --ac "New criterion" --ac "Another one"` |
@@ -83,6 +85,35 @@ Humans and agents can run `backlog instructions` for workflow guides and `backlo
 | Archive     | `backlog task archive 7`                             |
 
 Task comments are append-only discussion entries with optional author labels. Use comments for review questions and collaboration notes; use implementation notes for execution progress and final summary for PR-ready completion notes. Comment bodies may contain Markdown, but standalone `---` lines are reserved as comment delimiters.
+
+### Stable JSON output
+
+Use `--json` when a script or integration needs structured output:
+
+```bash
+backlog task list --status "To Do" --json | jq '.tasks[] | .id'
+backlog task view BACK-7 --json | jq '.task.acceptanceCriteria'
+backlog task BACK-7 --json
+backlog search "authentication" --json | jq '.results[] | [.type, .data.id]'
+```
+
+Each successful response is one pretty-printed JSON document followed by a newline. The top-level contract is versioned and identifies the command result:
+
+| Command | Envelope |
+|---------|----------|
+| `task list --json` | `{ "schemaVersion": 1, "kind": "task-list", "tasks": [...] }` |
+| `task view <id> --json` and `task <id> --json` | `{ "schemaVersion": 1, "kind": "task-view", "task": {...} }` |
+| `search [query] --json` | `{ "schemaVersion": 1, "kind": "search", "results": [...] }` |
+
+Task list and task search results use these compact fields: `id`, `title`, `status`, `type`, `priority`, `assignees`, `reporter`, `labels`, `milestone`, `parentTaskId`, `ordinal`, `createdAt`, and `updatedAt`.
+
+Task view adds `path`, `description`, `dependencies`, `references`, `documentation`, `modifiedFiles`, `subtasks`, `acceptanceCriteria`, `definitionOfDone`, `implementationPlan`, `implementationNotes`, `comments`, and `finalSummary`. `path` is relative to the project root. Checklist entries contain `index`, `text`, and `checked`. Comment entries contain `index`, `body`, `createdAt`, and `author`.
+
+Search keeps relevance order and discriminates every result with `type` and `data`. Task data uses the compact task fields. Document data contains `id`, `title`, `type`, `path`, `tags`, `createdAt`, and `updatedAt`. Decision data contains `id`, `title`, `status`, and `date`. Search scores are not part of the version 1 public contract.
+
+Absent scalar fields are `null`, and absent collections are `[]`. Date-only values remain `YYYY-MM-DD`; UTC date-times use RFC 3339. Internal fields, absolute paths, raw Markdown source objects, branch metadata, and search implementation details are not exposed.
+
+`--json` and `--plain` are mutually exclusive. Explicit JSON mode is always noninteractive, including in a terminal. Without `--json`, existing interactive, explicit plain, and automatic non-TTY plain behavior is unchanged. Errors leave stdout empty, write a concise message to stderr, and exit nonzero. Version 1 may gain backward-compatible fields, but removing, renaming, retyping, or changing documented field semantics requires a new `schemaVersion`.
 
 ### Multi-line input (description/plan/notes/comments/final summary)
 
@@ -170,6 +201,7 @@ Find tasks, documents, and decisions across your entire backlog with fuzzy searc
 | Filter by priority | `backlog search "bug" --priority high`        |
 | Combine filters    | `backlog search "web" --status "To Do" --priority medium` |
 | Plain text output  | `backlog search "feature" --plain` (for scripts/AI) |
+| JSON output        | `backlog search "feature" --json` (for structured integrations) |
 | Find by modified file | `backlog search --modified-file src/path.ts --plain` |
 
 **Search features:**

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ backlog task edit BACK-1 -d "Detailed context" --ac "Clear acceptance criteria"
 
 # Track work
 backlog task list -s "To Do"
+backlog task list --json | jq '.tasks[] | .id'
 backlog task edit BACK-1 --comment "Can we split the UI work into a separate PR?" --comment-author @sara
 backlog search "kanban"
 backlog board
@@ -155,6 +156,8 @@ backlog browser
 ```
 
 You can switch between AI-assisted and manual workflows at any time; both operate on the same Markdown task files. Just prefer Backlog.md commands (CLI/MCP/Web) over hand-editing task files, so field types and metadata stay consistent.
+
+Read commands support stable, versioned JSON for scripts and integrations. Use `--json` with `task list`, `task view`, the `task <id>` shorthand, and `search`. JSON mode is noninteractive and keeps successful stdout machine-readable.
 
 **Learn more:** [CLI reference](CLI-INSTRUCTIONS.md) | [Advanced configuration](ADVANCED-CONFIG.md)
 

--- a/backlog/tasks/back-545 - Add-stable-JSON-output-to-read-commands.md
+++ b/backlog/tasks/back-545 - Add-stable-JSON-output-to-read-commands.md
@@ -1,16 +1,28 @@
 ---
 id: BACK-545
 title: Add stable JSON output to read commands
-status: To Do
+status: In Progress
 assignee:
-  - '@alex-agent'
+  - '@back545-agent'
 created_date: '2026-07-13 16:06'
+updated_date: '2026-07-15 06:05'
 labels:
   - cli
   - enhancement
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/784'
+modified_files:
+  - src/cli.ts
+  - src/formatters/json-output.ts
+  - src/utils/read-output-mode.ts
+  - src/utils/read-output-mode.test.ts
+  - src/test/cli-json-output.test.ts
+  - README.md
+  - CLI-INSTRUCTIONS.md
+  - src/guidelines/agent-guidelines.md
+  - src/guidelines/cli-instructions/overview.md
+  - src/guidelines/cli-instructions/task-execution.md
 type: enhancement
 ordinal: 192000
 ---
@@ -38,3 +50,29 @@ Provide a documented, curated public JSON surface for task list, task view, and 
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Approved public JSON contract:
+1. Add --json to task list, task view, the task <id> shorthand, and heterogeneous search. Successful output is one pretty-printed JSON document plus a trailing newline on stdout.
+2. Use schemaVersion 1 and command-specific envelopes with kind discriminators: task-list with tasks, task-view with task, and search with results. Backward-compatible fields may be added within version 1; breaking contract changes require a schemaVersion increment.
+3. Use a fixed compact task summary projection for list and task search data. Task view extends it with curated task content. Fixed absent scalars serialize as null and absent collections as []. Do not expose internal TypeScript objects or internal-only fields.
+4. Expose project-relative paths only. Normalize documented public dates, preserve Markdown body strings, and serialize checklist indexes, ordinals, and checked states with stable JSON types.
+5. Search results discriminate task, document, and decision data and preserve rank order. Do not expose search scores in version 1.
+6. Reject --json with --plain on stderr with exit code 1. Explicit --json is always noninteractive and bypasses TTY auto-plain behavior. Existing behavior remains unchanged when --json is absent.
+7. In JSON mode, successful output is JSON only on stdout. Any validation, lookup, ambiguity, or runtime error leaves stdout empty, emits a concise human-readable message on stderr, and exits nonzero. There is no JSON error envelope in version 1.
+8. Implement one minimal shared formatter and one shared output-mode resolver. Route existing list, view, shorthand, and search results through curated projections only in JSON mode. Do not add JSON to other commands or MCP.
+9. Add focused tests for empty, single, multiple, heterogeneous, error, conflicting flags, non-TTY, deterministic ordering, shell piping, stdout/stderr separation, stable null and array semantics, and absence of internal fields.
+10. Update CLI help and public user documentation with the contract, mode behavior, examples, and piping usage. Run focused tests, typecheck, Biome, full suite, and final diff simplification.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Alex approved the version 1 JSON contract on 2026-07-15, including named envelopes, curated compact and full projections, fixed null and array semantics, project-relative paths, no public search score, strict output flag exclusivity, JSON-only stdout, and human-readable stderr errors.
+
+Implemented the approved version 1 CLI JSON contract for task list, task view, task shorthand, and search. Added curated compact and full projections, project-relative task paths, stable null and array semantics, RFC 3339 UTC date-time normalization, heterogeneous search discrimination without scores, one shared output-mode resolver, JSON-only stdout, and nonzero stderr errors. Updated CLI help, README, CLI reference, and canonical agent guidance. Validation: 12 focused JSON/output-mode tests passed; 79 related CLI and regression tests passed; full suite passed with 1706 tests and 2 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
+
+Post-rebase validation on origin/main at 9c29c4c9: 12 focused JSON/output-mode tests passed; full suite passed with 1717 tests and 4 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-545 - Add-stable-JSON-output-to-read-commands.md
+++ b/backlog/tasks/back-545 - Add-stable-JSON-output-to-read-commands.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-545
 title: Add stable JSON output to read commands
-status: In Progress
+status: Done
 assignee:
   - '@back545-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-07-15 17:49'
+updated_date: '2026-07-15 17:55'
 labels:
   - cli
   - enhancement
@@ -35,20 +35,20 @@ Provide a documented, curated public JSON surface for task list, task view, and 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 An explicit --json option is available on task list, task view, and search
-- [ ] #2 Successful JSON mode writes valid JSON only to stdout; errors use stderr and a nonzero exit code
-- [ ] #3 Plan review defines the stable public fields, envelope, and heterogeneous result discrimination before implementation
-- [ ] #4 Precedence with --plain, interactive behavior, and non-TTY behavior is documented and deterministic
-- [ ] #5 Output represents documented public semantics only and does not expose internal TypeScript objects
-- [ ] #6 Tests cover empty, single, multiple, heterogeneous, error, and shell-piping cases
-- [ ] #7 CLI help and user documentation describe the JSON contract and examples
+- [x] #1 An explicit --json option is available on task list, task view, and search
+- [x] #2 Successful JSON mode writes valid JSON only to stdout; errors use stderr and a nonzero exit code
+- [x] #3 Plan review defines the stable public fields, envelope, and heterogeneous result discrimination before implementation
+- [x] #4 Precedence with --plain, interactive behavior, and non-TTY behavior is documented and deterministic
+- [x] #5 Output represents documented public semantics only and does not expose internal TypeScript objects
+- [x] #6 Tests cover empty, single, multiple, heterogeneous, error, and shell-piping cases
+- [x] #7 CLI help and user documentation describe the JSON contract and examples
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -79,4 +79,12 @@ Post-rebase validation on origin/main at 9c29c4c9: 12 focused JSON/output-mode t
 Addressed specification review findings. Empty parsed descriptions now serialize as null while nonempty Markdown remains verbatim. Task-level --json is rejected before unsupported subcommand handlers, while list, view, and shorthand retain JSON support. Read output modes now use Commander-parsed options so tokens after -- remain literal search queries. Validation: 15 focused JSON/output-mode tests passed; 44 related CLI regression tests passed; full suite passed with 1720 tests and 4 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
 
 Corrected heterogeneous search document paths to include the configured project-relative docs directory. Added default and custom backlog directory coverage. Validation: 16 focused JSON and output-mode tests passed; 30 adjacent CLI tests passed; full suite passed with 1721 tests and 4 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
+
+Finalization validation on 2026-07-15: 16 focused JSON/output-mode tests passed, covering list, view, shorthand, empty results, heterogeneous search, conflicting flags, TTY behavior, unsupported commands, errors, shell piping, help, null semantics, Markdown preservation, and project-relative paths. bunx tsc --noEmit passed. bun run check . passed across 336 files. git diff --check passed.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a versioned, curated JSON output contract for task list, task view, task shorthand, and search. The implementation keeps the CLI canonical, avoids internal object exposure, documents deterministic output and error behavior, and is verified by 16 focused tests, the full 1721-test suite from the implementation pass, TypeScript, Biome, and diff checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-545 - Add-stable-JSON-output-to-read-commands.md
+++ b/backlog/tasks/back-545 - Add-stable-JSON-output-to-read-commands.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@back545-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-07-15 06:05'
+updated_date: '2026-07-15 15:02'
 labels:
   - cli
   - enhancement
@@ -75,4 +75,6 @@ Alex approved the version 1 JSON contract on 2026-07-15, including named envelop
 Implemented the approved version 1 CLI JSON contract for task list, task view, task shorthand, and search. Added curated compact and full projections, project-relative task paths, stable null and array semantics, RFC 3339 UTC date-time normalization, heterogeneous search discrimination without scores, one shared output-mode resolver, JSON-only stdout, and nonzero stderr errors. Updated CLI help, README, CLI reference, and canonical agent guidance. Validation: 12 focused JSON/output-mode tests passed; 79 related CLI and regression tests passed; full suite passed with 1706 tests and 2 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
 
 Post-rebase validation on origin/main at 9c29c4c9: 12 focused JSON/output-mode tests passed; full suite passed with 1717 tests and 4 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed.
+
+Addressed specification review findings. Empty parsed descriptions now serialize as null while nonempty Markdown remains verbatim. Task-level --json is rejected before unsupported subcommand handlers, while list, view, and shorthand retain JSON support. Read output modes now use Commander-parsed options so tokens after -- remain literal search queries. Validation: 15 focused JSON/output-mode tests passed; 44 related CLI regression tests passed; full suite passed with 1720 tests and 4 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-545 - Add-stable-JSON-output-to-read-commands.md
+++ b/backlog/tasks/back-545 - Add-stable-JSON-output-to-read-commands.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@back545-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-07-15 15:02'
+updated_date: '2026-07-15 17:49'
 labels:
   - cli
   - enhancement
@@ -77,4 +77,6 @@ Implemented the approved version 1 CLI JSON contract for task list, task view, t
 Post-rebase validation on origin/main at 9c29c4c9: 12 focused JSON/output-mode tests passed; full suite passed with 1717 tests and 4 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed.
 
 Addressed specification review findings. Empty parsed descriptions now serialize as null while nonempty Markdown remains verbatim. Task-level --json is rejected before unsupported subcommand handlers, while list, view, and shorthand retain JSON support. Read output modes now use Commander-parsed options so tokens after -- remain literal search queries. Validation: 15 focused JSON/output-mode tests passed; 44 related CLI regression tests passed; full suite passed with 1720 tests and 4 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
+
+Corrected heterogeneous search document paths to include the configured project-relative docs directory. Added default and custom backlog directory coverage. Validation: 16 focused JSON and output-mode tests passed; 30 adjacent CLI tests passed; full suite passed with 1721 tests and 4 interactive TUI skips; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
 <!-- SECTION:NOTES:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -543,7 +543,6 @@ if (process.platform === "win32") {
 const hasInteractiveTTY = Boolean(process.stdout.isTTY && process.stdin.isTTY);
 const shouldAutoPlain = !hasInteractiveTTY;
 const plainFlagInArgv = process.argv.includes("--plain");
-const jsonFlagInArgv = process.argv.includes("--json");
 
 function isPlainRequested(options?: { plain?: boolean }): boolean {
 	return Boolean(options?.plain || plainFlagInArgv);
@@ -551,11 +550,7 @@ function isPlainRequested(options?: { plain?: boolean }): boolean {
 
 function getReadOutputMode(options: { json?: boolean; plain?: boolean }): ReadOutputMode | null {
 	try {
-		return resolveReadOutputMode(
-			{ ...options, json: options.json || jsonFlagInArgv },
-			hasInteractiveTTY,
-			plainFlagInArgv,
-		);
+		return resolveReadOutputMode(options, hasInteractiveTTY);
 	} catch (error) {
 		console.error(error instanceof Error ? error.message : String(error));
 		process.exitCode = 1;
@@ -1670,6 +1665,20 @@ export async function generateNextDecisionId(core: Core): Promise<string> {
 
 const taskCmd = program.command("task").aliases(["tasks"]);
 
+function getTaskReadOutputMode(options: { json?: boolean; plain?: boolean }): ReadOutputMode | null {
+	const taskOptions = taskCmd.opts<{ json?: boolean; plain?: boolean }>();
+	return getReadOutputMode({
+		json: Boolean(options.json || taskOptions.json),
+		plain: Boolean(options.plain || taskOptions.plain),
+	});
+}
+
+taskCmd.hook("preSubcommand", (command, subcommand) => {
+	if (command.opts().json && !["list", "view"].includes(subcommand.name())) {
+		command.error("error: unknown option '--json'", { code: "commander.unknownOption", exitCode: 1 });
+	}
+});
+
 addHelpSchema(taskCmd.command("create [title]"), {
 	required: [{ name: "title", type: "String", description: "Task title; prompted when omitted in interactive mode" }],
 	optional: [
@@ -2311,7 +2320,7 @@ addHelpSchema(taskCmd.command("list"), {
 	.option("--plain", "use plain text output instead of interactive UI")
 	.option("--json", "print versioned machine-readable JSON output")
 	.action(async (options) => {
-		const outputMode = getReadOutputMode(options);
+		const outputMode = getTaskReadOutputMode(options);
 		if (!outputMode) return;
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
@@ -3161,7 +3170,7 @@ addHelpSchema(taskCmd.command("view <taskId>"), {
 	.option("--plain", "use plain text output instead of interactive UI")
 	.option("--json", "print versioned machine-readable JSON output")
 	.action(async (taskId: string, options) => {
-		const outputMode = getReadOutputMode(options);
+		const outputMode = getTaskReadOutputMode(options);
 		if (!outputMode) return;
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES } from "./constant
 import { type DuplicateRepairPlan, findLocalDuplicateTaskIds } from "./core/duplicate-task-repair.ts";
 import { initializeProject } from "./core/init.ts";
 import { buildMilestoneBuckets, collectArchivedMilestoneKeys, milestoneKey } from "./core/milestones.ts";
+import { printJson, searchJson, taskListJson, taskViewJson } from "./formatters/json-output.ts";
 import { formatTaskPlainText } from "./formatters/task-plain-text.ts";
 import {
 	type AgentInstructionFile,
@@ -76,6 +77,7 @@ import { createMilestoneFilterValueResolver, resolveClosestMilestoneFilterValue 
 import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
 import { hasAnyPrefix } from "./utils/prefix-config.ts";
 import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
+import { type ReadOutputMode, resolveReadOutputMode } from "./utils/read-output-mode.ts";
 import { type RuntimeCwdResolution, resolveRuntimeCwd } from "./utils/runtime-cwd.ts";
 import { formatValidStatuses, getCanonicalStatus, getCanonicalStatuses, getValidStatuses } from "./utils/status.ts";
 import {
@@ -541,9 +543,24 @@ if (process.platform === "win32") {
 const hasInteractiveTTY = Boolean(process.stdout.isTTY && process.stdin.isTTY);
 const shouldAutoPlain = !hasInteractiveTTY;
 const plainFlagInArgv = process.argv.includes("--plain");
+const jsonFlagInArgv = process.argv.includes("--json");
 
 function isPlainRequested(options?: { plain?: boolean }): boolean {
 	return Boolean(options?.plain || plainFlagInArgv);
+}
+
+function getReadOutputMode(options: { json?: boolean; plain?: boolean }): ReadOutputMode | null {
+	try {
+		return resolveReadOutputMode(
+			{ ...options, json: options.json || jsonFlagInArgv },
+			hasInteractiveTTY,
+			plainFlagInArgv,
+		);
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+		return null;
+	}
 }
 
 // Temporarily isolate BUN_OPTIONS during CLI parsing to prevent conflicts
@@ -1872,10 +1889,13 @@ addHelpSchema(program.command("search [query]"), {
 			description: "Filter by modified file path substring",
 		},
 		{ name: "limit", type: "Integer", description: "Maximum number of results" },
+		{ name: "plain", type: "Boolean", description: "Use text output instead of interactive UI" },
+		{ name: "json", type: "Boolean", description: "Use versioned machine-readable JSON output" },
 	],
-	output: "Interactive search UI or plain text with --plain",
+	output: "Interactive search UI, plain text with --plain, or versioned JSON with --json",
 	examples: [
 		'backlog search "auth" --plain',
+		'backlog search "auth" --json',
 		'backlog search "api" --type task --status "<active status>"',
 		`backlog search "crash" --task-type ${TASK_TYPE_EXAMPLE} --plain`,
 	],
@@ -1901,16 +1921,23 @@ addHelpSchema(program.command("search [query]"), {
 	)
 	.option("--limit <number>", "limit total results returned")
 	.option("--plain", "print plain text output instead of interactive UI")
+	.option("--json", "print versioned machine-readable JSON output")
 	.action(async (query: string | undefined, options) => {
+		const outputMode = getReadOutputMode(options);
+		if (!outputMode) return;
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
-		await printDuplicateIntegrityWarning(core);
+		const hasDuplicateIds = await printDuplicateIntegrityWarning(core);
 		const searchService = await core.getSearchService();
 		const contentStore = await core.getContentStore();
 		const cleanup = () => {
 			searchService.dispose();
 			contentStore.dispose();
 		};
+		if (hasDuplicateIds && outputMode === "json") {
+			cleanup();
+			return;
+		}
 
 		const modifiedFileFilters = parseDelimitedStringList(options.modifiedFile);
 		const rawTaskTypes = parseDelimitedStringList(options.taskType) ?? [];
@@ -1992,8 +2019,13 @@ addHelpSchema(program.command("search [query]"), {
 			filters,
 		});
 
-		const usePlainOutput = isPlainRequested(options) || shouldAutoPlain;
-		if (usePlainOutput) {
+		if (outputMode === "json") {
+			printJson(searchJson(searchResults));
+			cleanup();
+			return;
+		}
+
+		if (outputMode === "plain") {
 			printSearchResults(searchResults);
 			cleanup();
 			return;
@@ -2239,10 +2271,13 @@ addHelpSchema(taskCmd.command("list"), {
 		{ name: "search", type: "String", description: "Search task title, description, notes, comments, and metadata" },
 		{ name: "limit", type: "Positive integer", description: "Maximum tasks to display after sorting" },
 		{ name: "sort", type: choiceType(TASK_SORT_FIELDS), description: "Task ordering before applying limit" },
+		{ name: "plain", type: "Boolean", description: "Use text output instead of interactive UI" },
+		{ name: "json", type: "Boolean", description: "Use versioned machine-readable JSON output" },
 	],
-	output: "Interactive task list or plain text with --plain",
+	output: "Interactive task list, plain text with --plain, or versioned JSON with --json",
 	examples: [
 		'backlog task list --status "<todo status>" --plain',
+		'backlog task list --status "<todo status>" --json',
 		"backlog task list --parent {{TASK_ID:1}}",
 		`backlog task list --type ${TASK_TYPE_EXAMPLE} --plain`,
 		'backlog task list --labels frontend,bug --search "login" --limit 10 --plain',
@@ -2274,14 +2309,21 @@ addHelpSchema(taskCmd.command("list"), {
 	.option("--limit <number>", "limit tasks displayed after sorting")
 	.option("--sort <field>", `sort tasks by field (${TASK_SORT_FIELD_LIST})`)
 	.option("--plain", "use plain text output instead of interactive UI")
+	.option("--json", "print versioned machine-readable JSON output")
 	.action(async (options) => {
+		const outputMode = getReadOutputMode(options);
+		if (!outputMode) return;
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
-		await printDuplicateIntegrityWarning(core);
+		const hasDuplicateIds = await printDuplicateIntegrityWarning(core);
 		const cleanup = () => {
 			core.disposeSearchService();
 			core.disposeContentStore();
 		};
+		if (hasDuplicateIds && outputMode === "json") {
+			cleanup();
+			return;
+		}
 		if (options.assignee && options.unassigned) {
 			console.error("--unassigned cannot be combined with --assignee.");
 			process.exitCode = 1;
@@ -2357,8 +2399,7 @@ addHelpSchema(taskCmd.command("list"), {
 			}
 		}
 
-		const usePlainOutput = isPlainRequested(options) || shouldAutoPlain;
-		if (usePlainOutput) {
+		if (outputMode !== "interactive") {
 			const tasks = await core.queryTasks({
 				query: searchQuery || undefined,
 				filters: Object.keys(baseFilters).length > 0 ? baseFilters : undefined,
@@ -2400,6 +2441,14 @@ addHelpSchema(taskCmd.command("list"), {
 				filtered = filtered.filter((task) => taskMatchesAllLabels(task, labelFilters));
 			}
 
+			const displayTasks = taskLimit !== undefined ? filtered.slice(0, taskLimit) : filtered;
+
+			if (outputMode === "json") {
+				printJson(taskListJson(displayTasks));
+				cleanup();
+				return;
+			}
+
 			if (filtered.length === 0) {
 				if (options.parent) {
 					const canonicalParent = normalizeTaskId(String(options.parent));
@@ -2410,8 +2459,6 @@ addHelpSchema(taskCmd.command("list"), {
 				cleanup();
 				return;
 			}
-
-			const displayTasks = taskLimit !== undefined ? filtered.slice(0, taskLimit) : filtered;
 
 			if (options.sort && options.sort.toLowerCase() === "priority") {
 				console.log("Tasks (sorted by priority):");
@@ -3103,19 +3150,26 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 addHelpSchema(taskCmd.command("view <taskId>"), {
 	reads: "Task metadata, description, plan, notes, comments, final summary, AC, and DoD",
 	required: [{ name: "taskId", type: "Task ID", description: "Task to display" }],
-	optional: [{ name: "plain", type: "Boolean", description: "Use text output instead of interactive UI" }],
-	output: "Interactive task detail view or plain text with --plain",
-	examples: ["backlog task view {{TASK_ID:1}} --plain"],
+	optional: [
+		{ name: "plain", type: "Boolean", description: "Use text output instead of interactive UI" },
+		{ name: "json", type: "Boolean", description: "Use versioned machine-readable JSON output" },
+	],
+	output: "Interactive task detail view, plain text with --plain, or versioned JSON with --json",
+	examples: ["backlog task view {{TASK_ID:1}} --plain", "backlog task view {{TASK_ID:1}} --json"],
 })
 	.description("display task details")
 	.option("--plain", "use plain text output instead of interactive UI")
+	.option("--json", "print versioned machine-readable JSON output")
 	.action(async (taskId: string, options) => {
+		const outputMode = getReadOutputMode(options);
+		if (!outputMode) return;
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		const localTasks = await core.fs.listTasks();
 		const task = await core.getTaskWithSubtasks(taskId, localTasks);
 		if (!task) {
 			console.error(`Task ${taskId} not found.`);
+			process.exitCode = 1;
 			return;
 		}
 
@@ -3124,8 +3178,12 @@ addHelpSchema(taskCmd.command("view <taskId>"), {
 			: [...localTasks, task];
 
 		// Plain text output for non-interactive environments
-		const usePlainOutput = isPlainRequested(options) || shouldAutoPlain;
-		if (usePlainOutput) {
+		if (outputMode === "json") {
+			printJson(taskViewJson(task, cwd));
+			return;
+		}
+
+		if (outputMode === "plain") {
 			console.log(formatTaskPlainText(task));
 			return;
 		}
@@ -3261,7 +3319,10 @@ taskCmd
 taskCmd
 	.argument("[taskId]")
 	.option("--plain", "use plain text output")
-	.action(async (taskId: string | undefined, options: { plain?: boolean }) => {
+	.option("--json", "print versioned machine-readable JSON output")
+	.action(async (taskId: string | undefined, options: { json?: boolean; plain?: boolean }) => {
+		const outputMode = getReadOutputMode(options);
+		if (!outputMode) return;
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 
@@ -3283,6 +3344,7 @@ taskCmd
 		const task = await core.getTaskWithSubtasks(taskId, localTasks);
 		if (!task) {
 			console.error(`Task ${taskId} not found.`);
+			process.exitCode = 1;
 			return;
 		}
 
@@ -3291,8 +3353,12 @@ taskCmd
 			: [...localTasks, task];
 
 		// Plain text output for non-interactive environments
-		const usePlainOutput = isPlainRequested(options) || shouldAutoPlain;
-		if (usePlainOutput) {
+		if (outputMode === "json") {
+			printJson(taskViewJson(task, cwd));
+			return;
+		}
+
+		if (outputMode === "plain") {
 			console.log(formatTaskPlainText(task));
 			return;
 		}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2029,7 +2029,7 @@ addHelpSchema(program.command("search [query]"), {
 		});
 
 		if (outputMode === "json") {
-			printJson(searchJson(searchResults));
+			printJson(searchJson(searchResults, cwd, core.filesystem.docsDir));
 			cleanup();
 			return;
 		}

--- a/src/formatters/json-output.ts
+++ b/src/formatters/json-output.ts
@@ -74,6 +74,10 @@ function nullable(value: string | undefined): string | null {
 	return value ?? null;
 }
 
+function nullableDescription(value: string | undefined): string | null {
+	return value === undefined || value === "" ? null : value;
+}
+
 function normalizePublicDate(value: string | undefined): string | null {
 	if (!value) return null;
 	if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
@@ -123,7 +127,7 @@ function toTaskDetailsJson(task: Task, projectRoot: string): TaskDetailsJson {
 	return {
 		...toTaskSummaryJson(task),
 		path: toProjectRelativePath(projectRoot, task.filePath),
-		description: nullable(task.description),
+		description: nullableDescription(task.description),
 		dependencies: task.dependencies ?? [],
 		references: task.references ?? [],
 		documentation: task.documentation ?? [],

--- a/src/formatters/json-output.ts
+++ b/src/formatters/json-output.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import type { Decision, Document, SearchResult, Task } from "../types/index.ts";
 import { isLocalEditableTask } from "../types/index.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
@@ -150,12 +150,12 @@ function toTaskDetailsJson(task: Task, projectRoot: string): TaskDetailsJson {
 	};
 }
 
-function toDocumentSummaryJson(document: Document): DocumentSummaryJson {
+function toDocumentSummaryJson(document: Document, projectRoot: string, docsDir: string): DocumentSummaryJson {
 	return {
 		id: document.id,
 		title: document.title,
 		type: document.type,
-		path: nullable(document.path),
+		path: document.path ? toProjectRelativePath(projectRoot, join(docsDir, document.path)) : null,
 		tags: document.tags ?? [],
 		createdAt: normalizePublicDate(document.createdDate),
 		updatedAt: normalizePublicDate(document.updatedDate),
@@ -179,7 +179,7 @@ export function taskViewJson(task: Task, projectRoot: string) {
 	return { schemaVersion: 1, kind: "task-view" as const, task: toTaskDetailsJson(task, projectRoot) };
 }
 
-export function searchJson(results: SearchResult[]) {
+export function searchJson(results: SearchResult[], projectRoot: string, docsDir: string) {
 	const publicResults: SearchResultJson[] = [];
 	for (const result of results) {
 		if (result.type === "task") {
@@ -189,7 +189,7 @@ export function searchJson(results: SearchResult[]) {
 			continue;
 		}
 		if (result.type === "document") {
-			publicResults.push({ type: "document", data: toDocumentSummaryJson(result.document) });
+			publicResults.push({ type: "document", data: toDocumentSummaryJson(result.document, projectRoot, docsDir) });
 			continue;
 		}
 		publicResults.push({ type: "decision", data: toDecisionSummaryJson(result.decision) });

--- a/src/formatters/json-output.ts
+++ b/src/formatters/json-output.ts
@@ -1,0 +1,198 @@
+import { isAbsolute, relative } from "node:path";
+import type { Decision, Document, SearchResult, Task } from "../types/index.ts";
+import { isLocalEditableTask } from "../types/index.ts";
+import { sortByTaskId } from "../utils/task-sorting.ts";
+
+type TaskSummaryJson = {
+	id: string;
+	title: string;
+	status: string;
+	type: string | null;
+	priority: string | null;
+	assignees: string[];
+	reporter: string | null;
+	labels: string[];
+	milestone: string | null;
+	parentTaskId: string | null;
+	ordinal: number | null;
+	createdAt: string | null;
+	updatedAt: string | null;
+};
+
+type ChecklistItemJson = {
+	index: number;
+	text: string;
+	checked: boolean;
+};
+
+type TaskCommentJson = {
+	index: number;
+	body: string;
+	createdAt: string | null;
+	author: string | null;
+};
+
+type TaskDetailsJson = TaskSummaryJson & {
+	path: string | null;
+	description: string | null;
+	dependencies: string[];
+	references: string[];
+	documentation: string[];
+	modifiedFiles: string[];
+	subtasks: Array<{ id: string; title: string }>;
+	acceptanceCriteria: ChecklistItemJson[];
+	definitionOfDone: ChecklistItemJson[];
+	implementationPlan: string | null;
+	implementationNotes: string | null;
+	comments: TaskCommentJson[];
+	finalSummary: string | null;
+};
+
+type DocumentSummaryJson = {
+	id: string;
+	title: string;
+	type: Document["type"];
+	path: string | null;
+	tags: string[];
+	createdAt: string | null;
+	updatedAt: string | null;
+};
+
+type DecisionSummaryJson = {
+	id: string;
+	title: string;
+	status: Decision["status"];
+	date: string | null;
+};
+
+type SearchResultJson =
+	| { type: "task"; data: TaskSummaryJson }
+	| { type: "document"; data: DocumentSummaryJson }
+	| { type: "decision"; data: DecisionSummaryJson };
+
+function nullable(value: string | undefined): string | null {
+	return value ?? null;
+}
+
+function normalizePublicDate(value: string | undefined): string | null {
+	if (!value) return null;
+	if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+
+	const minutePrecision = value.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2})(?::(\d{2}))?(?:\.\d+)?Z?$/);
+	if (minutePrecision) {
+		const [, date, time, seconds = "00"] = minutePrecision;
+		return `${date}T${time}:${seconds}Z`;
+	}
+
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function toTaskSummaryJson(task: Task): TaskSummaryJson {
+	return {
+		id: task.id,
+		title: task.title,
+		status: task.status,
+		type: nullable(task.type),
+		priority: nullable(task.priority),
+		assignees: task.assignee ?? [],
+		reporter: nullable(task.reporter),
+		labels: task.labels ?? [],
+		milestone: nullable(task.milestone),
+		parentTaskId: nullable(task.parentTaskId),
+		ordinal: task.ordinal ?? null,
+		createdAt: normalizePublicDate(task.createdDate),
+		updatedAt: normalizePublicDate(task.updatedDate),
+	};
+}
+
+function toProjectRelativePath(projectRoot: string, filePath: string | undefined): string | null {
+	if (!filePath) return null;
+	const projectRelative = isAbsolute(filePath) ? relative(projectRoot, filePath) : filePath;
+	return projectRelative.replaceAll("\\", "/");
+}
+
+function toChecklistJson(items: Task["acceptanceCriteriaItems"]): ChecklistItemJson[] {
+	return (items ?? [])
+		.slice()
+		.sort((a, b) => a.index - b.index)
+		.map(({ index, text, checked }) => ({ index, text, checked }));
+}
+
+function toTaskDetailsJson(task: Task, projectRoot: string): TaskDetailsJson {
+	return {
+		...toTaskSummaryJson(task),
+		path: toProjectRelativePath(projectRoot, task.filePath),
+		description: nullable(task.description),
+		dependencies: task.dependencies ?? [],
+		references: task.references ?? [],
+		documentation: task.documentation ?? [],
+		modifiedFiles: task.modifiedFiles ?? [],
+		subtasks: sortByTaskId(task.subtaskSummaries ?? []),
+		acceptanceCriteria: toChecklistJson(task.acceptanceCriteriaItems),
+		definitionOfDone: toChecklistJson(task.definitionOfDoneItems),
+		implementationPlan: nullable(task.implementationPlan),
+		implementationNotes: nullable(task.implementationNotes),
+		comments: (task.comments ?? [])
+			.slice()
+			.sort((a, b) => a.index - b.index)
+			.map((comment) => ({
+				index: comment.index,
+				body: comment.body,
+				createdAt: normalizePublicDate(comment.createdDate),
+				author: nullable(comment.author),
+			})),
+		finalSummary: nullable(task.finalSummary),
+	};
+}
+
+function toDocumentSummaryJson(document: Document): DocumentSummaryJson {
+	return {
+		id: document.id,
+		title: document.title,
+		type: document.type,
+		path: nullable(document.path),
+		tags: document.tags ?? [],
+		createdAt: normalizePublicDate(document.createdDate),
+		updatedAt: normalizePublicDate(document.updatedDate),
+	};
+}
+
+function toDecisionSummaryJson(decision: Decision): DecisionSummaryJson {
+	return {
+		id: decision.id,
+		title: decision.title,
+		status: decision.status,
+		date: normalizePublicDate(decision.date),
+	};
+}
+
+export function taskListJson(tasks: Task[]) {
+	return { schemaVersion: 1, kind: "task-list" as const, tasks: tasks.map(toTaskSummaryJson) };
+}
+
+export function taskViewJson(task: Task, projectRoot: string) {
+	return { schemaVersion: 1, kind: "task-view" as const, task: toTaskDetailsJson(task, projectRoot) };
+}
+
+export function searchJson(results: SearchResult[]) {
+	const publicResults: SearchResultJson[] = [];
+	for (const result of results) {
+		if (result.type === "task") {
+			if (isLocalEditableTask(result.task)) {
+				publicResults.push({ type: "task", data: toTaskSummaryJson(result.task) });
+			}
+			continue;
+		}
+		if (result.type === "document") {
+			publicResults.push({ type: "document", data: toDocumentSummaryJson(result.document) });
+			continue;
+		}
+		publicResults.push({ type: "decision", data: toDecisionSummaryJson(result.decision) });
+	}
+	return { schemaVersion: 1, kind: "search" as const, results: publicResults };
+}
+
+export function printJson(value: unknown): void {
+	process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -18,7 +18,7 @@ remains fully synchronized and up-to-date.
 - ✅ **Dependencies**: Task relationships and subtask hierarchies
 - ✅ **Documentation & Decisions**: Structured docs and architectural decision records
 - ✅ **Export & Reporting**: Generate markdown reports and board snapshots
-- ✅ **AI-Optimized**: `--plain` flag provides clean text output for AI processing
+- ✅ **Machine-readable output**: `--json` provides a stable, versioned contract for scripts; `--plain` provides readable text
 
 ### Why This Matters to You (AI Agent)
 
@@ -32,7 +32,7 @@ remains fully synchronized and up-to-date.
 
 - **Tasks** live in `backlog/tasks/` as `task-<id> - <title>.md` files
 - **You interact via CLI only**: `backlog task create`, `backlog task edit`, etc.
-- **Use `--plain` flag** for AI-friendly output when viewing/listing
+- **Use `--plain`** for readable task context, or **use `--json`** when code needs structured fields
 - **Never bypass the CLI** - It handles Git, metadata, file naming, and relationships
 
 ---
@@ -65,7 +65,7 @@ remains fully synchronized and up-to-date.
 
 - **All task operations MUST use the Backlog.md CLI tool**
 - This ensures metadata is correctly updated and the project stays in sync
-- **Always use `--plain` flag** when listing or viewing tasks for AI-friendly text output
+- **Use `--plain`** when listing or viewing tasks for readable text. Use `--json` when consuming fields programmatically.
 - Create and update project docs through Backlog.md APIs so frontmatter and paths stay valid. For CLI users, run `backlog doc create "Title" -p guides/setup` or `backlog doc update doc-1 --content "Updated markdown"`; MCP users should use `document_create` / `document_update`.
 - Document paths are relative to `backlog/docs/`; absolute paths and `..` traversal are rejected.
 

--- a/src/guidelines/cli-instructions/overview.md
+++ b/src/guidelines/cli-instructions/overview.md
@@ -25,6 +25,8 @@ Search and read before changing anything:
 - `backlog task list --search "login" --labels frontend,bug --limit 20 --plain`
 - `backlog task view {{TASK_ID:123}} --plain`
 
+Use `--json` instead of `--plain` on `task list`, `task view`, `task <id>`, or `search` when a script needs stable versioned fields. Do not combine the two flags.
+
 ### Detailed Guides
 
 **Required: read the matching guide below before creating, executing, or finalizing tasks. Do not rely on this overview alone for these actions.** The overview only tells you when to act; the guides define the required procedure, and skipping them produces inconsistent tasks and metadata.

--- a/src/guidelines/cli-instructions/task-execution.md
+++ b/src/guidelines/cli-instructions/task-execution.md
@@ -60,6 +60,8 @@ Use CLI commands for Backlog changes:
 - Create docs: `backlog doc create "Title"`
 - Update docs: `backlog doc update doc-1 --content "Markdown"`
 
+For programmatic reads, `task list`, `task view`, `task <id>`, and `search` accept `--json`. JSON mode is noninteractive, versioned, and cannot be combined with `--plain`.
+
 Do not edit Backlog markdown files directly. The CLI preserves metadata, IDs, filenames, relationships, and structured sections.
 
 ### Finishing

--- a/src/test/cli-json-output.test.ts
+++ b/src/test/cli-json-output.test.ts
@@ -9,8 +9,8 @@ const CLI_PATH = join(process.cwd(), "src", "cli.ts");
 
 let TEST_DIR: string;
 
-async function runCli(args: string[]) {
-	return await $`bun ${[CLI_PATH, ...args]}`.cwd(TEST_DIR).nothrow().quiet();
+async function runCli(args: string[], cwd = TEST_DIR) {
+	return await $`bun ${[CLI_PATH, ...args]}`.cwd(cwd).nothrow().quiet();
 }
 
 describe("CLI JSON output", () => {
@@ -181,7 +181,7 @@ describe("CLI JSON output", () => {
 			id: "doc-1",
 			title: "JSON guide",
 			type: "guide",
-			path: "doc-1 - JSON-guide.md",
+			path: "backlog/docs/doc-1 - JSON-guide.md",
 			tags: ["cli"],
 			createdAt: "2026-07-13",
 			updatedAt: "2026-07-14T08:00:00Z",
@@ -194,6 +194,35 @@ describe("CLI JSON output", () => {
 		});
 		for (const entry of output.results) {
 			expect(entry.score).toBeUndefined();
+		}
+	});
+
+	it("uses the configured project-relative docs directory in search paths", async () => {
+		const customTestDir = createUniqueTestDir("test-cli-json-output-custom-dir");
+		try {
+			await mkdir(customTestDir, { recursive: true });
+			await $`git init -b main`.cwd(customTestDir).quiet();
+			await $`git config user.name "Test User"`.cwd(customTestDir).quiet();
+			await $`git config user.email test@example.com`.cwd(customTestDir).quiet();
+
+			const core = new Core(customTestDir);
+			await initializeTestProject(core, "Custom JSON Output Test", false, "planning/backlog-data");
+			await core.filesystem.saveDocument({
+				id: "doc-1",
+				title: "Custom guide",
+				type: "guide",
+				createdDate: "2026-07-15",
+				rawContent: "Custom directory JSON documentation",
+			});
+
+			const result = await runCli(["search", "Custom directory JSON", "--json"], customTestDir);
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr.toString()).toBe("");
+			const output = JSON.parse(result.stdout.toString());
+			expect(output.results).toHaveLength(1);
+			expect(output.results[0].data.path).toBe("planning/backlog-data/docs/doc-1 - Custom-guide.md");
+		} finally {
+			await safeCleanup(customTestDir);
 		}
 	});
 

--- a/src/test/cli-json-output.test.ts
+++ b/src/test/cli-json-output.test.ts
@@ -147,6 +147,28 @@ describe("CLI JSON output", () => {
 		}
 	});
 
+	it("serializes an absent description as null and preserves Markdown verbatim", async () => {
+		const withoutDescription = await runCli(["task", "create", "No description", "--plain"]);
+		expect(withoutDescription.exitCode).toBe(0);
+		const withMarkdown = await runCli([
+			"task",
+			"create",
+			"Markdown description",
+			"--description",
+			"First line\n\n- item with `code`",
+			"--plain",
+		]);
+		expect(withMarkdown.exitCode).toBe(0);
+
+		const absent = await runCli(["task", "view", "2", "--json"]);
+		expect(absent.exitCode).toBe(0);
+		expect(JSON.parse(absent.stdout.toString()).task.description).toBeNull();
+
+		const markdown = await runCli(["task", "view", "3", "--json"]);
+		expect(markdown.exitCode).toBe(0);
+		expect(JSON.parse(markdown.stdout.toString()).task.description).toBe("First line\n\n- item with `code`");
+	});
+
 	it("preserves heterogeneous search rank and omits scores", async () => {
 		const result = await runCli(["search", "JSON task", "--json"]);
 		expect(result.exitCode).toBe(0);
@@ -194,6 +216,31 @@ describe("CLI JSON output", () => {
 			expect(result.exitCode).toBe(1);
 			expect(result.stdout.toString()).toBe("");
 			expect(result.stderr.toString()).toContain("--json cannot be combined with --plain");
+		}
+	});
+
+	it("treats output-looking search terms after -- as literal queries", async () => {
+		const json = await runCli(["search", "--json", "--", "--plain"]);
+		expect(json.exitCode).toBe(0);
+		expect(json.stderr.toString()).toBe("");
+		expect(JSON.parse(json.stdout.toString())).toEqual({ schemaVersion: 1, kind: "search", results: [] });
+
+		const plain = await runCli(["search", "--plain", "--", "--json"]);
+		expect(plain.exitCode).toBe(0);
+		expect(plain.stderr.toString()).toBe("");
+		expect(plain.stdout.toString()).toContain("TASK-1 - JSON task");
+	});
+
+	it("rejects --json on unsupported task subcommands", async () => {
+		for (const args of [
+			["task", "archive", "999", "--json"],
+			["task", "--json", "archive", "999"],
+		]) {
+			const result = await runCli(args);
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout.toString()).toBe("");
+			expect(result.stderr.toString()).toContain("--json");
+			expect(result.stderr.toString()).not.toContain("Task 999 not found");
 		}
 	});
 

--- a/src/test/cli-json-output.test.ts
+++ b/src/test/cli-json-output.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+
+let TEST_DIR: string;
+
+async function runCli(args: string[]) {
+	return await $`bun ${[CLI_PATH, ...args]}`.cwd(TEST_DIR).nothrow().quiet();
+}
+
+describe("CLI JSON output", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-cli-json-output");
+		await mkdir(TEST_DIR, { recursive: true });
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await initializeTestProject(core, "JSON Output Test");
+		await core.createTask(
+			{
+				id: "task-1",
+				title: "JSON task",
+				status: "In Progress",
+				type: "enhancement",
+				priority: "high",
+				assignee: ["@alex"],
+				reporter: "@sam",
+				createdDate: "2026-07-14 09:30",
+				updatedDate: "2026-07-14 10:45",
+				labels: ["cli", "json"],
+				milestone: "m-1",
+				dependencies: ["TASK-2"],
+				references: ["https://example.com/issue"],
+				documentation: ["doc-1"],
+				modifiedFiles: ["src/cli.ts"],
+				description: "Machine-readable output",
+				implementationPlan: "1. Add formatter",
+				implementationNotes: "Formatter added",
+				finalSummary: "Ready for review",
+				acceptanceCriteriaItems: [{ index: 1, text: "Produces JSON", checked: true }],
+				definitionOfDoneItems: [{ index: 1, text: "Tests pass", checked: false }],
+				comments: [{ index: 1, body: "Keep this stable", createdDate: "2026-07-14 11:00", author: "@alex" }],
+				ordinal: 1000,
+				branch: "secret-branch",
+				rawContent: "internal markdown",
+				source: "local",
+				onStatusChange: "echo secret",
+			},
+			false,
+		);
+
+		await core.filesystem.saveDocument({
+			id: "doc-1",
+			title: "JSON guide",
+			type: "guide",
+			createdDate: "2026-07-13",
+			updatedDate: "2026-07-14 08:00",
+			rawContent: "JSON task documentation",
+			tags: ["cli"],
+			path: "guides/json.md",
+		});
+
+		await core.filesystem.saveDecision({
+			id: "decision-1",
+			title: "Use stable JSON",
+			date: "2026-07-12",
+			status: "accepted",
+			context: "JSON task consumers need stability",
+			decision: "Publish curated fields",
+			consequences: "Version the contract",
+			rawContent: "JSON task decision",
+		});
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("returns a compact versioned task-list envelope", async () => {
+		const result = await runCli(["task", "list", "--json"]);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toBe("");
+		expect(result.stdout.toString().endsWith("\n")).toBe(true);
+
+		const output = JSON.parse(result.stdout.toString());
+		expect(output).toEqual({
+			schemaVersion: 1,
+			kind: "task-list",
+			tasks: [
+				{
+					id: "TASK-1",
+					title: "JSON task",
+					status: "In Progress",
+					type: "enhancement",
+					priority: "high",
+					assignees: ["@alex"],
+					reporter: "@sam",
+					labels: ["cli", "json"],
+					milestone: "m-1",
+					parentTaskId: null,
+					ordinal: 1000,
+					createdAt: "2026-07-14T09:30:00Z",
+					updatedAt: "2026-07-14T10:45:00Z",
+				},
+			],
+		});
+		expect(result.stdout.toString()).not.toContain("rawContent");
+		expect(result.stdout.toString()).not.toContain("secret-branch");
+		expect(result.stdout.toString()).not.toContain("onStatusChange");
+	});
+
+	it("returns curated task details for view and shorthand", async () => {
+		for (const args of [
+			["task", "view", "1", "--json"],
+			["task", "1", "--json"],
+		]) {
+			const result = await runCli(args);
+			expect(result.exitCode).toBe(0);
+			const output = JSON.parse(result.stdout.toString());
+			expect(output.schemaVersion).toBe(1);
+			expect(output.kind).toBe("task-view");
+			expect(output.task.path).toMatch(/^backlog\/tasks\/task-1 - JSON-task\.md$/);
+			expect(output.task.description).toBe("Machine-readable output");
+			expect(output.task.dependencies).toEqual(["TASK-2"]);
+			expect(output.task.acceptanceCriteria).toEqual([{ index: 1, text: "Produces JSON", checked: true }]);
+			expect(output.task.definitionOfDone).toEqual([{ index: 1, text: "Tests pass", checked: false }]);
+			expect(output.task.comments).toEqual([
+				{
+					index: 1,
+					body: "Keep this stable",
+					createdAt: "2026-07-14T11:00:00Z",
+					author: "@alex",
+				},
+			]);
+			expect(output.task.subtasks).toEqual([]);
+			expect(output.task.finalSummary).toBe("Ready for review");
+			expect(output.task.rawContent).toBeUndefined();
+			expect(output.task.filePath).toBeUndefined();
+			expect(output.task.branch).toBeUndefined();
+		}
+	});
+
+	it("preserves heterogeneous search rank and omits scores", async () => {
+		const result = await runCli(["search", "JSON task", "--json"]);
+		expect(result.exitCode).toBe(0);
+		const output = JSON.parse(result.stdout.toString());
+		expect(output.schemaVersion).toBe(1);
+		expect(output.kind).toBe("search");
+		expect(output.results.map((entry: { type: string }) => entry.type)).toEqual(["task", "document", "decision"]);
+		expect(output.results[0].data.id).toBe("TASK-1");
+		expect(output.results[1].data).toEqual({
+			id: "doc-1",
+			title: "JSON guide",
+			type: "guide",
+			path: "doc-1 - JSON-guide.md",
+			tags: ["cli"],
+			createdAt: "2026-07-13",
+			updatedAt: "2026-07-14T08:00:00Z",
+		});
+		expect(output.results[2].data).toEqual({
+			id: "decision-1",
+			title: "Use stable JSON",
+			status: "accepted",
+			date: "2026-07-12",
+		});
+		for (const entry of output.results) {
+			expect(entry.score).toBeUndefined();
+		}
+	});
+
+	it("returns successful empty envelopes", async () => {
+		const list = await runCli(["task", "list", "--status", "Done", "--json"]);
+		expect(JSON.parse(list.stdout.toString())).toEqual({ schemaVersion: 1, kind: "task-list", tasks: [] });
+
+		const search = await runCli(["search", "no-such-content", "--json"]);
+		expect(JSON.parse(search.stdout.toString())).toEqual({ schemaVersion: 1, kind: "search", results: [] });
+	});
+
+	it("rejects conflicting output modes without stdout", async () => {
+		for (const args of [
+			["task", "list", "--json", "--plain"],
+			["task", "view", "1", "--json", "--plain"],
+			["task", "1", "--json", "--plain"],
+			["search", "JSON", "--json", "--plain"],
+		]) {
+			const result = await runCli(args);
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout.toString()).toBe("");
+			expect(result.stderr.toString()).toContain("--json cannot be combined with --plain");
+		}
+	});
+
+	it("uses stderr and a nonzero exit for JSON errors", async () => {
+		for (const args of [
+			["task", "view", "999", "--json"],
+			["task", "999", "--json"],
+			["task", "list", "--limit", "0", "--json"],
+		]) {
+			const result = await runCli(args);
+			expect(result.exitCode).toBe(1);
+			expect(result.stdout.toString()).toBe("");
+			expect(result.stderr.toString().length).toBeGreaterThan(0);
+		}
+	});
+
+	it("is parseable through a shell pipe", async () => {
+		const result =
+			await $`bun ${CLI_PATH} task list --json | bun -e ${"const value = await Bun.stdin.json(); console.log(value.kind);"}`
+				.cwd(TEST_DIR)
+				.nothrow()
+				.quiet();
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toBe("task-list\n");
+	});
+
+	it("documents JSON mode in command help", async () => {
+		for (const args of [
+			["task", "list", "--help"],
+			["task", "view", "--help"],
+			["task", "--help"],
+			["search", "--help"],
+		]) {
+			const result = await runCli(args);
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toContain("--json");
+		}
+	});
+});

--- a/src/utils/read-output-mode.test.ts
+++ b/src/utils/read-output-mode.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { resolveReadOutputMode } from "./read-output-mode.ts";
+
+describe("resolveReadOutputMode", () => {
+	it("keeps explicit JSON noninteractive in a TTY", () => {
+		expect(resolveReadOutputMode({ json: true }, true)).toBe("json");
+	});
+
+	it("preserves explicit and automatic plain modes", () => {
+		expect(resolveReadOutputMode({ plain: true }, true)).toBe("plain");
+		expect(resolveReadOutputMode({}, false)).toBe("plain");
+	});
+
+	it("uses the interactive mode only when both streams are TTYs", () => {
+		expect(resolveReadOutputMode({}, true)).toBe("interactive");
+	});
+
+	it("rejects conflicting explicit modes", () => {
+		expect(() => resolveReadOutputMode({ json: true, plain: true }, true)).toThrow(
+			"--json cannot be combined with --plain.",
+		);
+	});
+});

--- a/src/utils/read-output-mode.ts
+++ b/src/utils/read-output-mode.ts
@@ -1,0 +1,20 @@
+export type ReadOutputMode = "json" | "plain" | "interactive";
+
+export type ReadOutputOptions = {
+	json?: boolean;
+	plain?: boolean;
+};
+
+export function resolveReadOutputMode(
+	options: ReadOutputOptions,
+	hasInteractiveTTY: boolean,
+	plainFlagInArgv = false,
+): ReadOutputMode {
+	const plain = Boolean(options.plain || plainFlagInArgv);
+	if (options.json && plain) {
+		throw new Error("--json cannot be combined with --plain.");
+	}
+	if (options.json) return "json";
+	if (plain || !hasInteractiveTTY) return "plain";
+	return "interactive";
+}

--- a/src/utils/read-output-mode.ts
+++ b/src/utils/read-output-mode.ts
@@ -5,12 +5,8 @@ export type ReadOutputOptions = {
 	plain?: boolean;
 };
 
-export function resolveReadOutputMode(
-	options: ReadOutputOptions,
-	hasInteractiveTTY: boolean,
-	plainFlagInArgv = false,
-): ReadOutputMode {
-	const plain = Boolean(options.plain || plainFlagInArgv);
+export function resolveReadOutputMode(options: ReadOutputOptions, hasInteractiveTTY: boolean): ReadOutputMode {
+	const plain = Boolean(options.plain);
 	if (options.json && plain) {
 		throw new Error("--json cannot be combined with --plain.");
 	}


### PR DESCRIPTION
## Summary

- Add `--json` to task list, task view, task shorthand, and heterogeneous search
- Publish a versioned, curated contract with fixed null and array semantics and project-relative paths
- Keep JSON stdout clean, report errors on stderr, and reject conflicting output modes
- Document the contract in CLI help, README, and canonical CLI instructions

## Validation

- 16 focused JSON and output-mode tests passed
- Full suite passed with 1721 tests and 4 interactive TUI skips
- `bunx tsc --noEmit` passed
- `bun run check .` passed across 336 files
- `git diff --check` passed

Closes #784