### PR TITLE
BACK-558 - Prevent browser shortcuts from intercepting inline task fields

### DIFF
--- a/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
+++ b/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 18:03'
+updated_date: '2026-07-30 18:46'
 labels:
   - web-ui
   - keyboard
@@ -15,6 +15,9 @@ references:
 modified_files:
   - src/web/components/TaskDetailsModal.tsx
   - src/test/web-task-details-modal-keyboard-shortcuts.test.tsx
+  - src/commands/advanced-config-wizard.ts
+  - src/commands/configure-advanced-settings.ts
+  - src/test/config-commands.test.ts
 type: bug
 ordinal: 203000
 ---
@@ -49,6 +52,8 @@ Global task-detail shortcuts currently intercept ordinary text entry in inline-e
 2. Run the focused test before production changes and confirm it fails specifically because the capture-phase preview shortcuts prevent editable-target key events.
 3. Add one local editable-target predicate in TaskDetailsModal and use it only to gate the preview e/E and c shortcut branches, leaving edit-mode Escape and Cmd/Ctrl+S unchanged.
 4. Run the focused and related Web task-detail tests, typecheck, Biome, broader tests, git diff checks, and interactive desktop-browser QA; simplify if the implementation can be reduced without weakening coverage.
+
+5. Characterize the Windows config-wizard timeout, replace only the slow test fixture boundary with a deterministic real filesystem fixture, and repeat focused plus full verification before returning a new reviewed head.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -63,10 +68,12 @@ Rendered QA: Chrome on the Default profile connected through the enabled extensi
 Browser-control tooling timed out while dismissing that final native confirmation. Recovery rediscovered the tab, but subsequent dialog inspection, Escape dismissal, and DOM snapshot timed out, so no screenshot or final tab-cleanup verification was captured. The fresh reviewer accepted this as tooling cleanup after the required behavior had already been observed, not an unmet product gate.
 
 Final verification on the unchanged implementation head: bun test passed 1,785 tests with 4 skipped and 0 failures (7,596 assertions); bunx tsc --noEmit passed; bun run check . checked 339 files with no fixes.
+
+Windows CI reliability follow-up: the only slow config-wizard case submitted a non-empty editor, so it spawned the real PATH lookup (where bun on Windows) even though the test contract is applying and persisting wizard selections. The original Windows run timed out at 10,063.60ms and the single rerun at 10,120.40ms; all BACK-558 shortcut tests passed there. TDD RED replaced the host editor with a fixture editor and requested an injected availability checker; before the seam, the test followed the missing-editor branch and failed (expected installClaudeAgent true, received false). The minimal optional seam defaults to the existing production checker and changes no production behavior. GREEN kept the full wizard, real config save/reload, and all 19 assertions. Local characterization before was 20/20 at 30.89-48.18ms (median 33.11ms); after was 30/30 at 30.69-47.74ms (median 32.88ms), now independent of PATH subprocess latency. Adjacent config/editor tests passed 25/25; shortcut tests passed 6/6; TypeScript, Biome (339 files), and diff checks passed; full suite passed 1,785 with 4 skipped, 0 failed, and 7,596 assertions.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Prevented task-detail preview shortcuts from intercepting editable fields with one shared ancestor-aware target guard, while preserving e/E and c outside editors plus edit-mode Escape and Cmd/Ctrl+S. Added focused regression and mutation coverage. Verified with 1,785 passing tests, TypeScript, Biome, and accepted real Chrome interaction QA.
+Prevented task-detail preview shortcuts from intercepting editable fields while preserving existing shortcuts, and made the Windows-blocking config wizard test deterministic by injecting only its external editor-availability boundary. Verified TDD RED/GREEN, 30 repeated focused runs, adjacent config/editor tests, shortcut tests, TypeScript, Biome, and the full 1,785-test suite.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
+++ b/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
@@ -1,15 +1,20 @@
 ---
 id: BACK-558
 title: Prevent browser shortcuts from intercepting inline task fields
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-30 17:11'
+updated_date: '2026-07-30 17:22'
 labels:
   - web-ui
   - keyboard
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/816'
+modified_files:
+  - src/web/components/TaskDetailsModal.tsx
+  - src/test/web-task-details-modal-keyboard-shortcuts.test.tsx
 type: bug
 ordinal: 203000
 ---
@@ -36,3 +41,18 @@ Global task-detail shortcuts currently intercept ordinary text entry in inline-e
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused TaskDetailsModal keyboard interaction test that mounts the real component, reproduces e/E interception across representative input, textarea, select, and content-editable targets, and proves c is protected while non-editable e/E, edit-mode Escape, and Cmd/Ctrl+S remain active.
+2. Run the focused test before production changes and confirm it fails specifically because the capture-phase preview shortcuts prevent editable-target key events.
+3. Add one local editable-target predicate in TaskDetailsModal and use it only to gate the preview e/E and c shortcut branches, leaving edit-mode Escape and Cmd/Ctrl+S unchanged.
+4. Run the focused and related Web task-detail tests, typecheck, Biome, broader tests, git diff checks, and interactive desktop-browser QA; simplify if the implementation can be reduced without weakening coverage.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the preview shortcut guard with one local editable-target rule covering input, textarea, select, and content-editable elements. Added focused mounted-component coverage for all named inline fields, c protection, non-editable e/E, edit-mode Escape, and Cmd/Ctrl+S. RED proof: the new test initially failed because reference e and Done-task c were default-prevented. GREEN proof: all five focused cases pass after the guard. Rendered QA remains pending because the browser-control runtime exposed no available desktop browser in this session.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
+++ b/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 18:46'
+updated_date: '2026-07-30 19:14'
 labels:
   - web-ui
   - keyboard
@@ -18,6 +18,7 @@ modified_files:
   - src/commands/advanced-config-wizard.ts
   - src/commands/configure-advanced-settings.ts
   - src/test/config-commands.test.ts
+  - src/test/tui-task-composer.test.ts
 type: bug
 ordinal: 203000
 ---
@@ -54,6 +55,8 @@ Global task-detail shortcuts currently intercept ordinary text entry in inline-e
 4. Run the focused and related Web task-detail tests, typecheck, Biome, broader tests, git diff checks, and interactive desktop-browser QA; simplify if the implementation can be reduced without weakening coverage.
 
 5. Characterize the Windows config-wizard timeout, replace only the slow test fixture boundary with a deterministic real filesystem fixture, and repeat focused plus full verification before returning a new reviewed head.
+
+6. Characterize the Windows TUI rollback/retry timeout, isolate only non-contract Git/process/filesystem setup through TDD, preserve every rollback, ID-reuse, and unrelated-state assertion, then repeat focused and full verification before review.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -70,10 +73,12 @@ Browser-control tooling timed out while dismissing that final native confirmatio
 Final verification on the unchanged implementation head: bun test passed 1,785 tests with 4 skipped and 0 failures (7,596 assertions); bunx tsc --noEmit passed; bun run check . checked 339 files with no fixes.
 
 Windows CI reliability follow-up: the only slow config-wizard case submitted a non-empty editor, so it spawned the real PATH lookup (where bun on Windows) even though the test contract is applying and persisting wizard selections. The original Windows run timed out at 10,063.60ms and the single rerun at 10,120.40ms; all BACK-558 shortcut tests passed there. TDD RED replaced the host editor with a fixture editor and requested an injected availability checker; before the seam, the test followed the missing-editor branch and failed (expected installClaudeAgent true, received false). The minimal optional seam defaults to the existing production checker and changes no production behavior. GREEN kept the full wizard, real config save/reload, and all 19 assertions. Local characterization before was 20/20 at 30.89-48.18ms (median 33.11ms); after was 30/30 at 30.69-47.74ms (median 32.88ms), now independent of PATH subprocess latency. Adjacent config/editor tests passed 25/25; shortcut tests passed 6/6; TypeScript, Biome (339 files), and diff checks passed; full suite passed 1,785 with 4 skipped, 0 failed, and 7,596 assertions.
+
+Windows TUI reliability follow-up: profiling isolated the rollback/retry timeout to the fixture's real failing Git hook. The failure path invoked three selected-file commit attempts plus 100ms and 200ms backoffs before exercising Core rollback; Windows Git and process startup expanded that non-contract setup to 10,064.28ms. The test now injects one deterministic auto-commit failure after real staging and index capture, then restores the real commit path for retry. Production code is unchanged, and all 8 rollback, clean-state, input-preservation, same-ID, and no-duplicate assertions remain. The 1.2s characterization changed from RED at 1,205.49ms to GREEN at 695.91ms. Thirty repeated runs passed with 627.84ms minimum, 640.31ms median, and 883.84ms maximum, compared with the prior observed local 1,526.70ms minimum, about 1,552ms median, and 1,736.25ms maximum. The full TUI file passed 47 tests and 222 assertions; adjacent shortcut, config, Core, Git, and auto-commit tests passed 86 tests and 264 assertions; TypeScript and Biome passed; the full suite passed 1,785 tests with 4 skipped, 0 failed, and 7,596 assertions.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Prevented task-detail preview shortcuts from intercepting editable fields while preserving existing shortcuts, and made the Windows-blocking config wizard test deterministic by injecting only its external editor-availability boundary. Verified TDD RED/GREEN, 30 repeated focused runs, adjacent config/editor tests, shortcut tests, TypeScript, Biome, and the full 1,785-test suite.
+Prevented task-detail preview shortcuts from intercepting editable fields, made the config wizard test independent of Windows PATH subprocess latency, and made the TUI rollback/retry test deterministic at the auto-commit boundary while preserving real staging, rollback, and retry behavior. Verified focused repetition, adjacent suites, TypeScript, Biome, and the full 1,785-test suite with 0 failures.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
+++ b/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 17:22'
+updated_date: '2026-07-30 17:42'
 labels:
   - web-ui
   - keyboard
@@ -55,4 +55,6 @@ Global task-detail shortcuts currently intercept ordinary text entry in inline-e
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the preview shortcut guard with one local editable-target rule covering input, textarea, select, and content-editable elements. Added focused mounted-component coverage for all named inline fields, c protection, non-editable e/E, edit-mode Escape, and Cmd/Ctrl+S. RED proof: the new test initially failed because reference e and Done-task c were default-prevented. GREEN proof: all five focused cases pass after the guard. Rendered QA remains pending because the browser-control runtime exposed no available desktop browser in this session.
+
+Fresh reviewer proof gaps addressed without changing production code. The content-editable case now dispatches e from a nested span inside the editable ancestor; mutating the guard from closest() to matches() made that test fail with defaultPrevented=true. A new non-editable Done-task c test verifies apiClient.completeTask receives BACK-558; temporarily removing handleComplete() made it fail with a null completed task ID. Restored the original production implementation after both mutation checks. Rendered browser QA remains pending.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
+++ b/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 19:14'
+updated_date: '2026-07-30 19:45'
 labels:
   - web-ui
   - keyboard
@@ -19,6 +19,8 @@ modified_files:
   - src/commands/configure-advanced-settings.ts
   - src/test/config-commands.test.ts
   - src/test/tui-task-composer.test.ts
+  - src/utils/editor.ts
+  - src/test/editor.test.ts
 type: bug
 ordinal: 203000
 ---
@@ -57,6 +59,8 @@ Global task-detail shortcuts currently intercept ordinary text entry in inline-e
 5. Characterize the Windows config-wizard timeout, replace only the slow test fixture boundary with a deterministic real filesystem fixture, and repeat focused plus full verification before returning a new reviewed head.
 
 6. Characterize the Windows TUI rollback/retry timeout, isolate only non-contract Git/process/filesystem setup through TDD, preserve every rollback, ID-reuse, and unrelated-state assertion, then repeat focused and full verification before review.
+
+7. Characterize the Windows editor-availability timeout, replace only uncontrolled host command discovery with a deterministic injectable process boundary through TDD, preserve all editor detection contracts, and repeat focused plus full verification before fresh review.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -75,10 +79,12 @@ Final verification on the unchanged implementation head: bun test passed 1,785 t
 Windows CI reliability follow-up: the only slow config-wizard case submitted a non-empty editor, so it spawned the real PATH lookup (where bun on Windows) even though the test contract is applying and persisting wizard selections. The original Windows run timed out at 10,063.60ms and the single rerun at 10,120.40ms; all BACK-558 shortcut tests passed there. TDD RED replaced the host editor with a fixture editor and requested an injected availability checker; before the seam, the test followed the missing-editor branch and failed (expected installClaudeAgent true, received false). The minimal optional seam defaults to the existing production checker and changes no production behavior. GREEN kept the full wizard, real config save/reload, and all 19 assertions. Local characterization before was 20/20 at 30.89-48.18ms (median 33.11ms); after was 30/30 at 30.69-47.74ms (median 32.88ms), now independent of PATH subprocess latency. Adjacent config/editor tests passed 25/25; shortcut tests passed 6/6; TypeScript, Biome (339 files), and diff checks passed; full suite passed 1,785 with 4 skipped, 0 failed, and 7,596 assertions.
 
 Windows TUI reliability follow-up: profiling isolated the rollback/retry timeout to the fixture's real failing Git hook. The failure path invoked three selected-file commit attempts plus 100ms and 200ms backoffs before exercising Core rollback; Windows Git and process startup expanded that non-contract setup to 10,064.28ms. The test now injects one deterministic auto-commit failure after real staging and index capture, then restores the real commit path for retry. Production code is unchanged, and all 8 rollback, clean-state, input-preservation, same-ID, and no-duplicate assertions remain. The 1.2s characterization changed from RED at 1,205.49ms to GREEN at 695.91ms. Thirty repeated runs passed with 627.84ms minimum, 640.31ms median, and 883.84ms maximum, compared with the prior observed local 1,526.70ms minimum, about 1,552ms median, and 1,736.25ms maximum. The full TUI file passed 47 tests and 222 assertions; adjacent shortcut, config, Core, Git, and auto-commit tests passed 86 tests and 264 assertions; TypeScript and Biome passed; the full suite passed 1,785 tests with 4 skipped, 0 failed, and 7,596 assertions.
+
+Windows editor-availability reliability follow-up: the fresh Windows full-unit run exposed a 10,007.23ms timeout in should detect available editors. The test delegated all cases to uncontrolled host PATH discovery through where or which, and its positive case asserted only that the result was a boolean. TDD introduced one internal injectable command-lookup boundary while retaining the same production where and which behavior and failure-to-false contract. The final tests keep one real cmd or sh positive smoke and deterministically prove found, absent, first-token argument handling, and lookup failure behavior without a real negative PATH scan. Thirty focused repetitions passed 150 tests and 150 assertions; the real smoke ranged from 0.05ms to 3.37ms locally. Final verification passed 33 adjacent editor, config, and shortcut tests with 140 assertions; 8 rollback, config, and shortcut regressions with 80 assertions; TypeScript; Biome across 339 files; diff checks; and the full suite with 1,787 passed, 4 skipped, 0 failed, and 7,598 assertions across 200 files in 200.77 seconds.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Prevented task-detail preview shortcuts from intercepting editable fields, made the config wizard test independent of Windows PATH subprocess latency, and made the TUI rollback/retry test deterministic at the auto-commit boundary while preserving real staging, rollback, and retry behavior. Verified focused repetition, adjacent suites, TypeScript, Biome, and the full 1,785-test suite with 0 failures.
+Prevented task-detail preview shortcuts from intercepting editable fields, removed Windows PATH subprocess latency from the config wizard test, made the TUI rollback and retry test deterministic at the auto-commit boundary, and made editor-availability contracts deterministic while retaining one real platform smoke test. Verified focused repetition, adjacent regression suites, TypeScript, Biome, diff checks, and the full 1,787-test suite with 0 failures.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
+++ b/backlog/tasks/back-558 - Prevent-browser-shortcuts-from-intercepting-inline-task-fields.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-558
 title: Prevent browser shortcuts from intercepting inline task fields
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 17:42'
+updated_date: '2026-07-30 18:03'
 labels:
   - web-ui
   - keyboard
@@ -27,19 +27,19 @@ Global task-detail shortcuts currently intercept ordinary text entry in inline-e
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 In task preview, typing e or E in assignee, labels, references, title, or dependencies does not prevent the keystroke or enter full edit mode.
-- [ ] #2 Preview shortcuts do not intercept keystrokes originating from input, textarea, select, or content-editable targets.
-- [ ] #3 The c completion shortcut follows the same editable-target rule.
-- [ ] #4 Plain e or E outside editable controls still opens edit mode.
-- [ ] #5 Existing edit-mode Escape and Cmd/Ctrl+S behavior remains unchanged.
-- [ ] #6 Automated tests and rendered browser QA cover inline text entry and preserved shortcut behavior.
+- [x] #1 In task preview, typing e or E in assignee, labels, references, title, or dependencies does not prevent the keystroke or enter full edit mode.
+- [x] #2 Preview shortcuts do not intercept keystrokes originating from input, textarea, select, or content-editable targets.
+- [x] #3 The c completion shortcut follows the same editable-target rule.
+- [x] #4 Plain e or E outside editable controls still opens edit mode.
+- [x] #5 Existing edit-mode Escape and Cmd/Ctrl+S behavior remains unchanged.
+- [x] #6 Automated tests and rendered browser QA cover inline text entry and preserved shortcut behavior.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -54,7 +54,19 @@ Global task-detail shortcuts currently intercept ordinary text entry in inline-e
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented the preview shortcut guard with one local editable-target rule covering input, textarea, select, and content-editable elements. Added focused mounted-component coverage for all named inline fields, c protection, non-editable e/E, edit-mode Escape, and Cmd/Ctrl+S. RED proof: the new test initially failed because reference e and Done-task c were default-prevented. GREEN proof: all five focused cases pass after the guard. Rendered QA remains pending because the browser-control runtime exposed no available desktop browser in this session.
+Implemented one ancestor-aware editable-target rule for input, textarea, select, and content-editable elements. Preview e/E and c shortcuts now return before interception when the event originates in an editable target, while edit-mode Escape and Cmd/Ctrl+S remain unchanged.
 
-Fresh reviewer proof gaps addressed without changing production code. The content-editable case now dispatches e from a nested span inside the editable ancestor; mutating the guard from closest() to matches() made that test fail with defaultPrevented=true. A new non-editable Done-task c test verifies apiClient.completeTask receives BACK-558; temporarily removing handleComplete() made it fail with a null completed task ID. Restored the original production implementation after both mutation checks. Rendered browser QA remains pending.
+Test-first proof: the focused suite initially failed because reference e and Done-task c were default-prevented, then passed after the guard. Reviewer follow-up added non-editable c completion coverage and dispatch from a nested content-editable descendant. Mutating closest() to matches() failed the descendant case; removing handleComplete() failed the completion case. Production code was restored after both mutation checks.
+
+Rendered QA: Chrome on the Default profile connected through the enabled extension at http://localhost:6421 on head 0931b6465c257ea0033217cf5a219386a0d77079. Native e/E text was preserved in assignee, labels, references, title, and dependencies while the modal stayed in preview. Non-editable E opened edit mode. Escape returned to preview. Cmd+S entered Saving and resolved without error, and the timestamp-only fixture write was restored. On Done BACK-522, editable c remained literal text; non-editable C opened the native completion confirmation, and completion was not accepted.
+
+Browser-control tooling timed out while dismissing that final native confirmation. Recovery rediscovered the tab, but subsequent dialog inspection, Escape dismissal, and DOM snapshot timed out, so no screenshot or final tab-cleanup verification was captured. The fresh reviewer accepted this as tooling cleanup after the required behavior had already been observed, not an unmet product gate.
+
+Final verification on the unchanged implementation head: bun test passed 1,785 tests with 4 skipped and 0 failures (7,596 assertions); bunx tsc --noEmit passed; bun run check . checked 339 files with no fixes.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Prevented task-detail preview shortcuts from intercepting editable fields with one shared ancestor-aware target guard, while preserving e/E and c outside editors plus edit-mode Escape and Cmd/Ctrl+S. Added focused regression and mutation coverage. Verified with 1,785 passing tests, TypeScript, Biome, and accepted real Chrome interaction QA.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/commands/advanced-config-wizard.ts
+++ b/src/commands/advanced-config-wizard.ts
@@ -1,6 +1,6 @@
 import * as clack from "@clack/prompts";
 import type { BacklogConfig } from "../types/index.ts";
-import { isEditorAvailable, resolveEditor } from "../utils/editor.ts";
+import { isEditorAvailable as checkEditorAvailability, resolveEditor } from "../utils/editor.ts";
 
 interface PromptChoice {
 	title: string;
@@ -29,11 +29,14 @@ export type PromptRunner = (
 	options?: PromptOptions,
 ) => Promise<Record<string, unknown>>;
 
+export type EditorAvailabilityChecker = (editor: string) => Promise<boolean>;
+
 interface WizardOptions {
 	existingConfig?: BacklogConfig | null;
 	cancelMessage: string;
 	includeClaudePrompt?: boolean;
 	promptImpl?: PromptRunner;
+	isEditorAvailable?: EditorAvailabilityChecker;
 }
 
 export interface AdvancedConfigWizardResult {
@@ -198,6 +201,7 @@ export async function runAdvancedConfigWizard({
 	cancelMessage,
 	includeClaudePrompt = false,
 	promptImpl = clackPromptRunner,
+	isEditorAvailable = checkEditorAvailability,
 }: WizardOptions): Promise<AdvancedConfigWizardResult> {
 	const onCancel = () => handlePromptCancel(cancelMessage);
 	const config = existingConfig ?? null;

--- a/src/commands/configure-advanced-settings.ts
+++ b/src/commands/configure-advanced-settings.ts
@@ -1,15 +1,20 @@
 import type { Core } from "../core/backlog.ts";
 import type { BacklogConfig } from "../types/index.ts";
-import { type PromptRunner, runAdvancedConfigWizard } from "./advanced-config-wizard.ts";
+import {
+	type EditorAvailabilityChecker,
+	type PromptRunner,
+	runAdvancedConfigWizard,
+} from "./advanced-config-wizard.ts";
 
 interface ConfigureAdvancedOptions {
 	promptImpl?: PromptRunner;
+	isEditorAvailable?: EditorAvailabilityChecker;
 	cancelMessage?: string;
 }
 
 export async function configureAdvancedSettings(
 	core: Core,
-	{ promptImpl, cancelMessage = "Aborting configuration." }: ConfigureAdvancedOptions = {},
+	{ promptImpl, isEditorAvailable, cancelMessage = "Aborting configuration." }: ConfigureAdvancedOptions = {},
 ): Promise<{ mergedConfig: BacklogConfig; installClaudeAgent: boolean; installShellCompletions: boolean }> {
 	const existingConfig = await core.filesystem.loadConfig();
 	if (!existingConfig) {
@@ -21,6 +26,7 @@ export async function configureAdvancedSettings(
 		cancelMessage,
 		includeClaudePrompt: true,
 		promptImpl,
+		isEditorAvailable,
 	});
 
 	const mergedConfig: BacklogConfig = { ...existingConfig, ...wizardResult.config };

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -85,7 +85,7 @@ describe("Config commands", () => {
 			{ autoCommit: true },
 			{ enableZeroPadding: true },
 			{ paddingWidth: 4 },
-			{ editor: "bun" },
+			{ editor: "backlog-test-editor" },
 			{ definitionOfDoneAction: "add" },
 			{ definitionOfDoneItem: "Ship release notes" },
 			{ definitionOfDoneAction: "done" },
@@ -96,6 +96,7 @@ describe("Config commands", () => {
 
 		const { mergedConfig, installClaudeAgent, installShellCompletions } = await configureAdvancedSettings(core, {
 			promptImpl: promptStub,
+			isEditorAvailable: async (editor) => editor === "backlog-test-editor",
 		});
 
 		expect(installClaudeAgent).toBe(true);
@@ -106,14 +107,14 @@ describe("Config commands", () => {
 		expect(mergedConfig.bypassGitHooks).toBe(true);
 		expect(mergedConfig.autoCommit).toBe(true);
 		expect(mergedConfig.zeroPaddedIds).toBe(4);
-		expect(mergedConfig.defaultEditor).toBe("bun");
+		expect(mergedConfig.defaultEditor).toBe("backlog-test-editor");
 		expect(mergedConfig.definitionOfDone).toEqual(["Ship release notes"]);
 		expect(mergedConfig.defaultPort).toBe(7007);
 		expect(mergedConfig.autoOpenBrowser).toBe(false);
 
 		const reloadedConfig = await core.filesystem.loadConfig();
 		expect(reloadedConfig?.zeroPaddedIds).toBe(4);
-		expect(reloadedConfig?.defaultEditor).toBe("bun");
+		expect(reloadedConfig?.defaultEditor).toBe("backlog-test-editor");
 		expect(reloadedConfig?.definitionOfDone).toEqual(["Ship release notes"]);
 		expect(reloadedConfig?.defaultPort).toBe(7007);
 		expect(reloadedConfig?.autoOpenBrowser).toBe(false);

--- a/src/test/editor.test.ts
+++ b/src/test/editor.test.ts
@@ -92,23 +92,37 @@ describe("Editor utilities", () => {
 	});
 
 	describe("isEditorAvailable", () => {
-		it("should detect available editors", async () => {
-			// Test with a command that should exist on the current platform
-			const testEditor = process.platform === "win32" ? "notepad" : "ls";
-			const available = await isEditorAvailable(testEditor);
-			// We can't guarantee any specific editor exists, so just verify the function works
-			expect(typeof available).toBe("boolean");
+		it("should detect a guaranteed platform command", async () => {
+			const editor = process.platform === "win32" ? "cmd" : "sh";
+			expect(await isEditorAvailable(editor)).toBe(true);
+		});
+
+		it("should detect available editors through the lookup boundary", async () => {
+			const available = await isEditorAvailable("fixture-editor", async (command) => command === "fixture-editor");
+			expect(available).toBe(true);
 		});
 
 		it("should return false for non-existent editors", async () => {
-			const available = await isEditorAvailable("definitely-not-a-real-editor-command");
+			const available = await isEditorAvailable(
+				"definitely-not-a-real-editor-command",
+				async (command) => command === "fixture-editor",
+			);
 			expect(available).toBe(false);
 		});
 
 		it("should handle editor commands with arguments", async () => {
-			const editor = process.platform === "win32" ? "notepad.exe" : "echo test";
-			const available = await isEditorAvailable(editor);
+			const available = await isEditorAvailable(
+				"fixture-editor --wait",
+				async (command) => command === "fixture-editor",
+			);
 			expect(available).toBe(true);
+		});
+
+		it("should return false when editor discovery fails", async () => {
+			const available = await isEditorAvailable("fixture-editor", async () => {
+				throw new Error("simulated editor discovery failure");
+			});
+			expect(available).toBe(false);
 		});
 	});
 

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -222,20 +222,29 @@ describe("TUI task composer canonical persistence", () => {
 
 	it("rolls back a task when auto-commit fails and retries with the same ID", async () => {
 		await initializeGitRepository(testDir);
-		const hookPath = await installFailingHook(testDir);
+		const addAndCommitTaskFile = core.gitOps.addAndCommitTaskFile.bind(core.gitOps);
+		core.gitOps.addAndCommitTaskFile = async (_taskId, filePath, _action, onStaged) => {
+			await core.gitOps.addFile(filePath);
+			const stagedEntries = await core.gitOps.getIndexEntries(filePath);
+			onStaged?.(stagedEntries);
+			throw new Error("simulated auto-commit failed");
+		};
 
 		const controller = new TaskComposerController(["To Do", "Done"]);
 		controller.values.title = "Retry without a duplicate";
 		controller.values.description = "Preserve this value";
 		const persist = async (input: TaskCreateInput) => (await core.createTaskFromInput(input, true)).task;
 
-		expect(await controller.create(persist)).toBeNull();
-		expect(controller.error).toContain("failed");
-		expect(await core.fs.loadTask("TASK-1")).toBeNull();
-		expect((await core.gitOps.getStatus()).trim()).toBe("");
-		expect(controller.values.description).toBe("Preserve this value");
+		try {
+			expect(await controller.create(persist)).toBeNull();
+			expect(controller.error).toContain("failed");
+			expect(await core.fs.loadTask("TASK-1")).toBeNull();
+			expect((await core.gitOps.getStatus()).trim()).toBe("");
+			expect(controller.values.description).toBe("Preserve this value");
+		} finally {
+			core.gitOps.addAndCommitTaskFile = addAndCommitTaskFile;
+		}
 
-		await rm(hookPath);
 		const retried = await controller.create(persist);
 		expect(retried?.id).toBe("TASK-1");
 		expect(await core.fs.loadTask("TASK-2")).toBeNull();

--- a/src/test/web-task-details-modal-keyboard-shortcuts.test.tsx
+++ b/src/test/web-task-details-modal-keyboard-shortcuts.test.tsx
@@ -125,6 +125,8 @@ describe("Web task popup keyboard shortcuts", () => {
 		expect(dialog).toBeTruthy();
 		const contentEditable = document.createElement("div");
 		contentEditable.setAttribute("contenteditable", "true");
+		const contentEditableChild = document.createElement("span");
+		contentEditable.append(contentEditableChild);
 		(dialog as HTMLElement).append(contentEditable);
 
 		const targets: Array<[string, Element | undefined | null, string]> = [
@@ -138,7 +140,7 @@ describe("Web task popup keyboard shortcuts", () => {
 			],
 			["dependency", container.querySelector("#dependency-input"), "e"],
 			["select", container.querySelector("select"), "e"],
-			["content editable", contentEditable, "e"],
+			["content editable descendant", contentEditableChild, "e"],
 		];
 
 		for (const [name, target, key] of targets) {
@@ -159,6 +161,28 @@ describe("Web task popup keyboard shortcuts", () => {
 
 		expect(event.defaultPrevented).toBe(false);
 		expect(findButton(container, "Edit")).toBeTruthy();
+	});
+
+	it("keeps c completion active outside editable controls", async () => {
+		const originalCompleteTask = apiClient.completeTask.bind(apiClient);
+		const completedTaskIds: string[] = [];
+		apiClient.completeTask = async (taskId) => {
+			completedTaskIds.push(taskId);
+		};
+		try {
+			const container = await mountModal({ ...task, status: "Done" });
+			window.confirm = () => true;
+			const dialog = container.querySelector("[role='dialog']");
+			expect(dialog).toBeTruthy();
+
+			const event = await press(dialog as Element, "c");
+			await waitFor(() => completedTaskIds.length > 0);
+
+			expect(event.defaultPrevented).toBe(true);
+			expect(completedTaskIds).toEqual(["BACK-558"]);
+		} finally {
+			apiClient.completeTask = originalCompleteTask;
+		}
 	});
 
 	it("keeps e and E shortcuts active outside editable controls", async () => {

--- a/src/test/web-task-details-modal-keyboard-shortcuts.test.tsx
+++ b/src/test/web-task-details-modal-keyboard-shortcuts.test.tsx
@@ -1,0 +1,222 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Task } from "../types/index.ts";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal";
+import { ThemeProvider } from "../web/contexts/ThemeContext";
+import { apiClient } from "../web/lib/api.ts";
+
+let activeRoot: Root | null = null;
+let activeDom: JSDOM | null = null;
+
+const task: Task = {
+	id: "BACK-558",
+	title: "Keyboard shortcut task",
+	status: "To Do",
+	assignee: [],
+	createdDate: "2026-07-30",
+	labels: [],
+	dependencies: [],
+	references: [],
+};
+
+const setupDom = () => {
+	activeDom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: "http://localhost",
+	});
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = activeDom.window as unknown as Window & typeof globalThis;
+	globalThis.document = activeDom.window.document as Document;
+	globalThis.navigator = activeDom.window.navigator as Navigator;
+	globalThis.localStorage = activeDom.window.localStorage;
+	globalThis.Element = activeDom.window.Element;
+	globalThis.HTMLElement = activeDom.window.HTMLElement;
+	globalThis.HTMLInputElement = activeDom.window.HTMLInputElement;
+	globalThis.HTMLTextAreaElement = activeDom.window.HTMLTextAreaElement;
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(callback, 0);
+	globalThis.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
+
+	window.matchMedia = () =>
+		({
+			matches: false,
+			media: "",
+			onchange: null,
+			addListener: () => {},
+			removeListener: () => {},
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			dispatchEvent: () => false,
+		}) as MediaQueryList;
+
+	const htmlElementPrototype = window.HTMLElement.prototype as unknown as {
+		attachEvent?: () => void;
+		detachEvent?: () => void;
+	};
+	htmlElementPrototype.attachEvent = () => {};
+	htmlElementPrototype.detachEvent = () => {};
+};
+
+const mountModal = async (modalTask: Task = task): Promise<HTMLElement> => {
+	setupDom();
+	const container = document.getElementById("root");
+	expect(container).toBeTruthy();
+	activeRoot = createRoot(container as HTMLElement);
+	await act(async () => {
+		activeRoot?.render(
+			<ThemeProvider>
+				<TaskDetailsModal task={modalTask} isOpen={true} onClose={() => {}} />
+			</ThemeProvider>,
+		);
+		await Promise.resolve();
+	});
+	return container as HTMLElement;
+};
+
+const findButton = (container: HTMLElement, text: string): HTMLButtonElement | undefined =>
+	Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes(text));
+
+const press = async (element: Element, key: string, init: KeyboardEventInit = {}): Promise<KeyboardEvent> => {
+	const event = new window.KeyboardEvent("keydown", {
+		key,
+		bubbles: true,
+		cancelable: true,
+		...init,
+	});
+	await act(async () => {
+		(element as HTMLElement).focus();
+		element.dispatchEvent(event);
+		await Promise.resolve();
+	});
+	return event;
+};
+
+const click = async (element: Element) => {
+	await act(async () => {
+		element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+		await Promise.resolve();
+	});
+};
+
+const waitFor = async (predicate: () => boolean) => {
+	for (let attempt = 0; attempt < 10; attempt += 1) {
+		if (predicate()) return;
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+	}
+};
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => {
+			activeRoot?.unmount();
+		});
+		activeRoot = null;
+	}
+	activeDom?.window.close();
+	activeDom = null;
+});
+
+describe("Web task popup keyboard shortcuts", () => {
+	it("leaves e and E available to every preview editor", async () => {
+		const container = await mountModal();
+		const dialog = container.querySelector("[role='dialog']");
+		expect(dialog).toBeTruthy();
+		const contentEditable = document.createElement("div");
+		contentEditable.setAttribute("contenteditable", "true");
+		(dialog as HTMLElement).append(contentEditable);
+
+		const targets: Array<[string, Element | undefined | null, string]> = [
+			["reference", container.querySelector("input[name='newRef']"), "e"],
+			["assignee", container.querySelector("#chip-input-assignee"), "e"],
+			["label", container.querySelector("#chip-input-labels"), "E"],
+			[
+				"title",
+				Array.from(container.querySelectorAll("input")).find((input) => input.value === task.title),
+				"e",
+			],
+			["dependency", container.querySelector("#dependency-input"), "e"],
+			["select", container.querySelector("select"), "e"],
+			["content editable", contentEditable, "e"],
+		];
+
+		for (const [name, target, key] of targets) {
+			expect(target, `${name} target`).toBeTruthy();
+			const event = await press(target as Element, key);
+			expect(event.defaultPrevented, `${name} keydown`).toBe(false);
+			expect(findButton(container, "Edit"), `${name} keeps preview mode`).toBeTruthy();
+		}
+	});
+
+	it("leaves c available to preview editors on Done tasks", async () => {
+		const container = await mountModal({ ...task, status: "Done" });
+		window.confirm = () => false;
+		const referenceInput = container.querySelector("input[name='newRef']");
+		expect(referenceInput).toBeTruthy();
+
+		const event = await press(referenceInput as Element, "c");
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(findButton(container, "Edit")).toBeTruthy();
+	});
+
+	it("keeps e and E shortcuts active outside editable controls", async () => {
+		for (const key of ["e", "E"]) {
+			const container = await mountModal();
+			const dialog = container.querySelector("[role='dialog']");
+			expect(dialog).toBeTruthy();
+
+			const event = await press(dialog as Element, key);
+
+			expect(event.defaultPrevented).toBe(true);
+			expect(findButton(container, "Save")).toBeTruthy();
+
+			act(() => {
+				activeRoot?.unmount();
+			});
+			activeRoot = null;
+			activeDom?.window.close();
+			activeDom = null;
+		}
+	});
+
+	it("keeps Escape active inside full-edit inputs", async () => {
+		const container = await mountModal();
+		const editButton = findButton(container, "Edit");
+		expect(editButton).toBeTruthy();
+		await click(editButton as HTMLButtonElement);
+		const titleInput = Array.from(container.querySelectorAll("input")).find((input) => input.value === task.title);
+		expect(titleInput).toBeTruthy();
+
+		const event = await press(titleInput as HTMLInputElement, "Escape");
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(findButton(container, "Edit")).toBeTruthy();
+	});
+
+	it("keeps Cmd+S and Ctrl+S active inside full-edit inputs", async () => {
+		const originalUpdateTask = apiClient.updateTask.bind(apiClient);
+		apiClient.updateTask = async () => task;
+		try {
+			const container = await mountModal();
+			for (const modifier of [{ metaKey: true }, { ctrlKey: true }]) {
+				const editButton = findButton(container, "Edit");
+				expect(editButton).toBeTruthy();
+				await click(editButton as HTMLButtonElement);
+				const titleInput = Array.from(container.querySelectorAll("input")).find(
+					(input) => input.value === task.title,
+				);
+				expect(titleInput).toBeTruthy();
+
+				const event = await press(titleInput as HTMLInputElement, "s", modifier);
+				await waitFor(() => Boolean(findButton(container, "Edit")));
+
+				expect(event.defaultPrevented).toBe(true);
+				expect(findButton(container, "Edit")).toBeTruthy();
+			}
+		} finally {
+			apiClient.updateTask = originalUpdateTask;
+		}
+	});
+});

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -44,30 +44,27 @@ export function resolveEditor(config?: BacklogConfig | null): string {
 /**
  * Check if an editor command is available on the system
  */
-export async function isEditorAvailable(editor: string): Promise<boolean> {
+type EditorCommandLookup = (command: string) => Promise<boolean>;
+
+async function lookupEditorCommand(command: string): Promise<boolean> {
+	if (platform() === "win32") {
+		await $`where ${command}`.quiet();
+		return true;
+	}
+
+	await $`which ${command}`.quiet();
+	return true;
+}
+
+export async function isEditorAvailable(
+	editor: string,
+	lookupCommand: EditorCommandLookup = lookupEditorCommand,
+): Promise<boolean> {
 	try {
-		// Try to run the editor with --version or --help to check if it exists
 		// Split the editor command in case it has arguments
 		const parts = editor.split(" ");
 		const command = parts[0] ?? editor;
-
-		// For Windows, just check if the command exists
-		if (platform() === "win32") {
-			try {
-				await $`where ${command}`.quiet();
-				return true;
-			} catch {
-				return false;
-			}
-		}
-
-		// For Unix-like systems, use which
-		try {
-			await $`which ${command}`.quiet();
-			return true;
-		} catch {
-			return false;
-		}
+		return await lookupCommand(command);
 	} catch {
 		return false;
 	}

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -69,6 +69,10 @@ const containsCommentDelimiterLine = (value: string): boolean => /^\s*---\s*$/m.
 
 const areJsonEqual = (first: unknown, second: unknown): boolean => JSON.stringify(first) === JSON.stringify(second);
 
+const isEditableKeyboardTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element &&
+  target.closest('input, textarea, select, [contenteditable]:not([contenteditable="false"])') !== null;
+
 const preserveDirtyRefreshValue = <T,>(
   current: T,
   previous: T,
@@ -360,12 +364,15 @@ export const TaskDetailsModal: React.FC<Props> = ({
         e.stopPropagation();
         void handleSave();
       }
-      if (mode === "preview" && (e.key.toLowerCase() === "e") && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      if (mode !== "preview" || isEditableKeyboardTarget(e.target)) {
+        return;
+      }
+      if (e.key.toLowerCase() === "e" && !e.metaKey && !e.ctrlKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
         setMode("edit");
       }
-      if (mode === "preview" && isDoneStatus && (e.key.toLowerCase() === "c") && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      if (isDoneStatus && (e.key.toLowerCase() === "c") && !e.metaKey && !e.ctrlKey && !e.altKey) {
         e.preventDefault();
         e.stopPropagation();
         void handleComplete();


### PR DESCRIPTION
## Summary

- Prevent task-detail preview shortcuts from intercepting native typing in inputs, textareas, selects, and content-editable regions.
- Apply the same editable-target rule to the `e`/`E` edit shortcut and the `c` completion shortcut.
- Preserve edit and completion shortcuts outside editable controls, plus edit-mode Escape and Cmd/Ctrl+S behavior.
- Make the config wizard persistence test deterministic by injecting its editor-availability boundary while keeping the production PATH check as the default.
- Make the TUI rollback and retry test deterministic at the auto-commit failure boundary while retaining real Git staging, rollback, and retry behavior.
- Make editor-availability tests deterministic through an injectable command lookup while retaining one real `cmd` or `sh` smoke test.

## Related issue

Fixes #816.

## Windows test reliability

The config wizard selection test was the only case that submitted a non-empty editor, so it invoked the host PATH lookup (`where bun` on Windows). The test verifies that wizard selections are applied and persisted, not operating-system command discovery. It now supplies a deterministic editor-availability checker while retaining the real wizard flow, config merge, filesystem save and reload, and all 19 assertions. Production behavior is unchanged because the existing editor checker remains the default.

The TUI rollback and retry test installed a real failing Git hook, causing three selected-file commit attempts plus 100ms and 200ms backoffs before reaching the rollback behavior under test. Windows Git and process startup expanded this path to 10,064.28ms. The test now triggers one deterministic auto-commit failure after real staging and index capture, then restores the real commit path for the successful retry. Production code is unchanged, and all 8 assertions remain, covering rollback, clean Git state, preserved input, same-ID reuse, and absence of a duplicate task.

The editor-availability tests delegated every case to host PATH discovery through `where` or `which`, and the original positive case asserted only that the result was a boolean. On Windows, that test reached 10,007.23ms. The tests now inject command lookup results to cover available and missing editors, commands with arguments, and lookup failures deterministically. One real `cmd` or `sh` lookup remains as a platform smoke test. Production behavior is unchanged because the existing `where` and `which` lookup remains the default.

## Verification

- Config wizard selection test: 30 consecutive passes, 30.69ms to 47.74ms locally
- TUI rollback and retry test: 30 consecutive passes, 627.84ms to 883.84ms locally, 640.31ms median
- Editor-availability tests: 30 consecutive focused runs, 150 passed and 0 failed; real `cmd` or `sh` smoke ranged from 0.05ms to 3.37ms locally
- Full TUI composer test file: 47 passed, 0 failed, 222 assertions
- Adjacent editor, config, and shortcut tests: 33 passed, 0 failed, 140 assertions
- Adjacent shortcut, config, Core, Git, and auto-commit tests: 86 passed, 0 failed, 264 assertions
- Full suite: 1,787 passed, 4 skipped, 0 failed, 7,598 assertions
- `bunx tsc --noEmit`
- `bun run check .`: 339 files checked
- Rendered Chrome QA verified native typing in assignee, labels, references, title, and dependencies; preview and edit shortcuts; completion confirmation behavior; Escape; and Cmd+S
