### PR TITLE
BACK-546 - Add dependency readiness guidance to TUI and browser

### DIFF
--- a/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
+++ b/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-546
 title: Add dependency readiness guidance to TUI and browser
-status: To Do
+status: Done
 assignee:
-  - '@alex-agent'
+  - '@codex'
 created_date: '2026-07-13 16:06'
+updated_date: '2026-08-02 20:31'
 labels:
   - tui
   - web
@@ -24,17 +25,35 @@ Address the reported need to see what can be worked next without silently restor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Plan review defines ready and blocked semantics for partial graphs, cycles, missing dependencies, and dependencies in other statuses
-- [ ] #2 The TUI and browser present consistent, non-mutating readiness and blocked guidance
-- [ ] #3 Existing ordinal order remains authoritative unless Alex explicitly approves an ordering change
-- [ ] #4 Cycles and ambiguous dependency data are represented honestly and fail safely
-- [ ] #5 Users can identify which dependencies block a task
-- [ ] #6 Automated tests and rendered QA cover ready, blocked, cross-status, missing, and cyclic examples
+- [x] #1 Plan review defines ready and blocked semantics for partial graphs, cycles, missing dependencies, and dependencies in other statuses
+- [x] #2 The TUI and browser present consistent, non-mutating readiness and blocked guidance
+- [x] #3 Existing ordinal order remains authoritative unless Alex explicitly approves an ordering change
+- [x] #4 Cycles and ambiguous dependency data are represented honestly and fail safely
+- [x] #5 Users can identify which dependencies block a task
+- [x] #6 Automated tests and rendered QA cover ready, blocked, cross-status, missing, and cyclic examples
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rebuild dependency-readiness changes from current main without Kanban ready-filter controls. 2. Verify readiness semantics across CLI, MCP, browser, and interactive TUI. 3. Finalize the task and update the existing draft PR to contain only this task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Rebuilt the split from current main without the Kanban ready-filter controls. Verified the CLI, MCP, browser, and interactive TUI readiness behavior with rendered and integration tests; full bun test, bunx tsc --noEmit, bun run check ., and bun run build all pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added canonical dependency-readiness guidance across CLI, MCP parity, browser, and interactive TUI without changing ordinal ordering. Verified by full bun test, TypeScript, Biome, and production build.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,6 +88,7 @@ import {
 } from "./utils/task-builders.ts";
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
 import { normalizeTaskId, taskIdsEqual } from "./utils/task-path.ts";
+import { applyTaskFilters } from "./utils/task-search.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
 import { formatValidTaskTypeValues, getTaskTypeValues, resolveTaskTypeValues } from "./utils/task-type-config.ts";
 import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
@@ -2353,6 +2354,9 @@ addHelpSchema(taskCmd.command("list"), {
 		if (options.unassigned) {
 			baseFilters.unassigned = true;
 		}
+		if (options.ready) {
+			baseFilters.ready = true;
+		}
 		if (options.milestone) {
 			baseFilters.milestone = options.milestone;
 		}
@@ -2404,12 +2408,14 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 
 		if (outputMode !== "interactive") {
-			const tasks = await core.queryTasks({
-				query: searchQuery || undefined,
-				filters: Object.keys(baseFilters).length > 0 ? baseFilters : undefined,
-				includeCrossBranch: false,
-			});
+			const allTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
 			const config = await core.filesystem.loadConfig();
+			const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
+			const tasks = applyTaskFilters(allTasks, {
+				...baseFilters,
+				query: searchQuery || undefined,
+				statuses,
+			});
 
 			if (parentId) {
 				const parentExists = (await core.queryTasks({ includeCrossBranch: false })).some((task) =>
@@ -2474,7 +2480,6 @@ addHelpSchema(taskCmd.command("list"), {
 			}
 
 			const canonicalByLower = new Map<string, string>();
-			const statuses = config?.statuses || [];
 			for (const status of statuses) {
 				canonicalByLower.set(status.toLowerCase(), status);
 			}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2594,9 +2594,6 @@ addHelpSchema(taskCmd.command("list"), {
 		if (parentId) {
 			interactiveLoaderFilters.parentTaskId = parentId;
 		}
-		if (options.ready) {
-			interactiveLoaderFilters.ready = true;
-		}
 		await runUnifiedView({
 			core,
 			initialView: "task-list",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2270,6 +2270,7 @@ addHelpSchema(taskCmd.command("list"), {
 			description: "Require every listed label; repeat --labels or use label1,label2",
 		},
 		{ name: "search", type: "String", description: "Search task title, description, notes, comments, and metadata" },
+		{ name: "ready", type: "Boolean", description: "Only show unblocked tasks with all dependencies completed" },
 		{ name: "limit", type: "Positive integer", description: "Maximum tasks to display after sorting" },
 		{ name: "sort", type: choiceType(TASK_SORT_FIELDS), description: "Task ordering before applying limit" },
 		{ name: "plain", type: "Boolean", description: "Use text output instead of interactive UI" },
@@ -2278,6 +2279,7 @@ addHelpSchema(taskCmd.command("list"), {
 	output: "Interactive task list, plain text with --plain, or versioned JSON with --json",
 	examples: [
 		'backlog task list --status "<todo status>" --plain',
+		"backlog task list --ready --plain",
 		'backlog task list --status "<todo status>" --json',
 		"backlog task list --parent {{TASK_ID:1}}",
 		`backlog task list --type ${TASK_TYPE_EXAMPLE} --plain`,
@@ -2307,6 +2309,7 @@ addHelpSchema(taskCmd.command("list"), {
 		createMultiValueAccumulator(),
 	)
 	.option("--search <query>", "search task title, description, notes, comments, and metadata")
+	.option("--ready", "only show unblocked tasks with all dependencies completed")
 	.option("--limit <number>", "limit tasks displayed after sorting")
 	.option("--sort <field>", `sort tasks by field (${TASK_SORT_FIELD_LIST})`)
 	.option("--plain", "use plain text output instead of interactive UI")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,7 @@ import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
 import { hasAnyPrefix } from "./utils/prefix-config.ts";
 import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
 import { type ReadOutputMode, resolveReadOutputMode } from "./utils/read-output-mode.ts";
+import { getTaskReadiness } from "./utils/readiness.ts";
 import { type RuntimeCwdResolution, resolveRuntimeCwd } from "./utils/runtime-cwd.ts";
 import { formatValidStatuses, getCanonicalStatus, getCanonicalStatuses, getValidStatuses } from "./utils/status.ts";
 import {
@@ -88,7 +89,6 @@ import {
 } from "./utils/task-builders.ts";
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
 import { normalizeTaskId, taskIdsEqual } from "./utils/task-path.ts";
-import { applyTaskFilters } from "./utils/task-search.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
 import { formatValidTaskTypeValues, getTaskTypeValues, resolveTaskTypeValues } from "./utils/task-type-config.ts";
 import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
@@ -2408,14 +2408,18 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 
 		if (outputMode !== "interactive") {
-			const allTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
+			let tasks = await core.queryTasks({
+				query: searchQuery || undefined,
+				filters: Object.keys(baseFilters).length > 0 ? baseFilters : undefined,
+				includeCrossBranch: false,
+			});
 			const config = await core.filesystem.loadConfig();
 			const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
-			const tasks = applyTaskFilters(allTasks, {
-				...baseFilters,
-				query: searchQuery || undefined,
-				statuses,
-			});
+
+			if (options.ready) {
+				const fullTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
+				tasks = tasks.filter((task) => getTaskReadiness(task, fullTasks, statuses).isReady);
+			}
 
 			if (parentId) {
 				const parentExists = (await core.queryTasks({ includeCrossBranch: false })).some((task) =>
@@ -2443,7 +2447,7 @@ addHelpSchema(taskCmd.command("list"), {
 				sortedTasks = sortTasks(tasks, "priority", config?.priorities);
 			}
 
-			let filtered = sortedTasks.filter((task) => isLocalEditableTask(task));
+			let filtered = sortedTasks;
 			if (parentId) {
 				filtered = filtered.filter((task) => task.parentTaskId && taskIdsEqual(parentId, task.parentTaskId));
 			}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2443,7 +2443,7 @@ addHelpSchema(taskCmd.command("list"), {
 				sortedTasks = sortTasks(tasks, "priority", config?.priorities);
 			}
 
-			let filtered = sortedTasks;
+			let filtered = sortedTasks.filter((task) => isLocalEditableTask(task));
 			if (parentId) {
 				filtered = filtered.filter((task) => task.parentTaskId && taskIdsEqual(parentId, task.parentTaskId));
 			}
@@ -2537,6 +2537,8 @@ addHelpSchema(taskCmd.command("list"), {
 		if (taskLimit !== undefined) activeFilters.push(`Limit: ${taskLimit}`);
 		if (options.sort) activeFilters.push(`Sort: ${options.sort}`);
 
+		if (options.ready) activeFilters.push("Ready");
+
 		if (activeFilters.length > 0) {
 			filterDescription = activeFilters.join(", ");
 			title = `Tasks (${activeFilters.join(" • ")})`;
@@ -2556,6 +2558,7 @@ addHelpSchema(taskCmd.command("list"), {
 			filterDescription?: string;
 			parentTaskId?: string;
 			limit?: number;
+			ready?: boolean;
 		} = {
 			status: options.status,
 			excludeStatus: Array.isArray(baseFilters.excludeStatus) ? baseFilters.excludeStatus : undefined,
@@ -2570,6 +2573,7 @@ addHelpSchema(taskCmd.command("list"), {
 			filterDescription,
 			parentTaskId: parentId,
 			limit: taskLimit,
+			ready: options.ready,
 		};
 		if (searchQuery) {
 			initialUnifiedFilter.searchQuery = searchQuery;
@@ -2585,6 +2589,9 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 		if (parentId) {
 			interactiveLoaderFilters.parentTaskId = parentId;
+		}
+		if (options.ready) {
+			interactiveLoaderFilters.ready = true;
 		}
 		await runUnifiedView({
 			core,

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -13,7 +13,7 @@ import { formatDuplicateTaskIdWarning } from "../../../utils/duplicate-detection
 import { createMilestoneFilterMatcher, createMilestoneFilterValueResolver } from "../../../utils/milestone-filter.ts";
 import { resolveMilestoneInputForStorage } from "../../../utils/milestone-storage.ts";
 import { buildTaskUpdateInput } from "../../../utils/task-edit-builder.ts";
-import { createTaskSearchIndex } from "../../../utils/task-search.ts";
+import { applyTaskFilters, createTaskSearchIndex } from "../../../utils/task-search.ts";
 import { sortByOrdinalAndPriority } from "../../../utils/task-sorting.ts";
 import { getTerminalStatus, isTerminalStatus } from "../../../utils/terminal-status.ts";
 import { BacklogToolError } from "../../errors/mcp-errors.ts";
@@ -50,6 +50,7 @@ export type TaskListArgs = {
 	milestone?: string;
 	labels?: string[];
 	search?: string;
+	ready?: boolean;
 	limit?: number;
 };
 
@@ -239,11 +240,16 @@ export class TaskHandlers {
 		if (args.milestone) {
 			filters.milestone = args.milestone;
 		}
+		if (args.ready) {
+			filters.ready = true;
+		}
 
-		const tasks = await this.core.queryTasks({
+		const allTasks = await this.core.loadTasks(undefined, undefined, { includeCompleted: true });
+		const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
+		const tasks = applyTaskFilters(allTasks, {
+			...filters,
 			query: args.search,
-			filters: Object.keys(filters).length > 0 ? filters : undefined,
-			includeCrossBranch: false,
+			statuses,
 		});
 
 		let filteredByLabels = tasks.filter((task) => isLocalEditableTask(task));
@@ -265,8 +271,6 @@ export class TaskHandlers {
 				],
 			};
 		}
-
-		const statuses = config?.statuses ?? [];
 
 		const canonicalByLower = new Map<string, string>();
 		for (const status of statuses) {

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -14,7 +14,7 @@ import { createMilestoneFilterMatcher, createMilestoneFilterValueResolver } from
 import { resolveMilestoneInputForStorage } from "../../../utils/milestone-storage.ts";
 import { getTaskReadiness } from "../../../utils/readiness.ts";
 import { buildTaskUpdateInput } from "../../../utils/task-edit-builder.ts";
-import { applyTaskFilters, createTaskSearchIndex } from "../../../utils/task-search.ts";
+import { createTaskSearchIndex } from "../../../utils/task-search.ts";
 import { sortByOrdinalAndPriority } from "../../../utils/task-sorting.ts";
 import { getTerminalStatus, isTerminalStatus } from "../../../utils/terminal-status.ts";
 import { BacklogToolError } from "../../errors/mcp-errors.ts";
@@ -251,13 +251,17 @@ export class TaskHandlers {
 			filters.ready = true;
 		}
 
-		const allTasks = await this.core.loadTasks(undefined, undefined, { includeCompleted: true });
-		const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
-		const tasks = applyTaskFilters(allTasks, {
-			...filters,
+		let tasks = await this.core.queryTasks({
 			query: args.search,
-			statuses,
+			filters: Object.keys(filters).length > 0 ? filters : undefined,
+			includeCrossBranch: false,
 		});
+		const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
+
+		if (args.ready) {
+			const fullTasks = await this.core.loadTasks(undefined, undefined, { includeCompleted: true });
+			tasks = tasks.filter((task) => getTaskReadiness(task, fullTasks, statuses).isReady);
+		}
 
 		let filteredByLabels = tasks.filter((task) => isLocalEditableTask(task));
 		const labelFilters = args.labels ?? [];

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -12,6 +12,7 @@ import type { TaskEditArgs, TaskEditRequest } from "../../../types/task-edit-arg
 import { formatDuplicateTaskIdWarning } from "../../../utils/duplicate-detection.ts";
 import { createMilestoneFilterMatcher, createMilestoneFilterValueResolver } from "../../../utils/milestone-filter.ts";
 import { resolveMilestoneInputForStorage } from "../../../utils/milestone-storage.ts";
+import { getTaskReadiness } from "../../../utils/readiness.ts";
 import { buildTaskUpdateInput } from "../../../utils/task-edit-builder.ts";
 import { applyTaskFilters, createTaskSearchIndex } from "../../../utils/task-search.ts";
 import { sortByOrdinalAndPriority } from "../../../utils/task-sorting.ts";
@@ -192,6 +193,12 @@ export class TaskHandlers {
 					const draftLabels = draft.labels ?? [];
 					return labelFilters.every((label) => draftLabels.includes(label));
 				});
+			}
+
+			if (args.ready) {
+				const allTasksForDrafts = await this.core.loadTasks(undefined, undefined, { includeCompleted: true });
+				const statusesForDrafts: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
+				drafts = drafts.filter((draft) => getTaskReadiness(draft, allTasksForDrafts, statusesForDrafts).isReady);
 			}
 
 			if (drafts.length === 0) {

--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -90,6 +90,10 @@ export function generateTaskListSchema(config: Pick<BacklogConfig, "types">): Js
 				type: "string",
 				maxLength: 200,
 			},
+			ready: {
+				type: "boolean",
+				description: "When true, filter tasks that are ready for work (all dependencies satisfied/completed).",
+			},
 			limit: {
 				type: "number",
 				minimum: 1,

--- a/src/test/cli-task-list.test.ts
+++ b/src/test/cli-task-list.test.ts
@@ -507,6 +507,77 @@ describe("CLI Integration", () => {
 			expect(out).not.toContain("TASK-2 - OAuth Callback Other Parent");
 		});
 
+		it("should filter tasks by readiness using --ready and --ready --json", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-1",
+					title: "Done Dep",
+					status: "Done",
+					assignee: [],
+					labels: [],
+					dependencies: [],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-2",
+					title: "In Progress Dep",
+					status: "In Progress",
+					assignee: [],
+					labels: [],
+					dependencies: [],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-3",
+					title: "Blocked Task",
+					status: "To Do",
+					assignee: [],
+					labels: [],
+					dependencies: ["task-2"],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-4",
+					title: "Ready Task",
+					status: "To Do",
+					assignee: [],
+					labels: [],
+					dependencies: ["task-1"],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+
+			const plainResult = await $`bun ${CLI_PATH} task list --plain --ready`.cwd(TEST_DIR).quiet();
+			const plainOut = plainResult.stdout.toString();
+			expect(plainOut).toContain("TASK-4 - Ready Task");
+			expect(plainOut).toContain("TASK-2 - In Progress Dep");
+			expect(plainOut).not.toContain("TASK-3 - Blocked Task");
+
+			const jsonResult = await $`bun ${CLI_PATH} task list --json --ready`.cwd(TEST_DIR).quiet();
+			const json = JSON.parse(jsonResult.stdout.toString());
+			const readyIds = json.tasks.map((t: { id: string }) => t.id);
+			expect(readyIds).toContain("TASK-4");
+			expect(readyIds).toContain("TASK-2");
+			expect(readyIds).not.toContain("TASK-3");
+			expect(readyIds).not.toContain("TASK-1");
+		});
+
 		it("should reject invalid task list limit", async () => {
 			const result = await $`bun ${CLI_PATH} task list --plain --limit 0`.cwd(TEST_DIR).nothrow().quiet();
 			const out = result.stdout.toString() + result.stderr.toString();

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -492,6 +492,28 @@ describe("MCP task tools (MVP)", () => {
 		expect(getText(conflictResult.content)).toContain("unassigned cannot be combined with assignee");
 	});
 
+	it("filters task_list by ready argument in MCP tool", async () => {
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Completed Dep", status: "Done" } },
+		});
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "InProgress Dep", status: "In Progress" } },
+		});
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Blocked Task", status: "To Do", dependencies: ["TASK-2"] } },
+		});
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Ready Task", status: "To Do", dependencies: ["TASK-1"] } },
+		});
+
+		const readyResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_list", arguments: { ready: true } },
+		});
+		const text = getText(readyResult.content);
+		expect(text).toContain("TASK-4 - Ready Task");
+		expect(text).not.toContain("TASK-3 - Blocked Task");
+	});
+
 	it("applies unassigned filtering in task_list draft status path", async () => {
 		await mcpServer.testInterface.callTool({
 			params: {

--- a/src/test/readiness.test.ts
+++ b/src/test/readiness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Task } from "../types/index.ts";
 import { getTaskReadiness } from "../utils/readiness.ts";
+import { applyTaskFilters } from "../utils/task-search.ts";
 
 const statuses = ["To Do", "In Progress", "Done"];
 
@@ -86,5 +87,24 @@ describe("getTaskReadiness", () => {
 		const readiness = getTaskReadiness(task, [dep, task], customStatuses);
 		expect(readiness.isReady).toBe(true);
 		expect(readiness.isBlocked).toBe(false);
+	});
+});
+
+describe("applyTaskFilters with readiness filter integration", () => {
+	it("filters candidates correctly when ready: true is requested", () => {
+		const doneDep = makeTask("BACK-1", "Done");
+		const blockedTask = makeTask("BACK-2", "To Do", ["BACK-3"]);
+		const inProgDep = makeTask("BACK-3", "In Progress");
+		const readyTask = makeTask("BACK-4", "To Do", ["BACK-1"]);
+
+		const allTasks = [doneDep, blockedTask, inProgDep, readyTask];
+
+		// Filter for ready tasks: BACK-3 (In Progress, no deps) and BACK-4 (To Do, BACK-1 dep is Done) are unblocked/ready
+		const readyFiltered = applyTaskFilters(allTasks, { ready: true, statuses });
+		expect(readyFiltered.map((t) => t.id)).toEqual(["BACK-3", "BACK-4"]);
+
+		// Combine ready filter with status filter
+		const readyToDoFiltered = applyTaskFilters(allTasks, { ready: true, status: "To Do", statuses });
+		expect(readyToDoFiltered.map((t) => t.id)).toEqual(["BACK-4"]);
 	});
 });

--- a/src/test/readiness.test.ts
+++ b/src/test/readiness.test.ts
@@ -62,4 +62,29 @@ describe("getTaskReadiness", () => {
 		expect(readiness.isReady).toBe(false);
 		expect(readiness.isBlocked).toBe(false);
 	});
+
+	it("handles dependency cycles safely without infinite recursion", () => {
+		const task1 = makeTask("BACK-1", "To Do", ["BACK-2"]);
+		const task2 = makeTask("BACK-2", "To Do", ["BACK-1"]);
+		const readiness1 = getTaskReadiness(task1, [task1, task2], statuses);
+		const readiness2 = getTaskReadiness(task2, [task1, task2], statuses);
+
+		expect(readiness1.isReady).toBe(false);
+		expect(readiness1.isBlocked).toBe(true);
+		expect(readiness1.blockingDependencies).toEqual(["BACK-2"]);
+
+		expect(readiness2.isReady).toBe(false);
+		expect(readiness2.isBlocked).toBe(true);
+		expect(readiness2.blockingDependencies).toEqual(["BACK-1"]);
+	});
+
+	it("respects custom configured terminal statuses (e.g. Closed)", () => {
+		const customStatuses = ["Open", "In Review", "Closed"];
+		const dep = makeTask("BACK-1", "Closed");
+		const task = makeTask("BACK-2", "Open", ["BACK-1"]);
+
+		const readiness = getTaskReadiness(task, [dep, task], customStatuses);
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.isBlocked).toBe(false);
+	});
 });

--- a/src/test/readiness.test.ts
+++ b/src/test/readiness.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "../types/index.ts";
+import { getTaskReadiness } from "../utils/readiness.ts";
+
+const statuses = ["To Do", "In Progress", "Done"];
+
+function makeTask(id: string, status: string, dependencies: string[] = []): Task {
+	return {
+		id,
+		title: `Task ${id}`,
+		status,
+		dependencies,
+		assignee: [],
+		labels: [],
+		createdDate: "2026-07-24",
+		rawContent: "",
+	};
+}
+
+describe("getTaskReadiness", () => {
+	it("returns ready for a task with no dependencies", () => {
+		const task = makeTask("BACK-1", "To Do");
+		const readiness = getTaskReadiness(task, [task], statuses);
+
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.isBlocked).toBe(false);
+		expect(readiness.blockingDependencies).toEqual([]);
+	});
+
+	it("returns ready when all dependencies are in terminal status", () => {
+		const dep = makeTask("BACK-1", "Done");
+		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
+		const readiness = getTaskReadiness(task, [dep, task], statuses);
+
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.isBlocked).toBe(false);
+	});
+
+	it("returns blocked when a dependency is in non-terminal status", () => {
+		const dep = makeTask("BACK-1", "In Progress");
+		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
+		const readiness = getTaskReadiness(task, [dep, task], statuses);
+
+		expect(readiness.isReady).toBe(false);
+		expect(readiness.isBlocked).toBe(true);
+		expect(readiness.blockingDependencies).toEqual(["BACK-1"]);
+	});
+
+	it("returns blocked when a dependency is missing", () => {
+		const task = makeTask("BACK-2", "To Do", ["BACK-99"]);
+		const readiness = getTaskReadiness(task, [task], statuses);
+
+		expect(readiness.isReady).toBe(false);
+		expect(readiness.isBlocked).toBe(true);
+		expect(readiness.missingDependencies).toEqual(["BACK-99"]);
+	});
+
+	it("returns not ready and not blocked for tasks already in terminal status", () => {
+		const task = makeTask("BACK-1", "Done");
+		const readiness = getTaskReadiness(task, [task], statuses);
+
+		expect(readiness.isReady).toBe(false);
+		expect(readiness.isBlocked).toBe(false);
+	});
+});

--- a/src/test/readiness.test.ts
+++ b/src/test/readiness.test.ts
@@ -107,4 +107,16 @@ describe("applyTaskFilters with readiness filter integration", () => {
 		const readyToDoFiltered = applyTaskFilters(allTasks, { ready: true, status: "To Do", statuses });
 		expect(readyToDoFiltered.map((t) => t.id)).toEqual(["BACK-4"]);
 	});
+
+	it("evaluates readiness against fullGraphTasks when display candidates omit completed tasks", () => {
+		const archivedDoneDep = makeTask("BACK-1", "Done");
+		const activeTask = makeTask("BACK-2", "To Do", ["BACK-1"]);
+
+		const displayCandidates = [activeTask]; // BACK-1 excluded from active candidates
+		const fullGraph = [archivedDoneDep, activeTask];
+
+		// Filtering display candidates with fullGraphTasks supplied
+		const result = applyTaskFilters(displayCandidates, { ready: true, statuses, fullGraphTasks: fullGraph });
+		expect(result.map((t) => t.id)).toEqual(["BACK-2"]);
+	});
 });

--- a/src/test/readiness.test.tsx
+++ b/src/test/readiness.test.tsx
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { renderToString } from "react-dom/server";
 import type { Task } from "../types/index.ts";
+import { generateDetailContent } from "../ui/task-viewer-with-search.ts";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
+import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
 import { getTaskReadiness } from "../utils/readiness.ts";
 import { applyTaskFilters } from "../utils/task-search.ts";
 
@@ -118,5 +123,82 @@ describe("applyTaskFilters with readiness filter integration", () => {
 		// Filtering display candidates with fullGraphTasks supplied
 		const result = applyTaskFilters(displayCandidates, { ready: true, statuses, fullGraphTasks: fullGraph });
 		expect(result.map((t) => t.id)).toEqual(["BACK-2"]);
+	});
+});
+
+describe("Rendered TUI and Web UI readiness guidance assertions", () => {
+	it("renders TUI detail readiness guidance for ready, blocked, and terminal tasks", () => {
+		const doneDep = makeTask("BACK-1", "Done");
+		const inProgDep = makeTask("BACK-2", "In Progress");
+		const readyTask = makeTask("BACK-3", "To Do", ["BACK-1"]);
+		const blockedTask = makeTask("BACK-4", "To Do", ["BACK-2"]);
+		const fullGraph = [doneDep, inProgDep, readyTask, blockedTask];
+
+		const readyDetail = generateDetailContent(readyTask, undefined, undefined, fullGraph, statuses);
+		const readyText = readyDetail.bodyContent.join("\n");
+		expect(readyText).toContain("Readiness:");
+		expect(readyText).toContain("✓ Ready to start");
+
+		const blockedDetail = generateDetailContent(blockedTask, undefined, undefined, fullGraph, statuses);
+		const blockedText = blockedDetail.bodyContent.join("\n");
+		expect(blockedText).toContain("Readiness:");
+		expect(blockedText).toContain("⏳ Blocked by: BACK-2");
+
+		const terminalDetail = generateDetailContent(doneDep, undefined, undefined, fullGraph, statuses);
+		const terminalText = terminalDetail.bodyContent.join("\n");
+		expect(terminalText).toContain("Readiness:");
+		expect(terminalText).toContain("Terminal status (Done)");
+	});
+
+	it("renders Web TaskDetailsModal readiness badge accurately for ready, blocked, and terminal tasks", () => {
+		const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost" });
+		globalThis.window = dom.window as unknown as Window & typeof globalThis;
+		globalThis.document = dom.window.document as Document;
+		globalThis.navigator = dom.window.navigator as Navigator;
+		globalThis.localStorage = dom.window.localStorage;
+
+		if (!window.matchMedia) {
+			window.matchMedia = () =>
+				({
+					matches: false,
+					media: "",
+					onchange: null,
+					addListener: () => {},
+					removeListener: () => {},
+					addEventListener: () => {},
+					removeEventListener: () => {},
+					dispatchEvent: () => false,
+				}) as MediaQueryList;
+		}
+
+		const doneDep = makeTask("BACK-1", "Done");
+		const inProgDep = makeTask("BACK-2", "In Progress");
+		const readyTask = makeTask("BACK-3", "To Do", ["BACK-1"]);
+		const blockedTask = makeTask("BACK-4", "To Do", ["BACK-2"]);
+		const availableTasks = [doneDep, inProgDep, readyTask, blockedTask];
+
+		const readyHtml = renderToString(
+			<ThemeProvider>
+				<TaskDetailsModal task={readyTask} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
+			</ThemeProvider>,
+		);
+		expect(readyHtml).toContain("Readiness:");
+		expect(readyHtml).toContain("✓ Ready to start");
+
+		const blockedHtml = renderToString(
+			<ThemeProvider>
+				<TaskDetailsModal task={blockedTask} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
+			</ThemeProvider>,
+		);
+		expect(blockedHtml).toContain("Readiness:");
+		expect(blockedHtml).toContain("BACK-2");
+
+		const terminalHtml = renderToString(
+			<ThemeProvider>
+				<TaskDetailsModal task={doneDep} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
+			</ThemeProvider>,
+		);
+		expect(terminalHtml).toContain("Readiness:");
+		expect(terminalHtml).toContain("Done");
 	});
 });

--- a/src/test/unified-view-filters.test.ts
+++ b/src/test/unified-view-filters.test.ts
@@ -502,4 +502,36 @@ describe("unified view filter state", () => {
 		expect(listResults).toEqual(["task-1", "task-2"]);
 		expect(literalMilestoneResults).toEqual(["task-4"]);
 	});
+
+	it("evaluates interactive TUI --ready filter against fullGraphTasks when active candidates omit completed tasks", () => {
+		const archivedDoneDep: Task = {
+			id: "task-1",
+			title: "Archived Completed Dep",
+			status: "Done",
+			assignee: [],
+			createdDate: "2026-07-01",
+			labels: [],
+			dependencies: [],
+		};
+		const activeTask: Task = {
+			id: "task-2",
+			title: "Active Dependent Task",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-07-24",
+			labels: [],
+			dependencies: ["task-1"],
+		};
+
+		const displayCandidates = [activeTask];
+		const fullGraph = [archivedDoneDep, activeTask];
+
+		const readyFiltered = applyTaskFilters(displayCandidates, {
+			ready: true,
+			statuses: ["To Do", "In Progress", "Done"],
+			fullGraphTasks: fullGraph,
+		});
+
+		expect(readyFiltered.map((task) => task.id)).toEqual(["task-2"]);
+	});
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,6 +180,7 @@ export interface TaskListFilter {
 	milestone?: string;
 	parentTaskId?: string;
 	labels?: string[];
+	ready?: boolean;
 }
 
 export interface Decision {

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -236,6 +236,9 @@ export async function viewTaskEnhanced(
 
 	let dateFormat: string | undefined;
 
+	// Load complete task graph for dependency readiness resolution across all surfaces
+	const fullGraphTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
+
 	if (options.tasks) {
 		// Tasks already provided - use in-memory search (no ContentStore loading)
 		allTasks = options.tasks.filter((t) => t.id && t.id.trim() !== "" && hasAnyPrefix(t.id));
@@ -1059,7 +1062,7 @@ export async function viewTaskEnhanced(
 			currentSelectedTask,
 			resolveMilestoneLabel,
 			dateFormat,
-			allTasks,
+			fullGraphTasks,
 			statuses,
 		);
 

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -182,6 +182,7 @@ export async function viewTaskEnhanced(
 		milestoneFilter?: string;
 		labelFilter?: string[];
 		labelMatch?: LabelMatchMode;
+		readyFilter?: boolean;
 		limit?: number;
 		startWithDetailFocus?: boolean;
 		startWithSearchFocus?: boolean;
@@ -664,7 +665,8 @@ export async function viewTaskEnhanced(
 				taskTypeFilter.length > 0 ||
 				priorityFilter ||
 				labelFilter.length > 0 ||
-				milestoneFilter,
+				milestoneFilter ||
+				options.readyFilter,
 		);
 		let nextFilteredTasks: Task[];
 		if (!hasActiveFilters) {
@@ -682,6 +684,8 @@ export async function viewTaskEnhanced(
 					labelMatch,
 					milestone: milestoneFilter || undefined,
 					resolveMilestoneLabel,
+					ready: options.readyFilter,
+					statuses,
 				},
 				taskSearchIndex,
 			);
@@ -1530,6 +1534,8 @@ function generateDetailContent(
 		metadata.push("{bold}Readiness:{/bold} {green-fg}✓ Ready to start{/}");
 	} else if (readiness.isBlocked) {
 		metadata.push(`{bold}Readiness:{/bold} {yellow-fg}⏳ Blocked by: ${readiness.blockingDependencies.join(", ")}{/}`);
+	} else {
+		metadata.push(`{bold}Readiness:{/bold} {gray-fg}Terminal status (${task.status}){/}`);
 	}
 	if (task.modifiedFiles?.length) {
 		metadata.push(`{bold}Modified files:{/bold} ${task.modifiedFiles.join(", ")}`);

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -691,6 +691,7 @@ export async function viewTaskEnhanced(
 					resolveMilestoneLabel,
 					ready: options.readyFilter,
 					statuses,
+					fullGraphTasks,
 				},
 				taskSearchIndex,
 			);

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -171,6 +171,7 @@ export async function viewTaskEnhanced(
 	task: Task,
 	options: {
 		tasks?: Task[];
+		fullGraphTasks?: Task[];
 		core?: Core;
 		title?: string;
 		filterDescription?: string;
@@ -237,7 +238,8 @@ export async function viewTaskEnhanced(
 	let dateFormat: string | undefined;
 
 	// Load complete task graph for dependency readiness resolution across all surfaces
-	const fullGraphTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
+	const fullGraphTasks =
+		options.fullGraphTasks ?? (await core.loadTasks(undefined, undefined, { includeCompleted: true }));
 
 	if (options.tasks) {
 		// Tasks already provided - use in-memory search (no ContentStore loading)

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -725,6 +725,11 @@ export async function viewTaskEnhanced(
 					return requiredLabels.every((label) => taskLabels.has(label));
 				});
 			}
+			if (options.readyFilter) {
+				nextFilteredTasks = nextFilteredTasks.filter(
+					(task) => getTaskReadiness(task, fullGraphTasks, statuses).isReady,
+				);
+			}
 		} else {
 			nextFilteredTasks = [...allTasks];
 		}

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -1479,7 +1479,7 @@ export async function viewTaskEnhanced(
 	});
 }
 
-function generateDetailContent(
+export function generateDetailContent(
 	task: Task,
 	resolveMilestoneLabel?: (milestone: string) => string,
 	dateFormat?: string,

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -21,6 +21,7 @@ import {
 } from "../utils/milestone-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
 import { formatPriorityLabel, getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
+import { getTaskReadiness } from "../utils/readiness.ts";
 import { applyTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
@@ -1050,7 +1051,13 @@ export async function viewTaskEnhanced(
 
 		screen.title = `Task ${currentSelectedTask.id} - ${currentSelectedTask.title}`;
 
-		const detailContent = generateDetailContent(currentSelectedTask, resolveMilestoneLabel, dateFormat);
+		const detailContent = generateDetailContent(
+			currentSelectedTask,
+			resolveMilestoneLabel,
+			dateFormat,
+			allTasks,
+			statuses,
+		);
 
 		// Calculate header height based on content and available width
 		const detailPaneWidth = typeof detailPane.width === "number" ? detailPane.width : 60;
@@ -1461,6 +1468,8 @@ function generateDetailContent(
 	task: Task,
 	resolveMilestoneLabel?: (milestone: string) => string,
 	dateFormat?: string,
+	allTasks: Task[] = [],
+	statuses: readonly string[] = ["To Do", "In Progress", "Done"],
 ): { headerContent: string[]; bodyContent: string[] } {
 	const headerContent = [
 		` ${wrapStatusColor(formatStatusWithIcon(task.status), getStatusColor(task.status))} {bold}{blue-fg}${task.id}{/blue-fg}{/bold} - ${task.title}`,
@@ -1515,6 +1524,12 @@ function generateDetailContent(
 	}
 	if (task.dependencies?.length) {
 		metadata.push(`{bold}Dependencies:{/bold} ${task.dependencies.join(", ")}`);
+	}
+	const readiness = getTaskReadiness(task, allTasks, statuses);
+	if (readiness.isReady) {
+		metadata.push("{bold}Readiness:{/bold} {green-fg}✓ Ready to start{/}");
+	} else if (readiness.isBlocked) {
+		metadata.push(`{bold}Readiness:{/bold} {yellow-fg}⏳ Blocked by: ${readiness.blockingDependencies.join(", ")}{/}`);
 	}
 	if (task.modifiedFiles?.length) {
 		metadata.push(`{bold}Modified files:{/bold} ${task.modifiedFiles.join(", ")}`);

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -21,7 +21,10 @@ export interface UnifiedViewOptions {
 	initialView: ViewType;
 	selectedTask?: Task;
 	tasks?: Task[];
-	tasksLoader?: (updateProgress: (message: string) => void) => Promise<{ tasks: Task[]; statuses: string[] }>;
+	fullGraphTasks?: Task[];
+	tasksLoader?: (
+		updateProgress: (message: string) => void,
+	) => Promise<{ tasks: Task[]; statuses: string[]; fullGraphTasks?: Task[] }>;
 	loadingScreenFactory?: (initialMessage: string) => Promise<LoadingScreen | null>;
 	title?: string;
 	filter?: {
@@ -57,6 +60,7 @@ type LoadingScreen = {
 export interface UnifiedViewLoadResult {
 	tasks: Task[];
 	statuses: string[];
+	fullGraphTasks?: Task[];
 }
 
 export type UnifiedTaskUpdate = { type: "upsert"; task: Task } | { type: "remove"; taskId: string };
@@ -207,24 +211,29 @@ export function mergeUnifiedViewFilters(
 
 export async function loadTasksForUnifiedView(
 	core: Core,
-	options: Pick<UnifiedViewOptions, "tasks" | "tasksLoader" | "loadingScreenFactory">,
+	options: Pick<UnifiedViewOptions, "tasks" | "fullGraphTasks" | "tasksLoader" | "loadingScreenFactory">,
 ): Promise<UnifiedViewLoadResult> {
 	if (options.tasks && options.tasks.length > 0) {
 		const config = await core.filesystem.loadConfig();
 		return {
 			tasks: options.tasks,
 			statuses: config?.statuses || ["To Do", "In Progress", "Done"],
+			fullGraphTasks: options.fullGraphTasks,
 		};
 	}
 
 	const loader =
 		options.tasksLoader ||
-		(async (updateProgress: (message: string) => void): Promise<{ tasks: Task[]; statuses: string[] }> => {
+		(async (
+			updateProgress: (message: string) => void,
+		): Promise<{ tasks: Task[]; statuses: string[]; fullGraphTasks?: Task[] }> => {
 			const tasks = await core.loadTasks(updateProgress);
+			const fullGraphTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
 			const config = await core.filesystem.loadConfig();
 			return {
 				tasks,
 				statuses: config?.statuses || ["To Do", "In Progress", "Done"],
+				fullGraphTasks,
 			};
 		});
 
@@ -239,6 +248,7 @@ export async function loadTasksForUnifiedView(
 		return {
 			tasks: result.tasks,
 			statuses: result.statuses,
+			fullGraphTasks: result.fullGraphTasks,
 		};
 	} finally {
 		await loadingScreen?.close();
@@ -273,8 +283,13 @@ export async function createTaskFromBoard(
  */
 export async function runUnifiedView(options: UnifiedViewOptions): Promise<void> {
 	try {
-		const { tasks: loadedTasks, statuses: loadedStatuses } = await loadTasksForUnifiedView(options.core, {
+		const {
+			tasks: loadedTasks,
+			statuses: loadedStatuses,
+			fullGraphTasks: loadedFullGraphTasks,
+		} = await loadTasksForUnifiedView(options.core, {
 			tasks: options.tasks,
+			fullGraphTasks: options.fullGraphTasks,
 			tasksLoader: options.tasksLoader,
 			loadingScreenFactory: options.loadingScreenFactory,
 		});
@@ -409,6 +424,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 
 				viewTaskEnhanced(taskToView, {
 					tasks: availableTasks,
+					fullGraphTasks: loadedFullGraphTasks,
 					core: options.core,
 					title: options.filter?.title,
 					filterDescription: options.filter?.filterDescription,

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -39,6 +39,7 @@ export interface UnifiedViewOptions {
 		excludeStatus?: string[];
 		parentTaskId?: string;
 		limit?: number;
+		ready?: boolean;
 	};
 	preloadedKanbanData?: {
 		tasks: Task[];
@@ -419,6 +420,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					labelFilter: currentFilters.labelFilter,
 					labelMatch: currentFilters.labelMatch,
 					milestoneFilter: currentFilters.milestoneFilter,
+					readyFilter: options.filter?.ready,
 					limit: currentFilters.limit,
 					startWithDetailFocus: currentView === "task-detail",
 					startWithSearchFocus: shouldFocusSearch,

--- a/src/utils/readiness.ts
+++ b/src/utils/readiness.ts
@@ -1,0 +1,57 @@
+import type { Task } from "../types/index.ts";
+import { isTerminalStatus } from "./terminal-status.ts";
+
+export interface TaskReadiness {
+	isReady: boolean;
+	isBlocked: boolean;
+	blockingDependencies: string[];
+	missingDependencies: string[];
+}
+
+export function getTaskReadiness(task: Task, allTasks: Task[], statuses: readonly string[]): TaskReadiness {
+	// If task itself is already terminal/done, it is not "ready for work"
+	if (isTerminalStatus(task.status, statuses)) {
+		return {
+			isReady: false,
+			isBlocked: false,
+			blockingDependencies: [],
+			missingDependencies: [],
+		};
+	}
+
+	const dependencies = task.dependencies ?? [];
+	if (dependencies.length === 0) {
+		return {
+			isReady: true,
+			isBlocked: false,
+			blockingDependencies: [],
+			missingDependencies: [],
+		};
+	}
+
+	const taskMap = new Map<string, Task>();
+	for (const t of allTasks) {
+		taskMap.set(t.id.toLowerCase(), t);
+	}
+
+	const blockingDependencies: string[] = [];
+	const missingDependencies: string[] = [];
+
+	for (const depId of dependencies) {
+		const targetTask = taskMap.get(depId.toLowerCase());
+		if (!targetTask) {
+			missingDependencies.push(depId);
+			blockingDependencies.push(depId);
+		} else if (!isTerminalStatus(targetTask.status, statuses)) {
+			blockingDependencies.push(targetTask.id);
+		}
+	}
+
+	const isBlocked = blockingDependencies.length > 0;
+	return {
+		isReady: !isBlocked,
+		isBlocked,
+		blockingDependencies,
+		missingDependencies,
+	};
+}

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -326,6 +326,7 @@ export function applySharedTaskFilters(
 			resolveMilestoneLabel: options.resolveMilestoneLabel,
 			ready: options.ready,
 			statuses: options.statuses,
+			fullGraphTasks: options.fullGraphTasks,
 		},
 		index,
 	);

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -28,6 +28,9 @@ export interface TaskSearchOptions {
 	modifiedFiles?: string[];
 }
 
+import { DEFAULT_STATUSES } from "../constants/index.ts";
+import { getTaskReadiness } from "./readiness.ts";
+
 export interface SharedTaskFilterOptions {
 	query?: string;
 	excludeStatus?: string | string[];
@@ -38,6 +41,8 @@ export interface SharedTaskFilterOptions {
 	modifiedFiles?: string[];
 	milestone?: string;
 	resolveMilestoneLabel?: (milestone: string) => string;
+	ready?: boolean;
+	statuses?: readonly string[];
 }
 
 export interface TaskFilterOptions extends SharedTaskFilterOptions {
@@ -292,6 +297,11 @@ export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, inde
 		results = applyMilestoneFilter(results, options.milestone, options.resolveMilestoneLabel, tasks);
 	}
 
+	if (options.ready) {
+		const statuses = options.statuses ?? DEFAULT_STATUSES;
+		results = results.filter((task) => getTaskReadiness(task, tasks, statuses).isReady);
+	}
+
 	return results;
 }
 
@@ -312,6 +322,8 @@ export function applySharedTaskFilters(
 			modifiedFiles: options.modifiedFiles,
 			milestone: options.milestone,
 			resolveMilestoneLabel: options.resolveMilestoneLabel,
+			ready: options.ready,
+			statuses: options.statuses,
 		},
 		index,
 	);

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -43,6 +43,7 @@ export interface SharedTaskFilterOptions {
 	resolveMilestoneLabel?: (milestone: string) => string;
 	ready?: boolean;
 	statuses?: readonly string[];
+	fullGraphTasks?: Task[];
 }
 
 export interface TaskFilterOptions extends SharedTaskFilterOptions {
@@ -299,7 +300,8 @@ export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, inde
 
 	if (options.ready) {
 		const statuses = options.statuses ?? DEFAULT_STATUSES;
-		results = results.filter((task) => getTaskReadiness(task, tasks, statuses).isReady);
+		const graph = options.fullGraphTasks ?? tasks;
+		results = results.filter((task) => getTaskReadiness(task, graph, statuses).isReady);
 	}
 
 	return results;

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -929,6 +929,17 @@ export const TaskDetailsModal: React.FC<Props> = ({
           availableStatuses ?? ["To Do", "In Progress", "Done"],
         );
 
+        if (!readiness.isReady && !readiness.isBlocked) {
+          return (
+            <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
+              <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                Task in terminal status ({task.status})
+              </span>
+            </div>
+          );
+        }
+
         return (
           <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
             <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -11,6 +11,7 @@ import DependencyInput from "./DependencyInput";
 import { formatStoredUtcDateForDisplay } from "../utils/date-display";
 import { getPriorityOptions } from "../../utils/priority-config";
 import { getTaskTypeValues, resolveTaskTypeValue } from "../../utils/task-type-config";
+import { getTaskReadiness } from "../../utils/readiness";
 
 interface Props {
   task?: Task; // Optional for create mode
@@ -921,23 +922,23 @@ export const TaskDetailsModal: React.FC<Props> = ({
       )}
 
       {/* Task Readiness Guidance */}
-      {task && (dependencies.length > 0) && (() => {
-        const blockingDeps = dependencies.filter((depId) => {
-          const target = availableTasks.find((t) => t.id.toLowerCase() === depId.toLowerCase());
-          return !target || (target.status !== "Done" && target.status !== "Completed");
-        });
-        const isReady = blockingDeps.length === 0;
+      {task && (() => {
+        const readiness = getTaskReadiness(
+          { ...task, dependencies },
+          availableTasks,
+          availableStatuses ?? ["To Do", "In Progress", "Done"],
+        );
 
         return (
           <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
             <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
-            {isReady ? (
+            {readiness.isReady ? (
               <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">
-                ✓ Ready to start (all dependencies satisfied)
+                ✓ Ready to start ({dependencies.length === 0 ? "no dependencies" : "all dependencies satisfied"})
               </span>
             ) : (
               <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300">
-                ⏳ Blocked by: {blockingDeps.join(", ")}
+                ⏳ Blocked by: {readiness.blockingDependencies.join(", ")}
               </span>
             )}
           </div>

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -920,6 +920,22 @@ export const TaskDetailsModal: React.FC<Props> = ({
         </div>
       )}
 
+      {/* Task Readiness Guidance */}
+      {task && (dependencies.length > 0) && (
+        <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
+          <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
+          {dependencies.every((depId) => availableTasks.some((t) => t.id.toLowerCase() === depId.toLowerCase() && (t.status === "Done" || t.status === "Completed"))) ? (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">
+              ✓ Ready to start (all dependencies satisfied)
+            </span>
+          ) : (
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300">
+              ⏳ Blocked by unresolved dependencies
+            </span>
+          )}
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Main content */}
         <div className="md:col-span-2 space-y-6">

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -921,20 +921,28 @@ export const TaskDetailsModal: React.FC<Props> = ({
       )}
 
       {/* Task Readiness Guidance */}
-      {task && (dependencies.length > 0) && (
-        <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
-          <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
-          {dependencies.every((depId) => availableTasks.some((t) => t.id.toLowerCase() === depId.toLowerCase() && (t.status === "Done" || t.status === "Completed"))) ? (
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">
-              ✓ Ready to start (all dependencies satisfied)
-            </span>
-          ) : (
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300">
-              ⏳ Blocked by unresolved dependencies
-            </span>
-          )}
-        </div>
-      )}
+      {task && (dependencies.length > 0) && (() => {
+        const blockingDeps = dependencies.filter((depId) => {
+          const target = availableTasks.find((t) => t.id.toLowerCase() === depId.toLowerCase());
+          return !target || (target.status !== "Done" && target.status !== "Completed");
+        });
+        const isReady = blockingDeps.length === 0;
+
+        return (
+          <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
+            <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
+            {isReady ? (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">
+                ✓ Ready to start (all dependencies satisfied)
+              </span>
+            ) : (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300">
+                ⏳ Blocked by: {blockingDeps.join(", ")}
+              </span>
+            )}
+          </div>
+        );
+      })()}
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Main content */}

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -29,6 +29,7 @@ interface Props {
   archivedMilestoneEntities?: Milestone[];
   definitionOfDoneDefaults?: string[];
   dateFormat?: string;
+  availableTasks?: Task[];
 }
 
 type Mode = "preview" | "edit" | "create";
@@ -137,6 +138,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   isDraftMode,
   definitionOfDoneDefaults,
   dateFormat,
+  availableTasks: availableTasksProp,
 }) => {
   const { theme } = useTheme();
   const isCreateMode = !task;
@@ -319,7 +321,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const [dependencies, setDependencies] = useState<string[]>(task?.dependencies || []);
   const [references, setReferences] = useState<string[]>(task?.references || []);
   const [milestone, setMilestone] = useState<string>(task?.milestone || "");
-  const [availableTasks, setAvailableTasks] = useState<Task[]>([]);
+  const [availableTasks, setAvailableTasks] = useState<Task[]>(availableTasksProp || []);
   const canonicalTypeSelection = resolveTaskTypeValue(taskType, typeOptions);
   const typeSelectionValue = canonicalTypeSelection ?? taskType;
   const milestoneSelectionValue = resolveMilestoneToId(milestone);
@@ -455,8 +457,11 @@ export const TaskDetailsModal: React.FC<Props> = ({
       previousTaskId.current = nextTaskId;
       previousIsOpen.current = isOpen;
       formBaselineRef.current = nextFormState;
-      setError(null);
-      apiClient.fetchTasks().then(setAvailableTasks).catch(() => setAvailableTasks([]));
+      if (availableTasksProp) {
+        setAvailableTasks(availableTasksProp);
+      } else {
+        apiClient.fetchTasks().then(setAvailableTasks).catch(() => setAvailableTasks([]));
+      }
       return;
     }
 
@@ -487,8 +492,12 @@ export const TaskDetailsModal: React.FC<Props> = ({
     formBaselineRef.current = nextFormState;
     setError(null);
     // Preload tasks for dependency picker
-    apiClient.fetchTasks().then(setAvailableTasks).catch(() => setAvailableTasks([]));
-  }, [task, isOpen, isCreateMode, isDraftMode, availableStatuses, defaultDefinitionOfDone]);
+    if (availableTasksProp) {
+      setAvailableTasks(availableTasksProp);
+    } else {
+      apiClient.fetchTasks().then(setAvailableTasks).catch(() => setAvailableTasks([]));
+    }
+  }, [task, isOpen, isCreateMode, isDraftMode, availableStatuses, defaultDefinitionOfDone, availableTasksProp]);
 
   const refreshAfterCommentChange = useCallback(() => {
     if (!commentsChanged) return;


### PR DESCRIPTION
## What changed

- Adds canonical dependency-readiness semantics and guidance across the CLI, browser, and interactive TUI.
- Keeps MCP changes as adapter parity for the CLI-defined behavior.
- Resolves readiness against the full task graph without changing task ordering or state.

## Why

Users can identify work that is ready to start and understand what blocks a task without restoring the abandoned derived-sequence model.

## Validation

- `bun test`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`

Recommended merge strategy: squash merge.