### PR TITLE
BACK-559 - Eliminate repeated task-corpus scans from browser updates

### DIFF
--- a/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
+++ b/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:12'
-updated_date: '2026-07-30 18:07'
+updated_date: '2026-07-30 18:33'
 labels:
   - web-ui
   - performance
@@ -62,6 +62,8 @@ Browser task mutations repeatedly parse the complete active and completed task c
 3. Apply the reorder response to App task state immediately and leave the existing WebSocket refresh as reconciliation. Run focused server/collision/Web tests, type-check, Biome, broader relevant tests, an ephemeral same-machine 20/430 before/after measurement, rendered-browser validation where available, simplification review, and final scoped diff inspection.
 
 4. Review-and-fix cycle one: reproduce the live multi-task reorder WebSocket fan-out and delayed-response race with real-path regressions. Batch only reorder-triggered server publications into one reconciliation, and publish mutation responses only while the task still has the object identity captured when the request began. Preserve immediate response application when no reconciliation won, then rerun collision/server/WebSocket/Board coverage and the end-to-end fixture including the surviving reconciliation.
+
+5. Final review cycle: reproduce the disconnected-WebSocket rebalance gap, return Core changedTasks through the existing reorder response, apply every returned task through the request-object stale guard without a foreground refresh or extra corpus scan, and cover the server plus rendered App boundaries before rerunning the benchmark and full verification.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -84,10 +86,16 @@ Verification for the correction: the two new real-path tests were observed faili
 Revised ephemeral benchmark uses fresh same-machine macOS arm64 Git fixture copies with 20 active and 430 completed tasks, forces a two-task ordinal rebalance for every sample, and defines completion as both the mutation response and all surviving App refresh requests (statuses, config, search, milestones, archived milestones, and duplicate preview). Across 12-sample medians, current main actual sequential mutation + foreground refresh is 1308.412 ms (p95 1701.177); corrected branch with one WebSocket reconciliation is 230.886 ms (p95 269.255), an 82.4% reduction. Versus pre-review 79103a01 specifically, two WebSocket reconciliations took 319.125 ms (p95 410.763), so coalescing to one reduces this corrected-path median another 27.6%. No benchmark artifact was added.
 
 Independent final review at e6e56ee9544d4c1de71dc016b88f0418f25356f1 declared READY with no Critical or Important findings.
+
+Automatic Codex review on PR #828 at commit 343260f06a2d1cc1466c716ba59acf16879576b1 found one P2: a forced ordinal rebalance persists sibling tasks but the browser response applies only the moved task, so a disconnected WebSocket leaves sibling ordinals stale. Reproduction with TASK-1, TASK-2, and TASK-3 all at ordinal 1000 returned only TASK-3 at 2000 while disk also persisted TASK-2 at 3000. Root cause is the HTTP handler discarding Core changedTasks; the TUI already applies changedTasks plus updatedTask.
+
+Final review cycle TDD: the real server regression first failed because changedTasks was absent, and the rendered full-App regression with a closed data WebSocket first failed because the moved task rendered ahead of its stale sibling. The server now returns Core changedTasks alongside the existing task field; ApiClient types the complete response; Board applies updatedTask plus every changed task through the request-start object guard. No foreground refresh, corpus load, persistence operation, or WebSocket reconnect layer was added. Focused server and rendered Web suite: 37 pass, 0 fail. Full suite: 1789 pass, 4 interactive skips, 0 fail, 7590 expectations across 200 files in 228.62 seconds. bunx tsc --noEmit, bun run check . across 340 files, and git diff --check pass.
+
+Fresh ephemeral benchmark after the final correction used alternating same-machine macOS arm64 Git fixture copies with 20 active and 430 completed tasks and 12 measured samples per variant. Every sample forced the same two-task ordinal rebalance. Completion included the mutation response and every surviving App refresh request: statuses, config, search, milestones, archived milestones, and duplicate preview. Current origin/main fef6e763d9300ab6ba4d123c5555d2db55b6914e included its foreground refresh plus both WebSocket reconciliations and measured 1285.543 ms median, 1366.933 ms p95. The corrected path returned both changed tasks and used one WebSocket reconciliation, measuring 108.588 ms median, 241.318 ms p95, a 91.6 percent median reduction. No benchmark artifact or framework was retained.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Eliminated repeated task-corpus scans from browser updates by persisting resolved identities, reusing task snapshots, coalescing reorder reconciliation, and rejecting stale mutation responses. Preserved fail-closed collision handling, ContentStore and Git semantics, callbacks, completed-task filtering, and WebSocket external reconciliation. Verified by 1,788 passing tests with 4 interactive skips, 179 focused server, collision, and watcher passes, rendered full-App race and immediate-response regressions, TypeScript and Biome checks, and an ephemeral 20-active and 430-completed benchmark. For a forced two-task rebalance, end-to-end completion including the mutation response plus surviving refreshes improved from 1,308.412 ms to 230.886 ms median, an 82.4% reduction.
+Eliminated repeated task-corpus scans from browser updates by persisting resolved identities, reusing task snapshots, coalescing reorder reconciliation, and rejecting stale mutation responses. Reorder responses now carry every persisted changed task through the existing stale-response guard, so forced two-task rebalances remain correct when WebSocket delivery is unavailable while the connected path still uses one reconciliation. Preserved fail-closed collision handling, ContentStore and Git semantics, callbacks, completed-task filtering, and external WebSocket reconciliation. Verified by 1,789 passing tests with 4 interactive skips, 37 focused server and rendered-App passes, TypeScript and Biome checks, and a fresh 20-active and 430-completed benchmark. End-to-end completion including the mutation response plus every surviving refresh improved from 1,285.543 ms to 108.588 ms median, a 91.6 percent reduction.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
+++ b/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-559
 title: Eliminate repeated task-corpus scans from browser updates
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:12'
-updated_date: '2026-07-30 18:03'
+updated_date: '2026-07-30 18:07'
 labels:
   - web-ui
   - performance
@@ -39,19 +39,19 @@ Browser task mutations repeatedly parse the complete active and completed task c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One ordinary browser task status update performs at most one active/completed identity scan, persists the change, and returns the updated task.
-- [ ] #2 Duplicate repair preview loads active and completed tasks once and reuses that snapshot for duplicate detection, existing-ID allocation input, and fingerprint preparation.
-- [ ] #3 One board drag applies the returned task immediately and does not cause two duplicate-plan builds; the existing WebSocket refresh still reconciles external changes.
-- [ ] #4 Fail-closed behavior remains for active/active, active/completed, zero-padded, cross-prefix, and filename/frontmatter ID collisions, and ambiguous mutations alter no file.
-- [ ] #5 Completed tasks remain excluded from the active board, and current auto-commit, Git staging and commit, updated-date, and status callback behavior remains unchanged.
-- [ ] #6 An ephemeral same-machine fixture with 20 active and 430 completed tasks records before and after status-update, duplicate-preview, and drag-path measurements with at least a 70 percent reduction in the combined mutation and refresh median; no durable benchmark framework is added.
+- [x] #1 One ordinary browser task status update performs at most one active/completed identity scan, persists the change, and returns the updated task.
+- [x] #2 Duplicate repair preview loads active and completed tasks once and reuses that snapshot for duplicate detection, existing-ID allocation input, and fingerprint preparation.
+- [x] #3 One board drag applies the returned task immediately and does not cause two duplicate-plan builds; the existing WebSocket refresh still reconciles external changes.
+- [x] #4 Fail-closed behavior remains for active/active, active/completed, zero-padded, cross-prefix, and filename/frontmatter ID collisions, and ambiguous mutations alter no file.
+- [x] #5 Completed tasks remain excluded from the active board, and current auto-commit, Git staging and commit, updated-date, and status callback behavior remains unchanged.
+- [x] #6 An ephemeral same-machine fixture with 20 active and 430 completed tasks records before and after status-update, duplicate-preview, and drag-path measurements with at least a 70 percent reduction in the combined mutation and refresh median; no durable benchmark framework is added.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -82,4 +82,12 @@ Review cycle one disposition: fixed both Important findings without changing per
 Verification for the correction: the two new real-path tests were observed failing on 79103a01 (two WebSocket publications; stale response overwrote the external edit) and pass after the fix. Focused server/WebSocket/Board/collision/ContentStore/watcher suite: 179 pass, 0 fail. Post-simplification Web tests: 36 pass, 0 fail. Full suite: 1788 pass, 4 skip, 0 fail across 200 files. bunx tsc --noEmit, bun run check . (340 files), and git diff --check pass.
 
 Revised ephemeral benchmark uses fresh same-machine macOS arm64 Git fixture copies with 20 active and 430 completed tasks, forces a two-task ordinal rebalance for every sample, and defines completion as both the mutation response and all surviving App refresh requests (statuses, config, search, milestones, archived milestones, and duplicate preview). Across 12-sample medians, current main actual sequential mutation + foreground refresh is 1308.412 ms (p95 1701.177); corrected branch with one WebSocket reconciliation is 230.886 ms (p95 269.255), an 82.4% reduction. Versus pre-review 79103a01 specifically, two WebSocket reconciliations took 319.125 ms (p95 410.763), so coalescing to one reduces this corrected-path median another 27.6%. No benchmark artifact was added.
+
+Independent final review at e6e56ee9544d4c1de71dc016b88f0418f25356f1 declared READY with no Critical or Important findings.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Eliminated repeated task-corpus scans from browser updates by persisting resolved identities, reusing task snapshots, coalescing reorder reconciliation, and rejecting stale mutation responses. Preserved fail-closed collision handling, ContentStore and Git semantics, callbacks, completed-task filtering, and WebSocket external reconciliation. Verified by 1,788 passing tests with 4 interactive skips, 179 focused server, collision, and watcher passes, rendered full-App race and immediate-response regressions, TypeScript and Biome checks, and an ephemeral 20-active and 430-completed benchmark. For a forced two-task rebalance, end-to-end completion including the mutation response plus surviving refreshes improved from 1,308.412 ms to 230.886 ms median, an 82.4% reduction.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
+++ b/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:12'
-updated_date: '2026-07-30 17:36'
+updated_date: '2026-07-30 18:03'
 labels:
   - web-ui
   - performance
@@ -24,7 +24,9 @@ modified_files:
   - src/test/duplicate-task-repair.test.ts
   - src/test/reorder-utils.test.ts
   - src/test/server-duplicate-repair.test.ts
+  - src/test/server-reorder-publication.test.ts
   - src/test/web-board-filters.test.tsx
+  - src/test/web-task-detail-deeplink.test.tsx
 type: bug
 ordinal: 204000
 ---
@@ -58,6 +60,8 @@ Browser task mutations repeatedly parse the complete active and completed task c
 1. Add focused regression tests first: count active/completed corpus loads for one HTTP task mutation and one duplicate preview; assert ambiguous active/active, active/completed, zero-padded, cross-prefix, and filename/frontmatter mutations remain fail-closed without file changes; assert a board reorder applies the returned task without invoking a foreground refresh. Baseline on the 20-active/430-completed fixture: status PUT median 607.8 ms, duplicate preview 201.7 ms, full refresh 202.5 ms on current main.
 2. Collapse task persistence around the already-resolved original task: remove the server pre-read, preserve the one FileSystem identity scan, pass the original into a private persistence path, use the save result for ContentStore/Git, and return the updated task without reloading the corpus. Reuse one active/completed snapshot throughout duplicate detection and local repair-ID allocation.
 3. Apply the reorder response to App task state immediately and leave the existing WebSocket refresh as reconciliation. Run focused server/collision/Web tests, type-check, Biome, broader relevant tests, an ephemeral same-machine 20/430 before/after measurement, rendered-browser validation where available, simplification review, and final scoped diff inspection.
+
+4. Review-and-fix cycle one: reproduce the live multi-task reorder WebSocket fan-out and delayed-response race with real-path regressions. Batch only reorder-triggered server publications into one reconciliation, and publish mutation responses only while the task still has the object identity captured when the request began. Preserve immediate response application when no reconciliation won, then rerun collision/server/WebSocket/Board coverage and the end-to-end fixture including the surviving reconciliation.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -70,4 +74,12 @@ TDD evidence: new scan-count, ambiguity/no-mutation, duplicate-preview, reorder,
 Ephemeral same-machine fixture (macOS arm64, 20 active + 430 completed, 12-sample medians): status PUT 751.365 -> 123.848 ms (83.5%); duplicate preview 244.863 -> 127.052 ms (48.1%); full App refresh 232.057 -> 116.739 ms (49.7%); reorder endpoint 507.279 -> 125.493 ms (75.3%). Combined board drag + foreground refresh fell from 739.336 ms to 125.493 ms (83.0%) because the redundant foreground refresh was removed. No durable benchmark framework or fixture was added.
 
 Simplification review removed redundant Core ContentStore upsert ownership and retained one persistence helper plus the existing snapshot-aware ID allocator.
+
+Review cycle one red probes on commit 79103a01: a live server/WebSocket test observed two tasks-updated messages for a two-task ordinal rebalance (expected one), and a rendered App test showed a delayed reorder response replacing a newer WebSocket-reconciled external edit. Root causes are per-task ContentStore events forwarded during reorder and mutation responses applied without guarding the request-start task identity.
+
+Review cycle one disposition: fixed both Important findings without changing persistence, ContentStore publication, collision checks, callbacks, or WebSocket external reconciliation. BacklogServer now defers ContentStore task broadcasts only while a reorder request is active and flushes exactly one tasks-updated message, including on partial-failure exit. Board captures the task object at request start; App applies the response only if reconciliation has not replaced that object. A separate full-App regression confirms uninterrupted responses still update the board immediately.
+
+Verification for the correction: the two new real-path tests were observed failing on 79103a01 (two WebSocket publications; stale response overwrote the external edit) and pass after the fix. Focused server/WebSocket/Board/collision/ContentStore/watcher suite: 179 pass, 0 fail. Post-simplification Web tests: 36 pass, 0 fail. Full suite: 1788 pass, 4 skip, 0 fail across 200 files. bunx tsc --noEmit, bun run check . (340 files), and git diff --check pass.
+
+Revised ephemeral benchmark uses fresh same-machine macOS arm64 Git fixture copies with 20 active and 430 completed tasks, forces a two-task ordinal rebalance for every sample, and defines completion as both the mutation response and all surviving App refresh requests (statuses, config, search, milestones, archived milestones, and duplicate preview). Across 12-sample medians, current main actual sequential mutation + foreground refresh is 1308.412 ms (p95 1701.177); corrected branch with one WebSocket reconciliation is 230.886 ms (p95 269.255), an 82.4% reduction. Versus pre-review 79103a01 specifically, two WebSocket reconciliations took 319.125 ms (p95 410.763), so coalescing to one reduces this corrected-path median another 27.6%. No benchmark artifact was added.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
+++ b/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
@@ -1,15 +1,30 @@
 ---
 id: BACK-559
 title: Eliminate repeated task-corpus scans from browser updates
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-30 17:12'
+updated_date: '2026-07-30 17:36'
 labels:
   - web-ui
   - performance
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/807'
+modified_files:
+  - src/core/backlog.ts
+  - src/core/content-store.ts
+  - src/core/duplicate-task-repair.ts
+  - src/server/index.ts
+  - src/web/App.tsx
+  - src/web/components/Board.tsx
+  - src/web/components/BoardPage.tsx
+  - src/test/core.test.ts
+  - src/test/duplicate-task-repair.test.ts
+  - src/test/reorder-utils.test.ts
+  - src/test/server-duplicate-repair.test.ts
+  - src/test/web-board-filters.test.tsx
 type: bug
 ordinal: 204000
 ---
@@ -36,3 +51,23 @@ Browser task mutations repeatedly parse the complete active and completed task c
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused regression tests first: count active/completed corpus loads for one HTTP task mutation and one duplicate preview; assert ambiguous active/active, active/completed, zero-padded, cross-prefix, and filename/frontmatter mutations remain fail-closed without file changes; assert a board reorder applies the returned task without invoking a foreground refresh. Baseline on the 20-active/430-completed fixture: status PUT median 607.8 ms, duplicate preview 201.7 ms, full refresh 202.5 ms on current main.
+2. Collapse task persistence around the already-resolved original task: remove the server pre-read, preserve the one FileSystem identity scan, pass the original into a private persistence path, use the save result for ContentStore/Git, and return the updated task without reloading the corpus. Reuse one active/completed snapshot throughout duplicate detection and local repair-ID allocation.
+3. Apply the reorder response to App task state immediately and leave the existing WebSocket refresh as reconciliation. Run focused server/collision/Web tests, type-check, Biome, broader relevant tests, an ephemeral same-machine 20/430 before/after measurement, rendered-browser validation where available, simplification review, and final scoped diff inspection.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the browser mutation fast path around one resolved task identity and one reusable active/completed snapshot. Core task updates now persist the resolved task directly, exact-parse only the saved file for normalized response data, and reuse the saved path for ContentStore publication and Git auto-commit. HTTP update no longer preloads the task; duplicate repair and reorder reuse their local snapshots; cross-worktree/branch ID collision checks remain intact. Board reorder/status responses replace the local task immediately, while the existing WebSocket refresh remains the external-change reconciliation path.
+
+TDD evidence: new scan-count, ambiguity/no-mutation, duplicate-preview, reorder, and rendered React board tests failed on the previous behavior and pass after the change. Focused suites: 157 pass, 0 fail. Full suite: 1785 pass, 4 skip, 0 fail across 199 files. bunx tsc --noEmit, bun run check ., and git diff --check pass. The in-app browser connector was unavailable, so foreground-refresh behavior was verified with the rendered JSDOM/React interaction test.
+
+Ephemeral same-machine fixture (macOS arm64, 20 active + 430 completed, 12-sample medians): status PUT 751.365 -> 123.848 ms (83.5%); duplicate preview 244.863 -> 127.052 ms (48.1%); full App refresh 232.057 -> 116.739 ms (49.7%); reorder endpoint 507.279 -> 125.493 ms (75.3%). Combined board drag + foreground refresh fell from 739.336 ms to 125.493 ms (83.0%) because the redundant foreground refresh was removed. No durable benchmark framework or fixture was added.
+
+Simplification review removed redundant Core ContentStore upsert ownership and retained one persistence helper plus the existing snapshot-aware ID allocator.
+<!-- SECTION:NOTES:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -3,6 +3,7 @@ import { basename, isAbsolute, join, relative } from "node:path";
 import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
 import { FileSystem, isCreateLockError } from "../file-system/operations.ts";
 import { type GitIndexEntry, GitOperations } from "../git/operations.ts";
+import { parseTask } from "../markdown/parser.ts";
 import {
 	type AcceptanceCriterion,
 	type BacklogConfig,
@@ -65,6 +66,7 @@ import {
 	getTaskFilename,
 	getTaskPath,
 	normalizeTaskId,
+	normalizeTaskIdentity,
 	taskIdsEqual,
 } from "../utils/task-path.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
@@ -1076,12 +1078,16 @@ export class Core {
 	 * - Document: /documents only
 	 * - Decision: /decisions only
 	 */
-	async generateNextId(type: EntityType = EntityType.Task, parent?: string): Promise<string> {
+	async generateNextId(
+		type: EntityType = EntityType.Task,
+		parent?: string,
+		taskSnapshot?: { activeTasks: Task[]; completedTasks: Task[] },
+	): Promise<string> {
 		const config = await this.fs.loadConfig();
 		const prefix = getPrefixForType(type, config ?? undefined);
 
 		// Collect existing IDs based on entity type
-		const allIds = await this.getExistingIdsForType(type);
+		const allIds = await this.getExistingIdsForType(type, taskSnapshot);
 
 		if (parent) {
 			// Subtask generation (only applicable for tasks)
@@ -1160,13 +1166,16 @@ export class Core {
 		return entries;
 	}
 
-	private async getActiveAndCompletedTaskIds(): Promise<string[]> {
+	private async getActiveAndCompletedTaskIds(taskSnapshot?: {
+		activeTasks: Task[];
+		completedTasks: Task[];
+	}): Promise<string[]> {
 		const config = await this.fs.loadConfig();
 		const taskPrefix = config?.prefixes?.task ?? "task";
 
 		// Load local active and completed tasks
-		const localTasks = await this.listTasksWithMetadata();
-		const localCompletedTasks = await this.fs.listCompletedTasks();
+		const localTasks = taskSnapshot?.activeTasks ?? (await this.listTasksWithMetadata());
+		const localCompletedTasks = taskSnapshot?.completedTasks ?? (await this.fs.listCompletedTasks());
 
 		// Build initial state entries from local tasks
 		const stateEntries: BranchTaskStateEntry[] = [];
@@ -1228,12 +1237,15 @@ export class Core {
 	 * Note: Archived tasks are intentionally excluded - archived IDs can be reused.
 	 * This makes archive act as a soft delete for ID purposes.
 	 */
-	private async getExistingIdsForType(type: EntityType): Promise<string[]> {
+	private async getExistingIdsForType(
+		type: EntityType,
+		taskSnapshot?: { activeTasks: Task[]; completedTasks: Task[] },
+	): Promise<string[]> {
 		switch (type) {
 			case EntityType.Task: {
 				// Get active + completed task IDs from all branches (respects config)
 				// Archived IDs are excluded - they can be reused (soft delete behavior)
-				return this.getActiveAndCompletedTaskIds();
+				return this.getActiveAndCompletedTaskIds(taskSnapshot);
 			}
 			case EntityType.Draft: {
 				const drafts = await this.fs.listDrafts();
@@ -1522,42 +1534,41 @@ export class Core {
 	}
 
 	async updateTask(task: Task, autoCommit?: boolean): Promise<void> {
+		const originalTask = await this.fs.loadTask(task.id);
+		if (!originalTask) {
+			throw new Error(`Task not found: ${task.id}`);
+		}
+		await this.persistResolvedTask(originalTask, task, autoCommit);
+	}
+
+	private async persistResolvedTask(originalTask: Task, task: Task, autoCommit?: boolean): Promise<Task> {
 		normalizeAssignee(task);
 
-		// Load original task to detect status changes for callbacks
-		const originalTask = await this.fs.loadTask(task.id);
-		const oldStatus = originalTask?.status ?? "";
+		const oldStatus = originalTask.status ?? "";
 		const newStatus = task.status ?? "";
 		const statusChanged = oldStatus !== newStatus;
 
 		if (hasUpdatedDateRelevantChanges(originalTask, task)) {
 			task.updatedDate = new Date().toISOString().slice(0, 16).replace("T", " ");
-		} else if (originalTask?.updatedDate) {
+		} else if (originalTask.updatedDate) {
 			task.updatedDate = originalTask.updatedDate;
 		} else {
 			delete task.updatedDate;
 		}
 
-		await this.fs.saveTask(task);
-		// Keep any in-process ContentStore in sync for immediate UI/search freshness.
-		if (this.contentStore) {
-			const savedTask = await this.fs.loadTask(task.id);
-			if (savedTask) {
-				this.contentStore.upsertTask(savedTask);
-			}
-		}
-
+		task.filePath ??= originalTask.filePath;
+		const filePath = await this.fs.saveTask(task);
+		const savedTask = { ...normalizeTaskIdentity(parseTask(await Bun.file(filePath).text())), filePath };
 		if (await this.shouldAutoCommit(autoCommit)) {
-			const filePath = await getTaskPath(task.id, this);
-			if (filePath) {
-				await this.git.addAndCommitTaskFile(task.id, filePath, "update");
-			}
+			await this.git.addAndCommitTaskFile(savedTask.id, filePath, "update");
 		}
 
 		// Fire status change callback if status changed
 		if (statusChanged) {
-			await this.executeStatusChangeCallback(task, oldStatus, newStatus);
+			await this.executeStatusChangeCallback(savedTask, oldStatus, newStatus);
 		}
+
+		return savedTask;
 	}
 
 	private async applyTaskUpdateInput(
@@ -2135,6 +2146,7 @@ export class Core {
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
 		}
+		const originalTask = structuredClone(task);
 
 		const requestedStatus = input.status?.trim().toLowerCase();
 		if (requestedStatus === "draft") {
@@ -2149,9 +2161,7 @@ export class Core {
 			return task;
 		}
 
-		await this.updateTask(task, autoCommit);
-		const refreshed = await this.fs.loadTask(taskId);
-		return refreshed ?? task;
+		return await this.persistResolvedTask(originalTask, task, autoCommit);
 	}
 
 	async updateDraft(task: Task, autoCommit?: boolean): Promise<void> {
@@ -2393,13 +2403,42 @@ export class Core {
 			seen.add(id);
 		}
 
-		// Load all tasks from the ordered list - use getTask to include cross-branch tasks from the store
-		const loadedTasks = await Promise.all(
-			orderedTaskIds.map(async (id) => {
-				const task = await this.getTask(id);
-				return task;
-			}),
-		);
+		const [localTasks, completedTasks, store] = await Promise.all([
+			this.fs.listTasks(),
+			this.fs.listCompletedTasks(),
+			this.getContentStore(),
+		]);
+		const storedTasks = store.getTasks();
+		const loadedTasks = orderedTaskIds.map((id) => {
+			const localMatches = [...localTasks, ...completedTasks].filter((task) => taskIdsEqual(id, task.id));
+			if (localMatches.length > 1) {
+				throw new AmbiguousTaskIdError(
+					id,
+					localMatches.map((task) => task.filePath ?? task.id),
+				);
+			}
+			const localTask = localTasks.find((task) => taskIdsEqual(id, task.id));
+			const storedResolution = resolveTaskById(storedTasks, id);
+			if (storedResolution.status === "ambiguous") {
+				throw new AmbiguousTaskIdError(
+					id,
+					storedResolution.tasks.map((task) => task.filePath ?? `${task.branch ?? "unknown branch"}:${task.id}`),
+				);
+			}
+			if (
+				localTask &&
+				storedResolution.status === "found" &&
+				localTask.id.toLowerCase() !== storedResolution.task.id.toLowerCase()
+			) {
+				throw new AmbiguousTaskIdError(id, [
+					localTask.filePath ?? localTask.id,
+					storedResolution.task.filePath ??
+						`${storedResolution.task.branch ?? "unknown branch"}:${storedResolution.task.id}`,
+				]);
+			}
+			if (storedResolution.status === "found") return storedResolution.task;
+			return localTask ?? null;
+		});
 
 		// Filter out any tasks that couldn't be loaded (may have been moved/deleted)
 		const validTasks = loadedTasks.filter((t): t is Task => t !== null);
@@ -2476,11 +2515,18 @@ export class Core {
 		});
 
 		if (changedTasks.length > 0) {
-			await this.updateTasksBulk(
-				changedTasks,
-				params.commitMessage ?? `Reorder tasks in ${targetStatus}`,
-				params.autoCommit,
-			);
+			for (const changedTask of changedTasks) {
+				const originalTask = originalMap.get(changedTask.id);
+				if (!originalTask) {
+					throw new Error(`Task ${changedTask.id} not found while persisting reorder`);
+				}
+				await this.persistResolvedTask(originalTask, changedTask, false);
+			}
+			if (await this.shouldAutoCommit(params.autoCommit)) {
+				const backlogDir = await this.getBacklogDirectoryName();
+				const repoRoot = await this.git.stageBacklogDirectory(backlogDir);
+				await this.git.commitChanges(params.commitMessage ?? `Reorder tasks in ${targetStatus}`, repoRoot);
+			}
 		}
 
 		const updatedTask = updatesMap.get(taskId) ?? updatedMoved;

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -1051,7 +1051,7 @@ export class ContentStore {
 		this.filesystem.saveTask = (async (task: Task): Promise<string> => {
 			const owner: PublicationOwner = { root: this.currentRoot() };
 			const result = await originalSaveTask.call(this.filesystem, task);
-			await this.handleTaskWrite(task.id, owner);
+			await this.handleTaskWrite(task.id, owner, result);
 			return result;
 		}) as FileSystem["saveTask"];
 
@@ -1075,12 +1075,12 @@ export class ContentStore {
 		};
 	}
 
-	private async handleTaskWrite(taskId: string, owner: PublicationOwner): Promise<void> {
+	private async handleTaskWrite(taskId: string, owner: PublicationOwner, filePath: string): Promise<void> {
 		if (!this.canPublishContent() || !this.isPublicationOwnerCurrent(owner)) {
 			return;
 		}
 		await this.enqueuePublication(owner, async () => {
-			await this.updateTaskFromDisk(taskId, owner);
+			await this.updateTaskFromDisk(taskId, owner, filePath);
 		});
 	}
 
@@ -1434,6 +1434,7 @@ export class ContentStore {
 	private async updateTaskFromDisk(
 		taskId: string,
 		owner: PublicationOwner = { root: this.currentRoot() },
+		filePath?: string,
 	): Promise<void> {
 		const normalizedTaskId = normalizeTaskId(taskId);
 		const generation = this.nextContentItemGeneration("tasks", normalizedTaskId);
@@ -1446,7 +1447,9 @@ export class ContentStore {
 				return false;
 			let task: Task | null;
 			try {
-				task = await this.filesystem.loadTask(taskId);
+				task = filePath
+					? { ...normalizeTaskIdentity(parseTask(await Bun.file(filePath).text())), filePath }
+					: await this.filesystem.loadTask(taskId);
 			} catch {
 				return true;
 			}

--- a/src/core/duplicate-task-repair.ts
+++ b/src/core/duplicate-task-repair.ts
@@ -1,6 +1,6 @@
 import { link, lstat, mkdtemp, rename, rmdir, unlink } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
-import { EntityType, type Task } from "../types/index.ts";
+import { type BacklogConfig, EntityType, type Task } from "../types/index.ts";
 import { type DuplicateGroup, detectDuplicateTaskIds } from "../utils/duplicate-detection.ts";
 import { escapeRegex, generateNextId, generateNextSubtaskId, idForFilename } from "../utils/prefix-config.ts";
 import { canonicalTaskId, isNumericTaskId } from "../utils/task-id.ts";
@@ -8,6 +8,11 @@ import type { Core } from "./backlog.ts";
 import { type BranchTaskStateEntry, loadLocalBranchTasks, loadRemoteTasks } from "./task-loader.ts";
 
 export type DuplicateTaskLocation = "active" | "completed";
+
+interface LocalTaskSnapshot {
+	activeTasks: Task[];
+	completedTasks: Task[];
+}
 
 export interface DuplicateRepairChange {
 	sourcePath: string;
@@ -90,15 +95,23 @@ function withLocation(task: Task, location: DuplicateTaskLocation, rootDir: stri
 	};
 }
 
-export async function findLocalDuplicateTaskIds(core: Core): Promise<DuplicateGroup[]> {
+async function loadLocalTaskSnapshot(core: Core): Promise<LocalTaskSnapshot> {
 	const [activeTasks, completedTasks] = await Promise.all([
 		core.filesystem.listTasks(),
 		core.filesystem.listCompletedTasks(),
 	]);
+	return { activeTasks, completedTasks };
+}
+
+function findLocalDuplicateTaskIdsInSnapshot(core: Core, snapshot: LocalTaskSnapshot): DuplicateGroup[] {
 	return detectDuplicateTaskIds([
-		...activeTasks.map((task) => withLocation(task, "active", core.filesystem.rootDir)),
-		...completedTasks.map((task) => withLocation(task, "completed", core.filesystem.rootDir)),
+		...snapshot.activeTasks.map((task) => withLocation(task, "active", core.filesystem.rootDir)),
+		...snapshot.completedTasks.map((task) => withLocation(task, "completed", core.filesystem.rootDir)),
 	]);
+}
+
+export async function findLocalDuplicateTaskIds(core: Core): Promise<DuplicateGroup[]> {
+	return findLocalDuplicateTaskIdsInSnapshot(core, await loadLocalTaskSnapshot(core));
 }
 
 function logicalBranchTaskPath(path: string, id: string): string {
@@ -108,14 +121,14 @@ function logicalBranchTaskPath(path: string, id: string): string {
 	return `${canonicalTaskId(id).toLowerCase()}${filename.slice(separatorIndex)}`;
 }
 
-export async function findCrossBranchDuplicateTaskIds(core: Core): Promise<CrossBranchDuplicateFinding[]> {
-	const config = await core.filesystem.loadConfig();
+async function findCrossBranchDuplicateTaskIdsInSnapshot(
+	core: Core,
+	snapshot: LocalTaskSnapshot,
+	config: BacklogConfig | null,
+): Promise<CrossBranchDuplicateFinding[]> {
 	if (config?.checkActiveBranches === false) return [];
-	const [activeTasks, completedTasks, currentBranch] = await Promise.all([
-		core.filesystem.listTasks(),
-		core.filesystem.listCompletedTasks(),
-		core.gitOps.getCurrentBranch(),
-	]);
+	const { activeTasks, completedTasks } = snapshot;
+	const currentBranch = await core.gitOps.getCurrentBranch();
 	const stateEntries: BranchTaskStateEntry[] = [];
 	await Promise.all([
 		loadLocalBranchTasks(
@@ -178,6 +191,11 @@ export async function findCrossBranchDuplicateTaskIds(core: Core): Promise<Cross
 	return findings.sort((left, right) => left.id.localeCompare(right.id, undefined, { numeric: true }));
 }
 
+export async function findCrossBranchDuplicateTaskIds(core: Core): Promise<CrossBranchDuplicateFinding[]> {
+	const [snapshot, config] = await Promise.all([loadLocalTaskSnapshot(core), core.filesystem.loadConfig()]);
+	return await findCrossBranchDuplicateTaskIdsInSnapshot(core, snapshot, config);
+}
+
 function getTaskLocation(task: Task): DuplicateTaskLocation {
 	return task.source === "completed" ? "completed" : "active";
 }
@@ -230,13 +248,14 @@ function validateGroupParent(group: DuplicateGroup): { parentId?: string; blocke
 
 async function allocateRepairId(
 	core: Core,
+	snapshot: LocalTaskSnapshot,
 	parentId: string | undefined,
 	existingIds: string[],
 	plannedIds: string[],
 	taskPrefix: string,
 	zeroPaddedIds?: number,
 ): Promise<string> {
-	const generatedId = await core.generateNextId(EntityType.Task, parentId);
+	const generatedId = await core.generateNextId(EntityType.Task, parentId, snapshot);
 	const occupiedIds = [...existingIds, ...plannedIds];
 	if (!occupiedIds.some((occupiedId) => canonicalTaskId(occupiedId) === canonicalTaskId(generatedId))) {
 		return generatedId;
@@ -246,8 +265,9 @@ async function allocateRepairId(
 	if (!parentId) {
 		nextId = generateNextId(occupiedIds, taskPrefix, zeroPaddedIds);
 	} else {
-		const generatedParent = generatedId.slice(0, generatedId.lastIndexOf("."));
-		nextId = generateNextSubtaskId(occupiedIds, generatedParent, taskPrefix, zeroPaddedIds);
+		const allocatedParent =
+			existingIds.find((existingId) => canonicalTaskId(existingId) === canonicalTaskId(parentId)) ?? parentId;
+		nextId = generateNextSubtaskId(occupiedIds, allocatedParent, taskPrefix, zeroPaddedIds);
 	}
 	if (occupiedIds.some((occupiedId) => canonicalTaskId(occupiedId) === canonicalTaskId(nextId))) {
 		throw new Error(`Could not allocate an unused repair ID after ${generatedId}.`);
@@ -393,15 +413,14 @@ export async function previewDuplicateTaskIdRepair(
 	core: Core,
 	options: { includeBranches?: boolean } = {},
 ): Promise<DuplicateRepairPlan> {
-	const groups = await findLocalDuplicateTaskIds(core);
-	const crossBranchFindings = options.includeBranches ? await findCrossBranchDuplicateTaskIds(core) : [];
+	const [snapshot, config] = await Promise.all([loadLocalTaskSnapshot(core), core.filesystem.loadConfig()]);
+	const groups = findLocalDuplicateTaskIdsInSnapshot(core, snapshot);
+	const crossBranchFindings = options.includeBranches
+		? await findCrossBranchDuplicateTaskIdsInSnapshot(core, snapshot, config)
+		: [];
 	const blockedReasons: string[] = [];
 	const changes: DuplicateRepairChange[] = [];
-	const [activeTasks, completedTasks, config] = await Promise.all([
-		core.filesystem.listTasks(),
-		core.filesystem.listCompletedTasks(),
-		core.filesystem.loadConfig(),
-	]);
+	const { activeTasks, completedTasks } = snapshot;
 	const existingIds = [...activeTasks, ...completedTasks].map((task) => task.id);
 	const plannedIds: string[] = [];
 
@@ -419,6 +438,7 @@ export async function previewDuplicateTaskIdRepair(
 			}
 			const nextId = await allocateRepairId(
 				core,
+				snapshot,
 				parentValidation.parentId,
 				existingIds,
 				plannedIds,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -192,6 +192,8 @@ export class BacklogServer {
 	private searchService: SearchService | null = null;
 	private unsubscribeContentStore?: () => void;
 	private storeReadyBroadcasted = false;
+	private tasksUpdatedBatchDepth = 0;
+	private tasksUpdatedBatchPending = false;
 
 	constructor(projectPath: string) {
 		this.core = new Core(projectPath, { enableWatchers: true });
@@ -223,13 +225,13 @@ export class BacklogServer {
 						this.storeReadyBroadcasted = true;
 						return;
 					}
-					this.broadcastTasksUpdated();
+					this.publishTasksUpdated();
 					return;
 				}
 
 				// Broadcast for tasks/documents/decisions so clients refresh caches/search
 				this.storeReadyBroadcasted = true;
-				this.broadcastTasksUpdated();
+				this.publishTasksUpdated();
 			});
 		}
 
@@ -262,6 +264,27 @@ export class BacklogServer {
 			try {
 				ws.send("tasks-updated");
 			} catch {}
+		}
+	}
+
+	private publishTasksUpdated() {
+		if (this.tasksUpdatedBatchDepth > 0) {
+			this.tasksUpdatedBatchPending = true;
+			return;
+		}
+		this.broadcastTasksUpdated();
+	}
+
+	private async batchTasksUpdated<T>(operation: () => Promise<T>): Promise<T> {
+		this.tasksUpdatedBatchDepth += 1;
+		try {
+			return await operation();
+		} finally {
+			this.tasksUpdatedBatchDepth -= 1;
+			if (this.tasksUpdatedBatchDepth === 0 && this.tasksUpdatedBatchPending) {
+				this.tasksUpdatedBatchPending = false;
+				this.broadcastTasksUpdated();
+			}
 		}
 	}
 
@@ -1622,12 +1645,14 @@ export class BacklogServer {
 				);
 			}
 
-			const { updatedTask } = await this.core.reorderTask({
-				taskId,
-				targetStatus,
-				orderedTaskIds,
-				targetMilestone,
-				commitMessage: `Reorder tasks in ${targetStatus}`,
+			const { updatedTask } = await this.batchTasksUpdated(async () => {
+				return await this.core.reorderTask({
+					taskId,
+					targetStatus,
+					orderedTaskIds,
+					targetMilestone,
+					commitMessage: `Reorder tasks in ${targetStatus}`,
+				});
 			});
 
 			return Response.json({ success: true, task: updatedTask });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -965,19 +965,6 @@ export class BacklogServer {
 
 	private async handleUpdateTask(req: Request, taskId: string): Promise<Response> {
 		const updates = await req.json();
-		let existingTask: Task | null;
-		try {
-			existingTask = await this.core.filesystem.loadTask(taskId);
-		} catch (error) {
-			if (isAmbiguousTaskIdError(error)) {
-				return Response.json({ error: error.message }, { status: 409 });
-			}
-			throw error;
-		}
-		if (!existingTask) {
-			return Response.json({ error: "Task not found" }, { status: 404 });
-		}
-
 		const updateInput: TaskUpdateInput = {};
 
 		if ("title" in updates && typeof updates.title === "string") {
@@ -1091,7 +1078,8 @@ export class BacklogServer {
 			return Response.json(updatedTask);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to update task";
-			return Response.json({ error: message }, { status: 400 });
+			const status = isAmbiguousTaskIdError(error) ? 409 : message.startsWith("Task not found:") ? 404 : 400;
+			return Response.json({ error: message }, { status });
 		}
 	}
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1645,7 +1645,7 @@ export class BacklogServer {
 				);
 			}
 
-			const { updatedTask } = await this.batchTasksUpdated(async () => {
+			const { updatedTask, changedTasks } = await this.batchTasksUpdated(async () => {
 				return await this.core.reorderTask({
 					taskId,
 					targetStatus,
@@ -1655,7 +1655,7 @@ export class BacklogServer {
 				});
 			});
 
-			return Response.json({ success: true, task: updatedTask });
+			return Response.json({ success: true, task: updatedTask, changedTasks });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to reorder task";
 			// Cross-branch and validation errors are client errors (400), not server errors (500)

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -114,6 +114,28 @@ describe("Core", () => {
 			expect(lastCommit.length).toBeGreaterThan(0);
 		});
 
+		it("updates from input with one active/completed identity scan", async () => {
+			await core.createTask(sampleTask, false);
+			const originalListTasks = core.filesystem.listTasks.bind(core.filesystem);
+			const originalListCompletedTasks = core.filesystem.listCompletedTasks.bind(core.filesystem);
+			let activeLoads = 0;
+			let completedLoads = 0;
+			core.filesystem.listTasks = async (...args) => {
+				activeLoads += 1;
+				return await originalListTasks(...args);
+			};
+			core.filesystem.listCompletedTasks = async (...args) => {
+				completedLoads += 1;
+				return await originalListCompletedTasks(...args);
+			};
+
+			const updatedTask = await core.updateTaskFromInput("task-1", { status: "In Progress" }, false);
+
+			expect(updatedTask.status).toBe("In Progress");
+			expect(activeLoads).toBe(1);
+			expect(completedLoads).toBe(1);
+		});
+
 		it("does not update a longer legacy sibling for a shorter numeric ID", async () => {
 			await core.createTask({ ...sampleTask, id: "BACK-1-EXTRA", title: "Longer sibling" }, false);
 

--- a/src/test/duplicate-task-repair.test.ts
+++ b/src/test/duplicate-task-repair.test.ts
@@ -61,9 +61,11 @@ afterEach(async () => {
 
 describe("duplicate task diagnosis", () => {
 	it("detects three-way, active/completed, and zero-padded collisions while ignoring archive reuse", async () => {
-		await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha"));
-		await writeTask(core.filesystem.tasksDir, "task-01 - Beta.md", makeTask("TASK-01", "Beta"));
-		await writeTask(core.filesystem.completedDir, "task-001 - Gamma.md", makeTask("TASK-001", "Gamma"));
+		const ambiguousPaths = [
+			await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha")),
+			await writeTask(core.filesystem.tasksDir, "task-01 - Beta.md", makeTask("TASK-01", "Beta")),
+			await writeTask(core.filesystem.completedDir, "task-001 - Gamma.md", makeTask("TASK-001", "Gamma")),
+		];
 		await writeTask(core.filesystem.archiveTasksDir, "task-2 - Archived.md", makeTask("TASK-2", "Archived"));
 		await writeTask(core.filesystem.tasksDir, "task-2 - Reused.md", makeTask("TASK-2", "Reused"));
 
@@ -76,13 +78,51 @@ describe("duplicate task diagnosis", () => {
 			"backlog/tasks/task-01 - Beta.md",
 			"backlog/tasks/task-1 - Alpha.md",
 		]);
+
+		const before = await Promise.all(ambiguousPaths.map(async (path) => await Bun.file(path).text()));
+		await expect(core.updateTaskFromInput("TASK-1", { status: "In Progress" }, false)).rejects.toBeInstanceOf(
+			AmbiguousTaskIdError,
+		);
+		expect(await Promise.all(ambiguousPaths.map(async (path) => await Bun.file(path).text()))).toEqual(before);
+	});
+
+	it("loads one local task snapshot for duplicate preview and repair ID allocation", async () => {
+		await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha"));
+		await writeTask(core.filesystem.tasksDir, "task-01 - Beta.md", makeTask("TASK-01", "Beta"));
+		await writeTask(core.filesystem.completedDir, "task-9 - Completed.md", makeTask("TASK-9", "Completed"));
+
+		const originalListTasks = core.filesystem.listTasks.bind(core.filesystem);
+		const originalListCompletedTasks = core.filesystem.listCompletedTasks.bind(core.filesystem);
+		let activeLoads = 0;
+		let completedLoads = 0;
+		core.filesystem.listTasks = async (...args) => {
+			activeLoads += 1;
+			return await originalListTasks(...args);
+		};
+		core.filesystem.listCompletedTasks = async (...args) => {
+			completedLoads += 1;
+			return await originalListCompletedTasks(...args);
+		};
+
+		const plan = await core.previewDuplicateTaskIdRepair();
+
+		expect(plan.changes).toHaveLength(1);
+		expect(activeLoads).toBe(1);
+		expect(completedLoads).toBe(1);
 	});
 
 	it("fails closed when an exact ID lookup matches active and completed files", async () => {
-		await writeTask(core.filesystem.tasksDir, "task-1 - Active.md", makeTask("TASK-1", "Active"));
-		await writeTask(core.filesystem.completedDir, "task-01 - Completed.md", makeTask("TASK-01", "Completed"));
+		const paths = [
+			await writeTask(core.filesystem.tasksDir, "task-1 - Active.md", makeTask("TASK-1", "Active")),
+			await writeTask(core.filesystem.completedDir, "task-01 - Completed.md", makeTask("TASK-01", "Completed")),
+		];
+		const before = await Promise.all(paths.map(async (path) => await Bun.file(path).text()));
 
 		await expect(core.filesystem.loadTask("TASK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+		await expect(core.updateTaskFromInput("TASK-1", { title: "Changed" }, false)).rejects.toBeInstanceOf(
+			AmbiguousTaskIdError,
+		);
+		expect(await Promise.all(paths.map(async (path) => await Bun.file(path).text()))).toEqual(before);
 		try {
 			await core.filesystem.loadTask("TASK-1");
 		} catch (error) {
@@ -94,10 +134,30 @@ describe("duplicate task diagnosis", () => {
 	});
 
 	it("fails closed when frontmatter IDs collide even if one filename differs", async () => {
-		await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha"));
-		await writeTask(core.filesystem.tasksDir, "task-2 - Misnamed.md", makeTask("TASK-1", "Misnamed"));
+		const paths = [
+			await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha")),
+			await writeTask(core.filesystem.tasksDir, "task-2 - Misnamed.md", makeTask("TASK-1", "Misnamed")),
+		];
+		const before = await Promise.all(paths.map(async (path) => await Bun.file(path).text()));
 
 		await expect(core.filesystem.loadTask("TASK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+		await expect(core.updateTaskFromInput("TASK-1", { title: "Changed" }, false)).rejects.toBeInstanceOf(
+			AmbiguousTaskIdError,
+		);
+		expect(await Promise.all(paths.map(async (path) => await Bun.file(path).text()))).toEqual(before);
+	});
+
+	it("fails closed for a numeric mutation that collides across prefixes", async () => {
+		const paths = [
+			await writeTask(core.filesystem.tasksDir, "task-10 - Default.md", makeTask("TASK-10", "Default")),
+			await writeTask(core.filesystem.tasksDir, "task-010 - Custom.md", makeTask("BACK-10", "Custom")),
+		];
+		const before = await Promise.all(paths.map(async (path) => await Bun.file(path).text()));
+
+		await expect(core.updateTaskFromInput("10", { title: "Changed" }, false)).rejects.toBeInstanceOf(
+			AmbiguousTaskIdError,
+		);
+		expect(await Promise.all(paths.map(async (path) => await Bun.file(path).text()))).toEqual(before);
 	});
 
 	it("does not overwrite either file through the low-level save path when lookup is ambiguous", async () => {

--- a/src/test/reorder-utils.test.ts
+++ b/src/test/reorder-utils.test.ts
@@ -269,6 +269,34 @@ describe("Core.reorderTask", () => {
 		expect(task3?.ordinal).toBe(2000);
 	});
 
+	it("uses one active/completed identity snapshot for a board move", async () => {
+		await createTasks([["task-1", "To Do", 1000]]);
+		await core.getContentStore();
+		const originalListTasks = core.filesystem.listTasks.bind(core.filesystem);
+		const originalListCompletedTasks = core.filesystem.listCompletedTasks.bind(core.filesystem);
+		let activeLoads = 0;
+		let completedLoads = 0;
+		core.filesystem.listTasks = async (...args) => {
+			activeLoads += 1;
+			return await originalListTasks(...args);
+		};
+		core.filesystem.listCompletedTasks = async (...args) => {
+			completedLoads += 1;
+			return await originalListCompletedTasks(...args);
+		};
+
+		const result = await core.reorderTask({
+			taskId: "task-1",
+			targetStatus: "In Progress",
+			orderedTaskIds: ["task-1"],
+			autoCommit: false,
+		});
+
+		expect(result.updatedTask.status).toBe("In Progress");
+		expect(activeLoads).toBe(1);
+		expect(completedLoads).toBe(1);
+	});
+
 	it("reorders tasks with legacy lowercase IDs", async () => {
 		await createTasks([
 			["task-1", "To Do", 1000],

--- a/src/test/server-duplicate-repair.test.ts
+++ b/src/test/server-duplicate-repair.test.ts
@@ -73,6 +73,29 @@ afterEach(async () => {
 });
 
 describe("duplicate repair server boundary", () => {
+	it("updates a task with one fail-closed task identity resolution", async () => {
+		const uniquePath = join(setupCore.filesystem.tasksDir, "task-2 - Unique.md");
+		await Bun.write(uniquePath, serializeTask(makeTask("TASK-2", "Unique")));
+		const serverCore = (server as unknown as { core: Core }).core;
+		const originalLoadTask = serverCore.filesystem.loadTask.bind(serverCore.filesystem);
+		let taskLoads = 0;
+		serverCore.filesystem.loadTask = async (...args) => {
+			taskLoads += 1;
+			return await originalLoadTask(...args);
+		};
+
+		const response = await request("/api/tasks/TASK-2", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ status: "In Progress" }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(((await response.json()) as Task).status).toBe("In Progress");
+		expect(taskLoads).toBe(1);
+		expect((await setupCore.filesystem.loadTask("TASK-2"))?.status).toBe("In Progress");
+	});
+
 	it("returns the shared preview and applies it with the preview fingerprint", async () => {
 		const previewResponse = await request("/api/tasks/duplicates");
 		expect(previewResponse.status).toBe(200);

--- a/src/test/server-reorder-publication.test.ts
+++ b/src/test/server-reorder-publication.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { Core } from "../core/backlog.ts";
+import { BacklogServer } from "../server/index.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, retry, safeCleanup, sleep, withTimeout } from "./test-utils.ts";
+
+let testDir: string;
+let server: BacklogServer | null = null;
+let serverPort = 0;
+let socket: WebSocket | null = null;
+
+const task = (id: string): Task => ({
+	id,
+	title: `Task ${id}`,
+	status: "To Do",
+	ordinal: 1000,
+	assignee: [],
+	createdDate: "2026-01-01",
+	labels: [],
+	dependencies: [],
+});
+
+beforeEach(async () => {
+	testDir = createUniqueTestDir("server-reorder-publication");
+	await mkdir(testDir, { recursive: true });
+	const core = new Core(testDir);
+	await core.filesystem.ensureBacklogStructure();
+	await core.filesystem.saveConfig({
+		projectName: "Server reorder publication",
+		statuses: ["To Do", "In Progress", "Done"],
+		labels: [],
+		milestones: [],
+		dateFormat: "YYYY-MM-DD",
+		remoteOperations: false,
+		checkActiveBranches: false,
+		autoCommit: false,
+	});
+	for (const id of ["TASK-1", "TASK-2", "TASK-3"]) {
+		await core.filesystem.saveTask(task(id));
+	}
+
+	server = new BacklogServer(testDir);
+	await server.start(0, false);
+	serverPort = server.getPort() ?? 0;
+	await retry(async () => {
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/status`);
+		if (!response.ok) throw new Error("Server is not ready");
+	});
+});
+
+afterEach(async () => {
+	socket?.close();
+	socket = null;
+	await server?.stop();
+	server = null;
+	await safeCleanup(testDir);
+});
+
+describe("reorder WebSocket publication", () => {
+	it("publishes one reconciliation after a multi-task ordinal rebalance", async () => {
+		const messages: string[] = [];
+		socket = new WebSocket(`ws://127.0.0.1:${serverPort}`);
+		await withTimeout(
+			new Promise<void>((resolve, reject) => {
+				if (!socket) return reject(new Error("WebSocket was not created"));
+				socket.onopen = () => resolve();
+				socket.onerror = () => reject(new Error("WebSocket failed to open"));
+			}),
+			"reorder test WebSocket",
+			2000,
+		);
+		socket.onmessage = (event) => messages.push(String(event.data));
+
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks/reorder`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				taskId: "TASK-3",
+				targetStatus: "To Do",
+				orderedTaskIds: ["TASK-1", "TASK-3", "TASK-2"],
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		const result = (await response.json()) as { success: boolean; task: Task };
+		expect(result.task.ordinal).toBe(2000);
+		await retry(async () => {
+			if (!messages.includes("tasks-updated")) throw new Error("Reconciliation was not published");
+		});
+		await sleep(50);
+		expect(messages.filter((message) => message === "tasks-updated")).toHaveLength(1);
+	});
+});

--- a/src/test/server-reorder-publication.test.ts
+++ b/src/test/server-reorder-publication.test.ts
@@ -58,7 +58,7 @@ afterEach(async () => {
 });
 
 describe("reorder WebSocket publication", () => {
-	it("publishes one reconciliation after a multi-task ordinal rebalance", async () => {
+	it("returns every changed task and publishes one reconciliation after a multi-task ordinal rebalance", async () => {
 		const messages: string[] = [];
 		socket = new WebSocket(`ws://127.0.0.1:${serverPort}`);
 		await withTimeout(
@@ -83,8 +83,16 @@ describe("reorder WebSocket publication", () => {
 		});
 
 		expect(response.status).toBe(200);
-		const result = (await response.json()) as { success: boolean; task: Task };
+		const result = (await response.json()) as { success: boolean; task: Task; changedTasks: Task[] };
 		expect(result.task.ordinal).toBe(2000);
+		expect(
+			result.changedTasks
+				.map((task) => ({ id: task.id, ordinal: task.ordinal }))
+				.sort((a, b) => a.id.localeCompare(b.id)),
+		).toEqual([
+			{ id: "TASK-2", ordinal: 3000 },
+			{ id: "TASK-3", ordinal: 2000 },
+		]);
 		await retry(async () => {
 			if (!messages.includes("tasks-updated")) throw new Error("Reconciliation was not published");
 		});

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -269,7 +269,7 @@ describe("Web board filters", () => {
 				taskId: movedTask.id,
 				targetStatus: "In Progress",
 			});
-			return { success: true, task: movedTask };
+			return { success: true, task: movedTask, changedTasks: [movedTask] };
 		};
 
 		try {

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -100,6 +100,8 @@ const renderBoardPage = (
 		availablePriorities?: string[];
 		availableTypes?: string[];
 		dateFormat?: string;
+		onRefreshData?: () => Promise<void>;
+		onTaskUpdated?: (task: Task) => void;
 	} = {},
 ): HTMLElement => {
 	setupDom(url);
@@ -123,6 +125,8 @@ const renderBoardPage = (
 					isLoading={false}
 					onEditTask={() => {}}
 					onNewTask={() => {}}
+					onRefreshData={options.onRefreshData}
+					onTaskUpdated={options.onTaskUpdated}
 					dateFormat={options.dateFormat}
 				/>
 			</BrowserRouter>,
@@ -253,6 +257,55 @@ afterEach(() => {
 });
 
 describe("Web board filters", () => {
+	it("publishes the returned task after a board drop without a foreground refresh", async () => {
+		const originalReorderTask = apiClient.reorderTask.bind(apiClient);
+		const sourceTask = tasks[0];
+		if (!sourceTask) throw new Error("Expected a source task");
+		const movedTask: Task = { ...sourceTask, status: "In Progress", ordinal: 2000 };
+		let refreshes = 0;
+		const publishedTasks: Task[] = [];
+		apiClient.reorderTask = async (payload) => {
+			expect(payload).toMatchObject({
+				taskId: movedTask.id,
+				targetStatus: "In Progress",
+			});
+			return { success: true, task: movedTask };
+		};
+
+		try {
+			const container = renderBoardPage(undefined, {
+				onRefreshData: async () => {
+					refreshes += 1;
+				},
+				onTaskUpdated: (task) => {
+					publishedTasks.push(task);
+				},
+			});
+			const targetHeading = Array.from(container.querySelectorAll("h3")).find(
+				(heading) => heading.textContent === "In Progress",
+			);
+			const targetColumn = targetHeading?.closest(".rounded-lg");
+			expect(targetColumn).toBeTruthy();
+			const dropEvent = new window.Event("drop", { bubbles: true, cancelable: true });
+			Object.defineProperty(dropEvent, "dataTransfer", {
+				value: {
+					getData: (type: string) => (type === "text/plain" ? movedTask.id : type === "text/status" ? "To Do" : ""),
+				},
+			});
+
+			await act(async () => {
+				targetColumn?.dispatchEvent(dropEvent);
+				await Promise.resolve();
+			});
+			await waitFor(() => publishedTasks.length === 1);
+
+			expect(publishedTasks).toEqual([movedTask]);
+			expect(refreshes).toBe(0);
+		} finally {
+			apiClient.reorderTask = originalReorderTask;
+		}
+	});
+
 	it("filters board cards by assignee, label, type, and priority while updating URL params", async () => {
 		const container = renderBoardPage(undefined, {
 			availableTypes: ["Bug", "Docs", "Enhancement"],

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -560,6 +560,30 @@ const pressWithHistory = async (element: Element, key: string, init: KeyboardEve
 	await act(async () => navigated);
 };
 
+const dropTaskIntoStatus = async (
+	container: HTMLElement,
+	taskId: string,
+	sourceStatus: string,
+	targetStatus: string,
+	requestStarted: Promise<void> | undefined,
+) => {
+	const targetHeading = Array.from(container.querySelectorAll("h3")).find(
+		(heading) => heading.textContent === targetStatus,
+	);
+	const targetColumn = targetHeading?.closest(".rounded-lg");
+	expect(targetColumn).toBeTruthy();
+	const dropEvent = new window.Event("drop", { bubbles: true, cancelable: true });
+	Object.defineProperty(dropEvent, "dataTransfer", {
+		value: {
+			getData: (type: string) => (type === "text/plain" ? taskId : type === "text/status" ? sourceStatus : ""),
+		},
+	});
+	await act(async () => {
+		targetColumn?.dispatchEvent(dropEvent);
+		await requestStarted;
+	});
+};
+
 const pushRoute = async (path: string, expectations: FetchExpectation[] = []) => {
 	await runOperation(`push route ${path}`, expectations, () => {
 		window.history.pushState({}, "", path);
@@ -758,6 +782,96 @@ describe("task detail routes", () => {
 		expect(new URLSearchParams(window.location.search).get("type")).toBe("Customer Request");
 		const typeSelect = container.querySelector("select[aria-label='Filter board by type']") as HTMLSelectElement;
 		expect(Array.from(typeSelect.options).map((option) => option.value)).toContain("Customer Request");
+	});
+
+	it("keeps a newer WebSocket-reconciled task when an earlier reorder response arrives late", async () => {
+		const container = await renderApp("/board?lane=none", { advanceHealthSocket: true });
+		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();
+		const sourceTask = tasks[0];
+		if (!sourceTask) throw new Error("Expected a source task");
+		const staleResponseTask: Task = {
+			...sourceTask,
+			title: "Stale reorder response",
+			status: "In Progress",
+			ordinal: 2000,
+		};
+		const externallyEditedTask: Task = {
+			...sourceTask,
+			title: "Newer external edit",
+			status: "In Progress",
+			ordinal: 2500,
+		};
+
+		const reorder = new FetchOperation("delayed reorder response", [
+			expectFetch("reorder response", "/api/tasks/reorder", { manual: true }),
+		]);
+		await dropTaskIntoStatus(
+			container,
+			sourceTask.id,
+			"To Do",
+			"In Progress",
+			reorder.startedSignals.get("reorder response")?.promise,
+		);
+		reorder.finish();
+
+		const reconciliation = new FetchOperation("newer WebSocket reconciliation", [
+			expectFetch("newer search", "/api/search", { manual: true }),
+			expectFetch("newer duplicate plan", "/api/tasks/duplicates"),
+		]);
+		await act(async () => {
+			dataSocket.deliver("tasks-updated");
+			await Promise.resolve();
+		});
+		await act(async () => {
+			reconciliation.respond(
+				"newer search",
+				json([
+					...searchResults.filter(
+						(result) => result.type !== "task" || result.task.id !== externallyEditedTask.id,
+					),
+					{ type: "task", task: externallyEditedTask, score: 1 } satisfies SearchResult,
+				]),
+			);
+			await reconciliation.settle("newer search", "newer duplicate plan");
+		});
+		reconciliation.finish();
+		expect(container.textContent).toContain(externallyEditedTask.title);
+
+		await act(async () => {
+			reorder.respond("reorder response", json({ success: true, task: staleResponseTask }));
+			await reorder.settle("reorder response");
+		});
+
+		expect(container.textContent).toContain(externallyEditedTask.title);
+		expect(container.textContent).not.toContain(staleResponseTask.title);
+	});
+
+	it("applies a reorder response immediately when no reconciliation has replaced its request task", async () => {
+		const container = await renderApp("/board?lane=none");
+		const sourceTask = tasks[0];
+		if (!sourceTask) throw new Error("Expected a source task");
+		const updatedTask: Task = {
+			...sourceTask,
+			status: "In Progress",
+			ordinal: 2000,
+		};
+
+		const reorder = new FetchOperation("immediate reorder response", [
+			expectFetch("reorder response", "/api/tasks/reorder", { manual: true }),
+		]);
+		const requestStarted = reorder.startedSignals.get("reorder response")?.promise;
+		await dropTaskIntoStatus(container, sourceTask.id, "To Do", "In Progress", requestStarted);
+		await act(async () => {
+			reorder.respond("reorder response", json({ success: true, task: updatedTask }));
+			await reorder.settle("reorder response");
+		});
+		reorder.finish();
+
+		const updatedTargetHeading = Array.from(container.querySelectorAll("h3")).find(
+			(heading) => heading.textContent === "In Progress",
+		);
+		const updatedTargetColumn = updatedTargetHeading?.closest(".rounded-lg");
+		expect(updatedTargetColumn?.textContent).toContain(sourceTask.title);
 	});
 
 	it("keeps a filtered board query when a sidebar search result opens and closes", async () => {

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -838,7 +838,10 @@ describe("task detail routes", () => {
 		expect(container.textContent).toContain(externallyEditedTask.title);
 
 		await act(async () => {
-			reorder.respond("reorder response", json({ success: true, task: staleResponseTask }));
+			reorder.respond(
+				"reorder response",
+				json({ success: true, task: staleResponseTask, changedTasks: [staleResponseTask] }),
+			);
 			await reorder.settle("reorder response");
 		});
 
@@ -862,7 +865,7 @@ describe("task detail routes", () => {
 		const requestStarted = reorder.startedSignals.get("reorder response")?.promise;
 		await dropTaskIntoStatus(container, sourceTask.id, "To Do", "In Progress", requestStarted);
 		await act(async () => {
-			reorder.respond("reorder response", json({ success: true, task: updatedTask }));
+			reorder.respond("reorder response", json({ success: true, task: updatedTask, changedTasks: [updatedTask] }));
 			await reorder.settle("reorder response");
 		});
 		reorder.finish();
@@ -872,6 +875,44 @@ describe("task detail routes", () => {
 		);
 		const updatedTargetColumn = updatedTargetHeading?.closest(".rounded-lg");
 		expect(updatedTargetColumn?.textContent).toContain(sourceTask.title);
+	});
+
+	it("applies every rebalanced task when the data WebSocket is disconnected", async () => {
+		const container = await renderApp("/board?lane=none", { advanceHealthSocket: true });
+		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();
+		dataSocket.close();
+		const sourceTask = tasks[0];
+		const siblingTask = tasks[1];
+		if (!sourceTask || !siblingTask) throw new Error("Expected source and sibling tasks");
+		const updatedSourceTask: Task = { ...sourceTask, ordinal: 2000 };
+		const updatedSiblingTask: Task = { ...siblingTask, ordinal: 1000 };
+
+		const reorder = new FetchOperation("disconnected WebSocket reorder response", [
+			expectFetch("reorder response", "/api/tasks/reorder", { manual: true }),
+		]);
+		const requestStarted = reorder.startedSignals.get("reorder response")?.promise;
+		await dropTaskIntoStatus(container, sourceTask.id, "To Do", "To Do", requestStarted);
+		await act(async () => {
+			reorder.respond(
+				"reorder response",
+				json({
+					success: true,
+					task: updatedSourceTask,
+					changedTasks: [updatedSiblingTask, updatedSourceTask],
+				}),
+			);
+			await reorder.settle("reorder response");
+		});
+		reorder.finish();
+
+		const targetHeading = Array.from(container.querySelectorAll("h3")).find(
+			(heading) => heading.textContent === "To Do",
+		);
+		const targetColumn = targetHeading?.closest(".rounded-lg");
+		const visibleTaskTitles = Array.from(targetColumn?.querySelectorAll("[draggable='true'] h4") ?? []).map(
+			(element) => element.textContent,
+		);
+		expect(visibleTaskTitles.slice(0, 2)).toEqual([siblingTask.title, sourceTask.title]);
 	});
 
 	it("keeps a filtered board query when a sidebar search result opens and closes", async () => {

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -518,10 +518,10 @@ function AppContent() {
     await loadAllData();
   }, [loadAllData]);
 
-  const handleBoardTaskUpdated = useCallback((updatedTask: Task) => {
+  const handleBoardTaskUpdated = useCallback((updatedTask: Task, requestTask: Task) => {
     setTasks((currentTasks) => {
       const resolution = resolveTaskById(currentTasks, updatedTask.id);
-      if (resolution.status !== 'found') {
+      if (resolution.status !== 'found' || resolution.task !== requestTask) {
         return currentTasks;
       }
       return currentTasks.map((task) => (task === resolution.task ? updatedTask : task));

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -26,7 +26,7 @@ import {
 } from '../types';
 import { ApiError, apiClient } from './lib/api';
 import type { DuplicateRepairPlan } from '../core/duplicate-task-repair';
-import { isValidTaskId } from '../utils/task-id';
+import { isValidTaskId, resolveTaskById } from '../utils/task-id';
 import { useHealthCheckContext } from './contexts/HealthCheckContext';
 import { getWebVersion } from './utils/version';
 import { collectArchivedMilestoneKeys, collectMilestoneIds, milestoneKey } from './utils/milestones';
@@ -518,6 +518,16 @@ function AppContent() {
     await loadAllData();
   }, [loadAllData]);
 
+  const handleBoardTaskUpdated = useCallback((updatedTask: Task) => {
+    setTasks((currentTasks) => {
+      const resolution = resolveTaskById(currentTasks, updatedTask.id);
+      if (resolution.status !== 'found') {
+        return currentTasks;
+      }
+      return currentTasks.map((task) => (task === resolution.task ? updatedTask : task));
+    });
+  }, []);
+
   // Sync editingTask with refreshed tasks data to prevent stale state
   // This fixes the bug where acceptance criteria disappears after save (GitHub #467)
   useEffect(() => {
@@ -608,6 +618,7 @@ function AppContent() {
       onNewTask={handleNewTask}
       tasks={tasks}
       onRefreshData={refreshData}
+      onTaskUpdated={handleBoardTaskUpdated}
       statuses={statuses}
       milestones={milestones}
       availableLabels={availableLabels}

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -296,10 +296,14 @@ const Board: React.FC<BoardProps> = ({
 
   const handleTaskReorder = async (payload: ReorderTaskPayload) => {
     try {
-      const requestTask = resolveTaskById(tasks, payload.taskId);
-      const { task } = await apiClient.reorderTask(payload);
-      if (requestTask.status === 'found') {
-        onTaskUpdated?.(task, requestTask.task);
+      const { task, changedTasks } = await apiClient.reorderTask(payload);
+      const responseTasks = new Map(changedTasks.map(updatedTask => [updatedTask.id, updatedTask]));
+      responseTasks.set(task.id, task);
+      for (const updatedTask of responseTasks.values()) {
+        const requestTask = resolveTaskById(tasks, updatedTask.id);
+        if (requestTask.status === 'found') {
+          onTaskUpdated?.(updatedTask, requestTask.task);
+        }
       }
       setUpdateError(null);
     } catch (err) {

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -19,6 +19,7 @@ interface BoardProps {
   highlightTaskId?: string | null;
   tasks: Task[];
   onRefreshData?: () => Promise<void>;
+  onTaskUpdated?: (task: Task) => void;
   statuses: string[];
   isLoading: boolean;
   milestones: string[];
@@ -51,6 +52,7 @@ const Board: React.FC<BoardProps> = ({
   highlightTaskId,
   tasks,
   onRefreshData,
+  onTaskUpdated,
   statuses,
   isLoading,
   availableLabels,
@@ -281,11 +283,8 @@ const Board: React.FC<BoardProps> = ({
 
   const handleTaskUpdate = async (taskId: string, updates: Partial<Task>) => {
     try {
-      await apiClient.updateTask(taskId, updates);
-      // Refresh data to reflect the changes
-      if (onRefreshData) {
-        await onRefreshData();
-      }
+      const updatedTask = await apiClient.updateTask(taskId, updates);
+      onTaskUpdated?.(updatedTask);
       setUpdateError(null);
     } catch (err) {
       setUpdateError(err instanceof Error ? err.message : 'Failed to update task');
@@ -294,11 +293,8 @@ const Board: React.FC<BoardProps> = ({
 
   const handleTaskReorder = async (payload: ReorderTaskPayload) => {
     try {
-      await apiClient.reorderTask(payload);
-      // Refresh data to reflect the changes
-      if (onRefreshData) {
-        await onRefreshData();
-      }
+      const { task } = await apiClient.reorderTask(payload);
+      onTaskUpdated?.(task);
       setUpdateError(null);
     } catch (err) {
       setUpdateError(err instanceof Error ? err.message : 'Failed to reorder task');

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -19,7 +19,7 @@ interface BoardProps {
   highlightTaskId?: string | null;
   tasks: Task[];
   onRefreshData?: () => Promise<void>;
-  onTaskUpdated?: (task: Task) => void;
+  onTaskUpdated?: (task: Task, requestTask: Task) => void;
   statuses: string[];
   isLoading: boolean;
   milestones: string[];
@@ -283,8 +283,11 @@ const Board: React.FC<BoardProps> = ({
 
   const handleTaskUpdate = async (taskId: string, updates: Partial<Task>) => {
     try {
+      const requestTask = resolveTaskById(tasks, taskId);
       const updatedTask = await apiClient.updateTask(taskId, updates);
-      onTaskUpdated?.(updatedTask);
+      if (requestTask.status === 'found') {
+        onTaskUpdated?.(updatedTask, requestTask.task);
+      }
       setUpdateError(null);
     } catch (err) {
       setUpdateError(err instanceof Error ? err.message : 'Failed to update task');
@@ -293,8 +296,11 @@ const Board: React.FC<BoardProps> = ({
 
   const handleTaskReorder = async (payload: ReorderTaskPayload) => {
     try {
+      const requestTask = resolveTaskById(tasks, payload.taskId);
       const { task } = await apiClient.reorderTask(payload);
-      onTaskUpdated?.(task);
+      if (requestTask.status === 'found') {
+        onTaskUpdated?.(task, requestTask.task);
+      }
       setUpdateError(null);
     } catch (err) {
       setUpdateError(err instanceof Error ? err.message : 'Failed to reorder task');

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -11,7 +11,7 @@ interface BoardPageProps {
 	onNewTask: () => void;
 	tasks: Task[];
 	onRefreshData?: () => Promise<void>;
-	onTaskUpdated?: (task: Task) => void;
+	onTaskUpdated?: (task: Task, requestTask: Task) => void;
 	statuses: string[];
 	milestones: string[];
 	availableLabels: string[];

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -11,6 +11,7 @@ interface BoardPageProps {
 	onNewTask: () => void;
 	tasks: Task[];
 	onRefreshData?: () => Promise<void>;
+	onTaskUpdated?: (task: Task) => void;
 	statuses: string[];
 	milestones: string[];
 	availableLabels: string[];
@@ -28,6 +29,7 @@ export default function BoardPage({
 	onNewTask,
 	tasks,
 	onRefreshData,
+	onTaskUpdated,
 	statuses,
 	milestones,
 	availableLabels,
@@ -163,6 +165,7 @@ export default function BoardPage({
 				highlightTaskId={highlightTaskId}
 				tasks={tasks}
 				onRefreshData={onRefreshData}
+				onTaskUpdated={onTaskUpdated}
 				statuses={statuses}
 				milestones={milestones}
 				milestoneEntities={milestoneEntities}

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -273,8 +273,8 @@ export class ApiClient {
 		});
 	}
 
-	async reorderTask(payload: ReorderTaskPayload): Promise<{ success: boolean; task: Task }> {
-		return this.fetchJson<{ success: boolean; task: Task }>(`${API_BASE}/tasks/reorder`, {
+	async reorderTask(payload: ReorderTaskPayload): Promise<{ success: boolean; task: Task; changedTasks: Task[] }> {
+		return this.fetchJson<{ success: boolean; task: Task; changedTasks: Task[] }>(`${API_BASE}/tasks/reorder`, {
 			method: "POST",
 			body: JSON.stringify(payload),
 		});


### PR DESCRIPTION
## Summary

- resolve browser task mutations once and persist the resolved task without reloading the full active and completed corpus
- reuse one active and completed snapshot for duplicate repair and reorder work while preserving fail-closed identity checks
- return every persisted reorder change and apply it through the existing stale-response guard, keeping a forced two-task rebalance correct when WebSocket delivery is unavailable
- coalesce multi-task reorder publication to one WebSocket reconciliation and ignore mutation responses superseded by newer reconciled state

## Verification

- `bun test`: 1,789 passed, 4 interactive tests skipped, 0 failed, with 7,590 expectation calls across 200 files
- focused server and rendered App correction suite: 37 passed, 0 failed
- `bunx tsc --noEmit`
- `bun run check .`: 340 files checked with no errors
- `git diff --check`

## Performance

On alternating fresh same-machine macOS arm64 Git fixture copies with 20 active and 430 completed tasks, each variant ran 12 measured samples. Every sample forced the same two-task ordinal rebalance. End-to-end completion included the mutation response and every surviving App refresh request: statuses, config, search, milestones, archived milestones, and duplicate preview. Current `origin/main` included its foreground refresh plus both WebSocket reconciliations. This change returned both changed tasks immediately and completed one WebSocket reconciliation.

- current `origin/main`: 1,285.543 ms median, 1,366.933 ms p95
- this change: 108.588 ms median, 241.318 ms p95
- median reduction: 91.6%

No durable benchmark framework or fixture is added.

Fixes #807
