### PR TITLE
BACK-560 - Bind the browser server to loopback only

### DIFF
--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -253,8 +253,10 @@ Manage task dependencies to express execution order:
 
 | Action      | Example                                              |
 |-------------|------------------------------------------------------|
-| Web interface | `backlog browser` (launches web UI on port 6420) |
+| Web interface | `backlog browser` (launches the local-machine-only web UI on `127.0.0.1:6420`) |
 | Web custom port | `backlog browser --port 8080 --no-open` |
+
+The Web UI listens only on `127.0.0.1`; it is not reachable from other devices on the LAN or VPN.
 
 To keep the Web UI running in the background with auto-start on boot, see [Running Backlog.md as a Service](backlog/docs/doc-003%20-%20Running-Backlog-Browser-as-a-Service.md).
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ Read commands support stable, versioned JSON for scripts and integrations. Use `
 
 ## <img src="./.github/web-interface-256.png" alt="Web Interface" width="28" height="28" align="center"> Web Interface
 
-Launch a local web interface for visual task management:
+Launch a web interface for visual task management on the local machine. The server listens on `127.0.0.1` and is not
+reachable from other devices on the LAN or VPN:
 
 ```bash
 # Start the web server (opens browser automatically)

--- a/backlog/docs/doc-003 - Running-Backlog-Browser-as-a-Service.md
+++ b/backlog/docs/doc-003 - Running-Backlog-Browser-as-a-Service.md
@@ -3,11 +3,13 @@ id: doc-003
 title: Running Backlog Browser as a Service
 type: guide
 created_date: '2026-04-25'
+updated_date: '2026-07-30 17:48'
 ---
-
 # Running Backlog.md as a Service
 
 `backlog browser --no-open` keeps the Web UI running without opening a browser tab. This is useful when you want a long-lived local dashboard that starts on boot and restarts on failure.
+
+The service listens only on `127.0.0.1`, so it is available on the same machine and is not exposed to other devices on the LAN or VPN.
 
 Pick the recipe that matches your OS.
 

--- a/backlog/tasks/back-560 - Bind-the-browser-server-to-loopback-only.md
+++ b/backlog/tasks/back-560 - Bind-the-browser-server-to-loopback-only.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-560
 title: Bind the browser server to loopback only
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-30 17:39'
+updated_date: '2026-07-30 17:54'
 labels:
   - browser
   - security
@@ -11,6 +13,16 @@ dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/810'
   - 'https://github.com/MrLesk/Backlog.md/pull/811'
+modified_files:
+  - src/server/index.ts
+  - src/cli.ts
+  - src/test/test-utils.ts
+  - src/test/server-port.test.ts
+  - src/test/cli-browser-port.test.ts
+  - src/test/server-hostname.test.ts
+  - README.md
+  - CLI-INSTRUCTIONS.md
+  - backlog/docs/doc-003 - Running-Backlog-Browser-as-a-Service.md
 priority: high
 type: bug
 ordinal: 205000
@@ -38,3 +50,27 @@ The local browser server currently omits Bun hostname configuration, which binds
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: Update the shared ephemeral-port fixture and port regressions to model an explicit 127.0.0.1 listener; add a real BacklogServer startup test that expects the bound hostname, displayed URL, automatic-open URL, and --no-open behavior to use 127.0.0.1; add CLI help coverage for local-machine-only wording and absence of --host. Run the focused server and CLI tests before production changes and confirm failures match the wildcard/localhost behavior.
+2. GREEN: In src/server/index.ts, define one internal 127.0.0.1 browser host value and reuse it for net probing, Bun.serve hostname, and the displayed/opened URL without adding any hostname parameter. Update the browser command description and README, CLI reference, and service guide to state that the Web UI is available only on the local machine.
+3. REFACTOR AND VERIFY: Keep the implementation to the shared constant and existing paths, then run the focused port/startup/CLI tests, relevant broader server tests, typecheck, Biome, a live loopback-versus-LAN/VPN reachability check when an external interface is available, git diff --check, and a final scope/simplification review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented loopback-only browser serving with a single internal 127.0.0.1 host constant shared by the port probe, Bun server binding, displayed URL, and browser launch URL. Updated browser help and public docs to state the local-only boundary.
+
+Verification:
+- RED: focused hostname/port/CLI suite produced 8 expected failures before implementation.
+- GREEN: focused suite passed 12 tests with 0 failures.
+- Broader server suite passed 74 tests with 0 failures.
+- Full suite passed 1,782 tests with 4 skipped and 0 failures across 200 files.
+- bunx tsc --noEmit passed.
+- bun run check . passed for 340 files.
+- git diff --check passed.
+- Live network proof returned HTTP 200 on 127.0.0.1 while the available Wi-Fi and VPN IPv4 addresses were unreachable.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-560 - Bind-the-browser-server-to-loopback-only.md
+++ b/backlog/tasks/back-560 - Bind-the-browser-server-to-loopback-only.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-560
 title: Bind the browser server to loopback only
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:39'
-updated_date: '2026-07-30 17:54'
+updated_date: '2026-07-30 17:59'
 labels:
   - browser
   - security
@@ -36,19 +36,19 @@ The local browser server currently omits Bun hostname configuration, which binds
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 backlog browser binds explicitly to 127.0.0.1 by default and does not accept a public host override.
-- [ ] #2 Port availability probing checks the same 127.0.0.1 interface used by the production server, including advancing when a loopback port is occupied.
-- [ ] #3 Startup output and automatic browser opening use the actual loopback URL.
-- [ ] #4 The browser API is not reachable through a machine LAN or VPN address under the supported default behavior.
-- [ ] #5 CLI help and browser documentation describe the interface as local-machine only and do not advertise unauthenticated external hosting.
-- [ ] #6 Tests cover explicit loopback binding, occupied-loopback-port selection, displayed and opened URL behavior, and unchanged --no-open behavior.
+- [x] #1 backlog browser binds explicitly to 127.0.0.1 by default and does not accept a public host override.
+- [x] #2 Port availability probing checks the same 127.0.0.1 interface used by the production server, including advancing when a loopback port is occupied.
+- [x] #3 Startup output and automatic browser opening use the actual loopback URL.
+- [x] #4 The browser API is not reachable through a machine LAN or VPN address under the supported default behavior.
+- [x] #5 CLI help and browser documentation describe the interface as local-machine only and do not advertise unauthenticated external hosting.
+- [x] #6 Tests cover explicit loopback binding, occupied-loopback-port selection, displayed and opened URL behavior, and unchanged --no-open behavior.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -73,4 +73,12 @@ Verification:
 - bun run check . passed for 340 files.
 - git diff --check passed.
 - Live network proof returned HTTP 200 on 127.0.0.1 while the available Wi-Fi and VPN IPv4 addresses were unreachable.
+
+Final review: an independent security reviewer approved implementation head d4d963adadfcf82089dc431fe4361f911ae28821. The live reachability check was limited to the available Wi-Fi address 192.168.0.194 and VPN address 100.109.216.122; both were unreachable while 127.0.0.1 returned HTTP 200.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Bound the browser server and its port probe explicitly to 127.0.0.1, aligned displayed and opened URLs, documented the local-machine-only boundary, and added regression coverage without introducing a public host override. Verified on reviewed head d4d963ad with 12 focused and 74 broader server tests, the full 1,782-test suite, TypeScript, Biome, diff hygiene, and a live check showing loopback HTTP 200 while the tested Wi-Fi and VPN addresses were unreachable.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4958,7 +4958,7 @@ addHelpSchema(program.command("cleanup"), {
 // Browser command for web UI
 program
 	.command("browser")
-	.description("open browser interface for task management (press Ctrl+C or Cmd+C to stop)")
+	.description("open browser interface on this machine only at 127.0.0.1 (press Ctrl+C or Cmd+C to stop)")
 	.option("-p, --port <port>", "port to run server on")
 	.option("--no-open", "don't automatically open browser")
 	.option("--non-interactive", "automatically use next free port without asking")

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -154,6 +154,7 @@ export function markHtmlBundleNoStore(bundle: Bun.HTMLBundle): Bun.HTMLBundle {
 
 const spaIndexHtml = markHtmlBundleNoStore(indexHtml);
 const BUNDLE_ASSET_DIR_ENV = "BACKLOG_BUNDLE_ASSET_DIR";
+const BROWSER_HOST = "127.0.0.1";
 const MIN_PORT = 1;
 const MAX_PORT = 65535;
 
@@ -161,10 +162,7 @@ export async function isPortAvailable(port: number): Promise<boolean> {
 	if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) return false;
 	return new Promise((resolve) => {
 		const srv = net.createServer();
-		// Probe the wildcard interface that Bun.serve binds: on macOS a loopback-specific
-		// bind does not collide with a wildcard bind, so probing 127.0.0.1 would report
-		// a port as free while the browser server already holds it.
-		srv.listen(port, () => srv.close(() => resolve(true)));
+		srv.listen(port, BROWSER_HOST, () => srv.close(() => resolve(true)));
 		srv.on("error", () => resolve(false));
 	});
 }
@@ -295,6 +293,7 @@ export class BacklogServer {
 			await this.ensureServicesReady();
 			const serveOptions = {
 				port: finalPort,
+				hostname: BROWSER_HOST,
 				development: process.env.NODE_ENV === "development",
 				routes: {
 					"/": spaIndexHtml,
@@ -450,7 +449,7 @@ export class BacklogServer {
 				throw error;
 			}
 
-			const url = `http://localhost:${finalPort}`;
+			const url = `http://${BROWSER_HOST}:${finalPort}`;
 			console.log(`🚀 Backlog.md browser interface running at ${url}`);
 			console.log(`📊 Project: ${this.projectName}`);
 			const stopKey = process.platform === "darwin" ? "Cmd+C" : "Ctrl+C";

--- a/src/test/cli-browser-port.test.ts
+++ b/src/test/cli-browser-port.test.ts
@@ -91,11 +91,21 @@ describe("browser command port selection", () => {
 		});
 
 		try {
-			const output = await waitForOutput(child, `Port ${port} is already in use. Using port`);
+			const output = await waitForOutput(child, "browser interface running");
+			expect(output).toContain(`Port ${port} is already in use. Using port`);
 			expect(output).not.toContain("Start on port");
+			expect(output).toContain("http://127.0.0.1:");
+			expect(output).not.toContain("Opening browser");
 		} finally {
 			await stopChild(child);
 			await closeServer(server);
 		}
+	});
+
+	it("documents the local-machine-only bind without offering a public host override", async () => {
+		const output = await $`bun ${CLI_PATH} browser --help`.cwd(TEST_DIR).text();
+
+		expect(output).toContain("this machine only at 127.0.0.1");
+		expect(output).not.toContain("--host");
 	});
 });

--- a/src/test/server-hostname.test.ts
+++ b/src/test/server-hostname.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { FileSystem } from "../file-system/operations.ts";
+import { BacklogServer } from "../server/index.ts";
+import { closeServer, createUniqueTestDir, listenOnEphemeralPort, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let server: BacklogServer | null = null;
+
+type ServerInternals = {
+	server: { hostname?: string } | null;
+	openBrowser: (url: string) => Promise<void>;
+};
+
+function internals(instance: BacklogServer): ServerInternals {
+	return instance as unknown as ServerInternals;
+}
+
+async function unusedLoopbackPort(): Promise<number> {
+	const { server: portProbe, port } = await listenOnEphemeralPort();
+	await closeServer(portProbe);
+	return port;
+}
+
+describe("BacklogServer loopback binding", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("server-hostname");
+		const filesystem = new FileSystem(TEST_DIR);
+		await filesystem.ensureBacklogStructure();
+		await filesystem.saveConfig({
+			projectName: "Server Hostname",
+			statuses: ["To Do", "In Progress", "Done"],
+			labels: [],
+			milestones: [],
+			dateFormat: "YYYY-MM-DD",
+			remoteOperations: false,
+		});
+	});
+
+	afterEach(async () => {
+		if (server) {
+			await server.stop();
+			server = null;
+		}
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("binds, displays, and automatically opens the same 127.0.0.1 URL", async () => {
+		const port = await unusedLoopbackPort();
+		const logs: string[] = [];
+		let openedUrl: string | undefined;
+		const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			logs.push(args.join(" "));
+		});
+
+		try {
+			server = new BacklogServer(TEST_DIR);
+			internals(server).openBrowser = async (url) => {
+				openedUrl = url;
+			};
+			await server.start(port, true);
+
+			expect(internals(server).server?.hostname).toBe("127.0.0.1");
+			expect(logs).toContain(`🚀 Backlog.md browser interface running at http://127.0.0.1:${port}`);
+			expect(openedUrl).toBe(`http://127.0.0.1:${port}`);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it("keeps --no-open behavior while displaying the 127.0.0.1 URL", async () => {
+		const port = await unusedLoopbackPort();
+		const logs: string[] = [];
+		let opened = false;
+		const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			logs.push(args.join(" "));
+		});
+
+		try {
+			server = new BacklogServer(TEST_DIR);
+			internals(server).openBrowser = async () => {
+				opened = true;
+			};
+			await server.start(port, false);
+
+			expect(opened).toBe(false);
+			expect(logs).toContain(`🚀 Backlog.md browser interface running at http://127.0.0.1:${port}`);
+			expect(logs).toContain("💡 Open your browser and navigate to the URL above");
+			expect(logs).not.toContain("🌐 Opening browser...");
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+});

--- a/src/test/server-port.test.ts
+++ b/src/test/server-port.test.ts
@@ -26,10 +26,10 @@ describe("isPortAvailable", () => {
 		expect(result).toBe(false);
 	});
 
-	it("detects a port held by a production-style Bun.serve on its default interface", async () => {
-		// Regression for BACK-538: the probe used to bind 127.0.0.1 while Bun.serve
-		// binds the wildcard interface, so on macOS an occupied port looked free.
-		const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+	it("detects a port held by a production-style Bun.serve on the loopback interface", async () => {
+		// The availability probe must use the same interface as the browser server.
+		// On macOS, wildcard and loopback-specific listeners can otherwise share a port.
+		const server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("ok") });
 		const port = server.port;
 		if (port === undefined) throw new Error("Expected Bun.serve to expose its port");
 		try {

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -185,9 +185,9 @@ export async function listenOnEphemeralPort(): Promise<{ server: net.Server; por
 	const server = net.createServer();
 	await new Promise<void>((resolve, reject) => {
 		server.once("error", reject);
-		// Bind the wildcard interface like the production Bun.serve does, so port
+		// Bind the loopback interface like the production Bun.serve does, so port
 		// fixtures collide with the same binds the real browser server would.
-		server.listen(0, () => {
+		server.listen(0, "127.0.0.1", () => {
 			server.off("error", reject);
 			resolve();
 		});


### PR DESCRIPTION
## Summary

- Bind the local browser server explicitly to `127.0.0.1`.
- Use the same loopback interface for port probing, startup output, and automatic browser opening.
- Document `backlog browser` as local-machine only and keep `--no-open` behavior unchanged.
- Do not add a public host override or unauthenticated LAN mode.

## Related issue and contribution

Fixes #810.

This takes over the safe loopback-binding portion of PR #811 after the maintainer decision to keep the browser server loopback-only. PR #811 could not be merged directly because its BACK-555 task ID collides with current main and its port probe still checked a different interface from the server binding.

## Verification

- Focused browser binding and port tests: 12 passed
- Broader server/browser tests: 74 passed
- Full suite: 1,782 passed, 4 skipped, 0 failed
- `bunx tsc --noEmit`
- `bun run check .`
- Live verification: loopback returned HTTP 200 while the tested Wi-Fi and VPN addresses were unreachable