### PR TITLE
Restrain invented acceptance criteria in task-creation guides

### DIFF
--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -109,8 +109,9 @@ Good criteria:
 - Are testable.
 - Include edge cases when relevant.
 - Include documentation and test expectations when required.
+- Reflect real needs only: prefer fewer true criteria over invented scope. For an observable bug, the reported failure mode is usually enough.
 
-Avoid criteria like "Implement helper function" unless the helper itself is the user-visible deliverable.
+Avoid criteria like "Implement helper function" unless the helper itself is the user-visible deliverable. Do not invent criteria to look thorough.
 
 ### Definition of Done
 

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -78,6 +78,7 @@ Create all tasks in the same session to maintain consistency and context.
 - Include negative or edge scenarios when relevant
 - Capture testing expectations explicitly
 - Include documentation expectations in the same task (no deferring to follow-up tasks)
+- Reflect real needs only: prefer fewer true criteria over invented scope. For an observable bug, the reported failure mode is usually enough.
 
 **Definition of Done defaults (optional):**
 - Project-level defaults are managed with `definition_of_done_defaults_get` / `definition_of_done_defaults_upsert`
@@ -109,7 +110,7 @@ If you will continue from task creation into implementation in the same session,
 ### Common Anti-patterns to Avoid
 
 - Creating a single task called "Build desktop application" with 10+ acceptance criteria
-- Adding implementation steps to acceptance criteria
+- Adding implementation steps to acceptance criteria, or inventing criteria to look thorough
 - Creating a task before understanding if it needs to be split
 - Deferring tests or documentation to "later tasks" (e.g., "Add tests/docs in a follow-up")
 

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -190,6 +190,8 @@ describe("CLI Integration", () => {
 			expect(taskCreation).toContain(
 				"Backlog.md cannot recover the original text after the shell has already executed it",
 			);
+			expect(taskCreation).toContain("Reflect real needs only: prefer fewer true criteria over invented scope");
+			expect(taskCreation).toContain("Do not invent criteria to look thorough");
 			expect(initRequired).toContain("This directory does not have Backlog.md initialized.");
 			expect(initRequired).toContain("backlog init --defaults");
 		}, 15_000);

--- a/src/test/mcp-server.test.ts
+++ b/src/test/mcp-server.test.ts
@@ -176,6 +176,16 @@ describe("McpServer bootstrap", () => {
 		);
 	});
 
+	it("task creation guide restrains invented acceptance criteria", () => {
+		TEST_DIR = createUniqueTestDir("mcp-server-guides");
+
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Reflect real needs only: prefer fewer true criteria over invented scope",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("For an observable bug, the reported failure mode is usually enough");
+		expect(MCP_TASK_CREATION_GUIDE).toContain("inventing criteria to look thorough");
+	});
+
 	it("legacy MCP guides preserve just-in-time planning parity with the canonical CLI lifecycle", () => {
 		TEST_DIR = createUniqueTestDir("mcp-server-guides");
 


### PR DESCRIPTION
## Summary

- Add a short rule in CLI and MCP task-creation guides: prefer fewer true acceptance criteria over invented scope; for an observable bug, the reported failure mode is usually enough.
- Warn against inventing criteria only to look thorough (MCP anti-patterns line updated in place).
- Add focused guide-content tests.

## Why

Agents often pad tasks with acceptance criteria that do not reflect real user or product needs. This is a minimal in-place edit (no new sections).

## Test plan

- [x] `bun test src/test/cli-guidance.test.ts src/test/mcp-server.test.ts`
- [ ] Confirm `backlog instructions task-creation` shows the new Good-criteria bullet after merge