### PR TITLE
BACK-550 - Add append-plan option to task edit CLI

### DIFF
--- a/backlog/tasks/back-550 - Add-append-plan-option-to-task-edit-CLI.md
+++ b/backlog/tasks/back-550 - Add-append-plan-option-to-task-edit-CLI.md
@@ -1,16 +1,22 @@
 ---
 id: BACK-550
 title: Add append-plan option to task edit CLI
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-17 06:45'
+updated_date: '2026-07-17 22:45'
 labels:
   - cli
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/792'
   - 'https://github.com/MrLesk/Backlog.md/pull/793'
+modified_files:
+  - src/cli.ts
+  - src/guidelines/cli-instructions/task-execution.md
+  - src/test/append-implementation-plan.test.ts
+  - src/test/cli-guidance.test.ts
 type: enhancement
 ordinal: 197000
 ---
@@ -23,20 +29,43 @@ Add repeatable `--append-plan` support to the canonical `backlog task edit` comm
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `backlog task edit --append-plan <text>` is a public repeatable option
-- [ ] #2 Multiple append values are applied in CLI order, with each addition separated from existing or previously appended plan text by exactly one blank line
-- [ ] #3 Each append preserves internal newlines and whitespace-only values are ignored, consistent with the shared plan append pipeline
-- [ ] #4 The first nonblank append creates the plan section when the task has no implementation plan
-- [ ] #5 When `--plan` and `--append-plan` are used together, `--plan` replaces the plan first and append values are then applied in CLI order
-- [ ] #6 Real CLI tests cover noninteractive and PTY no-editor behavior, including a missing plan and combined replacement plus append
-- [ ] #7 `backlog task edit --help` and the canonical task-execution guidance document `--append-plan` and its ordering relative to `--plan`
-- [ ] #8 Existing `--plan`, `--append-notes`, MCP planAppend, and unrelated task edit fields retain their current behavior
-- [ ] #9 The full test suite, `bunx tsc --noEmit`, `bun run check .`, and `bun run build` pass
+- [x] #1 `backlog task edit --append-plan <text>` is a public repeatable option
+- [x] #2 Multiple append values are applied in CLI order, with each addition separated from existing or previously appended plan text by exactly one blank line
+- [x] #3 Each append preserves internal newlines and whitespace-only values are ignored, consistent with the shared plan append pipeline
+- [x] #4 The first nonblank append creates the plan section when the task has no implementation plan
+- [x] #5 When `--plan` and `--append-plan` are used together, `--plan` replaces the plan first and append values are then applied in CLI order
+- [x] #6 Real CLI tests cover noninteractive and PTY no-editor behavior, including a missing plan and combined replacement plus append
+- [x] #7 `backlog task edit --help` and the canonical task-execution guidance document `--append-plan` and its ordering relative to `--plan`
+- [x] #8 Existing `--plan`, `--append-notes`, MCP planAppend, and unrelated task edit fields retain their current behavior
+- [x] #9 The full test suite, `bunx tsc --noEmit`, `bun run check .`, and `bun run build` pass
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Wire the repeatable --append-plan option into task edit parsing and interactive edit-field detection while reusing the existing shared plan append pipeline.
+2. Add focused real CLI coverage for existing and missing plans, ordered replacement plus append, whitespace filtering, multiline input, and PTY no-editor behavior.
+3. Document --append-plan and replacement-before-append ordering in the canonical task-execution guidance, then regenerate or synchronize shipped instruction artifacts as required.
+4. Run the focused tests, full test suite, type-check, Biome check, and build; update the task record with objective evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Completed the focused CLI slice. Added repeatable --append-plan help/schema wiring, documented replacement-before-append ordering in the canonical task-execution guide, and added noninteractive plus real PTY regression coverage. Focused verification passed: bun test src/test/append-implementation-plan.test.ts src/test/cli-guidance.test.ts (23 pass, 0 fail).
+
+Full verification passed: bun test (1729 pass, 4 skip, 0 fail), bunx tsc --noEmit, bun run check . (337 files, no fixes), and bun run build. The focused PTY test ran under a real pseudo-terminal and confirmed --append-plan mutates the plan without entering the interactive edit wizard.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the canonical repeatable `backlog task edit --append-plan` option by wiring the CLI into the existing shared plan-append pipeline. The option preserves ordered blank-line-separated appends, ignores blank input, creates a missing plan, and applies after `--plan` replacement. Updated task edit help and the canonical task-execution guide, with noninteractive and real PTY regression coverage. Verified with 1729 passing tests, type-check, Biome, and the production build.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2691,6 +2691,11 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			description: "Remove all labels; cannot combine with other label flags",
 		},
 		{ name: "plan", type: "Markdown", description: "Replacement implementation plan" },
+		{
+			name: "append-plan",
+			type: "Markdown",
+			description: "Append after --plan replacement; repeatable",
+		},
 		{ name: "notes", type: "Markdown", description: "Replacement implementation notes" },
 		{ name: "comment", type: "Markdown", description: "Append a discussion comment" },
 		{ name: "final-summary", type: "Markdown", description: "Completion summary" },
@@ -2781,7 +2786,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 	.option("--final-summary <text>", "set final summary (replaces existing)")
 	.option(
 		"--append-plan <text>",
-		"append to implementation plan (can be used multiple times)",
+		"append after --plan replacement (can be used multiple times)",
 		createMultiValueAccumulator(),
 	)
 	.option(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -466,6 +466,7 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.comment !== undefined ||
 			options.commentAuthor !== undefined ||
 			options.finalSummary !== undefined ||
+			options.appendPlan !== undefined ||
 			options.appendNotes !== undefined ||
 			options.appendFinalSummary !== undefined ||
 			options.clearFinalSummary ||
@@ -2723,6 +2724,11 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 	.option("--comment-author <author>", "author to record for appended comments")
 	.option("--final-summary <text>", "set final summary (replaces existing)")
 	.option(
+		"--append-plan <text>",
+		"append to implementation plan (can be used multiple times)",
+		createMultiValueAccumulator(),
+	)
+	.option(
 		"--append-notes <text>",
 		"append to implementation notes (can be used multiple times)",
 		createMultiValueAccumulator(),
@@ -2972,6 +2978,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		const normalizedDocumentation = parseDelimitedStringList(options.doc);
 		const normalizedModifiedFiles = parseDelimitedStringList(options.modifiedFile);
 
+		const planAppendValues = toStringArray(options.appendPlan);
 		const notesAppendValues = toStringArray(options.appendNotes);
 		const commentsAppendValues = toStringArray(options.comment);
 		const finalSummaryAppendValues = toStringArray(options.appendFinalSummary);
@@ -3030,6 +3037,9 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		}
 		if (typeof options.notes === "string") {
 			editArgs.notesSet = String(options.notes);
+		}
+		if (planAppendValues.length > 0) {
+			editArgs.planAppend = planAppendValues;
 		}
 		if (notesAppendValues.length > 0) {
 			editArgs.notesAppend = notesAppendValues;

--- a/src/guidelines/cli-instructions/task-execution.md
+++ b/src/guidelines/cli-instructions/task-execution.md
@@ -22,7 +22,12 @@ Before writing code for non-trivial work:
    review, present it and wait for explicit approval before implementation. Routine plans need not block when no review
    was requested and they stay within confirmed scope.
 
-Keep the Backlog task as the plan of record. If the approach changes, update the plan through `backlog task edit` before continuing.
+Keep the Backlog task as the plan of record. If the approach changes, replace it with `--plan` or extend it with one
+or more repeatable `--append-plan` values. When both options are provided, `--plan` replaces the existing plan first,
+then each `--append-plan` value is appended in CLI order:
+
+- `backlog task edit {{TASK_ID:123}} --append-plan "5. Verify the revised approach"`
+- `backlog task edit {{TASK_ID:123}} --plan "1. Revised approach" --append-plan "2. Verify it"`
 
 ### Execution Workflow
 

--- a/src/test/append-implementation-plan.test.ts
+++ b/src/test/append-implementation-plan.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { extractStructuredSection } from "../markdown/structured-sections.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+
+describe("Append Implementation Plan via task edit --append-plan", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-append-plan");
+		await mkdir(TEST_DIR, { recursive: true });
+
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email "test@example.com"`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await initializeTestProject(core, "Append Plan Test Project");
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("appends to existing Implementation Plan with single blank line separation", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-1",
+				title: "Existing plan",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-09-10 00:00",
+				labels: [],
+				dependencies: [],
+				description: "Test description",
+				implementationPlan: "Original plan",
+			},
+			false,
+		);
+
+		let res = await $`bun ${CLI_PATH} task edit 1 --append-plan "First addition" --append-plan "Second addition"`
+			.cwd(TEST_DIR)
+			.quiet()
+			.nothrow();
+		expect(res.exitCode).toBe(0);
+
+		res = await $`bun ${CLI_PATH} task edit 1 --append-plan "Third addition"`.cwd(TEST_DIR).quiet().nothrow();
+		expect(res.exitCode).toBe(0);
+
+		const updatedBody = await core.getTaskContent("task-1");
+		expect(updatedBody).not.toBeNull();
+
+		const body = extractStructuredSection(updatedBody ?? "", "implementationPlan") || "";
+		expect(body).toBe("Original plan\n\nFirst addition\n\nSecond addition\n\nThird addition");
+	});
+
+	it("creates Implementation Plan when missing", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-2",
+				title: "No plan yet",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-09-10 00:00",
+				labels: [],
+				dependencies: [],
+				description: "Desc here",
+			},
+			false,
+		);
+
+		const res = await $`bun ${CLI_PATH} task edit 2 --append-plan "Plan from scratch"`.cwd(TEST_DIR).quiet().nothrow();
+		expect(res.exitCode).toBe(0);
+
+		const content = (await core.getTaskContent("task-2")) ?? "";
+		expect(extractStructuredSection(content, "implementationPlan") || "").toBe("Plan from scratch");
+	});
+
+	it("supports multi-line appended content and preserves literal newlines", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-3",
+				title: "Multiline append",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-09-10 00:00",
+				labels: [],
+				dependencies: [],
+				description: "Simple description",
+			},
+			false,
+		);
+
+		const multiline = "Step1\nStep2\n\nPhase2";
+		const res = await $`bun ${[CLI_PATH, "task", "edit", "3", "--append-plan", multiline]}`
+			.cwd(TEST_DIR)
+			.quiet()
+			.nothrow();
+		expect(res.exitCode).toBe(0);
+
+		const updatedBody = await core.getTaskContent("task-3");
+		expect(extractStructuredSection(updatedBody ?? "", "implementationPlan") || "").toContain("Step1\nStep2\n\nPhase2");
+	});
+
+	it("allows combining --plan (replace) with --append-plan (append)", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-4",
+				title: "Mix flags",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-09-10 00:00",
+				labels: [],
+				dependencies: [],
+				description: "Description only",
+			},
+			false,
+		);
+
+		const res = await $`bun ${CLI_PATH} task edit 4 --plan "Replace" --append-plan "Append"`
+			.cwd(TEST_DIR)
+			.quiet()
+			.nothrow();
+
+		expect(res.exitCode).toBe(0);
+		const updatedBody = await core.getTaskContent("task-4");
+		expect(extractStructuredSection(updatedBody ?? "", "implementationPlan") || "").toBe("Replace\n\nAppend");
+	});
+
+	it("--append-plan alone counts as an edit (does not fall through to the editor)", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-5",
+				title: "Only append",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-09-10 00:00",
+				labels: [],
+				dependencies: [],
+				description: "Desc",
+			},
+			false,
+		);
+
+		const res = await $`bun ${CLI_PATH} task edit 5 --append-plan "Sole edit"`.cwd(TEST_DIR).quiet().nothrow();
+		expect(res.exitCode).toBe(0);
+		expect(extractStructuredSection((await core.getTaskContent("task-5")) ?? "", "implementationPlan") || "").toBe(
+			"Sole edit",
+		);
+	});
+});

--- a/src/test/append-implementation-plan.test.ts
+++ b/src/test/append-implementation-plan.test.ts
@@ -8,6 +8,43 @@ import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-
 
 let TEST_DIR: string;
 const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+const SCRIPT_PATH = Bun.which("script");
+const itPty = process.platform === "win32" || !SCRIPT_PATH ? it.skip : it;
+
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+async function runCliInPty(args: string[]): Promise<{ exitCode: number; output: string; timedOut: boolean }> {
+	if (!SCRIPT_PATH) {
+		throw new Error("script is required for PTY tests");
+	}
+
+	const bunPath = Bun.which("bun") ?? "bun";
+	const command = [bunPath, CLI_PATH, ...args];
+	const scriptArgs =
+		process.platform === "darwin"
+			? [SCRIPT_PATH, "-q", "/dev/null", ...command]
+			: [SCRIPT_PATH, "-q", "-e", "-c", command.map(shellQuote).join(" "), "/dev/null"];
+	const child = Bun.spawn(scriptArgs, {
+		cwd: TEST_DIR,
+		stdin: "ignore",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	let timedOut = false;
+	const timeout = setTimeout(() => {
+		timedOut = true;
+		child.kill();
+	}, 5_000);
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		child.stdout ? new Response(child.stdout).text() : Promise.resolve(""),
+		child.stderr ? new Response(child.stderr).text() : Promise.resolve(""),
+	]);
+	clearTimeout(timeout);
+	return { exitCode, output: `${stdout}${stderr}`, timedOut };
+}
 
 describe("Append Implementation Plan via task edit --append-plan", () => {
 	beforeEach(async () => {
@@ -109,6 +146,44 @@ describe("Append Implementation Plan via task edit --append-plan", () => {
 		expect(extractStructuredSection(updatedBody ?? "", "implementationPlan") || "").toContain("Step1\nStep2\n\nPhase2");
 	});
 
+	it("ignores whitespace-only values while preserving append order", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-6",
+				title: "Whitespace append",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-09-10 00:00",
+				labels: [],
+				dependencies: [],
+				description: "Description",
+				implementationPlan: "Original",
+			},
+			false,
+		);
+
+		const res = await $`bun ${[
+			CLI_PATH,
+			"task",
+			"edit",
+			"6",
+			"--append-plan",
+			"  ",
+			"--append-plan",
+			"First\nline",
+			"--append-plan",
+			"Second",
+		]}`
+			.cwd(TEST_DIR)
+			.quiet()
+			.nothrow();
+		expect(res.exitCode).toBe(0);
+		expect(extractStructuredSection((await core.getTaskContent("task-6")) ?? "", "implementationPlan")).toBe(
+			"Original\n\nFirst\nline\n\nSecond",
+		);
+	});
+
 	it("allows combining --plan (replace) with --append-plan (append)", async () => {
 		const core = new Core(TEST_DIR);
 		await core.createTask(
@@ -156,5 +231,37 @@ describe("Append Implementation Plan via task edit --append-plan", () => {
 		expect(extractStructuredSection((await core.getTaskContent("task-5")) ?? "", "implementationPlan") || "").toBe(
 			"Sole edit",
 		);
+	});
+
+	itPty("--append-plan bypasses the interactive edit wizard in a real PTY", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-7",
+				title: "PTY append",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-09-10 00:00",
+				labels: [],
+				dependencies: [],
+				description: "Description",
+			},
+			false,
+		);
+
+		const result = await runCliInPty(["task", "edit", "7", "--append-plan", "PTY addition"]);
+		expect(result.timedOut).toBe(false);
+		expect(result.exitCode, result.output).toBe(0);
+		expect(extractStructuredSection((await core.getTaskContent("task-7")) ?? "", "implementationPlan")).toBe(
+			"PTY addition",
+		);
+	});
+
+	it("documents repeatability and replacement ordering in task edit help", async () => {
+		const output = await $`bun ${CLI_PATH} task edit --help`.cwd(TEST_DIR).text();
+		const normalizedOutput = output.replace(/\s+/g, " ");
+		expect(output).toContain("--append-plan <text>");
+		expect(normalizedOutput).toContain("append after --plan replacement (can be used multiple times)");
+		expect(output).toContain("append-plan: Markdown - Append after --plan replacement; repeatable");
 	});
 });

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -145,6 +145,10 @@ describe("CLI Integration", () => {
 				"Research the current system, including relevant code, tests, conventions, and recent changes",
 			);
 			expect(taskExecution).toContain("Record the current plan in the task before implementation");
+			expect(taskExecution).toContain("or more repeatable `--append-plan` values");
+			expect(taskExecution).toContain(
+				'backlog task edit BACK-123 --plan "1. Revised approach" --append-plan "2. Verify it"',
+			);
 			expect(taskExecution).toContain(
 				"If the plan contains a material product, architecture, or workflow decision, or the project or user requires plan",
 			);


### PR DESCRIPTION
Closes #792.

## Summary

- add repeatable `backlog task edit --append-plan <text>` support through the existing shared plan-append pipeline
- apply appends after `--plan` replacement, preserving CLI order and blank-line separation while ignoring blank values
- document the option in task edit help and the canonical task-execution guide
- cover missing plans, multiline and whitespace handling, replacement plus append, and real PTY no-wizard behavior

## Verification

- `bun test` (1729 pass, 4 skip, 0 fail)
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`