### PR TITLE
Improve task-creation guides for work kind and AC legitimacy

### DIFF
--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -60,8 +60,8 @@ Write tasks so a future agent can act on them without prior conversation context
 Include:
 
 - A clear title.
-- A description explaining the outcome and why it matters. For bugs or friction, record what failed and how it was hit; mark open questions and unverified fix ideas as such rather than as settled requirements.
-- Acceptance criteria that are specific, testable, independent, and limited to agreed success conditions (see Acceptance Criteria).
+- A description explaining the outcome and why it matters.
+- Acceptance criteria that are specific, testable, and independent.
 - References or documentation when they are needed for implementation.
 - Dependencies when work must happen in order.
 
@@ -102,15 +102,16 @@ If single quotes are not practical in your shell, escape each literal backtick b
 
 ### Acceptance Criteria
 
-Acceptance criteria define expected behavior a stakeholder would accept, not implementation steps and not an agent's preferred build plan.
+Acceptance criteria define the expected behavior, not implementation steps.
 
 Good criteria:
 
-- Are testable and independent.
-- Reflect agreed user or product needs. For an observable bug, the reported failure mode is usually enough; prefer one honest criterion over none, and none over invented scope.
-- Include edge cases, tests, or documentation when those are part of the agreed deliverable (not as padding).
+- Are testable.
+- Include edge cases when relevant.
+- Include documentation and test expectations when required.
+- Reflect real needs only: prefer fewer true criteria over invented scope. For an observable bug, the reported failure mode is usually enough.
 
-Avoid criteria like "Implement helper function" unless the helper itself is the user-visible deliverable. Do not invent nice-to-haves to look thorough, force a feature-shaped criteria list onto a bug, or leave an observable bug with no success condition.
+Avoid criteria like "Implement helper function" unless the helper itself is the user-visible deliverable. Do not invent criteria to look thorough.
 
 ### Definition of Done
 

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -60,8 +60,9 @@ Write tasks so a future agent can act on them without prior conversation context
 Include:
 
 - A clear title.
-- A description explaining the outcome and why it matters.
-- Acceptance criteria that are specific, testable, and independent.
+- A description shaped by the work kind (see below).
+- Acceptance criteria only when they express legitimate success conditions (see Acceptance Criteria).
+- `--type` when the configured types fit (`bug`, `feature`, `enhancement`, `chore`, `docs`, `spike`, `task`, or project-configured values).
 - References or documentation when they are needed for implementation.
 - Dependencies when work must happen in order.
 
@@ -71,10 +72,24 @@ the current system and records the plan after picking up and activating the task
 change before then. The narrow exception is already-started work being created directly in a configured active status
 (for example, In Progress); its current researched plan may be supplied at creation.
 
+### Shape by Work Kind
+
+Not every task is a product feature. Match description and acceptance criteria to the kind of work:
+
+| Kind | Description | Acceptance criteria |
+| --- | --- | --- |
+| bug / friction | What failed or hurt, how it was hit, error or output when known; mark open questions and unverified fix ideas as such | Optional. Prefer 1–3 testable "done when" items if known. If the finish line is a decision, one decision/spike criterion is enough. Empty criteria beat invented ones. |
+| feature / enhancement | Outcome and why it matters to the user or product | Required: specific, testable, independent criteria for stakeholder-accepted success |
+| chore / docs / task | Outcome | Optional; add only when "done" would otherwise be ambiguous |
+| spike | Question to answer | What decision, note, or artifact must exist when the spike ends |
+
+Do not force a feature-shaped work order onto a bug report or friction capture.
+
 Examples:
 
 ```bash
 backlog task create "Add project search" \
+  --type feature \
   -d "Users can search tasks, docs, and decisions from one CLI command." \
   --ac "Search returns matching tasks by title and description" \
   --ac "Search supports --plain output" \
@@ -82,7 +97,15 @@ backlog task create "Add project search" \
 ```
 
 ```bash
+backlog task create "Session start digest shows stale task count" \
+  --type bug \
+  -d "Observation: after completing TASK-12, the next session start still reported 1 open task until board refresh. Hypothesis (untested): digest cache is not invalidated on status change." \
+  --ac "After a task moves to Done, a new session start digest reports the updated open count"
+```
+
+```bash
 backlog task create "Add settings docs" \
+  --type docs \
   --doc docs/settings.md \
   --ref https://example.com/spec
 ```
@@ -102,15 +125,21 @@ If single quotes are not practical in your shell, escape each literal backtick b
 
 ### Acceptance Criteria
 
-Acceptance criteria define the expected behavior, not implementation steps.
+Acceptance criteria define **observable success conditions a stakeholder would accept**, not implementation steps and not an agent's preferred build plan.
+
+**Legitimacy first.** Prefer fewer true criteria over a complete-looking list. Do not invent acceptance criteria for nice-to-haves, speculative edge cases, tests, docs, or follow-on work unless the user, product decision, or existing task scope requires them. If requirements are ambiguous, ask or record an open question — do not paper over uncertainty with confident criteria.
 
 Good criteria:
 
-- Are testable.
-- Include edge cases when relevant.
-- Include documentation and test expectations when required.
+- Are testable and independent.
+- Reflect user or product needs you could defend to the requester.
+- Include edge cases, tests, or documentation **only when those are part of the agreed deliverable**.
 
-Avoid criteria like "Implement helper function" unless the helper itself is the user-visible deliverable.
+Avoid:
+
+- Criteria like "Implement helper function" unless the helper itself is the user-visible deliverable.
+- Padding with invented scope ("also support dark mode", "add unit tests for unrelated helpers") to look thorough.
+- Turning an unverified implementation idea into a criterion labeled as a user need.
 
 ### Definition of Done
 

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -60,9 +60,8 @@ Write tasks so a future agent can act on them without prior conversation context
 Include:
 
 - A clear title.
-- A description shaped by the work kind (see below).
-- Acceptance criteria that express legitimate success conditions (see Acceptance Criteria).
-- `--type` when the configured types fit (`bug`, `feature`, `enhancement`, `chore`, `docs`, `spike`, `task`, or project-configured values).
+- A description explaining the outcome and why it matters. For bugs or friction, record what failed and how it was hit; mark open questions and unverified fix ideas as such rather than as settled requirements.
+- Acceptance criteria that are specific, testable, independent, and limited to agreed success conditions (see Acceptance Criteria).
 - References or documentation when they are needed for implementation.
 - Dependencies when work must happen in order.
 
@@ -72,24 +71,10 @@ the current system and records the plan after picking up and activating the task
 change before then. The narrow exception is already-started work being created directly in a configured active status
 (for example, In Progress); its current researched plan may be supplied at creation.
 
-### Shape by Work Kind
-
-Not every task is a product feature. Match description and acceptance criteria to the kind of work:
-
-| Kind | Description | Acceptance criteria |
-| --- | --- | --- |
-| bug / friction | What failed or hurt, how it was hit, error or output when known; mark open questions and unverified fix ideas as such | When the failure is observable, name it as done-when (prefer 1–3 testable items). If the finish line is a choice, one decision/spike or WONTFIX criterion. Prefer one honest criterion over none; never invent scope to fill the list. |
-| feature / enhancement | Outcome and why it matters to the user or product | Required: specific, testable, independent criteria for stakeholder-accepted success |
-| chore / docs / task | Outcome | Add when success is not obvious from the title alone |
-| spike | Question to answer | What decision, note, or artifact must exist when the spike ends |
-
-Do not force a feature-shaped work order onto a bug report or friction capture. Do not leave an observable bug without a success condition.
-
 Examples:
 
 ```bash
 backlog task create "Add project search" \
-  --type feature \
   -d "Users can search tasks, docs, and decisions from one CLI command." \
   --ac "Search returns matching tasks by title and description" \
   --ac "Search supports --plain output" \
@@ -97,15 +82,7 @@ backlog task create "Add project search" \
 ```
 
 ```bash
-backlog task create "Session start digest shows stale task count" \
-  --type bug \
-  -d "Observation: after completing TASK-12, the next session start still reported 1 open task until board refresh. Hypothesis (untested): digest cache is not invalidated on status change." \
-  --ac "After a task moves to Done, a new session start digest reports the updated open count"
-```
-
-```bash
 backlog task create "Add settings docs" \
-  --type docs \
   --doc docs/settings.md \
   --ref https://example.com/spec
 ```
@@ -125,22 +102,15 @@ If single quotes are not practical in your shell, escape each literal backtick b
 
 ### Acceptance Criteria
 
-Acceptance criteria define **observable success conditions a stakeholder would accept**, not implementation steps and not an agent's preferred build plan.
-
-**Legitimacy first.** Prefer fewer true criteria over a complete-looking list. Prefer one honest criterion over none when a success condition is observable. Prefer none over invented criteria. Do not invent acceptance criteria for nice-to-haves, speculative edge cases, or follow-on work, and do not invent tests or docs criteria unless the user, product decision, or existing task scope requires them. If requirements are ambiguous, ask, record an open question, or use a decision/spike criterion — do not paper over uncertainty with confident product criteria, and do not omit a finish line when the failure is already observable.
+Acceptance criteria define expected behavior a stakeholder would accept, not implementation steps and not an agent's preferred build plan.
 
 Good criteria:
 
 - Are testable and independent.
-- Reflect user or product needs you could defend to the requester (for bugs: the reported failure mode is usually enough).
-- Include edge cases, tests, or documentation **that are part of the agreed deliverable**.
+- Reflect agreed user or product needs. For an observable bug, the reported failure mode is usually enough; prefer one honest criterion over none, and none over invented scope.
+- Include edge cases, tests, or documentation when those are part of the agreed deliverable (not as padding).
 
-Avoid:
-
-- Criteria like "Implement helper function" unless the helper itself is the user-visible deliverable.
-- Padding with invented scope ("also support dark mode", "add unit tests for unrelated helpers") to look thorough.
-- Turning an unverified implementation idea into a criterion labeled as a user need.
-- Filing an observable bug or friction item with no acceptance criteria and no decision criterion.
+Avoid criteria like "Implement helper function" unless the helper itself is the user-visible deliverable. Do not invent nice-to-haves to look thorough, force a feature-shaped criteria list onto a bug, or leave an observable bug with no success condition.
 
 ### Definition of Done
 

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -61,7 +61,7 @@ Include:
 
 - A clear title.
 - A description shaped by the work kind (see below).
-- Acceptance criteria only when they express legitimate success conditions (see Acceptance Criteria).
+- Acceptance criteria that express legitimate success conditions (see Acceptance Criteria).
 - `--type` when the configured types fit (`bug`, `feature`, `enhancement`, `chore`, `docs`, `spike`, `task`, or project-configured values).
 - References or documentation when they are needed for implementation.
 - Dependencies when work must happen in order.
@@ -133,7 +133,7 @@ Good criteria:
 
 - Are testable and independent.
 - Reflect user or product needs you could defend to the requester.
-- Include edge cases, tests, or documentation **only when those are part of the agreed deliverable**.
+- Include edge cases, tests, or documentation **that are part of the agreed deliverable**.
 
 Avoid:
 

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -78,12 +78,12 @@ Not every task is a product feature. Match description and acceptance criteria t
 
 | Kind | Description | Acceptance criteria |
 | --- | --- | --- |
-| bug / friction | What failed or hurt, how it was hit, error or output when known; mark open questions and unverified fix ideas as such | Optional. Prefer 1–3 testable "done when" items if known. If the finish line is a decision, one decision/spike criterion is enough. Empty criteria beat invented ones. |
+| bug / friction | What failed or hurt, how it was hit, error or output when known; mark open questions and unverified fix ideas as such | When the failure is observable, name it as done-when (prefer 1–3 testable items). If the finish line is a choice, one decision/spike or WONTFIX criterion. Prefer one honest criterion over none; never invent scope to fill the list. |
 | feature / enhancement | Outcome and why it matters to the user or product | Required: specific, testable, independent criteria for stakeholder-accepted success |
-| chore / docs / task | Outcome | Optional; add only when "done" would otherwise be ambiguous |
+| chore / docs / task | Outcome | Add when success is not obvious from the title alone |
 | spike | Question to answer | What decision, note, or artifact must exist when the spike ends |
 
-Do not force a feature-shaped work order onto a bug report or friction capture.
+Do not force a feature-shaped work order onto a bug report or friction capture. Do not leave an observable bug without a success condition.
 
 Examples:
 
@@ -127,12 +127,12 @@ If single quotes are not practical in your shell, escape each literal backtick b
 
 Acceptance criteria define **observable success conditions a stakeholder would accept**, not implementation steps and not an agent's preferred build plan.
 
-**Legitimacy first.** Prefer fewer true criteria over a complete-looking list. Do not invent acceptance criteria for nice-to-haves, speculative edge cases, tests, docs, or follow-on work unless the user, product decision, or existing task scope requires them. If requirements are ambiguous, ask or record an open question — do not paper over uncertainty with confident criteria.
+**Legitimacy first.** Prefer fewer true criteria over a complete-looking list. Prefer one honest criterion over none when a success condition is observable. Prefer none over invented criteria. Do not invent acceptance criteria for nice-to-haves, speculative edge cases, or follow-on work, and do not invent tests or docs criteria unless the user, product decision, or existing task scope requires them. If requirements are ambiguous, ask, record an open question, or use a decision/spike criterion — do not paper over uncertainty with confident product criteria, and do not omit a finish line when the failure is already observable.
 
 Good criteria:
 
 - Are testable and independent.
-- Reflect user or product needs you could defend to the requester.
+- Reflect user or product needs you could defend to the requester (for bugs: the reported failure mode is usually enough).
 - Include edge cases, tests, or documentation **that are part of the agreed deliverable**.
 
 Avoid:
@@ -140,6 +140,7 @@ Avoid:
 - Criteria like "Implement helper function" unless the helper itself is the user-visible deliverable.
 - Padding with invented scope ("also support dark mode", "add unit tests for unrelated helpers") to look thorough.
 - Turning an unverified implementation idea into a criterion labeled as a user need.
+- Filing an observable bug or friction item with no acceptance criteria and no decision criterion.
 
 ### Definition of Done
 

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -71,18 +71,30 @@ Create all tasks in the same session to maintain consistency and context.
 
 ### Step 5: Create task(s) with proper scope
 
-**Title and description**: Explain desired outcome and user value (the WHY). Keep the description focused on outcome and essential handoff context.
+**Title and description**: Shape the description by work kind (see below). For features, explain outcome and user value (the WHY). For bugs and friction, record observation, how it was hit, and mark open questions or unverified fix ideas as such. Keep handoff context inside the task; do not rely on "as we discussed."
 
-**Acceptance criteria**: `acceptanceCriteria` is an array of strings; each item should be specific, testable, and independent (the WHAT)
-- Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S")
-- Include negative or edge scenarios when relevant
-- Capture testing expectations explicitly
-- Include documentation expectations in the same task (no deferring to follow-up tasks)
+**Shape by work kind** (set `type` when configured types fit: bug, feature, enhancement, chore, docs, spike, task):
+
+| Kind | Description | Acceptance criteria |
+| --- | --- | --- |
+| bug / friction | What failed or hurt, how found, error or output when known; mark hypotheses as untested | Optional. Prefer 1–3 testable "done when" items if known. One decision/spike criterion if the finish line is a decision. Empty criteria beat invented ones. |
+| feature / enhancement | Outcome and why it matters | Required: specific, testable, independent stakeholder success conditions |
+| chore / docs / task | Outcome | Optional; add only when "done" would otherwise be ambiguous |
+| spike | Question to answer | What decision, note, or artifact must exist when the spike ends |
+
+Do not force a feature-shaped work order onto a bug report or friction capture.
+
+**Acceptance criteria**: `acceptanceCriteria` is an array of strings. Each item must be a **legitimate, observable success condition a stakeholder would accept**, not an implementation step and not the agent's preferred build plan.
+- Prefer fewer true criteria over a complete-looking list. Do not invent nice-to-haves, speculative edges, tests, docs, or follow-on work unless the user, product decision, or existing task scope requires them.
+- Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S").
+- Include negative or edge scenarios only when they are part of the agreed deliverable.
+- When tests or documentation **are** part of the agreed deliverable, put them in this task (do not defer required tests/docs to a vague follow-up). Do not invent test/docs criteria to look thorough.
+- If requirements are ambiguous, ask or record an open question — do not paper over uncertainty with confident criteria.
 
 **Definition of Done defaults (optional):**
 - Project-level defaults are managed with `definition_of_done_defaults_get` / `definition_of_done_defaults_upsert`
 - DoD is not acceptance criteria: AC defines product scope/behavior, DoD defines completion hygiene
-- Per-task DoD customization should be exceptional; default to project-level DoD plus strong acceptance criteria
+- Per-task DoD customization should be exceptional; default to project-level DoD plus appropriate acceptance criteria for the work kind
 - Use `definitionOfDoneAdd` only for task-specific DoD items that apply to this one task
 - Use `disableDefinitionOfDoneDefaults` to skip project defaults for this task when needed
 - Do **not** duplicate project defaults into `definitionOfDoneAdd` unless you are intentionally customizing this task
@@ -110,8 +122,10 @@ If you will continue from task creation into implementation in the same session,
 
 - Creating a single task called "Build desktop application" with 10+ acceptance criteria
 - Adding implementation steps to acceptance criteria
+- Inventing acceptance criteria the user or product did not need in order to look thorough
+- Forcing feature-shaped acceptance criteria onto a bug or friction capture
 - Creating a task before understanding if it needs to be split
-- Deferring tests or documentation to "later tasks" (e.g., "Add tests/docs in a follow-up")
+- Deferring tests or documentation that **are** part of the agreed deliverable to "later tasks"
 
 ### Correct Pattern
 
@@ -119,7 +133,7 @@ If you will continue from task creation into implementation in the same session,
 
 Then create the tasks and report what was created.
 
-**Standalone task example (includes tests/docs):** "Add API endpoint for bulk updates" with acceptance criteria that include required tests and documentation updates in the same task.
+**Standalone feature example (includes agreed tests/docs):** "Add API endpoint for bulk updates" with acceptance criteria that include only the tests and documentation that are part of the agreed deliverable for that endpoint.
 
 ### Durable Context at Creation
 

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -87,7 +87,7 @@ Do not force a feature-shaped work order onto a bug report or friction capture.
 **Acceptance criteria**: `acceptanceCriteria` is an array of strings. Each item must be a **legitimate, observable success condition a stakeholder would accept**, not an implementation step and not the agent's preferred build plan.
 - Prefer fewer true criteria over a complete-looking list. Do not invent nice-to-haves, speculative edges, tests, docs, or follow-on work unless the user, product decision, or existing task scope requires them.
 - Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S").
-- Include negative or edge scenarios only when they are part of the agreed deliverable.
+- Include negative or edge scenarios that are part of the agreed deliverable.
 - When tests or documentation **are** part of the agreed deliverable, put them in this task (do not defer required tests/docs to a vague follow-up). Do not invent test/docs criteria to look thorough.
 - If requirements are ambiguous, ask or record an open question — do not paper over uncertainty with confident criteria.
 

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -71,13 +71,14 @@ Create all tasks in the same session to maintain consistency and context.
 
 ### Step 5: Create task(s) with proper scope
 
-**Title and description**: Explain desired outcome and user value (the WHY). For bugs or friction, record what failed and how it was hit; mark open questions and unverified fix ideas as such. Keep the description focused on handoff context rather than "as we discussed."
+**Title and description**: Explain desired outcome and user value (the WHY). Keep the description focused on outcome and essential handoff context.
 
-**Acceptance criteria**: `acceptanceCriteria` is an array of strings; each item should be specific, testable, independent, and limited to agreed success conditions (the WHAT)
+**Acceptance criteria**: `acceptanceCriteria` is an array of strings; each item should be specific, testable, and independent (the WHAT)
 - Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S")
-- Prefer one honest criterion over none when success is observable; prefer none over invented scope
-- For an observable bug, the reported failure mode is usually enough; do not force a feature-shaped criteria list onto a bug
-- Include negative or edge scenarios, tests, and documentation that are part of the agreed deliverable (same task; not padding)
+- Include negative or edge scenarios when relevant
+- Capture testing expectations explicitly
+- Include documentation expectations in the same task (no deferring to follow-up tasks)
+- Reflect real needs only: prefer fewer true criteria over invented scope. For an observable bug, the reported failure mode is usually enough.
 
 **Definition of Done defaults (optional):**
 - Project-level defaults are managed with `definition_of_done_defaults_get` / `definition_of_done_defaults_upsert`
@@ -110,9 +111,8 @@ If you will continue from task creation into implementation in the same session,
 
 - Creating a single task called "Build desktop application" with 10+ acceptance criteria
 - Adding implementation steps to acceptance criteria, or inventing criteria to look thorough
-- Leaving an observable bug with no success condition
 - Creating a task before understanding if it needs to be split
-- Deferring tests or documentation that are part of the agreed deliverable to "later tasks"
+- Deferring tests or documentation to "later tasks" (e.g., "Add tests/docs in a follow-up")
 
 ### Correct Pattern
 

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -71,31 +71,18 @@ Create all tasks in the same session to maintain consistency and context.
 
 ### Step 5: Create task(s) with proper scope
 
-**Title and description**: Shape the description by work kind (see below). For features, explain outcome and user value (the WHY). For bugs and friction, record observation, how it was hit, and mark open questions or unverified fix ideas as such. Keep handoff context inside the task; do not rely on "as we discussed."
+**Title and description**: Explain desired outcome and user value (the WHY). For bugs or friction, record what failed and how it was hit; mark open questions and unverified fix ideas as such. Keep the description focused on handoff context rather than "as we discussed."
 
-**Shape by work kind** (set `type` when configured types fit: bug, feature, enhancement, chore, docs, spike, task):
-
-| Kind | Description | Acceptance criteria |
-| --- | --- | --- |
-| bug / friction | What failed or hurt, how found, error or output when known; mark hypotheses as untested | When the failure is observable, name it as done-when (prefer 1–3 testable items). If the finish line is a choice, one decision/spike or WONTFIX criterion. Prefer one honest criterion over none; never invent scope to fill the list. |
-| feature / enhancement | Outcome and why it matters | Required: specific, testable, independent stakeholder success conditions |
-| chore / docs / task | Outcome | Add when success is not obvious from the title alone |
-| spike | Question to answer | What decision, note, or artifact must exist when the spike ends |
-
-Do not force a feature-shaped work order onto a bug report or friction capture. Do not leave an observable bug without a success condition.
-
-**Acceptance criteria**: `acceptanceCriteria` is an array of strings. Each item must be a **legitimate, observable success condition a stakeholder would accept**, not an implementation step and not the agent's preferred build plan.
-- Prefer fewer true criteria over a complete-looking list. Prefer one honest criterion over none when a success condition is observable. Prefer none over invented criteria.
-- Do not invent nice-to-haves, speculative edges, or follow-on work. Do not invent tests or docs criteria unless the user, product decision, or existing task scope requires them.
-- Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S").
-- Include negative or edge scenarios that are part of the agreed deliverable.
-- When tests or documentation **are** part of the agreed deliverable, put them in this task (do not defer required tests/docs to a vague follow-up).
-- If requirements are ambiguous, ask, record an open question, or use a decision/spike criterion — do not paper over uncertainty with confident product criteria, and do not omit a finish line when the failure is already observable.
+**Acceptance criteria**: `acceptanceCriteria` is an array of strings; each item should be specific, testable, independent, and limited to agreed success conditions (the WHAT)
+- Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S")
+- Prefer one honest criterion over none when success is observable; prefer none over invented scope
+- For an observable bug, the reported failure mode is usually enough; do not force a feature-shaped criteria list onto a bug
+- Include negative or edge scenarios, tests, and documentation that are part of the agreed deliverable (same task; not padding)
 
 **Definition of Done defaults (optional):**
 - Project-level defaults are managed with `definition_of_done_defaults_get` / `definition_of_done_defaults_upsert`
 - DoD is not acceptance criteria: AC defines product scope/behavior, DoD defines completion hygiene
-- Per-task DoD customization should be exceptional; default to project-level DoD plus appropriate acceptance criteria for the work kind
+- Per-task DoD customization should be exceptional; default to project-level DoD plus strong acceptance criteria
 - Use `definitionOfDoneAdd` only for task-specific DoD items that apply to this one task
 - Use `disableDefinitionOfDoneDefaults` to skip project defaults for this task when needed
 - Do **not** duplicate project defaults into `definitionOfDoneAdd` unless you are intentionally customizing this task
@@ -122,12 +109,10 @@ If you will continue from task creation into implementation in the same session,
 ### Common Anti-patterns to Avoid
 
 - Creating a single task called "Build desktop application" with 10+ acceptance criteria
-- Adding implementation steps to acceptance criteria
-- Inventing acceptance criteria the user or product did not need in order to look thorough
-- Filing an observable bug or friction item with no acceptance criteria and no decision criterion
-- Forcing feature-shaped acceptance criteria onto a bug or friction capture
+- Adding implementation steps to acceptance criteria, or inventing criteria to look thorough
+- Leaving an observable bug with no success condition
 - Creating a task before understanding if it needs to be split
-- Deferring tests or documentation that **are** part of the agreed deliverable to "later tasks"
+- Deferring tests or documentation that are part of the agreed deliverable to "later tasks"
 
 ### Correct Pattern
 
@@ -135,7 +120,7 @@ If you will continue from task creation into implementation in the same session,
 
 Then create the tasks and report what was created.
 
-**Standalone feature example (includes agreed tests/docs):** "Add API endpoint for bulk updates" with acceptance criteria that include only the tests and documentation that are part of the agreed deliverable for that endpoint.
+**Standalone task example (includes tests/docs):** "Add API endpoint for bulk updates" with acceptance criteria that include required tests and documentation updates in the same task.
 
 ### Durable Context at Creation
 

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -77,19 +77,20 @@ Create all tasks in the same session to maintain consistency and context.
 
 | Kind | Description | Acceptance criteria |
 | --- | --- | --- |
-| bug / friction | What failed or hurt, how found, error or output when known; mark hypotheses as untested | Optional. Prefer 1–3 testable "done when" items if known. One decision/spike criterion if the finish line is a decision. Empty criteria beat invented ones. |
+| bug / friction | What failed or hurt, how found, error or output when known; mark hypotheses as untested | When the failure is observable, name it as done-when (prefer 1–3 testable items). If the finish line is a choice, one decision/spike or WONTFIX criterion. Prefer one honest criterion over none; never invent scope to fill the list. |
 | feature / enhancement | Outcome and why it matters | Required: specific, testable, independent stakeholder success conditions |
-| chore / docs / task | Outcome | Optional; add only when "done" would otherwise be ambiguous |
+| chore / docs / task | Outcome | Add when success is not obvious from the title alone |
 | spike | Question to answer | What decision, note, or artifact must exist when the spike ends |
 
-Do not force a feature-shaped work order onto a bug report or friction capture.
+Do not force a feature-shaped work order onto a bug report or friction capture. Do not leave an observable bug without a success condition.
 
 **Acceptance criteria**: `acceptanceCriteria` is an array of strings. Each item must be a **legitimate, observable success condition a stakeholder would accept**, not an implementation step and not the agent's preferred build plan.
-- Prefer fewer true criteria over a complete-looking list. Do not invent nice-to-haves, speculative edges, tests, docs, or follow-on work unless the user, product decision, or existing task scope requires them.
+- Prefer fewer true criteria over a complete-looking list. Prefer one honest criterion over none when a success condition is observable. Prefer none over invented criteria.
+- Do not invent nice-to-haves, speculative edges, or follow-on work. Do not invent tests or docs criteria unless the user, product decision, or existing task scope requires them.
 - Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S").
 - Include negative or edge scenarios that are part of the agreed deliverable.
-- When tests or documentation **are** part of the agreed deliverable, put them in this task (do not defer required tests/docs to a vague follow-up). Do not invent test/docs criteria to look thorough.
-- If requirements are ambiguous, ask or record an open question — do not paper over uncertainty with confident criteria.
+- When tests or documentation **are** part of the agreed deliverable, put them in this task (do not defer required tests/docs to a vague follow-up).
+- If requirements are ambiguous, ask, record an open question, or use a decision/spike criterion — do not paper over uncertainty with confident product criteria, and do not omit a finish line when the failure is already observable.
 
 **Definition of Done defaults (optional):**
 - Project-level defaults are managed with `definition_of_done_defaults_get` / `definition_of_done_defaults_upsert`
@@ -123,6 +124,7 @@ If you will continue from task creation into implementation in the same session,
 - Creating a single task called "Build desktop application" with 10+ acceptance criteria
 - Adding implementation steps to acceptance criteria
 - Inventing acceptance criteria the user or product did not need in order to look thorough
+- Filing an observable bug or friction item with no acceptance criteria and no decision criterion
 - Forcing feature-shaped acceptance criteria onto a bug or friction capture
 - Creating a task before understanding if it needs to be split
 - Deferring tests or documentation that **are** part of the agreed deliverable to "later tasks"

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -190,16 +190,8 @@ describe("CLI Integration", () => {
 			expect(taskCreation).toContain(
 				"Backlog.md cannot recover the original text after the shell has already executed it",
 			);
-			expect(taskCreation).toContain("### Shape by Work Kind");
-			expect(taskCreation).toContain("Do not force a feature-shaped work order onto a bug report or friction capture.");
-			expect(taskCreation).toContain("Do not leave an observable bug without a success condition.");
-			expect(taskCreation).toContain("**Legitimacy first.**");
-			expect(taskCreation).toContain("Prefer one honest criterion over none when a success condition is observable.");
-			expect(taskCreation).toContain("Prefer none over invented criteria.");
-			expect(taskCreation).toContain(
-				"Filing an observable bug or friction item with no acceptance criteria and no decision criterion",
-			);
-			expect(taskCreation).toContain('backlog task create "Session start digest shows stale task count"');
+			expect(taskCreation).toContain("prefer one honest criterion over none, and none over invented scope");
+			expect(taskCreation).toContain("leave an observable bug with no success condition");
 			expect(initRequired).toContain("This directory does not have Backlog.md initialized.");
 			expect(initRequired).toContain("backlog init --defaults");
 		}, 15_000);

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -192,9 +192,12 @@ describe("CLI Integration", () => {
 			);
 			expect(taskCreation).toContain("### Shape by Work Kind");
 			expect(taskCreation).toContain("Do not force a feature-shaped work order onto a bug report or friction capture.");
+			expect(taskCreation).toContain("Do not leave an observable bug without a success condition.");
 			expect(taskCreation).toContain("**Legitimacy first.**");
+			expect(taskCreation).toContain("Prefer one honest criterion over none when a success condition is observable.");
+			expect(taskCreation).toContain("Prefer none over invented criteria.");
 			expect(taskCreation).toContain(
-				"Do not invent acceptance criteria for nice-to-haves, speculative edge cases, tests, docs, or follow-on work",
+				"Filing an observable bug or friction item with no acceptance criteria and no decision criterion",
 			);
 			expect(taskCreation).toContain('backlog task create "Session start digest shows stale task count"');
 			expect(initRequired).toContain("This directory does not have Backlog.md initialized.");

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -190,6 +190,13 @@ describe("CLI Integration", () => {
 			expect(taskCreation).toContain(
 				"Backlog.md cannot recover the original text after the shell has already executed it",
 			);
+			expect(taskCreation).toContain("### Shape by Work Kind");
+			expect(taskCreation).toContain("Do not force a feature-shaped work order onto a bug report or friction capture.");
+			expect(taskCreation).toContain("**Legitimacy first.**");
+			expect(taskCreation).toContain(
+				"Do not invent acceptance criteria for nice-to-haves, speculative edge cases, tests, docs, or follow-on work",
+			);
+			expect(taskCreation).toContain('backlog task create "Session start digest shows stale task count"');
 			expect(initRequired).toContain("This directory does not have Backlog.md initialized.");
 			expect(initRequired).toContain("backlog init --defaults");
 		}, 15_000);

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -190,8 +190,8 @@ describe("CLI Integration", () => {
 			expect(taskCreation).toContain(
 				"Backlog.md cannot recover the original text after the shell has already executed it",
 			);
-			expect(taskCreation).toContain("prefer one honest criterion over none, and none over invented scope");
-			expect(taskCreation).toContain("leave an observable bug with no success condition");
+			expect(taskCreation).toContain("Reflect real needs only: prefer fewer true criteria over invented scope");
+			expect(taskCreation).toContain("Do not invent criteria to look thorough");
 			expect(initRequired).toContain("This directory does not have Backlog.md initialized.");
 			expect(initRequired).toContain("backlog init --defaults");
 		}, 15_000);

--- a/src/test/mcp-server.test.ts
+++ b/src/test/mcp-server.test.ts
@@ -183,14 +183,18 @@ describe("McpServer bootstrap", () => {
 		expect(MCP_TASK_CREATION_GUIDE).toContain(
 			"Do not force a feature-shaped work order onto a bug report or friction capture.",
 		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("Do not leave an observable bug without a success condition.");
 		expect(MCP_TASK_CREATION_GUIDE).toContain("legitimate, observable success condition a stakeholder would accept");
 		expect(MCP_TASK_CREATION_GUIDE).toContain(
-			"Do not invent nice-to-haves, speculative edges, tests, docs, or follow-on work unless the user, product decision, or existing task scope requires them.",
+			"Prefer one honest criterion over none when a success condition is observable.",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("Prefer none over invented criteria.");
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Filing an observable bug or friction item with no acceptance criteria and no decision criterion",
 		);
 		expect(MCP_TASK_CREATION_GUIDE).toContain(
 			"Inventing acceptance criteria the user or product did not need in order to look thorough",
 		);
-		expect(MCP_TASK_CREATION_GUIDE).toContain("Empty criteria beat invented ones.");
 	});
 
 	it("legacy MCP guides preserve just-in-time planning parity with the canonical CLI lifecycle", () => {

--- a/src/test/mcp-server.test.ts
+++ b/src/test/mcp-server.test.ts
@@ -176,25 +176,14 @@ describe("McpServer bootstrap", () => {
 		);
 	});
 
-	it("task creation guide shapes work by kind and restrains invented acceptance criteria", () => {
+	it("task creation guide restrains invented acceptance criteria and empty observable bugs", () => {
 		TEST_DIR = createUniqueTestDir("mcp-server-guides");
 
-		expect(MCP_TASK_CREATION_GUIDE).toContain("**Shape by work kind**");
 		expect(MCP_TASK_CREATION_GUIDE).toContain(
-			"Do not force a feature-shaped work order onto a bug report or friction capture.",
+			"Prefer one honest criterion over none when success is observable; prefer none over invented scope",
 		);
-		expect(MCP_TASK_CREATION_GUIDE).toContain("Do not leave an observable bug without a success condition.");
-		expect(MCP_TASK_CREATION_GUIDE).toContain("legitimate, observable success condition a stakeholder would accept");
-		expect(MCP_TASK_CREATION_GUIDE).toContain(
-			"Prefer one honest criterion over none when a success condition is observable.",
-		);
-		expect(MCP_TASK_CREATION_GUIDE).toContain("Prefer none over invented criteria.");
-		expect(MCP_TASK_CREATION_GUIDE).toContain(
-			"Filing an observable bug or friction item with no acceptance criteria and no decision criterion",
-		);
-		expect(MCP_TASK_CREATION_GUIDE).toContain(
-			"Inventing acceptance criteria the user or product did not need in order to look thorough",
-		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("do not force a feature-shaped criteria list onto a bug");
+		expect(MCP_TASK_CREATION_GUIDE).toContain("Leaving an observable bug with no success condition");
 	});
 
 	it("legacy MCP guides preserve just-in-time planning parity with the canonical CLI lifecycle", () => {

--- a/src/test/mcp-server.test.ts
+++ b/src/test/mcp-server.test.ts
@@ -176,14 +176,14 @@ describe("McpServer bootstrap", () => {
 		);
 	});
 
-	it("task creation guide restrains invented acceptance criteria and empty observable bugs", () => {
+	it("task creation guide restrains invented acceptance criteria", () => {
 		TEST_DIR = createUniqueTestDir("mcp-server-guides");
 
 		expect(MCP_TASK_CREATION_GUIDE).toContain(
-			"Prefer one honest criterion over none when success is observable; prefer none over invented scope",
+			"Reflect real needs only: prefer fewer true criteria over invented scope",
 		);
-		expect(MCP_TASK_CREATION_GUIDE).toContain("do not force a feature-shaped criteria list onto a bug");
-		expect(MCP_TASK_CREATION_GUIDE).toContain("Leaving an observable bug with no success condition");
+		expect(MCP_TASK_CREATION_GUIDE).toContain("For an observable bug, the reported failure mode is usually enough");
+		expect(MCP_TASK_CREATION_GUIDE).toContain("inventing criteria to look thorough");
 	});
 
 	it("legacy MCP guides preserve just-in-time planning parity with the canonical CLI lifecycle", () => {

--- a/src/test/mcp-server.test.ts
+++ b/src/test/mcp-server.test.ts
@@ -176,6 +176,23 @@ describe("McpServer bootstrap", () => {
 		);
 	});
 
+	it("task creation guide shapes work by kind and restrains invented acceptance criteria", () => {
+		TEST_DIR = createUniqueTestDir("mcp-server-guides");
+
+		expect(MCP_TASK_CREATION_GUIDE).toContain("**Shape by work kind**");
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Do not force a feature-shaped work order onto a bug report or friction capture.",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("legitimate, observable success condition a stakeholder would accept");
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Do not invent nice-to-haves, speculative edges, tests, docs, or follow-on work unless the user, product decision, or existing task scope requires them.",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Inventing acceptance criteria the user or product did not need in order to look thorough",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("Empty criteria beat invented ones.");
+	});
+
 	it("legacy MCP guides preserve just-in-time planning parity with the canonical CLI lifecycle", () => {
 		TEST_DIR = createUniqueTestDir("mcp-server-guides");
 


### PR DESCRIPTION
## Summary

- Document **type-aware** description and acceptance-criteria expectations in CLI and MCP task-creation guides (bug/friction vs feature vs chore/docs vs spike).
- Require **stakeholder-legitimate** acceptance criteria: prefer fewer true criteria over complete-looking lists; do not invent nice-to-haves, tests, docs, or implementation scope the user/product did not need.
- Add focused guide-content tests for the new wording.

## Why

Agents often force a feature-shaped work order onto mid-session bugs, and invent acceptance criteria to look thorough. That pads tasks with false scope and makes pickup harder. Existing guide text stressed testable AC and "include tests/docs" more than *whether* a criterion should exist.

## Test plan

- [x] `bun test src/test/cli-guidance.test.ts src/test/mcp-server.test.ts` (28 pass)
- [ ] Confirm `backlog instructions task-creation` renders the new sections after merge