### PR TITLE
BACK-555 - Default web server hostname to 127.0.0.1

### DIFF
--- a/backlog/tasks/back-555 - Default-web-server-hostname-to-127.0.0.1.md
+++ b/backlog/tasks/back-555 - Default-web-server-hostname-to-127.0.0.1.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-555
 title: Default web server hostname to 127.0.0.1
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-23 22:01'
-updated_date: '2026-07-23 22:05'
+updated_date: '2026-07-23 23:08'
 labels: []
 dependencies: []
 modified_files:
@@ -22,16 +22,16 @@ Fix GitHub issue #810: the web UI server binds to 0.0.0.0 (all interfaces) with 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 BacklogServer.start() with no hostname arg binds to 127.0.0.1, not Bun's wildcard default
-- [ ] #2 start() accepts a third positional hostname argument and honors it when passed
-- [ ] #3 browser command accepts --host <address> and boots the server successfully when passed
+- [x] #1 BacklogServer.start() with no hostname arg binds to 127.0.0.1, not Bun's wildcard default
+- [x] #2 start() accepts a third positional hostname argument and honors it when passed
+- [x] #3 browser command accepts --host <address> and boots the server successfully when passed
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -41,3 +41,9 @@ Fix GitHub issue #810: the web UI server binds to 0.0.0.0 (all interfaces) with 
 2. Add browser --host <address> and pass options.host as start argument three without changing the localhost startup log (src/cli.ts:L4960-L5013; src/test/cli-browser-host.test.ts:L73-L88).
 3. Run the pinned tests, TypeScript, Biome write/check, and full suite; report exact counts (GitHub issue #810).
 <!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Defaulted BacklogServer.start() hostname to 127.0.0.1 and added a --host <address> opt-in on the browser CLI command, threaded through as a third start() argument. Verified: bunx tsc --noEmit clean, bunx biome lint . clean, full bun test suite 1770 pass/15 skip/1 pre-existing-baseline fail (unrelated, confirmed via stash-and-rerun on unmodified main). Frozen tests src/test/server-hostname.test.ts and src/test/cli-browser-host.test.ts: 3/3 pass (was 3 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-555 - Default-web-server-hostname-to-127.0.0.1.md
+++ b/backlog/tasks/back-555 - Default-web-server-hostname-to-127.0.0.1.md
@@ -1,0 +1,43 @@
+---
+id: BACK-555
+title: Default web server hostname to 127.0.0.1
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-07-23 22:01'
+updated_date: '2026-07-23 22:05'
+labels: []
+dependencies: []
+modified_files:
+  - src/server/index.ts
+  - src/cli.ts
+ordinal: 200000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix GitHub issue #810: the web UI server binds to 0.0.0.0 (all interfaces) with zero auth, exposing the full task API on the LAN. BacklogServer.start() should default hostname to 127.0.0.1 and accept an explicit hostname override; the CLI browser command should accept a --host <address> option.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 BacklogServer.start() with no hostname arg binds to 127.0.0.1, not Bun's wildcard default
+- [ ] #2 start() accepts a third positional hostname argument and honors it when passed
+- [ ] #3 browser command accepts --host <address> and boots the server successfully when passed
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [ ] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add an optional hostname parameter to BacklogServer.start and pass hostname ?? 127.0.0.1 to Bun.serve (src/server/index.ts:L276-L298; src/test/server-hostname.test.ts:L44-L55).
+2. Add browser --host <address> and pass options.host as start argument three without changing the localhost startup log (src/cli.ts:L4960-L5013; src/test/cli-browser-host.test.ts:L73-L88).
+3. Run the pinned tests, TypeScript, Biome write/check, and full suite; report exact counts (GitHub issue #810).
+<!-- SECTION:PLAN:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4960,6 +4960,7 @@ program
 	.command("browser")
 	.description("open browser interface for task management (press Ctrl+C or Cmd+C to stop)")
 	.option("-p, --port <port>", "port to run server on")
+	.option("--host <address>", "host address to bind server to")
 	.option("--no-open", "don't automatically open browser")
 	.option("--non-interactive", "automatically use next free port without asking")
 	.action(async (options) => {
@@ -5010,7 +5011,7 @@ program
 				}
 			}
 
-			await server.start(port, options.open !== false);
+			await server.start(port, options.open !== false, options.host);
 
 			// Graceful shutdown on common termination signals (register once)
 			let shuttingDown = false;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -273,7 +273,7 @@ export class BacklogServer {
 		}
 	}
 
-	async start(port?: number, openBrowser = true): Promise<void> {
+	async start(port?: number, openBrowser = true, hostname = "127.0.0.1"): Promise<void> {
 		// Prevent duplicate starts (e.g., accidental re-entry)
 		if (this.server) {
 			console.log("Server already running");
@@ -295,6 +295,7 @@ export class BacklogServer {
 			await this.ensureServicesReady();
 			const serveOptions = {
 				port: finalPort,
+				hostname,
 				development: process.env.NODE_ENV === "development",
 				routes: {
 					"/": spaIndexHtml,

--- a/src/test/cli-browser-host.test.ts
+++ b/src/test/cli-browser-host.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { type ChildProcessByStdio, spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { Readable } from "node:stream";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import {
+	closeServer,
+	createUniqueTestDir,
+	initializeTestProject,
+	listenOnEphemeralPort,
+	safeCleanup,
+} from "./test-utils.ts";
+
+const CLI_PATH = join(process.cwd(), "src", "cli.ts");
+type BrowserProcess = ChildProcessByStdio<null, Readable, Readable>;
+
+let TEST_DIR: string;
+
+async function waitForOutput(child: BrowserProcess, expected: string): Promise<string> {
+	let output = "";
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			cleanup();
+			reject(new Error(`Timed out waiting for "${expected}". Output:\n${output}`));
+		}, 10000);
+		const onData = (chunk: Buffer) => {
+			output += chunk.toString();
+			if (output.includes(expected)) {
+				cleanup();
+				resolve(output);
+			}
+		};
+		const onExit = (code: number | null) => {
+			cleanup();
+			reject(new Error(`Process exited with code ${code} before "${expected}". Output:\n${output}`));
+		};
+		const cleanup = () => {
+			clearTimeout(timer);
+			child.stdout.off("data", onData);
+			child.stderr.off("data", onData);
+			child.off("exit", onExit);
+		};
+
+		child.stdout.on("data", onData);
+		child.stderr.on("data", onData);
+		child.once("exit", onExit);
+	});
+}
+
+async function stopChild(child: BrowserProcess): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	await new Promise<void>((resolve) => {
+		const timer = setTimeout(() => {
+			if (child.exitCode === null && child.signalCode === null) {
+				child.kill("SIGKILL");
+			}
+			resolve();
+		}, 2000);
+		child.once("exit", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+		child.kill();
+	});
+}
+
+describe("browser command --host flag", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-cli-browser-host");
+		await mkdir(TEST_DIR, { recursive: true });
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		await initializeTestProject(core, "Browser Host Test");
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("accepts an opt-in --host flag and starts the server instead of rejecting it as unknown", async () => {
+		const { server: portProbe, port } = await listenOnEphemeralPort();
+		await closeServer(portProbe);
+
+		const child = spawn("bun", [CLI_PATH, "browser", "--host", "0.0.0.0", "--port", String(port), "--no-open"], {
+			cwd: TEST_DIR,
+			env: { ...process.env, NO_COLOR: "1" },
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		try {
+			const output = await waitForOutput(child, "browser interface running");
+			expect(output).not.toContain("unknown option");
+		} finally {
+			await stopChild(child);
+		}
+	});
+});

--- a/src/test/server-hostname.test.ts
+++ b/src/test/server-hostname.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { FileSystem } from "../file-system/operations.ts";
+import { BacklogServer } from "../server/index.ts";
+import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let server: BacklogServer | null = null;
+
+// BacklogServer keeps the Bun `Server` handle in a private field. Bun's own
+// `Server.hostname` getter reports back the address it actually bound to
+// (it echoes explicit values verbatim, e.g. "127.0.0.1" or "0.0.0.0"), so
+// reading it through the instance is the most direct, non-flaky way to
+// observe the real bind address without opening sockets or probing the
+// network ourselves.
+type ServerWithBunHandle = { server: { hostname?: string } | null };
+
+function boundHostname(instance: BacklogServer): string | undefined {
+	return (instance as unknown as ServerWithBunHandle).server?.hostname;
+}
+
+describe("BacklogServer hostname binding", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("server-hostname");
+		const filesystem = new FileSystem(TEST_DIR);
+		await filesystem.ensureBacklogStructure();
+		await filesystem.saveConfig({
+			projectName: "Server Hostname",
+			statuses: ["To Do", "In Progress", "Done"],
+			labels: [],
+			milestones: [],
+			dateFormat: "YYYY-MM-DD",
+			remoteOperations: false,
+		});
+	});
+
+	afterEach(async () => {
+		if (server) {
+			await server.stop();
+			server = null;
+		}
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("binds to the loopback interface (127.0.0.1) by default when no host is given", async () => {
+		server = new BacklogServer(TEST_DIR);
+		await server.start(0, false);
+
+		expect(boundHostname(server)).toBe("127.0.0.1");
+	});
+
+	it("binds to a caller-specified hostname when one is passed to start()", async () => {
+		server = new BacklogServer(TEST_DIR);
+		await server.start(0, false, "0.0.0.0");
+
+		expect(boundHostname(server)).toBe("0.0.0.0");
+	});
+});


### PR DESCRIPTION
## Summary
Fixes a security issue: `backlog browser`'s embedded web server bound to `0.0.0.0` (all network interfaces) with no authentication, exposing the full task API to anyone on the same LAN/VPN/Wi-Fi segment. The startup log printed `http://localhost:${port}`, which was misleading since the server wasn't actually localhost-restricted.

- `BacklogServer.start()` now defaults `hostname` to `127.0.0.1` in `serveOptions` passed to `Bun.serve()`.
- `start()` accepts a third, optional `hostname` argument so callers can opt into a different bind address.
- The `backlog browser` CLI command gains an opt-in `--host <address>` flag, threaded through to `start()`, for anyone who intentionally wants LAN access.

## Related Issue or Task
closes #810
Task: `backlog/tasks/back-555 - Default-web-server-hostname-to-127.0.0.1.md` (BACK-555)

## Task Checklist
- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Testing
Two new frozen-first tests were written before the fix (test-first split) and now pass:
- `src/test/server-hostname.test.ts` — `BacklogServer.start()` binds `127.0.0.1` by default; honors an explicit `hostname` override.
- `src/test/cli-browser-host.test.ts` — `browser --host <address>` is accepted by the CLI and the server boots successfully.

Full verification (mirrors CI):
- `bunx tsc --noEmit` — clean.
- `bunx biome lint .` — clean (341 files checked, no fixes needed).
- `bun test --isolate --timeout=10000 --max-concurrency=4` (full suite, CI flags) — **1770 pass / 15 skip / 1 fail**. The 1 failure (`installClaudeAgent > writes the project-manager-backlog.md file with correct content`) is a pre-existing baseline failure, confirmed identical on unmodified `main` via stash-and-rerun — unrelated to this change.

Diff is minimal: 2 implementation files (4 production lines changed), 2 new test files, 1 task record.

---
🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
