### PR TITLE
BACK-557 - Treat same-path cross-branch task versions as one identity

### DIFF
--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 18:00'
+updated_date: '2026-07-30 18:21'
 labels:
   - browser
   - git
@@ -46,6 +46,8 @@ Browser single-task reads currently return 409 when one canonical task ID exists
 3. Run focused server tests plus duplicate-repair, ID-generation, remote-conflict, and worktree-allocation coverage; run type-check, Biome, diff checks, and the full test suite, then simplify only if it reduces now-unused collision machinery without widening behavior.
 
 4. Review correction cycle 1: add endpoint regressions for a same-path padded ID variant and a distinct-path origin/main version; canonicalize cross-branch merge keys before store resolution, preserve full remote ref identity in branch state, and verify focused plus full coverage.
+
+5. Review correction cycle 2: reproduce the Core/MCP failure when most-progressed selects a same-path padded ID variant, add Core.getTask and task_archive regressions, then make the local/store identity comparison canonical and keep the current working copy authoritative before running focused and full verification.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -65,4 +67,15 @@ Review correction cycle 1:
 - Preserved full active remote ref identity (for example origin/main) in branch state while leaving hydrated task display branches unchanged, so a distinct-path origin/main collision remains fail-closed with 409.
 - Added endpoint regressions first and observed both fail before implementation; both pass after the fixes.
 - Verification: manual endpoint reproduction returned 200/local for the same-path variant and 409 for the distinct-path origin/main collision; focused branch/server suite 40 pass, 0 fail; broader duplicate/core/statistics suite 151 pass, 0 fail; full suite 1780 pass, 4 skip, 0 fail; bunx tsc --noEmit passed; bun run check . passed.
+
+Review correction cycle 2:
+- Reproduced against 73b442d1: with local BACK-1 in To Do and same-path active-branch BACK-001 in Done under most_progressed resolution, the merged store selected BACK-001 and Core.getTask("BACK-1") threw AmbiguousTaskIdError.
+- Added Core and MCP archive regressions first; both failed before production changes. Core now compares local/store identities with taskIdsEqual, reuses the existing active-branch path collision check, and returns the authoritative local task only when the canonical identity and normalized path agree.
+- Added a protective Core regression proving that the same padded identity at a distinct active path still throws; it failed before the path guard and passes afterward. MCP task_archive now mutates the local To Do task in the same-path case without weakening distinct-path or duplicate ambiguity handling.
+- Verification: standalone reproduction resolves BACK-1 to the local version; new Core/MCP regressions pass; server identity suite 21 pass, 0 fail; Core/MCP/identity/remote suite 99 pass, 0 fail; full suite 1783 pass, 4 skip, 0 fail across 199 files; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
+
+Origin integration before final re-review:
+- Fetched and rebased the three unpushed BACK-557 commits onto origin/main fef6e763 (BACK-560 loopback binding). The rebase completed without conflicts or manual executable-code resolution.
+- Confirmed BACK-560 remains intact: the server binds/displays 127.0.0.1 and BACK-557 changes only the task identity comparison in the overlapping server file.
+- Rebased verification: new Core/MCP regressions 3 pass; server identity suite 21 pass; Core/MCP/identity/remote suite 99 pass; BACK-560 hostname/port suite 12 pass; TypeScript, Biome, and diff checks passed. The full suite was not rerun because the rebase had no conflict resolution or manual executable changes.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-557
 title: Treat same-path cross-branch task versions as one identity
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-08-01 10:51'
+updated_date: '2026-08-01 10:57'
 labels:
   - browser
   - git
@@ -39,15 +39,15 @@ Cross-branch task loading currently folds display selection, lifecycle state, co
 <!-- AC:BEGIN -->
 - [x] #1 Same canonical ID at the same normalized path across local and branch versions resolves as one identity, with the working copy authoritative.
 - [x] #2 The same canonical ID at distinct local paths fails closed.
-- [ ] #3 Branch-only variants of the same canonical ID at distinct paths fail closed.
-- [ ] #4 An active local identity plus a completed identity at a distinct path fails closed.
+- [x] #3 Branch-only variants of the same canonical ID at distinct paths fail closed.
+- [x] #4 An active local identity plus a completed identity at a distinct path fails closed.
 - [x] #5 An active working-copy record plus an archived version at the same logical path remains active and keeps the ID occupied.
 - [x] #6 An identity whose variants are all archived is hidden and its ID is reusable.
 - [x] #7 Equal timestamps for active and archived records resolve deterministically, remain scan-order independent, and cannot free an ID while a live record exists.
-- [ ] #8 includeCompleted preserves active canonical state and agrees with All Tasks and task detail resolution.
+- [x] #8 includeCompleted preserves active canonical state and agrees with All Tasks and task detail resolution.
 - [x] #9 Padded IDs at distinct paths fail closed consistently across supported surfaces.
 - [x] #10 Allocation compares IDs without padding while preserving the configured or existing output spelling.
-- [ ] #11 Core getTask applies collision safety without requiring a stale prior load.
+- [x] #11 Core getTask applies collision safety without requiring a stale prior load.
 - [x] #12 Nested project and backlog directories normalize local and Git paths into one repository-relative logical path.
 <!-- AC:END -->
 
@@ -55,7 +55,7 @@ Cross-branch task loading currently folds display selection, lifecycle state, co
 <!-- DOD:BEGIN -->
 - [x] #1 bunx tsc --noEmit passes when TypeScript touched
 - [x] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -83,4 +83,12 @@ Final exact-head verification on 27c1cc5d after rebasing onto origin/main deedb4
 Fresh exact-head independent review cycle 1 requested changes before push. P1: Core.getTask/MCP detail and mutation reads can reuse a stale task identity index after branch refs change, unlike the browser path that explicitly refreshes. P2: branch hydration still chooses one record per raw ID spelling, so includeCompleted/statistics can omit other branch-only logical-path identities with the same spelling. Reopened to add RED coverage and fix freshness plus per-logical-path hydration centrally.
 
 Review cycle 1 RED/GREEN: on 0e284a8e, three focused regressions all failed—long-lived Core getTask resolved after a late branch collision, MCP task_edit mutated the local task after the same late collision, and same-spelling branch-only active/completed identities returned only the completed task. Core freshness is now centralized in getTask with coalesced fingerprint refresh; loadTaskById, detail views, updates, archive, complete, and demote validate through that result. Branch hydration supplements the prior display winner with one deterministic candidate per canonical ID plus logical path, using shared lifecycle-path normalization. The three regressions pass, the broader Core/MCP/server/board/branch/allocation/index suite passes 135/135, the demote/freshness subset passes 4/4, and tsc, Biome (342 files), and diff-check are clean.
+
+Final review-cycle-1 verification on 571fc63f: bun test passed 1,808 tests with 4 documented interactive TUI skips and 0 failures across 202 files (7,657 assertions); bunx tsc --noEmit passed; bun run check . checked 342 files with no fixes; git diff --check passed. origin/main remains deedb4e0, the integration base used by this branch.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Introduced one shared task identity index keyed by padding-insensitive canonical ID plus normalized repository-relative logical path. Local, branch, worktree, completed, and archive records share deterministic working-copy/lifecycle/display rules; distinct live paths fail closed; any live variant occupies the ID and all-archived identities are reusable. Core freshness is checked at the central resolver for long-lived CLI, MCP, and browser reads/mutations, while branch hydration preserves one candidate per logical identity so includeCompleted and statistics cannot omit same-spelling distinct paths. Regression coverage spans late ref changes, branch-only and padded collisions, lifecycle shadows, equal timestamps, direct reads, mutation safety, allocation, and nested custom backlog paths.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-557
 title: Treat same-path cross-branch task versions as one identity
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 18:56'
+updated_date: '2026-08-01 10:26'
 labels:
   - browser
   - git
@@ -20,76 +20,49 @@ ordinal: 202000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Browser single-task reads currently return 409 when one canonical task ID exists at the same project-relative active-task path across refs but the file bytes differ. This includes normal browser saves, dirty working-copy edits, and branches carrying newer versions of the same task. Treat content as version state rather than identity, preserve the current working copy as authoritative, and retain ambiguity protection for distinct task locations and canonical ID collisions.
+Cross-branch task loading currently folds display selection, lifecycle state, collision detection, and ID occupancy independently. Treat each task identity as one canonical ID plus one normalized repository-relative logical task path. Versions at the same path resolve as one identity with working-copy authority, while live identities at distinct paths remain ambiguous and fail closed across CLI, MCP, browser, statistics, lifecycle, and allocation surfaces.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 With checkActiveBranches enabled, saving a task through the browser and immediately reopening it succeeds when active refs contain the same ID at the same project-relative task path; the local working-copy content is returned.
-- [x] #2 Divergent versions of the same canonical ID at the same task path across active local or remote refs resolve as one task, while branch-only cross-branch visibility remains intact.
-- [x] #3 The same normalized ID at distinct active task paths, or multiple matching local active or completed files, still fails closed with 409.
-- [x] #4 Incremental task allocation and archive-as-soft-delete semantics remain unchanged; archived IDs remain reusable.
+- [ ] #1 Same canonical ID at the same normalized path across local and branch versions resolves as one identity, with the working copy authoritative.
+- [ ] #2 The same canonical ID at distinct local paths fails closed.
+- [ ] #3 Branch-only variants of the same canonical ID at distinct paths fail closed.
+- [ ] #4 An active local identity plus a completed identity at a distinct path fails closed.
+- [ ] #5 An active working-copy record plus an archived version at the same logical path remains active and keeps the ID occupied.
+- [ ] #6 An identity whose variants are all archived is hidden and its ID is reusable.
+- [ ] #7 Equal timestamps for active and archived records resolve deterministically, remain scan-order independent, and cannot free an ID while a live record exists.
+- [ ] #8 includeCompleted preserves active canonical state and agrees with All Tasks and task detail resolution.
+- [ ] #9 Padded IDs at distinct paths fail closed consistently across supported surfaces.
+- [ ] #10 Allocation compares IDs without padding while preserving the configured or existing output spelling.
+- [ ] #11 Core getTask applies collision safety without requiring a stale prior load.
+- [ ] #12 Nested project and backlog directories normalize local and Git paths into one repository-relative logical path.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [x] #1 bunx tsc --noEmit passes when TypeScript touched
-- [x] #2 bun run check . passes when formatting/linting touched
-- [x] #3 bun test (or scoped test) passes
+- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Update server regressions first: same-ID same-path numeric and legacy variants must reopen the current working copy, and a browser save on a task inherited by an active branch must remain readable; keep padded/different-path collisions and branch-only visibility coverage fail-closed.
-2. Replace blob-content comparison in active-branch collision detection with normalized project-relative active-task path comparison, preserving multiple-local-file guards and the server’s current-worktree-authoritative response.
-3. Run focused server tests plus duplicate-repair, ID-generation, remote-conflict, and worktree-allocation coverage; run type-check, Biome, diff checks, and the full test suite, then simplify only if it reduces now-unused collision machinery without widening behavior.
-
-4. Review correction cycle 1: add endpoint regressions for a same-path padded ID variant and a distinct-path origin/main version; canonicalize cross-branch merge keys before store resolution, preserve full remote ref identity in branch state, and verify focused plus full coverage.
-
-5. Review correction cycle 2: reproduce the Core/MCP failure when most-progressed selects a same-path padded ID variant, add Core.getTask and task_archive regressions, then make the local/store identity comparison canonical and keep the current working copy authoritative before running focused and full verification.
-
-6. Reproduce automatic review findings for branch-only distinct-path canonical collisions and padded same-path lifecycle snapshots; fix each with failing regressions, rerun focused and full validation, and publish a corrected head.
+1. Add RED regressions on exact PR head 5026e3bb for lifecycle-hidden collisions, equal-time active versus archive allocation, and includeCompleted active versus completed collisions; map the remaining bounded matrix to existing or new public-surface tests.
+2. Add one internal task identity index keyed by canonical ID and normalized repository-relative logical task path. Each record carries lifecycle state, provenance, timestamp, working-copy authority, and optional hydrated task content; define deterministic tie rules and monotone occupancy there.
+3. Adapt branch record collection so hydrated versions stay attached to the indexed path, then replace the separate canonical maps and lifecycle filters in loadTasks, statistics loading, allocation, direct Core getTask, and active-branch collision checks with projections from the shared index.
+4. Route browser task detail through Core identity resolution and preserve local upsert behavior; verify MCP reads and mutations use the same Core result without weakening duplicate protection.
+5. Complete the 12-case proof matrix, including padded IDs, all-archived reuse, direct getTask, and a nested project/custom backlog path; rebase safely onto current origin/main and preserve BACK-560 loopback behavior.
+6. Run focused identity, Core, MCP, server, Web, lifecycle, allocation, and remote suites, then full bun test, TypeScript, Biome, and git diff checks. Simplify duplicate folds, finalize BACK-557 through the CLI, obtain one fresh exact-head review, and only then publish the corrected regular PR head.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented path-based cross-branch task identity: matching canonical IDs at the same normalized project-relative active-task path now resolve to the current working-copy task regardless of content differences. Distinct active paths and multiple local matches remain ambiguous.
+Reopened after automatic review on 5026e3bb found three root-cause symptoms: lifecycle filtering can hide a collision before the guard runs, equal active/archive timestamps depend on scan order and can free a live ID, and includeCompleted can replace active canonical state. The correction is re-scoped to one shared identity index rather than another set of per-surface conditions.
 
-Removed blob/tree metadata collection and the now-unused Git tree-entry API; branch scans still pin refs to commits and the ref-move retry coverage remains intact.
+RED evidence on exact PR head 5026e3bb: focused Core run executed three new public-API regressions and all failed for the intended reasons. Lifecycle-hidden collision resolved the local task instead of throwing AmbiguousTaskIdError; equal-time active/archive branch records generated BACK-1 instead of BACK-2; includeCompleted returned no distinct active/completed identities instead of preserving both paths.
 
-Regression proof: the new server expectations failed with 409 before the implementation for divergent numeric same-path, divergent legacy same-path, and browser save then reopen on an inherited branch task. After the change, same-path reads return 200 with local content while the padded different-path fixture remains 409.
-
-Verification: bunx tsc --noEmit; bun run check .; focused 44-test loader/server/Git suite; adjacent 38-test duplicate/ID/archive/worktree/remote suite; full bun test (1778 pass, 4 skip, 0 fail across 199 files).
-
-Review correction cycle 1:
-- Reproduced both reviewer findings against commit 8bb86f71 through the real task endpoint: a local BACK-1 plus active-branch BACK-001 at the same normalized project-relative path returned 409, while a local main task plus active origin/main task with the same ID at a distinct path returned the local task.
-- Canonicalized task IDs before cross-branch store merging and used normalized ID comparison when matching the local task to the store result, so same-path normalized-ID variants resolve to the local task.
-- Preserved full active remote ref identity (for example origin/main) in branch state while leaving hydrated task display branches unchanged, so a distinct-path origin/main collision remains fail-closed with 409.
-- Added endpoint regressions first and observed both fail before implementation; both pass after the fixes.
-- Verification: manual endpoint reproduction returned 200/local for the same-path variant and 409 for the distinct-path origin/main collision; focused branch/server suite 40 pass, 0 fail; broader duplicate/core/statistics suite 151 pass, 0 fail; full suite 1780 pass, 4 skip, 0 fail; bunx tsc --noEmit passed; bun run check . passed.
-
-Review correction cycle 2:
-- Reproduced against 73b442d1: with local BACK-1 in To Do and same-path active-branch BACK-001 in Done under most_progressed resolution, the merged store selected BACK-001 and Core.getTask("BACK-1") threw AmbiguousTaskIdError.
-- Added Core and MCP archive regressions first; both failed before production changes. Core now compares local/store identities with taskIdsEqual, reuses the existing active-branch path collision check, and returns the authoritative local task only when the canonical identity and normalized path agree.
-- Added a protective Core regression proving that the same padded identity at a distinct active path still throws; it failed before the path guard and passes afterward. MCP task_archive now mutates the local To Do task in the same-path case without weakening distinct-path or duplicate ambiguity handling.
-- Verification: standalone reproduction resolves BACK-1 to the local version; new Core/MCP regressions pass; server identity suite 21 pass, 0 fail; Core/MCP/identity/remote suite 99 pass, 0 fail; full suite 1783 pass, 4 skip, 0 fail across 199 files; bunx tsc --noEmit passed; bun run check . passed; git diff --check passed.
-
-Origin integration before final re-review:
-- Fetched and rebased the three unpushed BACK-557 commits onto origin/main fef6e763 (BACK-560 loopback binding). The rebase completed without conflicts or manual executable-code resolution.
-- Confirmed BACK-560 remains intact: the server binds/displays 127.0.0.1 and BACK-557 changes only the task identity comparison in the overlapping server file.
-- Rebased verification: new Core/MCP regressions 3 pass; server identity suite 21 pass; Core/MCP/identity/remote suite 99 pass; BACK-560 hostname/port suite 12 pass; TypeScript, Biome, and diff checks passed. The full suite was not rerun because the rebase had no conflict resolution or manual executable changes.
-
-Finalization validation on rebased origin/main tree bec40718: bun test completed with 1786 pass, 4 skip, 0 fail across 200 files; bunx tsc --noEmit passed; bun run check . passed. Focused evidence also covered browser save/reopen, same-path local and remote variants, distinct-path and duplicate ambiguity, Core and MCP mutation behavior, ID allocation, and archive soft-delete behavior.
-
-Automatic Codex review on 77df29dc identified two unresolved identity edge cases: branch-only canonical variants at distinct paths can be collapsed before ambiguity checking, and lifecycle state lookups can miss padded same-path variants. Reopened for test-first correction before merge.
-
-Approved correction cycle 3: branch-only canonical variants at distinct active paths now run through the existing path collision guard and fail closed. Lifecycle state maps and direct lookups use canonical IDs, so newer archive and completed snapshots apply to padded same-path variants; ID allocation still consumes the selected entry's original spelling to preserve zero padding. TDD evidence: the branch-only and archive regressions failed on 77df29dc, and the completed-source regression failed before its direct lookups were canonicalized. Validation: 5 identity/lifecycle cases passed; focused Core, MCP, server, branch, statistics, board, allocation, and remote suite 135 pass; zero-padding and identity follow-up 9 pass; full suite 1789 pass, 4 skip, 0 fail across 200 files; bunx tsc --noEmit, bun run check ., and git diff --check passed.
+GREEN evidence before integration: 197 focused tests pass across the shared index, Core identity/lifecycle/allocation cases, MCP/statistics/board/unified views, and browser/server/Web/search routes. bunx tsc --noEmit, bun run check ., and git diff --check are clean. The simplification pass removed the former per-surface canonical maps, lifecycle filters, and duplicate branch-collision helper in favor of TaskIdentityIndex projections.
 <!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Applied canonical task identity consistently to branch-only collision checks and lifecycle snapshots. Branch-only distinct paths now fail closed, while newer archived or completed states apply to padded same-path variants without changing zero-padded ID allocation. Verified with focused Core, MCP, browser, branch, lifecycle, allocation, and remote tests plus the full suite (1789 pass, 4 skip, 0 fail), TypeScript, Biome, and diff checks.
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-557
 title: Treat same-path cross-branch task versions as one identity
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-08-01 10:39'
+updated_date: '2026-08-01 10:51'
 labels:
   - browser
   - git
@@ -39,15 +39,15 @@ Cross-branch task loading currently folds display selection, lifecycle state, co
 <!-- AC:BEGIN -->
 - [x] #1 Same canonical ID at the same normalized path across local and branch versions resolves as one identity, with the working copy authoritative.
 - [x] #2 The same canonical ID at distinct local paths fails closed.
-- [x] #3 Branch-only variants of the same canonical ID at distinct paths fail closed.
-- [x] #4 An active local identity plus a completed identity at a distinct path fails closed.
+- [ ] #3 Branch-only variants of the same canonical ID at distinct paths fail closed.
+- [ ] #4 An active local identity plus a completed identity at a distinct path fails closed.
 - [x] #5 An active working-copy record plus an archived version at the same logical path remains active and keeps the ID occupied.
 - [x] #6 An identity whose variants are all archived is hidden and its ID is reusable.
 - [x] #7 Equal timestamps for active and archived records resolve deterministically, remain scan-order independent, and cannot free an ID while a live record exists.
-- [x] #8 includeCompleted preserves active canonical state and agrees with All Tasks and task detail resolution.
+- [ ] #8 includeCompleted preserves active canonical state and agrees with All Tasks and task detail resolution.
 - [x] #9 Padded IDs at distinct paths fail closed consistently across supported surfaces.
 - [x] #10 Allocation compares IDs without padding while preserving the configured or existing output spelling.
-- [x] #11 Core getTask applies collision safety without requiring a stale prior load.
+- [ ] #11 Core getTask applies collision safety without requiring a stale prior load.
 - [x] #12 Nested project and backlog directories normalize local and Git paths into one repository-relative logical path.
 <!-- AC:END -->
 
@@ -55,7 +55,7 @@ Cross-branch task loading currently folds display selection, lifecycle state, co
 <!-- DOD:BEGIN -->
 - [x] #1 bunx tsc --noEmit passes when TypeScript touched
 - [x] #2 bun run check . passes when formatting/linting touched
-- [x] #3 bun test (or scoped test) passes
+- [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -79,10 +79,8 @@ RED evidence on exact PR head 5026e3bb: focused Core run executed three new publ
 GREEN evidence before integration: 197 focused tests pass across the shared index, Core identity/lifecycle/allocation cases, MCP/statistics/board/unified views, and browser/server/Web/search routes. bunx tsc --noEmit, bun run check ., and git diff --check are clean. The simplification pass removed the former per-surface canonical maps, lifecycle filters, and duplicate branch-collision helper in favor of TaskIdentityIndex projections.
 
 Final exact-head verification on 27c1cc5d after rebasing onto origin/main deedb4e0: bun test passed 1,805 tests with 4 documented interactive TUI skips and 0 failures across 202 files (7,647 assertions); bunx tsc --noEmit passed; bun run check . checked 342 files with no fixes; git diff --check passed. A first full run exposed only two established progress-callback compatibility expectations; preserving the branch-scan message under the original checkActiveBranches gate made the isolated board-loading file 10/10 green before the clean full rerun.
+
+Fresh exact-head independent review cycle 1 requested changes before push. P1: Core.getTask/MCP detail and mutation reads can reuse a stale task identity index after branch refs change, unlike the browser path that explicitly refreshes. P2: branch hydration still chooses one record per raw ID spelling, so includeCompleted/statistics can omit other branch-only logical-path identities with the same spelling. Reopened to add RED coverage and fix freshness plus per-logical-path hydration centrally.
+
+Review cycle 1 RED/GREEN: on 0e284a8e, three focused regressions all failed—long-lived Core getTask resolved after a late branch collision, MCP task_edit mutated the local task after the same late collision, and same-spelling branch-only active/completed identities returned only the completed task. Core freshness is now centralized in getTask with coalesced fingerprint refresh; loadTaskById, detail views, updates, archive, complete, and demote validate through that result. Branch hydration supplements the prior display winner with one deterministic candidate per canonical ID plus logical path, using shared lifecycle-path normalization. The three regressions pass, the broader Core/MCP/server/board/branch/allocation/index suite passes 135/135, the demote/freshness subset passes 4/4, and tsc, Biome (342 files), and diff-check are clean.
 <!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Introduced one shared task identity index keyed by padding-insensitive canonical ID plus normalized repository-relative logical path. Local, branch, worktree, completed, and archive records now share deterministic working-copy/lifecycle/display rules; distinct live paths fail closed; allocation remains occupied by any live variant and frees all-archived identities. Core, MCP, browser, statistics, and task-loading paths use the shared result, with regression coverage for branch-only and padded collisions, lifecycle shadows, equal timestamps, includeCompleted, direct fresh reads, and nested custom backlog paths.
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-557
 title: Treat same-path cross-branch task versions as one identity
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-30 17:11'
+updated_date: '2026-07-30 17:28'
 labels:
   - browser
   - git
@@ -35,3 +37,23 @@ Browser single-task reads currently return 409 when one canonical task ID exists
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Update server regressions first: same-ID same-path numeric and legacy variants must reopen the current working copy, and a browser save on a task inherited by an active branch must remain readable; keep padded/different-path collisions and branch-only visibility coverage fail-closed.
+2. Replace blob-content comparison in active-branch collision detection with normalized project-relative active-task path comparison, preserving multiple-local-file guards and the server’s current-worktree-authoritative response.
+3. Run focused server tests plus duplicate-repair, ID-generation, remote-conflict, and worktree-allocation coverage; run type-check, Biome, diff checks, and the full test suite, then simplify only if it reduces now-unused collision machinery without widening behavior.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented path-based cross-branch task identity: matching canonical IDs at the same normalized project-relative active-task path now resolve to the current working-copy task regardless of content differences. Distinct active paths and multiple local matches remain ambiguous.
+
+Removed blob/tree metadata collection and the now-unused Git tree-entry API; branch scans still pin refs to commits and the ref-move retry coverage remains intact.
+
+Regression proof: the new server expectations failed with 409 before the implementation for divergent numeric same-path, divergent legacy same-path, and browser save then reopen on an inherited branch task. After the change, same-path reads return 200 with local content while the padded different-path fixture remains 409.
+
+Verification: bunx tsc --noEmit; bun run check .; focused 44-test loader/server/Git suite; adjacent 38-test duplicate/ID/archive/worktree/remote suite; full bun test (1778 pass, 4 skip, 0 fail across 199 files).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 17:28'
+updated_date: '2026-07-30 18:00'
 labels:
   - browser
   - git
@@ -44,6 +44,8 @@ Browser single-task reads currently return 409 when one canonical task ID exists
 1. Update server regressions first: same-ID same-path numeric and legacy variants must reopen the current working copy, and a browser save on a task inherited by an active branch must remain readable; keep padded/different-path collisions and branch-only visibility coverage fail-closed.
 2. Replace blob-content comparison in active-branch collision detection with normalized project-relative active-task path comparison, preserving multiple-local-file guards and the server’s current-worktree-authoritative response.
 3. Run focused server tests plus duplicate-repair, ID-generation, remote-conflict, and worktree-allocation coverage; run type-check, Biome, diff checks, and the full test suite, then simplify only if it reduces now-unused collision machinery without widening behavior.
+
+4. Review correction cycle 1: add endpoint regressions for a same-path padded ID variant and a distinct-path origin/main version; canonicalize cross-branch merge keys before store resolution, preserve full remote ref identity in branch state, and verify focused plus full coverage.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -56,4 +58,11 @@ Removed blob/tree metadata collection and the now-unused Git tree-entry API; bra
 Regression proof: the new server expectations failed with 409 before the implementation for divergent numeric same-path, divergent legacy same-path, and browser save then reopen on an inherited branch task. After the change, same-path reads return 200 with local content while the padded different-path fixture remains 409.
 
 Verification: bunx tsc --noEmit; bun run check .; focused 44-test loader/server/Git suite; adjacent 38-test duplicate/ID/archive/worktree/remote suite; full bun test (1778 pass, 4 skip, 0 fail across 199 files).
+
+Review correction cycle 1:
+- Reproduced both reviewer findings against commit 8bb86f71 through the real task endpoint: a local BACK-1 plus active-branch BACK-001 at the same normalized project-relative path returned 409, while a local main task plus active origin/main task with the same ID at a distinct path returned the local task.
+- Canonicalized task IDs before cross-branch store merging and used normalized ID comparison when matching the local task to the store result, so same-path normalized-ID variants resolve to the local task.
+- Preserved full active remote ref identity (for example origin/main) in branch state while leaving hydrated task display branches unchanged, so a distinct-path origin/main collision remains fail-closed with 409.
+- Added endpoint regressions first and observed both fail before implementation; both pass after the fixes.
+- Verification: manual endpoint reproduction returned 200/local for the same-path variant and 409 for the distinct-path origin/main collision; focused branch/server suite 40 pass, 0 fail; broader duplicate/core/statistics suite 151 pass, 0 fail; full suite 1780 pass, 4 skip, 0 fail; bunx tsc --noEmit passed; bun run check . passed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-557
 title: Treat same-path cross-branch task versions as one identity
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 18:21'
+updated_date: '2026-07-30 18:28'
 labels:
   - browser
   - git
@@ -25,17 +25,17 @@ Browser single-task reads currently return 409 when one canonical task ID exists
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With checkActiveBranches enabled, saving a task through the browser and immediately reopening it succeeds when active refs contain the same ID at the same project-relative task path; the local working-copy content is returned.
-- [ ] #2 Divergent versions of the same canonical ID at the same task path across active local or remote refs resolve as one task, while branch-only cross-branch visibility remains intact.
-- [ ] #3 The same normalized ID at distinct active task paths, or multiple matching local active or completed files, still fails closed with 409.
-- [ ] #4 Incremental task allocation and archive-as-soft-delete semantics remain unchanged; archived IDs remain reusable.
+- [x] #1 With checkActiveBranches enabled, saving a task through the browser and immediately reopening it succeeds when active refs contain the same ID at the same project-relative task path; the local working-copy content is returned.
+- [x] #2 Divergent versions of the same canonical ID at the same task path across active local or remote refs resolve as one task, while branch-only cross-branch visibility remains intact.
+- [x] #3 The same normalized ID at distinct active task paths, or multiple matching local active or completed files, still fails closed with 409.
+- [x] #4 Incremental task allocation and archive-as-soft-delete semantics remain unchanged; archived IDs remain reusable.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -78,4 +78,12 @@ Origin integration before final re-review:
 - Fetched and rebased the three unpushed BACK-557 commits onto origin/main fef6e763 (BACK-560 loopback binding). The rebase completed without conflicts or manual executable-code resolution.
 - Confirmed BACK-560 remains intact: the server binds/displays 127.0.0.1 and BACK-557 changes only the task identity comparison in the overlapping server file.
 - Rebased verification: new Core/MCP regressions 3 pass; server identity suite 21 pass; Core/MCP/identity/remote suite 99 pass; BACK-560 hostname/port suite 12 pass; TypeScript, Biome, and diff checks passed. The full suite was not rerun because the rebase had no conflict resolution or manual executable changes.
+
+Finalization validation on rebased origin/main tree bec40718: bun test completed with 1786 pass, 4 skip, 0 fail across 200 files; bunx tsc --noEmit passed; bun run check . passed. Focused evidence also covered browser save/reopen, same-path local and remote variants, distinct-path and duplicate ambiguity, Core and MCP mutation behavior, ID allocation, and archive soft-delete behavior.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Changed active-branch task identity to use the canonical task ID together with the normalized project-relative task path. Same-path versions now reopen and mutate the current working-copy task, while genuinely different paths and duplicate local files still fail closed. Verified with focused browser, Core, MCP, branch, remote, allocation, and archive tests plus the full suite (1786 pass, 4 skip, 0 fail), TypeScript, and Biome.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-07-30 18:28'
+updated_date: '2026-07-30 18:56'
 labels:
   - browser
   - git
@@ -48,6 +48,8 @@ Browser single-task reads currently return 409 when one canonical task ID exists
 4. Review correction cycle 1: add endpoint regressions for a same-path padded ID variant and a distinct-path origin/main version; canonicalize cross-branch merge keys before store resolution, preserve full remote ref identity in branch state, and verify focused plus full coverage.
 
 5. Review correction cycle 2: reproduce the Core/MCP failure when most-progressed selects a same-path padded ID variant, add Core.getTask and task_archive regressions, then make the local/store identity comparison canonical and keep the current working copy authoritative before running focused and full verification.
+
+6. Reproduce automatic review findings for branch-only distinct-path canonical collisions and padded same-path lifecycle snapshots; fix each with failing regressions, rerun focused and full validation, and publish a corrected head.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -80,10 +82,14 @@ Origin integration before final re-review:
 - Rebased verification: new Core/MCP regressions 3 pass; server identity suite 21 pass; Core/MCP/identity/remote suite 99 pass; BACK-560 hostname/port suite 12 pass; TypeScript, Biome, and diff checks passed. The full suite was not rerun because the rebase had no conflict resolution or manual executable changes.
 
 Finalization validation on rebased origin/main tree bec40718: bun test completed with 1786 pass, 4 skip, 0 fail across 200 files; bunx tsc --noEmit passed; bun run check . passed. Focused evidence also covered browser save/reopen, same-path local and remote variants, distinct-path and duplicate ambiguity, Core and MCP mutation behavior, ID allocation, and archive soft-delete behavior.
+
+Automatic Codex review on 77df29dc identified two unresolved identity edge cases: branch-only canonical variants at distinct paths can be collapsed before ambiguity checking, and lifecycle state lookups can miss padded same-path variants. Reopened for test-first correction before merge.
+
+Approved correction cycle 3: branch-only canonical variants at distinct active paths now run through the existing path collision guard and fail closed. Lifecycle state maps and direct lookups use canonical IDs, so newer archive and completed snapshots apply to padded same-path variants; ID allocation still consumes the selected entry's original spelling to preserve zero padding. TDD evidence: the branch-only and archive regressions failed on 77df29dc, and the completed-source regression failed before its direct lookups were canonicalized. Validation: 5 identity/lifecycle cases passed; focused Core, MCP, server, branch, statistics, board, allocation, and remote suite 135 pass; zero-padding and identity follow-up 9 pass; full suite 1789 pass, 4 skip, 0 fail across 200 files; bunx tsc --noEmit, bun run check ., and git diff --check passed.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Changed active-branch task identity to use the canonical task ID together with the normalized project-relative task path. Same-path versions now reopen and mutate the current working-copy task, while genuinely different paths and duplicate local files still fail closed. Verified with focused browser, Core, MCP, branch, remote, allocation, and archive tests plus the full suite (1786 pass, 4 skip, 0 fail), TypeScript, and Biome.
+Applied canonical task identity consistently to branch-only collision checks and lifecycle snapshots. Branch-only distinct paths now fail closed, while newer archived or completed states apply to padded same-path variants without changing zero-padded ID allocation. Verified with focused Core, MCP, browser, branch, lifecycle, allocation, and remote tests plus the full suite (1789 pass, 4 skip, 0 fail), TypeScript, Biome, and diff checks.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
+++ b/backlog/tasks/back-557 - Treat-same-path-cross-branch-task-versions-as-one-identity.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-557
 title: Treat same-path cross-branch task versions as one identity
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:11'
-updated_date: '2026-08-01 10:26'
+updated_date: '2026-08-01 10:39'
 labels:
   - browser
   - git
@@ -13,6 +13,18 @@ dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/818'
   - 'https://github.com/MrLesk/Backlog.md/issues/783'
+modified_files:
+  - src/core/backlog.ts
+  - src/core/task-identity-index.ts
+  - src/core/task-loader.ts
+  - src/git/operations.ts
+  - src/server/index.ts
+  - src/test/core.test.ts
+  - src/test/local-branch-tasks.test.ts
+  - src/test/mcp-tasks.test.ts
+  - src/test/server-tasks-spa-fallback.test.ts
+  - src/test/task-identity-index.test.ts
+  - src/test/test-utils.ts
 type: bug
 ordinal: 202000
 ---
@@ -25,25 +37,25 @@ Cross-branch task loading currently folds display selection, lifecycle state, co
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Same canonical ID at the same normalized path across local and branch versions resolves as one identity, with the working copy authoritative.
-- [ ] #2 The same canonical ID at distinct local paths fails closed.
-- [ ] #3 Branch-only variants of the same canonical ID at distinct paths fail closed.
-- [ ] #4 An active local identity plus a completed identity at a distinct path fails closed.
-- [ ] #5 An active working-copy record plus an archived version at the same logical path remains active and keeps the ID occupied.
-- [ ] #6 An identity whose variants are all archived is hidden and its ID is reusable.
-- [ ] #7 Equal timestamps for active and archived records resolve deterministically, remain scan-order independent, and cannot free an ID while a live record exists.
-- [ ] #8 includeCompleted preserves active canonical state and agrees with All Tasks and task detail resolution.
-- [ ] #9 Padded IDs at distinct paths fail closed consistently across supported surfaces.
-- [ ] #10 Allocation compares IDs without padding while preserving the configured or existing output spelling.
-- [ ] #11 Core getTask applies collision safety without requiring a stale prior load.
-- [ ] #12 Nested project and backlog directories normalize local and Git paths into one repository-relative logical path.
+- [x] #1 Same canonical ID at the same normalized path across local and branch versions resolves as one identity, with the working copy authoritative.
+- [x] #2 The same canonical ID at distinct local paths fails closed.
+- [x] #3 Branch-only variants of the same canonical ID at distinct paths fail closed.
+- [x] #4 An active local identity plus a completed identity at a distinct path fails closed.
+- [x] #5 An active working-copy record plus an archived version at the same logical path remains active and keeps the ID occupied.
+- [x] #6 An identity whose variants are all archived is hidden and its ID is reusable.
+- [x] #7 Equal timestamps for active and archived records resolve deterministically, remain scan-order independent, and cannot free an ID while a live record exists.
+- [x] #8 includeCompleted preserves active canonical state and agrees with All Tasks and task detail resolution.
+- [x] #9 Padded IDs at distinct paths fail closed consistently across supported surfaces.
+- [x] #10 Allocation compares IDs without padding while preserving the configured or existing output spelling.
+- [x] #11 Core getTask applies collision safety without requiring a stale prior load.
+- [x] #12 Nested project and backlog directories normalize local and Git paths into one repository-relative logical path.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -65,4 +77,12 @@ Reopened after automatic review on 5026e3bb found three root-cause symptoms: lif
 RED evidence on exact PR head 5026e3bb: focused Core run executed three new public-API regressions and all failed for the intended reasons. Lifecycle-hidden collision resolved the local task instead of throwing AmbiguousTaskIdError; equal-time active/archive branch records generated BACK-1 instead of BACK-2; includeCompleted returned no distinct active/completed identities instead of preserving both paths.
 
 GREEN evidence before integration: 197 focused tests pass across the shared index, Core identity/lifecycle/allocation cases, MCP/statistics/board/unified views, and browser/server/Web/search routes. bunx tsc --noEmit, bun run check ., and git diff --check are clean. The simplification pass removed the former per-surface canonical maps, lifecycle filters, and duplicate branch-collision helper in favor of TaskIdentityIndex projections.
+
+Final exact-head verification on 27c1cc5d after rebasing onto origin/main deedb4e0: bun test passed 1,805 tests with 4 documented interactive TUI skips and 0 failures across 202 files (7,647 assertions); bunx tsc --noEmit passed; bun run check . checked 342 files with no fixes; git diff --check passed. A first full run exposed only two established progress-callback compatibility expectations; preserving the branch-scan message under the original checkActiveBranches gate made the isolated board-loading file 10/10 green before the clean full rerun.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Introduced one shared task identity index keyed by padding-insensitive canonical ID plus normalized repository-relative logical path. Local, branch, worktree, completed, and archive records now share deterministic working-copy/lifecycle/display rules; distinct live paths fail closed; allocation remains occupied by any live variant and frees all-archived identities. Core, MCP, browser, statistics, and task-loading paths use the shared result, with regression coverage for branch-only and padded collisions, lifecycle shadows, equal timestamps, includeCompleted, direct fresh reads, and nested custom backlog paths.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -640,7 +640,8 @@ export class Core {
 	}
 
 	async getTask(taskId: string): Promise<Task | null> {
-		const localResolution = resolveTaskById(await this.fs.listTasks(), taskId);
+		const localTasks = await this.fs.listTasks();
+		const localResolution = resolveTaskById(localTasks, taskId);
 		if (localResolution.status === "invalid") {
 			return null;
 		}
@@ -666,15 +667,17 @@ export class Core {
 				resolution.tasks.map((task) => task.filePath ?? `${task.branch ?? "unknown branch"}:${task.id}`),
 			);
 		}
-		if (
-			localResolution.status === "found" &&
-			resolution.status === "found" &&
-			localResolution.task.id.toLowerCase() !== resolution.task.id.toLowerCase()
-		) {
-			throw new AmbiguousTaskIdError(taskId, [
-				localResolution.task.filePath ?? localResolution.task.id,
-				resolution.task.filePath ?? `${resolution.task.branch ?? "unknown branch"}:${resolution.task.id}`,
-			]);
+		if (localResolution.status === "found" && resolution.status === "found") {
+			if (
+				!taskIdsEqual(localResolution.task.id, resolution.task.id) ||
+				(await this.hasActiveBranchTaskIdCollision(taskId, localTasks))
+			) {
+				throw new AmbiguousTaskIdError(taskId, [
+					localResolution.task.filePath ?? localResolution.task.id,
+					resolution.task.filePath ?? `${resolution.task.branch ?? "unknown branch"}:${resolution.task.id}`,
+				]);
+			}
+			return localResolution.task;
 		}
 		if (resolution.status === "found") {
 			return resolution.task;

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -3070,7 +3070,9 @@ export class Core {
 		}
 		progressCallback?.("Loaded tasks");
 
-		progressCallback?.("Resolving task identities...");
+		if (config?.checkActiveBranches !== false) {
+			progressCallback?.("Applying latest task states from branch scans...");
+		}
 		const index = await this.buildTaskIdentityIndex(
 			localTasks,
 			completedTasks,
@@ -3167,7 +3169,9 @@ export class Core {
 			throw new Error("Loading cancelled");
 		}
 
-		progressCallback?.("Resolving task identities...");
+		if (config?.checkActiveBranches !== false) {
+			progressCallback?.("Applying latest task states from branch scans...");
+		}
 		const identityIndex = await this.buildTaskIdentityIndex(
 			localTasks,
 			completedTasks,

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -690,29 +690,17 @@ export class Core {
 			return false;
 		}
 
-		const branchPaths = new Map<string, Set<string>>();
+		const paths = new Set<string>();
 		for (const entry of branchMatches) {
-			const tree = entry.tree ?? entry.branch;
-			const paths = branchPaths.get(tree) ?? new Set<string>();
-			paths.add(entry.path);
-			branchPaths.set(tree, paths);
-			if (paths.size > 1) {
-				return true;
-			}
+			paths.add(entry.path.replaceAll("\\", "/"));
 		}
 
-		const identities = new Set(
-			branchMatches.map((entry) =>
-				entry.objectId ? `blob:${entry.objectId}` : `location:${entry.branch}\0${entry.path}`,
-			),
-		);
 		const localTask = localMatches[0];
-		if (localTask) {
-			const objectId = localTask.filePath ? await this.git.hashFile(localTask.filePath) : null;
-			identities.add(objectId ? `blob:${objectId}` : `local:${localTask.id}\0${localTask.filePath ?? ""}`);
+		if (localTask?.filePath) {
+			paths.add(relative(this.fs.rootDir, localTask.filePath).replaceAll("\\", "/"));
 		}
 
-		return identities.size > 1;
+		return paths.size > 1;
 	}
 
 	async getTaskWithSubtasks(taskId: string, localTasks?: Task[]): Promise<Task | null> {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -61,7 +61,6 @@ import {
 import { resolveTaskById } from "../utils/task-id.ts";
 import {
 	AmbiguousTaskIdError,
-	canonicalTaskId,
 	getDraftPath,
 	getTaskFilename,
 	getTaskPath,
@@ -83,6 +82,7 @@ import {
 import { migrateDraftPrefixes, needsDraftPrefixMigration } from "./prefix-migration.ts";
 import { calculateNewOrdinal, DEFAULT_ORDINAL_STEP, resolveOrdinalConflicts } from "./reorder.ts";
 import { SearchService } from "./search-service.ts";
+import { TaskIdentityIndex, type TaskIdentityRecord } from "./task-identity-index.ts";
 import {
 	type BranchTaskStateEntry,
 	findTaskInLocalBranches,
@@ -90,7 +90,6 @@ import {
 	getTaskLoadingMessage,
 	loadLocalBranchTasks,
 	loadRemoteTasks,
-	resolveTaskConflict,
 } from "./task-loader.ts";
 
 interface BlessedScreen {
@@ -186,58 +185,6 @@ function hasUpdatedDateRelevantChanges(originalTask: Task | null, nextTask: Task
 	);
 }
 
-function buildLatestStateMap(
-	stateEntries: BranchTaskStateEntry[] = [],
-	localTasks: Array<Task & { lastModified?: Date; updatedDate?: string }> = [],
-): Map<string, BranchTaskStateEntry> {
-	const latest = new Map<string, BranchTaskStateEntry>();
-	const update = (entry: BranchTaskStateEntry) => {
-		const taskId = canonicalTaskId(entry.id);
-		const existing = latest.get(taskId);
-		if (!existing || entry.lastModified > existing.lastModified) {
-			latest.set(taskId, entry);
-		}
-	};
-
-	for (const entry of stateEntries) {
-		update(entry);
-	}
-
-	for (const task of localTasks) {
-		if (!task.id) continue;
-		const lastModified = task.lastModified ?? (task.updatedDate ? new Date(task.updatedDate) : new Date(0));
-
-		update({
-			id: task.id,
-			type: "task",
-			branch: "local",
-			path: "",
-			lastModified,
-		});
-	}
-
-	return latest;
-}
-
-function filterTasksByStateSnapshots(tasks: Task[], latestState: Map<string, BranchTaskStateEntry>): Task[] {
-	return tasks.filter((task) => {
-		const latest = latestState.get(canonicalTaskId(task.id));
-		if (!latest) return true;
-		return latest.type === "task";
-	});
-}
-
-function mergeTaskByCanonicalId(
-	tasksById: Map<string, Task>,
-	task: Task,
-	statuses: string[],
-	resolutionStrategy: "most_recent" | "most_progressed",
-): void {
-	const taskId = canonicalTaskId(task.id);
-	const existing = tasksById.get(taskId);
-	tasksById.set(taskId, existing ? resolveTaskConflict(existing, task, statuses, resolutionStrategy) : task);
-}
-
 function normalizeDocumentTypeInput(type: unknown): DocumentType | undefined {
 	if (type === undefined) {
 		return undefined;
@@ -246,20 +193,6 @@ function normalizeDocumentTypeInput(type: unknown): DocumentType | undefined {
 		return type as DocumentType;
 	}
 	throw new Error(`Document type must be one of: ${DOCUMENT_TYPE_VALUES.join(", ")}.`);
-}
-
-/**
- * Extract IDs from state map where latest state is "task" or "completed" (not "archived" or "draft")
- * Used for ID generation to determine which IDs are in use.
- */
-function getActiveAndCompletedIdsFromStateMap(latestState: Map<string, BranchTaskStateEntry>): string[] {
-	const ids: string[] = [];
-	for (const entry of latestState.values()) {
-		if (entry.type === "task" || entry.type === "completed") {
-			ids.push(entry.id);
-		}
-	}
-	return ids;
 }
 
 function formatAvailableIndexHint(items: AcceptanceCriterion[], emptyMessage: string): string {
@@ -279,7 +212,7 @@ export class Core {
 	private contentStore?: ContentStore;
 	private searchService?: SearchService;
 	private readonly enableWatchers: boolean;
-	private activeBranchTaskEntries: BranchTaskStateEntry[] = [];
+	private taskIdentityIndex?: TaskIdentityIndex;
 	private activeBranchFingerprint: string | null = null;
 	private activeBranchFingerprintPromise: Promise<string> | null = null;
 	private activeBranchRefreshPromise: Promise<void> | null = null;
@@ -291,6 +224,50 @@ export class Core {
 		// Interactive modes (TUI, browser, MCP) should explicitly pass enableWatchers: true
 		this.enableWatchers = options?.enableWatchers ?? false;
 		// Note: Config is loaded lazily when needed since constructor can't be async
+	}
+
+	private async buildTaskIdentityIndex(
+		localTasks: Array<Task & { lastModified?: Date }>,
+		completedTasks: Task[],
+		branchRecords: BranchTaskStateEntry[],
+		statuses: string[],
+		resolutionStrategy: "most_recent" | "most_progressed",
+	): Promise<TaskIdentityIndex> {
+		const records: TaskIdentityRecord[] = [];
+		for (const task of localTasks) {
+			records.push({
+				id: task.id,
+				type: "task",
+				branch: "local",
+				path: task.filePath ?? join(this.fs.tasksDir, task.id),
+				lastModified: task.lastModified ?? (task.updatedDate ? new Date(task.updatedDate) : new Date(0)),
+				task: { ...task, source: "local" },
+				workingCopy: true,
+			});
+		}
+		for (const task of completedTasks) {
+			records.push({
+				id: task.id,
+				type: "completed",
+				branch: "local",
+				path: task.filePath ?? join(this.fs.completedDir, task.id),
+				lastModified: task.lastModified ?? (task.updatedDate ? new Date(task.updatedDate) : new Date(0)),
+				task: { ...task, source: "completed" },
+				workingCopy: true,
+			});
+		}
+		records.push(...branchRecords);
+
+		return new TaskIdentityIndex(
+			records,
+			{
+				repositoryRoot: await this.git.getRepositoryRoot(),
+				projectRoot: this.fs.rootDir,
+				backlogDirectory: this.fs.backlogDirName,
+			},
+			statuses,
+			resolutionStrategy,
+		);
 	}
 
 	async withCreateLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -657,72 +634,26 @@ export class Core {
 		await this.fs.loadTask(taskId);
 
 		const store = await this.getContentStore();
-		const tasks = store.getTasks();
-		const resolution = resolveTaskById(tasks, taskId);
-		if (resolution.status === "invalid") {
-			return null;
+		const identityResolution = this.taskIdentityIndex?.resolve(taskId);
+		if (identityResolution?.status === "ambiguous") {
+			throw new AmbiguousTaskIdError(taskId, identityResolution.candidates);
 		}
-		if (resolution.status === "ambiguous") {
+		const storeResolution = resolveTaskById(store.getTasks(), taskId);
+		if (storeResolution.status === "ambiguous") {
 			throw new AmbiguousTaskIdError(
 				taskId,
-				resolution.tasks.map((task) => task.filePath ?? `${task.branch ?? "unknown branch"}:${task.id}`),
+				storeResolution.tasks.map((task) => task.filePath ?? `${task.branch ?? "unknown branch"}:${task.id}`),
 			);
-		}
-		if (resolution.status === "found" && (await this.hasActiveBranchTaskIdCollision(taskId, localTasks))) {
-			const candidates = this.activeBranchTaskEntries
-				.filter((entry) => taskIdsEqual(taskId, entry.id))
-				.map((entry) => entry.path);
-			if (localResolution.status === "found") {
-				candidates.push(localResolution.task.filePath ?? localResolution.task.id);
-			}
-			throw new AmbiguousTaskIdError(taskId, candidates);
-		}
-		if (localResolution.status === "found" && resolution.status === "found") {
-			if (!taskIdsEqual(localResolution.task.id, resolution.task.id)) {
-				throw new AmbiguousTaskIdError(taskId, [
-					localResolution.task.filePath ?? localResolution.task.id,
-					resolution.task.filePath ?? `${resolution.task.branch ?? "unknown branch"}:${resolution.task.id}`,
-				]);
-			}
-			return localResolution.task;
-		}
-		if (resolution.status === "found") {
-			return resolution.task;
 		}
 		if (localResolution.status === "found") {
 			return localResolution.task;
 		}
+		if (identityResolution?.status === "found") {
+			return identityResolution.task;
+		}
+
+		if (storeResolution.status === "found") return storeResolution.task;
 		return null;
-	}
-
-	async hasActiveBranchTaskIdCollision(taskId: string, localTasks: Task[]): Promise<boolean> {
-		const localMatches = localTasks.filter((task) => taskIdsEqual(taskId, task.id));
-		if (localMatches.length > 1) {
-			return true;
-		}
-
-		const config = await this.fs.loadConfig();
-		if (config?.checkActiveBranches === false) {
-			this.activeBranchTaskEntries = [];
-			return false;
-		}
-
-		const branchMatches = this.activeBranchTaskEntries.filter((entry) => taskIdsEqual(taskId, entry.id));
-		if (branchMatches.length === 0) {
-			return false;
-		}
-
-		const paths = new Set<string>();
-		for (const entry of branchMatches) {
-			paths.add(entry.path.replaceAll("\\", "/"));
-		}
-
-		const localTask = localMatches[0];
-		if (localTask?.filePath) {
-			paths.add(relative(this.fs.rootDir, localTask.filePath).replaceAll("\\", "/"));
-		}
-
-		return paths.size > 1;
 	}
 
 	async getTaskWithSubtasks(taskId: string, localTasks?: Task[]): Promise<Task | null> {
@@ -822,7 +753,7 @@ export class Core {
 			this.contentStore.dispose();
 			this.contentStore = undefined;
 		}
-		this.activeBranchTaskEntries = [];
+		this.taskIdentityIndex = undefined;
 		this.activeBranchFingerprint = null;
 		this.activeBranchFingerprintPromise = null;
 		this.activeBranchRefreshPromise = null;
@@ -1173,43 +1104,16 @@ export class Core {
 	private async getActiveAndCompletedTaskIds(): Promise<string[]> {
 		const config = await this.fs.loadConfig();
 		const taskPrefix = config?.prefixes?.task ?? "task";
+		const statuses = config?.statuses || [...DEFAULT_STATUSES];
+		const resolutionStrategy = config?.taskResolutionStrategy || "most_progressed";
 
 		// Load local active and completed tasks
 		const localTasks = await this.listTasksWithMetadata();
 		const localCompletedTasks = await this.fs.listCompletedTasks();
 
-		// Build initial state entries from local tasks
-		const stateEntries: BranchTaskStateEntry[] = [];
-
-		// Add local active tasks to state
-		for (const task of localTasks) {
-			if (!task.id) continue;
-			const lastModified = task.lastModified ?? (task.updatedDate ? new Date(task.updatedDate) : new Date(0));
-			stateEntries.push({
-				id: task.id,
-				type: "task",
-				branch: "local",
-				path: "",
-				lastModified,
-			});
-		}
-
-		// Add local completed tasks to state
-		for (const task of localCompletedTasks) {
-			if (!task.id) continue;
-			const lastModified = task.updatedDate ? new Date(task.updatedDate) : new Date(0);
-			stateEntries.push({
-				id: task.id,
-				type: "completed",
-				branch: "local",
-				path: "",
-				lastModified,
-			});
-		}
-
 		// Same-repository worktrees share the task ID namespace even before their
 		// task files are committed, so include their filesystem state for allocation.
-		stateEntries.push(...(await this.loadWorktreeTaskStateEntries(taskPrefix)));
+		const stateEntries = await this.loadWorktreeTaskStateEntries(taskPrefix);
 
 		// If cross-branch checking is enabled, scan other branches for task states
 		if (config?.checkActiveBranches !== false) {
@@ -1226,9 +1130,14 @@ export class Core {
 			stateEntries.push(...branchStateEntries);
 		}
 
-		// Build the latest state map and extract active + completed IDs
-		const latestState = buildLatestStateMap(stateEntries, []);
-		return getActiveAndCompletedIdsFromStateMap(latestState);
+		const index = await this.buildTaskIdentityIndex(
+			localTasks,
+			localCompletedTasks,
+			stateEntries,
+			statuses,
+			resolutionStrategy,
+		);
+		return index.getOccupiedIds();
 	}
 
 	/**
@@ -3150,54 +3059,26 @@ export class Core {
 
 		// Load remote tasks and local branch tasks in parallel
 		// Skip entirely when cross-branch scanning is disabled
-		let remoteTasks: Task[] = [];
-		let localBranchTasks: Task[] = [];
-		let branchStateEntries: BranchTaskStateEntry[] | undefined;
+		const branchStateEntries: BranchTaskStateEntry[] = [];
 
 		if (config?.checkActiveBranches !== false) {
 			const backlogDir = await this.getBacklogDirectoryName();
-			branchStateEntries = [];
-			[remoteTasks, localBranchTasks] = await Promise.all([
-				loadRemoteTasks(this.git, config, progressCallback, localTasks, branchStateEntries, false, backlogDir),
-				loadLocalBranchTasks(this.git, config, progressCallback, localTasks, branchStateEntries, false, backlogDir),
+			await Promise.all([
+				loadRemoteTasks(this.git, config, progressCallback, localTasks, branchStateEntries, true, backlogDir),
+				loadLocalBranchTasks(this.git, config, progressCallback, localTasks, branchStateEntries, true, backlogDir),
 			]);
 		}
 		progressCallback?.("Loaded tasks");
 
-		// Create map with local tasks
-		const tasksById = new Map<string, Task>(
-			localTasks.map((task) => [canonicalTaskId(task.id), { ...task, source: "local" }]),
+		progressCallback?.("Resolving task identities...");
+		const index = await this.buildTaskIdentityIndex(
+			localTasks,
+			completedTasks,
+			branchStateEntries,
+			statuses,
+			resolutionStrategy,
 		);
-
-		// Add completed tasks to the map
-		for (const completedTask of completedTasks) {
-			const taskId = canonicalTaskId(completedTask.id);
-			if (!tasksById.has(taskId)) {
-				tasksById.set(taskId, { ...completedTask, source: "completed" });
-			}
-		}
-
-		// Merge tasks from other local branches
-		progressCallback?.("Merging tasks...");
-		for (const branchTask of localBranchTasks) {
-			mergeTaskByCanonicalId(tasksById, branchTask, statuses, resolutionStrategy);
-		}
-
-		// Merge remote tasks with local tasks
-		for (const remoteTask of remoteTasks) {
-			mergeTaskByCanonicalId(tasksById, remoteTask, statuses, resolutionStrategy);
-		}
-
-		// Get all tasks as array
-		const tasks = Array.from(tasksById.values());
-		let activeTasks: Task[];
-
-		if (config?.checkActiveBranches === false) {
-			activeTasks = tasks;
-		} else {
-			progressCallback?.("Applying latest task states from branch scans...");
-			activeTasks = filterTasksByStateSnapshots(tasks, buildLatestStateMap(branchStateEntries || [], localTasks));
-		}
+		const activeTasks = index.getTasks(true);
 
 		// Load drafts
 		progressCallback?.("Loading drafts...");
@@ -3249,15 +3130,12 @@ export class Core {
 
 		// Load tasks from remote branches and other local branches in parallel
 		// Skip entirely when cross-branch scanning is disabled
-		let remoteTasks: Task[] = [];
-		let localBranchTasks: Task[] = [];
-		let branchStateEntries: BranchTaskStateEntry[] | undefined;
+		const branchStateEntries: BranchTaskStateEntry[] = [];
 
 		if (config?.checkActiveBranches !== false) {
 			progressCallback?.(getTaskLoadingMessage(config));
-			branchStateEntries = [];
 			const backlogDir = await this.getBacklogDirectoryName();
-			[remoteTasks, localBranchTasks] = await Promise.all([
+			await Promise.all([
 				loadRemoteTasks(
 					this.git,
 					config,
@@ -3279,103 +3157,25 @@ export class Core {
 			]);
 		}
 
-		const currentBranch = config?.checkActiveBranches === false ? null : await this.git.getCurrentBranch();
-		const nextActiveBranchTaskEntries = (branchStateEntries ?? []).filter(
-			(entry) => entry.type === "task" && entry.branch !== currentBranch,
-		);
-
 		// Check for cancellation after loading
 		if (abortSignal?.aborted) {
 			throw new Error("Loading cancelled");
 		}
 
-		// Create map with local tasks (current branch filesystem)
-		const tasksById = new Map<string, Task>(
-			localTasks.map((task) => [canonicalTaskId(task.id), { ...task, source: "local" }]),
+		// Check for cancellation before identity resolution
+		if (abortSignal?.aborted) {
+			throw new Error("Loading cancelled");
+		}
+
+		progressCallback?.("Resolving task identities...");
+		const identityIndex = await this.buildTaskIdentityIndex(
+			localTasks,
+			completedTasks,
+			branchStateEntries,
+			statuses,
+			resolutionStrategy,
 		);
-
-		// Add local completed tasks when requested
-		if (includeCompleted) {
-			for (const completedTask of completedTasks) {
-				tasksById.set(canonicalTaskId(completedTask.id), { ...completedTask, source: "completed" });
-			}
-		}
-
-		// Merge tasks from other local branches
-		for (const branchTask of localBranchTasks) {
-			if (abortSignal?.aborted) {
-				throw new Error("Loading cancelled");
-			}
-
-			mergeTaskByCanonicalId(tasksById, branchTask, statuses, resolutionStrategy);
-		}
-
-		// Merge remote tasks with local tasks
-		for (const remoteTask of remoteTasks) {
-			// Check for cancellation during merge
-			if (abortSignal?.aborted) {
-				throw new Error("Loading cancelled");
-			}
-
-			mergeTaskByCanonicalId(tasksById, remoteTask, statuses, resolutionStrategy);
-		}
-
-		// Check for cancellation before cross-branch checking
-		if (abortSignal?.aborted) {
-			throw new Error("Loading cancelled");
-		}
-
-		// Get the latest directory location of each task across all branches
-		const tasks = Array.from(tasksById.values());
-
-		if (abortSignal?.aborted) {
-			throw new Error("Loading cancelled");
-		}
-
-		let filteredTasks: Task[];
-
-		if (config?.checkActiveBranches === false) {
-			filteredTasks = tasks;
-		} else {
-			progressCallback?.("Applying latest task states from branch scans...");
-			if (!includeCompleted) {
-				filteredTasks = filterTasksByStateSnapshots(tasks, buildLatestStateMap(branchStateEntries || [], localTasks));
-			} else {
-				const stateEntries = branchStateEntries || [];
-				for (const completedTask of completedTasks) {
-					if (!completedTask.id) continue;
-					const lastModified = completedTask.updatedDate ? new Date(completedTask.updatedDate) : new Date(0);
-					stateEntries.push({
-						id: completedTask.id,
-						type: "completed",
-						branch: "local",
-						path: "",
-						lastModified,
-					});
-				}
-
-				const latestState = buildLatestStateMap(stateEntries, localTasks);
-				const completedIds = new Set<string>();
-				for (const [id, entry] of latestState) {
-					if (entry.type === "completed") {
-						completedIds.add(id);
-					}
-				}
-
-				filteredTasks = tasks
-					.filter((task) => {
-						const latest = latestState.get(canonicalTaskId(task.id));
-						if (!latest) return true;
-						return latest.type === "task" || latest.type === "completed";
-					})
-					.map((task) => {
-						if (!completedIds.has(canonicalTaskId(task.id))) {
-							return task;
-						}
-						return { ...task, source: "completed" };
-					});
-			}
-		}
+		const filteredTasks = identityIndex.getTasks(includeCompleted);
 
 		const snapshotAfter = await this.getActiveBranchFingerprint();
 		if (snapshotBefore !== snapshotAfter) {
@@ -3384,7 +3184,7 @@ export class Core {
 			}
 			return await this.loadTasksWithStableBranchSnapshot(progressCallback, abortSignal, options, snapshotAttempt + 1);
 		}
-		this.activeBranchTaskEntries = nextActiveBranchTaskEntries;
+		this.taskIdentityIndex = identityIndex;
 		this.activeBranchFingerprint = snapshotAfter;
 		return filteredTasks;
 	}

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -192,9 +192,10 @@ function buildLatestStateMap(
 ): Map<string, BranchTaskStateEntry> {
 	const latest = new Map<string, BranchTaskStateEntry>();
 	const update = (entry: BranchTaskStateEntry) => {
-		const existing = latest.get(entry.id);
+		const taskId = canonicalTaskId(entry.id);
+		const existing = latest.get(taskId);
 		if (!existing || entry.lastModified > existing.lastModified) {
-			latest.set(entry.id, entry);
+			latest.set(taskId, entry);
 		}
 	};
 
@@ -220,7 +221,7 @@ function buildLatestStateMap(
 
 function filterTasksByStateSnapshots(tasks: Task[], latestState: Map<string, BranchTaskStateEntry>): Task[] {
 	return tasks.filter((task) => {
-		const latest = latestState.get(task.id);
+		const latest = latestState.get(canonicalTaskId(task.id));
 		if (!latest) return true;
 		return latest.type === "task";
 	});
@@ -253,9 +254,9 @@ function normalizeDocumentTypeInput(type: unknown): DocumentType | undefined {
  */
 function getActiveAndCompletedIdsFromStateMap(latestState: Map<string, BranchTaskStateEntry>): string[] {
 	const ids: string[] = [];
-	for (const [id, entry] of latestState) {
+	for (const entry of latestState.values()) {
 		if (entry.type === "task" || entry.type === "completed") {
-			ids.push(id);
+			ids.push(entry.id);
 		}
 	}
 	return ids;
@@ -667,11 +668,17 @@ export class Core {
 				resolution.tasks.map((task) => task.filePath ?? `${task.branch ?? "unknown branch"}:${task.id}`),
 			);
 		}
+		if (resolution.status === "found" && (await this.hasActiveBranchTaskIdCollision(taskId, localTasks))) {
+			const candidates = this.activeBranchTaskEntries
+				.filter((entry) => taskIdsEqual(taskId, entry.id))
+				.map((entry) => entry.path);
+			if (localResolution.status === "found") {
+				candidates.push(localResolution.task.filePath ?? localResolution.task.id);
+			}
+			throw new AmbiguousTaskIdError(taskId, candidates);
+		}
 		if (localResolution.status === "found" && resolution.status === "found") {
-			if (
-				!taskIdsEqual(localResolution.task.id, resolution.task.id) ||
-				(await this.hasActiveBranchTaskIdCollision(taskId, localTasks))
-			) {
+			if (!taskIdsEqual(localResolution.task.id, resolution.task.id)) {
 				throw new AmbiguousTaskIdError(taskId, [
 					localResolution.task.filePath ?? localResolution.task.id,
 					resolution.task.filePath ?? `${resolution.task.branch ?? "unknown branch"}:${resolution.task.id}`,
@@ -3357,12 +3364,12 @@ export class Core {
 
 				filteredTasks = tasks
 					.filter((task) => {
-						const latest = latestState.get(task.id);
+						const latest = latestState.get(canonicalTaskId(task.id));
 						if (!latest) return true;
 						return latest.type === "task" || latest.type === "completed";
 					})
 					.map((task) => {
-						if (!completedIds.has(task.id)) {
+						if (!completedIds.has(canonicalTaskId(task.id))) {
 							return task;
 						}
 						return { ...task, source: "completed" };

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -61,6 +61,7 @@ import {
 import { resolveTaskById } from "../utils/task-id.ts";
 import {
 	AmbiguousTaskIdError,
+	canonicalTaskId,
 	getDraftPath,
 	getTaskFilename,
 	getTaskPath,
@@ -223,6 +224,17 @@ function filterTasksByStateSnapshots(tasks: Task[], latestState: Map<string, Bra
 		if (!latest) return true;
 		return latest.type === "task";
 	});
+}
+
+function mergeTaskByCanonicalId(
+	tasksById: Map<string, Task>,
+	task: Task,
+	statuses: string[],
+	resolutionStrategy: "most_recent" | "most_progressed",
+): void {
+	const taskId = canonicalTaskId(task.id);
+	const existing = tasksById.get(taskId);
+	tasksById.set(taskId, existing ? resolveTaskConflict(existing, task, statuses, resolutionStrategy) : task);
 }
 
 function normalizeDocumentTypeInput(type: unknown): DocumentType | undefined {
@@ -3143,36 +3155,27 @@ export class Core {
 		progressCallback?.("Loaded tasks");
 
 		// Create map with local tasks
-		const tasksById = new Map<string, Task>(localTasks.map((t) => [t.id, { ...t, source: "local" }]));
+		const tasksById = new Map<string, Task>(
+			localTasks.map((task) => [canonicalTaskId(task.id), { ...task, source: "local" }]),
+		);
 
 		// Add completed tasks to the map
 		for (const completedTask of completedTasks) {
-			if (!tasksById.has(completedTask.id)) {
-				tasksById.set(completedTask.id, { ...completedTask, source: "completed" });
+			const taskId = canonicalTaskId(completedTask.id);
+			if (!tasksById.has(taskId)) {
+				tasksById.set(taskId, { ...completedTask, source: "completed" });
 			}
 		}
 
 		// Merge tasks from other local branches
 		progressCallback?.("Merging tasks...");
 		for (const branchTask of localBranchTasks) {
-			const existing = tasksById.get(branchTask.id);
-			if (!existing) {
-				tasksById.set(branchTask.id, branchTask);
-			} else {
-				const resolved = resolveTaskConflict(existing, branchTask, statuses, resolutionStrategy);
-				tasksById.set(branchTask.id, resolved);
-			}
+			mergeTaskByCanonicalId(tasksById, branchTask, statuses, resolutionStrategy);
 		}
 
 		// Merge remote tasks with local tasks
 		for (const remoteTask of remoteTasks) {
-			const existing = tasksById.get(remoteTask.id);
-			if (!existing) {
-				tasksById.set(remoteTask.id, remoteTask);
-			} else {
-				const resolved = resolveTaskConflict(existing, remoteTask, statuses, resolutionStrategy);
-				tasksById.set(remoteTask.id, resolved);
-			}
+			mergeTaskByCanonicalId(tasksById, remoteTask, statuses, resolutionStrategy);
 		}
 
 		// Get all tasks as array
@@ -3277,12 +3280,14 @@ export class Core {
 		}
 
 		// Create map with local tasks (current branch filesystem)
-		const tasksById = new Map<string, Task>(localTasks.map((t) => [t.id, { ...t, source: "local" }]));
+		const tasksById = new Map<string, Task>(
+			localTasks.map((task) => [canonicalTaskId(task.id), { ...task, source: "local" }]),
+		);
 
 		// Add local completed tasks when requested
 		if (includeCompleted) {
 			for (const completedTask of completedTasks) {
-				tasksById.set(completedTask.id, { ...completedTask, source: "completed" });
+				tasksById.set(canonicalTaskId(completedTask.id), { ...completedTask, source: "completed" });
 			}
 		}
 
@@ -3292,13 +3297,7 @@ export class Core {
 				throw new Error("Loading cancelled");
 			}
 
-			const existing = tasksById.get(branchTask.id);
-			if (!existing) {
-				tasksById.set(branchTask.id, branchTask);
-			} else {
-				const resolved = resolveTaskConflict(existing, branchTask, statuses, resolutionStrategy);
-				tasksById.set(branchTask.id, resolved);
-			}
+			mergeTaskByCanonicalId(tasksById, branchTask, statuses, resolutionStrategy);
 		}
 
 		// Merge remote tasks with local tasks
@@ -3308,13 +3307,7 @@ export class Core {
 				throw new Error("Loading cancelled");
 			}
 
-			const existing = tasksById.get(remoteTask.id);
-			if (!existing) {
-				tasksById.set(remoteTask.id, remoteTask);
-			} else {
-				const resolved = resolveTaskConflict(existing, remoteTask, statuses, resolutionStrategy);
-				tasksById.set(remoteTask.id, resolved);
-			}
+			mergeTaskByCanonicalId(tasksById, remoteTask, statuses, resolutionStrategy);
 		}
 
 		// Check for cancellation before cross-branch checking

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -85,8 +85,6 @@ import { SearchService } from "./search-service.ts";
 import { TaskIdentityIndex, type TaskIdentityRecord } from "./task-identity-index.ts";
 import {
 	type BranchTaskStateEntry,
-	findTaskInLocalBranches,
-	findTaskInRemoteBranches,
 	getTaskLoadingMessage,
 	loadLocalBranchTasks,
 	loadRemoteTasks,
@@ -381,9 +379,10 @@ export class Core {
 			}
 
 			if (!this.activeBranchRefreshPromise) {
+				const refreshExistingStore = this.contentStore !== undefined;
 				const refreshPromise = (async () => {
 					const store = await this.getContentStore();
-					await store.refreshTasks();
+					if (refreshExistingStore) await store.refreshTasks();
 				})();
 				this.activeBranchRefreshPromise = refreshPromise;
 				const clearRefreshPromise = () => {
@@ -633,6 +632,7 @@ export class Core {
 		// Also fail closed when an active task collides with a completed file.
 		await this.fs.loadTask(taskId);
 
+		await this.refreshTasksForTaskRead();
 		const store = await this.getContentStore();
 		const identityResolution = this.taskIdentityIndex?.resolve(taskId);
 		if (identityResolution?.status === "ambiguous") {
@@ -657,7 +657,7 @@ export class Core {
 	}
 
 	async getTaskWithSubtasks(taskId: string, localTasks?: Task[]): Promise<Task | null> {
-		const task = await this.loadTaskById(taskId);
+		const task = await this.getTask(taskId);
 		if (!task) {
 			return null;
 		}
@@ -667,41 +667,13 @@ export class Core {
 	}
 
 	async loadTaskById(taskId: string): Promise<Task | null> {
-		// Pass raw ID to loadTask - it will handle prefix detection via getTaskPath
-		const localTask = await this.fs.loadTask(taskId);
-		if (localTask) return localTask;
+		return await this.getTask(taskId);
+	}
 
-		// Check config for remote operations
-		const config = await this.fs.loadConfig();
-		if (config?.checkActiveBranches === false) return null;
-
-		const sinceDays = config?.activeBranchDays ?? 30;
-		const taskPrefix = config?.prefixes?.task ?? "task";
-
-		// For cross-branch search, normalize with configured prefix
-		const canonicalId = normalizeTaskId(taskId, taskPrefix);
-
-		// Try other local branches first (faster than remote)
-		const localBranchTask = await findTaskInLocalBranches(
-			this.git,
-			canonicalId,
-			await this.getBacklogDirectoryName(),
-			sinceDays,
-			taskPrefix,
-		);
-		if (localBranchTask) return localBranchTask;
-
-		// Skip remote if disabled
-		if (config?.remoteOperations === false) return null;
-
-		// Try remote branches
-		return await findTaskInRemoteBranches(
-			this.git,
-			canonicalId,
-			await this.getBacklogDirectoryName(),
-			sinceDays,
-			taskPrefix,
-		);
+	private async loadLocalTaskForMutation(taskId: string): Promise<Task | null> {
+		const resolvedTask = await this.getTask(taskId);
+		if (!resolvedTask || !isLocalEditableTask(resolvedTask) || resolvedTask.branch) return null;
+		return await this.fs.loadTask(resolvedTask.id);
 	}
 
 	async getTaskContent(taskId: string): Promise<string | null> {
@@ -2050,7 +2022,7 @@ export class Core {
 	}
 
 	async updateTaskFromInput(taskId: string, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
-		const task = await this.fs.loadTask(taskId);
+		const task = await this.loadLocalTaskForMutation(taskId);
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
 		}
@@ -2407,7 +2379,7 @@ export class Core {
 	}
 
 	async archiveTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const taskToArchive = await this.fs.loadTask(taskId);
+		const taskToArchive = await this.loadLocalTaskForMutation(taskId);
 		if (!taskToArchive) {
 			return false;
 		}
@@ -2516,7 +2488,7 @@ export class Core {
 	}
 
 	async completeTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const task = await this.fs.loadTask(taskId);
+		const task = await this.loadLocalTaskForMutation(taskId);
 		if (!task) return false;
 		// Get paths before moving the file
 		const completedDir = this.fs.completedDir;
@@ -2619,7 +2591,9 @@ export class Core {
 	}
 
 	async demoteTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const success = await this.fs.demoteTask(taskId);
+		const task = await this.loadLocalTaskForMutation(taskId);
+		if (!task) return false;
+		const success = await this.fs.demoteTask(task.id);
 
 		if (success && (await this.shouldAutoCommit(autoCommit))) {
 			const backlogDir = await this.getBacklogDirectoryName();

--- a/src/core/task-identity-index.ts
+++ b/src/core/task-identity-index.ts
@@ -45,6 +45,16 @@ function joinPosix(...parts: string[]): string {
 		.join("/");
 }
 
+export function normalizeTaskLifecyclePath(path: string, backlogDirectory: string): string {
+	for (const lifecycleDirectory of ["archive/tasks", "completed"]) {
+		const lifecyclePrefix = `${backlogDirectory}/${lifecycleDirectory}/`;
+		if (path.startsWith(lifecyclePrefix)) {
+			return `${backlogDirectory}/tasks/${path.slice(lifecyclePrefix.length)}`;
+		}
+	}
+	return path;
+}
+
 function normalizeRecordPath(record: TaskIdentityRecord, context: TaskIdentityPathContext): string {
 	const repositoryRoot = context.repositoryRoot ?? context.projectRoot;
 	const projectPrefix = context.repositoryRoot
@@ -71,14 +81,7 @@ function normalizeRecordPath(record: TaskIdentityRecord, context: TaskIdentityPa
 		path = joinPosix(projectPrefix, path);
 	}
 
-	for (const lifecycleDirectory of ["archive/tasks", "completed"]) {
-		const lifecyclePrefix = `${repositoryBacklogDirectory}/${lifecycleDirectory}/`;
-		if (path.startsWith(lifecyclePrefix)) {
-			return `${repositoryBacklogDirectory}/tasks/${path.slice(lifecyclePrefix.length)}`;
-		}
-	}
-
-	return path;
+	return normalizeTaskLifecyclePath(path, repositoryBacklogDirectory);
 }
 
 function recordKey(record: TaskIdentityRecord): string {

--- a/src/core/task-identity-index.ts
+++ b/src/core/task-identity-index.ts
@@ -1,0 +1,229 @@
+import { isAbsolute, relative } from "node:path";
+import type { Task } from "../types/index.ts";
+import { canonicalTaskId, taskIdsEqual } from "../utils/task-path.ts";
+import type { TaskDirectoryType } from "./cross-branch-tasks.ts";
+
+export interface TaskIdentityRecord {
+	id: string;
+	type: TaskDirectoryType;
+	branch: string;
+	path: string;
+	lastModified: Date;
+	task?: Task;
+	workingCopy?: boolean;
+}
+
+interface TaskIdentityPathContext {
+	repositoryRoot: string | null;
+	projectRoot: string;
+	backlogDirectory: string;
+}
+
+interface TaskIdentity {
+	path: string;
+	records: TaskIdentityRecord[];
+}
+
+interface TaskIdentityGroup {
+	id: string;
+	identities: Map<string, TaskIdentity>;
+}
+
+export type TaskIdentityResolution =
+	| { status: "found"; task: Task }
+	| { status: "ambiguous"; candidates: string[] }
+	| { status: "not-found" };
+
+function toPosixPath(path: string): string {
+	return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function joinPosix(...parts: string[]): string {
+	return parts
+		.map((part) => toPosixPath(part).replace(/^\/+|\/+$/g, ""))
+		.filter(Boolean)
+		.join("/");
+}
+
+function normalizeRecordPath(record: TaskIdentityRecord, context: TaskIdentityPathContext): string {
+	const repositoryRoot = context.repositoryRoot ?? context.projectRoot;
+	const projectPrefix = context.repositoryRoot
+		? toPosixPath(relative(context.repositoryRoot, context.projectRoot))
+		: "";
+	let path = record.path;
+
+	if (isAbsolute(path)) {
+		const worktreePrefix = "worktree:";
+		const sourceRoot = record.branch.startsWith(worktreePrefix)
+			? record.branch.slice(worktreePrefix.length)
+			: repositoryRoot;
+		path = relative(sourceRoot, path);
+	}
+
+	path = toPosixPath(path);
+	const repositoryBacklogDirectory = joinPosix(projectPrefix, context.backlogDirectory);
+	const projectBacklogDirectory = toPosixPath(context.backlogDirectory);
+	if (
+		projectPrefix &&
+		(path === projectBacklogDirectory || path.startsWith(`${projectBacklogDirectory}/`)) &&
+		!(path === repositoryBacklogDirectory || path.startsWith(`${repositoryBacklogDirectory}/`))
+	) {
+		path = joinPosix(projectPrefix, path);
+	}
+
+	for (const lifecycleDirectory of ["archive/tasks", "completed"]) {
+		const lifecyclePrefix = `${repositoryBacklogDirectory}/${lifecycleDirectory}/`;
+		if (path.startsWith(lifecyclePrefix)) {
+			return `${repositoryBacklogDirectory}/tasks/${path.slice(lifecyclePrefix.length)}`;
+		}
+	}
+
+	return path;
+}
+
+function recordKey(record: TaskIdentityRecord): string {
+	return `${record.branch}\0${toPosixPath(record.path)}\0${record.id}\0${record.task?.title ?? ""}`;
+}
+
+function stateRank(type: TaskDirectoryType): number {
+	switch (type) {
+		case "task":
+			return 3;
+		case "completed":
+			return 2;
+		case "archived":
+			return 1;
+		case "draft":
+			return 0;
+	}
+}
+
+function selectLifecycleRecord(records: TaskIdentityRecord[]): TaskIdentityRecord | undefined {
+	const workingTasks = records.filter((record) => record.workingCopy && record.type === "task");
+	if (workingTasks.length > 0) {
+		return [...workingTasks].sort((left, right) => recordKey(left).localeCompare(recordKey(right)))[0];
+	}
+	const workingCompleted = records.filter((record) => record.workingCopy && record.type === "completed");
+	if (workingCompleted.length > 0) {
+		return [...workingCompleted].sort((left, right) => recordKey(left).localeCompare(recordKey(right)))[0];
+	}
+
+	return [...records].sort((left, right) => {
+		const timeDifference = right.lastModified.getTime() - left.lastModified.getTime();
+		if (timeDifference !== 0) return timeDifference;
+		const rankDifference = stateRank(right.type) - stateRank(left.type);
+		if (rankDifference !== 0) return rankDifference;
+		return recordKey(left).localeCompare(recordKey(right));
+	})[0];
+}
+
+function selectTaskRecord(
+	records: TaskIdentityRecord[],
+	statuses: string[],
+	strategy: "most_recent" | "most_progressed",
+): TaskIdentityRecord | undefined {
+	const candidates = records.filter((record) => record.task);
+	return [...candidates].sort((left, right) => {
+		if (Boolean(left.workingCopy) !== Boolean(right.workingCopy)) {
+			return left.workingCopy ? -1 : 1;
+		}
+		if (strategy === "most_progressed") {
+			const leftRank = Math.max(0, statuses.indexOf(left.task?.status ?? ""));
+			const rightRank = Math.max(0, statuses.indexOf(right.task?.status ?? ""));
+			if (leftRank !== rightRank) return rightRank - leftRank;
+		}
+		const timeDifference = right.lastModified.getTime() - left.lastModified.getTime();
+		if (timeDifference !== 0) return timeDifference;
+		return recordKey(left).localeCompare(recordKey(right));
+	})[0];
+}
+
+function liveRecords(identity: TaskIdentity): TaskIdentityRecord[] {
+	return identity.records.filter((record) => record.type === "task" || record.type === "completed");
+}
+
+export class TaskIdentityIndex {
+	private readonly groups = new Map<string, TaskIdentityGroup>();
+
+	constructor(
+		records: TaskIdentityRecord[],
+		context: TaskIdentityPathContext,
+		private readonly statuses: string[],
+		private readonly resolutionStrategy: "most_recent" | "most_progressed",
+	) {
+		for (const record of records) {
+			const canonicalId = canonicalTaskId(record.id);
+			const path = normalizeRecordPath(record, context);
+			const group = this.groups.get(canonicalId) ?? { id: canonicalId, identities: new Map() };
+			const identity = group.identities.get(path) ?? { path, records: [] };
+			identity.records.push(record);
+			group.identities.set(path, identity);
+			this.groups.set(canonicalId, group);
+		}
+	}
+
+	private getGroup(taskId: string): TaskIdentityGroup | undefined {
+		return [...this.groups.values()].find((group) => taskIdsEqual(group.id, taskId));
+	}
+
+	private ambiguousCandidates(group: TaskIdentityGroup): string[] {
+		const liveIdentities = [...group.identities.values()].filter((identity) => liveRecords(identity).length > 0);
+		const candidates = new Set<string>();
+		if (liveIdentities.length > 1) {
+			for (const identity of liveIdentities) {
+				for (const record of liveRecords(identity)) candidates.add(record.path);
+			}
+		}
+		for (const identity of liveIdentities) {
+			const workingPaths = new Set(
+				liveRecords(identity)
+					.filter((record) => record.workingCopy)
+					.map((record) => toPosixPath(record.path)),
+			);
+			if (workingPaths.size > 1) {
+				for (const path of workingPaths) candidates.add(path);
+			}
+		}
+		return [...candidates].sort((left, right) => left.localeCompare(right));
+	}
+
+	getTasks(includeCompleted = false): Task[] {
+		const tasks: Task[] = [];
+		const groups = [...this.groups.values()].sort((left, right) => left.id.localeCompare(right.id));
+		for (const group of groups) {
+			const identities = [...group.identities.values()].sort((left, right) => left.path.localeCompare(right.path));
+			for (const identity of identities) {
+				const lifecycle = selectLifecycleRecord(identity.records);
+				if (!lifecycle || (lifecycle.type !== "task" && lifecycle.type !== "completed")) continue;
+				if (lifecycle.type === "completed" && !includeCompleted) continue;
+				const selected = selectTaskRecord(
+					identity.records.filter((record) => record.type === lifecycle.type),
+					this.statuses,
+					this.resolutionStrategy,
+				);
+				if (!selected?.task) continue;
+				tasks.push(lifecycle.type === "completed" ? { ...selected.task, source: "completed" } : selected.task);
+			}
+		}
+		return tasks;
+	}
+
+	resolve(taskId: string): TaskIdentityResolution {
+		const group = this.getGroup(taskId);
+		if (!group) return { status: "not-found" };
+		const candidates = this.ambiguousCandidates(group);
+		if (candidates.length > 0) return { status: "ambiguous", candidates };
+		const tasks = this.getTasks(false).filter((task) => taskIdsEqual(task.id, taskId));
+		return tasks[0] ? { status: "found", task: tasks[0] } : { status: "not-found" };
+	}
+
+	getOccupiedIds(): string[] {
+		const ids = new Set<string>();
+		for (const group of this.groups.values()) {
+			for (const identity of group.identities.values()) {
+				for (const record of liveRecords(identity)) ids.add(record.id);
+			}
+		}
+		return [...ids];
+	}
+}

--- a/src/core/task-loader.ts
+++ b/src/core/task-loader.ts
@@ -13,8 +13,14 @@ import type { GitOperations } from "../git/operations.ts";
 import { parseTask } from "../markdown/parser.ts";
 import type { BacklogConfig, Task } from "../types/index.ts";
 import { extractAnyPrefix, normalizeId } from "../utils/prefix-config.ts";
-import { extractTaskIdFromFilename, normalizeTaskId, normalizeTaskIdentity } from "../utils/task-path.ts";
+import {
+	canonicalTaskId,
+	extractTaskIdFromFilename,
+	normalizeTaskId,
+	normalizeTaskIdentity,
+} from "../utils/task-path.ts";
 import type { TaskDirectoryType } from "./cross-branch-tasks.ts";
+import { normalizeTaskLifecyclePath } from "./task-identity-index.ts";
 
 /** Default prefix for tasks */
 const DEFAULT_TASK_PREFIX = "task";
@@ -84,6 +90,73 @@ interface HydrationCandidate {
 	path: string;
 	commit?: string;
 	stateEntry?: BranchTaskStateEntry;
+}
+
+function logicalTaskPath(path: string, backlogDir: string): string {
+	const normalizedPath = path.replaceAll("\\", "/");
+	const normalizedBacklogDir = backlogDir
+		.replaceAll("\\", "/")
+		.replace(/^\.\//, "")
+		.replace(/^\/+|\/+$/g, "");
+	const backlogMarker = `/${normalizedBacklogDir}/`;
+	const markerIndex = normalizedPath.indexOf(backlogMarker);
+	const logicalPath = markerIndex >= 0 ? normalizedPath.slice(markerIndex + 1) : normalizedPath.replace(/^\.\//, "");
+	return normalizeTaskLifecyclePath(logicalPath, normalizedBacklogDir);
+}
+
+function lifecycleRank(type: TaskDirectoryType | undefined): number {
+	if (type === "task") return 2;
+	if (type === "completed") return 1;
+	return 0;
+}
+
+function isPreferredIdentityEntry(candidate: RemoteIndexEntry, current: RemoteIndexEntry): boolean {
+	const timeDifference = candidate.lastModified.getTime() - current.lastModified.getTime();
+	if (timeDifference !== 0) return timeDifference > 0;
+	const rankDifference = lifecycleRank(candidate.stateEntry?.type) - lifecycleRank(current.stateEntry?.type);
+	if (rankDifference !== 0) return rankDifference > 0;
+	return `${candidate.branch}\0${candidate.path}`.localeCompare(`${current.branch}\0${current.path}`) < 0;
+}
+
+function chooseIdentityHydrationCandidates(
+	index: Map<string, RemoteIndexEntry[]>,
+	localTasks: Task[] | undefined,
+	backlogDir: string,
+	toRef: (entry: RemoteIndexEntry) => string,
+): HydrationCandidate[] {
+	const localIdentities = new Set(
+		(localTasks ?? [])
+			.filter((task) => task.filePath)
+			.map((task) => `${canonicalTaskId(task.id)}\0${logicalTaskPath(task.filePath ?? "", backlogDir)}`),
+	);
+	const winners = new Map<string, RemoteIndexEntry>();
+	for (const entries of index.values()) {
+		for (const entry of entries) {
+			const identity = `${canonicalTaskId(entry.id)}\0${logicalTaskPath(entry.path, backlogDir)}`;
+			if (localIdentities.has(identity)) continue;
+			const current = winners.get(identity);
+			if (!current || isPreferredIdentityEntry(entry, current)) winners.set(identity, entry);
+		}
+	}
+
+	return [...winners.values()].map((entry) => ({
+		id: entry.id,
+		ref: toRef(entry),
+		path: entry.path,
+		commit: entry.commit,
+		stateEntry: entry.stateEntry,
+	}));
+}
+
+function mergeHydrationCandidates(
+	primary: HydrationCandidate[],
+	supplemental: HydrationCandidate[],
+): HydrationCandidate[] {
+	const candidates = new Map<string, HydrationCandidate>();
+	for (const candidate of [...primary, ...supplemental]) {
+		candidates.set(`${candidate.ref}\0${candidate.path}\0${candidate.commit ?? ""}`, candidate);
+	}
+	return [...candidates.values()];
 }
 
 /**
@@ -596,6 +669,13 @@ export async function loadRemoteTasks(
 			onProgress?.(`Hydrating ${winners.length} remote tasks...`);
 		}
 
+		if (stateCollector) {
+			winners = mergeHydrationCandidates(
+				winners,
+				chooseIdentityHydrationCandidates(remoteIndex, localTasks, backlogDir, (entry) => `origin/${entry.branch}`),
+			);
+		}
+
 		// Only fetch content for the tasks we actually need
 		const hydratedTasks = await hydrateTasks(gitOps, winners);
 
@@ -776,6 +856,13 @@ export async function loadLocalBranchTasks(
 					stateEntry: best.stateEntry,
 				});
 			}
+		}
+
+		if (stateCollector) {
+			winners = mergeHydrationCandidates(
+				winners,
+				chooseIdentityHydrationCandidates(localBranchIndex, localTasks, backlogDir, (entry) => entry.branch),
+			);
 		}
 
 		if (winners.length === 0) {

--- a/src/core/task-loader.ts
+++ b/src/core/task-loader.ts
@@ -25,25 +25,6 @@ export interface BranchTaskStateEntry {
 	lastModified: Date;
 	branch: string;
 	path: string;
-	objectId?: string;
-	tree?: string;
-}
-
-interface BranchTreeFile {
-	path: string;
-	objectId?: string;
-}
-
-async function listBranchTreeFiles(
-	git: GitOperations,
-	ref: string,
-	path: string,
-	includeObjectIds: boolean,
-): Promise<BranchTreeFile[]> {
-	if (includeObjectIds && typeof git.listTreeEntries === "function") {
-		return await git.listTreeEntries(ref, path);
-	}
-	return (await git.listFilesInTree(ref, path)).map((filePath) => ({ path: filePath }));
 }
 
 function extractConfiguredTaskId(filePath: string, prefix: string): string | null {
@@ -171,9 +152,7 @@ export async function buildRemoteTaskIndex(
 				const indexRef = commit ?? ref;
 
 				// Get backlog files for this branch
-				const treeFiles = await listBranchTreeFiles(git, indexRef, listPath, Boolean(stateCollector));
-				const files = treeFiles.map((entry) => entry.path);
-				const objectIds = new Map(treeFiles.map((entry) => [entry.path, entry.objectId]));
+				const files = await git.listFilesInTree(indexRef, listPath);
 				if (files.length === 0) continue;
 
 				// Get last modified times for all files in one pass
@@ -197,8 +176,6 @@ export async function buildRemoteTaskIndex(
 							branch: br,
 							path: f,
 							lastModified,
-							objectId: objectIds.get(f),
-							tree: commit ?? ref,
 						});
 					}
 
@@ -307,9 +284,7 @@ export async function buildLocalBranchTaskIndex(
 				const indexRef = commit ?? br;
 
 				// Get backlog files in this branch
-				const treeFiles = await listBranchTreeFiles(git, indexRef, listPath, Boolean(stateCollector));
-				const files = treeFiles.map((entry) => entry.path);
-				const objectIds = new Map(treeFiles.map((entry) => [entry.path, entry.objectId]));
+				const files = await git.listFilesInTree(indexRef, listPath);
 				if (files.length === 0) continue;
 
 				// Get last modified times for all files in one pass
@@ -333,8 +308,6 @@ export async function buildLocalBranchTaskIndex(
 							branch: br,
 							path: f,
 							lastModified,
-							objectId: objectIds.get(f),
-							tree: commit ?? br,
 						});
 					}
 

--- a/src/core/task-loader.ts
+++ b/src/core/task-loader.ts
@@ -173,7 +173,7 @@ export async function buildRemoteTaskIndex(
 						stateCollector.push({
 							id,
 							type,
-							branch: br,
+							branch: ref,
 							path: f,
 							lastModified,
 						});

--- a/src/core/task-loader.ts
+++ b/src/core/task-loader.ts
@@ -25,6 +25,7 @@ export interface BranchTaskStateEntry {
 	lastModified: Date;
 	branch: string;
 	path: string;
+	task?: Task;
 }
 
 function extractConfiguredTaskId(filePath: string, prefix: string): string | null {
@@ -74,6 +75,15 @@ interface RemoteIndexEntry {
 	 * `git show`. Undefined when the SHA could not be resolved (best effort).
 	 */
 	commit?: string;
+	stateEntry?: BranchTaskStateEntry;
+}
+
+interface HydrationCandidate {
+	id: string;
+	ref: string;
+	path: string;
+	commit?: string;
+	stateEntry?: BranchTaskStateEntry;
 }
 
 /**
@@ -170,13 +180,14 @@ export async function buildRemoteTaskIndex(
 						continue;
 					}
 					if (type && stateCollector) {
-						stateCollector.push({
+						entry.stateEntry = {
 							id,
 							type,
 							branch: ref,
 							path: f,
 							lastModified,
-						});
+						};
+						stateCollector.push(entry.stateEntry);
 					}
 
 					// Only index active tasks for hydration selection (optionally include completed)
@@ -204,10 +215,7 @@ export async function buildRemoteTaskIndex(
  * Hydrate tasks by fetching their content
  * Only call this for the "winner" tasks that we actually need
  */
-async function hydrateTasks(
-	git: GitOperations,
-	winners: Array<{ id: string; ref: string; path: string; commit?: string }>,
-): Promise<Task[]> {
+async function hydrateTasks(git: GitOperations, winners: HydrationCandidate[]): Promise<Task[]> {
 	const CONCURRENCY = 8;
 	const result: Task[] = [];
 	let i = 0;
@@ -232,6 +240,7 @@ async function hydrateTasks(
 					task.source = "remote";
 					// Extract branch name from ref (e.g., "origin/main" -> "main")
 					task.branch = w.ref.replace("origin/", "");
+					if (w.stateEntry) w.stateEntry.task = task;
 					result.push(task);
 				}
 			} catch (error) {
@@ -302,13 +311,14 @@ export async function buildLocalBranchTaskIndex(
 						continue;
 					}
 					if (type && stateCollector) {
-						stateCollector.push({
+						entry.stateEntry = {
 							id,
 							type,
 							branch: br,
 							path: f,
 							lastModified,
-						});
+						};
+						stateCollector.push(entry.stateEntry);
 					}
 
 					// Only index active tasks for hydration selection (optionally include completed)
@@ -342,8 +352,8 @@ function chooseWinners(
 	localById: Map<string, Task>,
 	remoteIndex: Map<string, RemoteIndexEntry[]>,
 	strategy: "most_recent" | "most_progressed" = "most_progressed",
-): Array<{ id: string; ref: string; path: string; commit?: string }> {
-	const winners: Array<{ id: string; ref: string; path: string; commit?: string }> = [];
+): HydrationCandidate[] {
+	const winners: HydrationCandidate[] = [];
 
 	for (const [id, entries] of remoteIndex) {
 		const local = localById.get(id);
@@ -351,7 +361,13 @@ function chooseWinners(
 		if (!local) {
 			// No local version - take the newest remote
 			const best = entries.reduce((a, b) => (a.lastModified >= b.lastModified ? a : b));
-			winners.push({ id, ref: `origin/${best.branch}`, path: best.path, commit: best.commit });
+			winners.push({
+				id,
+				ref: `origin/${best.branch}`,
+				path: best.path,
+				commit: best.commit,
+				stateEntry: best.stateEntry,
+			});
 			continue;
 		}
 
@@ -366,6 +382,7 @@ function chooseWinners(
 					ref: `origin/${newestRemote.branch}`,
 					path: newestRemote.path,
 					commit: newestRemote.commit,
+					stateEntry: newestRemote.stateEntry,
 				});
 			}
 			continue;
@@ -384,6 +401,7 @@ function chooseWinners(
 				ref: `origin/${newestRemote.branch}`,
 				path: newestRemote.path,
 				commit: newestRemote.commit,
+				stateEntry: newestRemote.stateEntry,
 			});
 		}
 	}
@@ -553,7 +571,7 @@ export async function loadRemoteTasks(
 		onProgress?.(`Found ${remoteIndex.size} unique tasks across remote branches`);
 
 		// If we have local tasks, use them to determine which remote tasks to hydrate
-		let winners: Array<{ id: string; ref: string; path: string; commit?: string }>;
+		let winners: HydrationCandidate[];
 
 		if (localTasks && localTasks.length > 0) {
 			const localById = new Map(localTasks.map((t) => [normalizeTaskId(t.id), t]));
@@ -567,7 +585,13 @@ export async function loadRemoteTasks(
 			winners = [];
 			for (const [id, entries] of remoteIndex) {
 				const best = entries.reduce((a, b) => (a.lastModified >= b.lastModified ? a : b));
-				winners.push({ id, ref: `origin/${best.branch}`, path: best.path, commit: best.commit });
+				winners.push({
+					id,
+					ref: `origin/${best.branch}`,
+					path: best.path,
+					commit: best.commit,
+					stateEntry: best.stateEntry,
+				});
 			}
 			onProgress?.(`Hydrating ${winners.length} remote tasks...`);
 		}
@@ -684,7 +708,7 @@ export async function loadLocalBranchTasks(
 		onProgress?.(`Found ${localBranchIndex.size} unique tasks in other local branches`);
 
 		// Determine which tasks to hydrate
-		let winners: Array<{ id: string; ref: string; path: string; commit?: string }>;
+		let winners: HydrationCandidate[];
 
 		if (localTasks && localTasks.length > 0) {
 			const localById = new Map(localTasks.map((t) => [normalizeTaskId(t.id), t]));
@@ -698,7 +722,13 @@ export async function loadLocalBranchTasks(
 				if (!local) {
 					// Task doesn't exist locally - take the newest from other branches
 					const best = entries.reduce((a, b) => (a.lastModified >= b.lastModified ? a : b));
-					winners.push({ id, ref: best.branch, path: best.path, commit: best.commit });
+					winners.push({
+						id,
+						ref: best.branch,
+						path: best.path,
+						commit: best.commit,
+						stateEntry: best.stateEntry,
+					});
 					continue;
 				}
 
@@ -708,7 +738,13 @@ export async function loadLocalBranchTasks(
 					const newestOther = entries.reduce((a, b) => (a.lastModified >= b.lastModified ? a : b));
 
 					if (newestOther.lastModified.getTime() > localTs) {
-						winners.push({ id, ref: newestOther.branch, path: newestOther.path, commit: newestOther.commit });
+						winners.push({
+							id,
+							ref: newestOther.branch,
+							path: newestOther.path,
+							commit: newestOther.commit,
+							stateEntry: newestOther.stateEntry,
+						});
 					}
 				} else {
 					// For most_progressed, we need to hydrate to check status
@@ -717,7 +753,13 @@ export async function loadLocalBranchTasks(
 
 					if (maybeNewer) {
 						const newestOther = entries.reduce((a, b) => (a.lastModified >= b.lastModified ? a : b));
-						winners.push({ id, ref: newestOther.branch, path: newestOther.path, commit: newestOther.commit });
+						winners.push({
+							id,
+							ref: newestOther.branch,
+							path: newestOther.path,
+							commit: newestOther.commit,
+							stateEntry: newestOther.stateEntry,
+						});
 					}
 				}
 			}
@@ -726,7 +768,13 @@ export async function loadLocalBranchTasks(
 			winners = [];
 			for (const [id, entries] of localBranchIndex) {
 				const best = entries.reduce((a, b) => (a.lastModified >= b.lastModified ? a : b));
-				winners.push({ id, ref: best.branch, path: best.path, commit: best.commit });
+				winners.push({
+					id,
+					ref: best.branch,
+					path: best.path,
+					commit: best.commit,
+					stateEntry: best.stateEntry,
+				});
 			}
 		}
 

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -17,11 +17,6 @@ export interface GitBranchTip {
 	current: boolean;
 }
 
-export interface GitTreeEntry {
-	path: string;
-	objectId: string;
-}
-
 export interface GitIndexEntry {
 	mode: string;
 	objectId: string;
@@ -900,25 +895,6 @@ export class GitOperations {
 		}
 		const { stdout } = await this.execGit(["ls-tree", "-r", "--name-only", "-z", ref, "--", path], { readOnly: true });
 		return stdout.split("\0").filter(Boolean);
-	}
-
-	async listTreeEntries(ref: string, path: string): Promise<GitTreeEntry[]> {
-		if (!(await this.isRepository())) {
-			return [];
-		}
-		const { stdout } = await this.execGit(["ls-tree", "-r", "-z", ref, "--", path], { readOnly: true });
-		const entries: GitTreeEntry[] = [];
-		for (const record of stdout.split("\0")) {
-			if (!record) continue;
-			const separatorIndex = record.indexOf("\t");
-			if (separatorIndex < 0) continue;
-			const metadata = record.slice(0, separatorIndex).split(" ");
-			const objectId = metadata[2];
-			const entryPath = record.slice(separatorIndex + 1);
-			if (!objectId || !entryPath) continue;
-			entries.push({ path: entryPath, objectId });
-		}
-		return entries;
 	}
 
 	async hashFile(filePath: string): Promise<string | null> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -925,7 +925,6 @@ export class BacklogServer {
 		}
 
 		const store = await this.getContentStoreInstance();
-		await this.core.refreshTasksForTaskRead();
 		let resolvedTask: Task | null;
 		try {
 			resolvedTask = await this.core.getTask(taskId);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,7 +22,7 @@ import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
 import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import { formatValidStatuses, getCanonicalStatuses, getValidStatuses } from "../utils/status.ts";
 import { resolveTaskById } from "../utils/task-id.ts";
-import { isAmbiguousTaskIdError, taskIdsEqual } from "../utils/task-path.ts";
+import { isAmbiguousTaskIdError } from "../utils/task-path.ts";
 import { getVersion } from "../utils/version.ts";
 
 // Regex pattern to match any prefix (letters followed by dash)
@@ -926,26 +926,11 @@ export class BacklogServer {
 
 		const store = await this.getContentStoreInstance();
 		await this.core.refreshTasksForTaskRead();
-		const config = await this.core.filesystem.loadConfig();
-		const checkActiveBranches = config?.checkActiveBranches !== false;
-		const storedResolution = resolveTaskById(store.getTasks(), taskId);
-		const activeBranchCollision = await this.core.hasActiveBranchTaskIdCollision(taskId, localTasks);
-		if (
-			localResolution.status === "ambiguous" ||
-			(checkActiveBranches && storedResolution.status === "ambiguous") ||
-			activeBranchCollision
-		) {
-			return Response.json(
-				{ error: `Task ID ${taskId} is ambiguous. Repair duplicate task IDs before opening it.` },
-				{ status: 409 },
-			);
-		}
-		if (
-			checkActiveBranches &&
-			localTask &&
-			storedResolution.status === "found" &&
-			!taskIdsEqual(localTask.id, storedResolution.task.id)
-		) {
+		let resolvedTask: Task | null;
+		try {
+			resolvedTask = await this.core.getTask(taskId);
+		} catch (error) {
+			if (!isAmbiguousTaskIdError(error)) throw error;
 			return Response.json(
 				{ error: `Task ID ${taskId} is ambiguous. Repair duplicate task IDs before opening it.` },
 				{ status: 409 },
@@ -955,8 +940,8 @@ export class BacklogServer {
 			store.upsertTask(localTask);
 			return Response.json(localTask);
 		}
-		if (storedResolution.status === "found") {
-			return Response.json(storedResolution.task);
+		if (resolvedTask) {
+			return Response.json(resolvedTask);
 		}
 
 		return Response.json({ error: `Task ${taskId} not found` }, { status: 404 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,7 +22,7 @@ import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
 import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import { formatValidStatuses, getCanonicalStatuses, getValidStatuses } from "../utils/status.ts";
 import { resolveTaskById } from "../utils/task-id.ts";
-import { isAmbiguousTaskIdError } from "../utils/task-path.ts";
+import { isAmbiguousTaskIdError, taskIdsEqual } from "../utils/task-path.ts";
 import { getVersion } from "../utils/version.ts";
 
 // Regex pattern to match any prefix (letters followed by dash)
@@ -944,7 +944,7 @@ export class BacklogServer {
 			checkActiveBranches &&
 			localTask &&
 			storedResolution.status === "found" &&
-			localTask.id.toLowerCase() !== storedResolution.task.id.toLowerCase()
+			!taskIdsEqual(localTask.id, storedResolution.task.id)
 		) {
 			return Response.json(
 				{ error: `Task ID ${taskId} is ambiguous. Repair duplicate task IDs before opening it.` },

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -5,7 +5,12 @@ import { Core } from "../core/backlog.ts";
 import { serializeTask } from "../markdown/serializer.ts";
 import type { Document, Task } from "../types/index.ts";
 import { AmbiguousTaskIdError } from "../utils/task-path.ts";
-import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+import {
+	commitSamePathBranchTaskVariant,
+	createUniqueTestDir,
+	initializeTestProject,
+	safeCleanup,
+} from "./test-utils.ts";
 
 let TEST_DIR: string;
 
@@ -160,6 +165,72 @@ describe("Core", () => {
 
 			const mixedCase = await core.getTask("Task-007");
 			expect(mixedCase?.id).toBe("TASK-007");
+		});
+
+		it("returns the local task when merge policy selects a same-path padded ID variant", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected config to be loaded");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				taskResolutionStrategy: "most_progressed",
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+
+			const localTask: Task = {
+				...sampleTask,
+				id: "BACK-1",
+				title: "Local task version",
+				status: "To Do",
+			};
+			await commitSamePathBranchTaskVariant(core, localTask, {
+				...localTask,
+				id: "BACK-001",
+				title: "Progressed branch version",
+				status: "Done",
+			});
+
+			const loaded = await core.getTask("BACK-1");
+			expect(loaded?.id).toBe("BACK-1");
+			expect(loaded?.title).toBe("Local task version");
+			expect(loaded?.status).toBe("To Do");
+		});
+
+		it("fails closed when merge policy selects a padded ID variant at a different path", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected config to be loaded");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				taskResolutionStrategy: "most_progressed",
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+
+			const localTask: Task = {
+				...sampleTask,
+				id: "BACK-1",
+				title: "Local task version",
+				status: "To Do",
+			};
+			await commitSamePathBranchTaskVariant(
+				core,
+				localTask,
+				{
+					...localTask,
+					id: "BACK-001",
+					title: "Progressed branch version",
+					status: "Done",
+				},
+				join(core.filesystem.tasksDir, "back-001 - Progressed-branch-version.md"),
+			);
+
+			await expect(core.getTask("BACK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
 		});
 
 		it("should resolve an exact legacy task ID without guessing", async () => {

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -324,6 +324,81 @@ describe("Core", () => {
 			await expect(core.getTask("BACK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
 		});
 
+		it("refreshes branch identities before resolving a long-lived Core read", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) throw new Error("Expected config to be loaded");
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+
+			await core.filesystem.saveTask({ ...sampleTask, id: "BACK-1", title: "Local identity" });
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add local identity"`.cwd(TEST_DIR).quiet();
+
+			expect((await core.getTask("BACK-1"))?.title).toBe("Local identity");
+
+			await $`git switch -c late-distinct-identity`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				join(core.filesystem.tasksDir, "back-1 - Late-distinct-identity.md"),
+				serializeTask({ ...sampleTask, id: "BACK-1", title: "Late distinct identity" }),
+			);
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add late distinct identity"`.cwd(TEST_DIR).quiet();
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+
+			await expect(core.getTask("BACK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+		});
+
+		it("hydrates every branch-only logical identity that shares one exact ID spelling", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) throw new Error("Expected config to be loaded");
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Configure branch identity loading"`.cwd(TEST_DIR).quiet();
+
+			await $`git switch -c exact-id-active`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				join(core.filesystem.tasksDir, "back-1 - Active-branch-identity.md"),
+				serializeTask({ ...sampleTask, id: "BACK-1", title: "Active branch identity" }),
+			);
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add active branch identity"`.cwd(TEST_DIR).quiet();
+
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+			await $`git switch -c exact-id-completed`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				join(core.filesystem.completedDir, "back-1 - Completed-branch-identity.md"),
+				serializeTask({
+					...sampleTask,
+					id: "BACK-1",
+					title: "Completed branch identity",
+					status: "Done",
+				}),
+			);
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add completed branch identity"`.cwd(TEST_DIR).quiet();
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+
+			const included = await core.loadTasks(undefined, undefined, { includeCompleted: true });
+			expect(included.map((task) => task.title).sort()).toEqual([
+				"Active branch identity",
+				"Completed branch identity",
+			]);
+			const statistics = (await core.loadAllTasksForStatistics()).tasks;
+			expect(statistics.map((task) => task.title).sort()).toEqual([
+				"Active branch identity",
+				"Completed branch identity",
+			]);
+		});
+
 		it("fails closed when an archive snapshot would otherwise hide distinct active paths", async () => {
 			const config = await core.filesystem.loadConfig();
 			if (!config) {

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { utimes } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -77,6 +78,60 @@ describe("Core", () => {
 		beforeEach(async () => {
 			await initializeTestProject(core, "Test Project", true);
 		});
+
+		async function commitPaddedTaskLifecycleVariant(type: "archived" | "completed"): Promise<void> {
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected config to be loaded");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				taskResolutionStrategy: "most_progressed",
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+
+			const taskPath = await core.filesystem.saveTask({
+				...sampleTask,
+				id: "BACK-1",
+				title: "Local task version",
+				status: "To Do",
+			});
+			const localDate = "2026-07-30T18:00:00Z";
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`GIT_AUTHOR_DATE="${localDate}" GIT_COMMITTER_DATE="${localDate}" git commit -m "Add local task"`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			await $`git switch -c progressed-task-variant`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				taskPath,
+				serializeTask({
+					...sampleTask,
+					id: "BACK-001",
+					title: "Progressed branch version",
+					status: "Done",
+				}),
+			);
+			const progressedDate = "2026-07-30T18:01:00Z";
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`GIT_AUTHOR_DATE="${progressedDate}" GIT_COMMITTER_DATE="${progressedDate}" git commit -m "Progress padded task variant"`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			await $`git switch -c ${`${type}-task-variant`}`.cwd(TEST_DIR).quiet();
+			const destinationDir = type === "archived" ? core.filesystem.archiveTasksDir : core.filesystem.completedDir;
+			const destinationPath = join(destinationDir, "back-1 - Local-task-version.md");
+			await $`git mv -- ${taskPath} ${destinationPath}`.cwd(TEST_DIR).quiet();
+			const lifecycleDate = "2026-07-30T18:02:00Z";
+			await $`GIT_AUTHOR_DATE="${lifecycleDate}" GIT_COMMITTER_DATE="${lifecycleDate}" git commit -m ${`${type} padded task variant`}`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+			await utimes(taskPath, new Date(localDate), new Date(localDate));
+		}
 
 		it("should create task without auto-commit", async () => {
 			await core.createTask(sampleTask, false);
@@ -231,6 +286,57 @@ describe("Core", () => {
 			);
 
 			await expect(core.getTask("BACK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+		});
+
+		it("fails closed when branch-only canonical ID variants use different paths", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected config to be loaded");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				taskResolutionStrategy: "most_progressed",
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Configure branch task loading"`.cwd(TEST_DIR).quiet();
+
+			await $`git switch -c branch-task-one`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				join(core.filesystem.tasksDir, "back-1 - Branch-one.md"),
+				serializeTask({ ...sampleTask, id: "BACK-1", title: "Branch one", status: "To Do" }),
+			);
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add first branch task"`.cwd(TEST_DIR).quiet();
+
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+			await $`git switch -c branch-task-two`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				join(core.filesystem.tasksDir, "back-001 - Branch-two.md"),
+				serializeTask({ ...sampleTask, id: "BACK-001", title: "Branch two", status: "Done" }),
+			);
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add second branch task"`.cwd(TEST_DIR).quiet();
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+
+			await expect(core.getTask("BACK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+		});
+
+		it("hides a padded same-path variant when a newer branch archives it", async () => {
+			await commitPaddedTaskLifecycleVariant("archived");
+
+			const tasks = await core.loadTasks();
+			expect(tasks.some((task) => task.id === "BACK-1" || task.id === "BACK-001")).toBe(false);
+		});
+
+		it("marks a padded same-path variant completed from a newer branch", async () => {
+			await commitPaddedTaskLifecycleVariant("completed");
+
+			const tasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
+			const task = tasks.find((candidate) => candidate.id === "BACK-1" || candidate.id === "BACK-001");
+			expect(task?.source).toBe("completed");
 		});
 
 		it("should resolve an exact legacy task ID without guessing", async () => {

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -324,19 +324,175 @@ describe("Core", () => {
 			await expect(core.getTask("BACK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
 		});
 
-		it("hides a padded same-path variant when a newer branch archives it", async () => {
+		it("fails closed when an archive snapshot would otherwise hide distinct active paths", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected config to be loaded");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+
+			const localTaskPath = await core.filesystem.saveTask({
+				...sampleTask,
+				id: "BACK-1",
+				title: "Local active path",
+			});
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add local active task"`.cwd(TEST_DIR).quiet();
+
+			await $`git switch -c distinct-active-path`.cwd(TEST_DIR).quiet();
+			await $`git rm -- ${localTaskPath}`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				join(core.filesystem.tasksDir, "back-001 - Distinct-branch-path.md"),
+				serializeTask({
+					...sampleTask,
+					id: "BACK-001",
+					title: "Distinct branch path",
+				}),
+			);
+			const activeDate = "2026-07-30T18:01:00Z";
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`GIT_AUTHOR_DATE="${activeDate}" GIT_COMMITTER_DATE="${activeDate}" git commit -m "Move task to a distinct active path"`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			await $`git switch -c archive-shadow`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				join(core.filesystem.archiveTasksDir, "back-1 - Local-active-path.md"),
+				serializeTask({ ...sampleTask, id: "BACK-1", title: "Archived local path" }),
+			);
+			const archiveDate = "2026-07-30T18:02:00Z";
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`GIT_AUTHOR_DATE="${archiveDate}" GIT_COMMITTER_DATE="${archiveDate}" git commit -m "Archive the original path"`
+				.cwd(TEST_DIR)
+				.quiet();
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+			await utimes(localTaskPath, new Date("2026-07-30T18:00:00Z"), new Date("2026-07-30T18:00:00Z"));
+
+			await expect(core.getTask("BACK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+		});
+
+		it("keeps an ID occupied when equal-time branch records are active and archived", async () => {
+			const config = await core.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected config to be loaded");
+			}
+			await core.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Configure identity loading"`.cwd(TEST_DIR).quiet();
+
+			await $`git switch -c equal-time-states`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				join(core.filesystem.archiveTasksDir, "back-1 - Archived-version.md"),
+				serializeTask({ ...sampleTask, id: "BACK-1", title: "Archived version" }),
+			);
+			await Bun.write(
+				join(core.filesystem.tasksDir, "back-001 - Active-version.md"),
+				serializeTask({ ...sampleTask, id: "BACK-001", title: "Active version" }),
+			);
+			const commitDate = "2026-07-30T18:00:00Z";
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`GIT_AUTHOR_DATE="${commitDate}" GIT_COMMITTER_DATE="${commitDate}" git commit -m "Add equal-time states"`
+				.cwd(TEST_DIR)
+				.quiet();
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+
+			expect(await core.generateNextId()).toBe("BACK-2");
+		});
+
+		it("keeps active and completed identities at distinct paths when completed tasks are included", async () => {
+			const activePath = await core.filesystem.saveTask({
+				...sampleTask,
+				id: "TASK-1",
+				title: "Active identity",
+			});
+			const completedPath = join(core.filesystem.completedDir, "task-001 - Completed-identity.md");
+			await Bun.write(
+				completedPath,
+				serializeTask({
+					...sampleTask,
+					id: "TASK-001",
+					title: "Completed identity",
+					status: "Done",
+				}),
+			);
+
+			const tasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
+			expect(tasks.map((task) => task.title).sort()).toEqual(["Active identity", "Completed identity"]);
+			expect((await core.loadTasks()).map((task) => task.title)).toEqual(["Active identity"]);
+			const statisticsTasks = (await core.loadAllTasksForStatistics()).tasks;
+			expect(statisticsTasks.map((task) => task.title).sort()).toEqual(["Active identity", "Completed identity"]);
+			expect(activePath).not.toBe(completedPath);
+			await expect(core.getTask("TASK-1")).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+		});
+
+		it("normalizes local and Git paths for a nested project with a custom backlog directory", async () => {
+			const nestedRoot = join(TEST_DIR, "packages", "app");
+			const nestedCore = new Core(nestedRoot);
+			await initializeTestProject(nestedCore, "Nested Project", false, "planning/backlog-data");
+			const config = await nestedCore.filesystem.loadConfig();
+			if (!config) {
+				throw new Error("Expected nested config to be loaded");
+			}
+			await nestedCore.filesystem.saveConfig({
+				...config,
+				checkActiveBranches: true,
+				remoteOperations: false,
+				prefixes: { ...config.prefixes, task: "back" },
+			});
+
+			const taskPath = await nestedCore.filesystem.saveTask({
+				...sampleTask,
+				id: "BACK-1",
+				title: "Nested local version",
+			});
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add nested local task"`.cwd(TEST_DIR).quiet();
+			await $`git switch -c nested-task-version`.cwd(TEST_DIR).quiet();
+			await Bun.write(
+				taskPath,
+				serializeTask({
+					...sampleTask,
+					id: "BACK-001",
+					title: "Nested branch version",
+					status: "Done",
+				}),
+			);
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Progress nested task"`.cwd(TEST_DIR).quiet();
+			await $`git switch main`.cwd(TEST_DIR).quiet();
+
+			const loaded = await new Core(nestedRoot).getTask("BACK-1");
+			expect(loaded?.id).toBe("BACK-1");
+			expect(loaded?.title).toBe("Nested local version");
+		});
+
+		it("keeps the working-copy task active when a branch archives the same padded identity path", async () => {
 			await commitPaddedTaskLifecycleVariant("archived");
 
 			const tasks = await core.loadTasks();
-			expect(tasks.some((task) => task.id === "BACK-1" || task.id === "BACK-001")).toBe(false);
+			const task = tasks.find((candidate) => candidate.id === "BACK-1" || candidate.id === "BACK-001");
+			expect(task?.id).toBe("BACK-1");
+			expect(task?.source).toBe("local");
+			expect(await core.generateNextId()).toBe("BACK-2");
 		});
 
-		it("marks a padded same-path variant completed from a newer branch", async () => {
+		it("keeps the working-copy task active when a branch completes the same padded identity path", async () => {
 			await commitPaddedTaskLifecycleVariant("completed");
 
 			const tasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
 			const task = tasks.find((candidate) => candidate.id === "BACK-1" || candidate.id === "BACK-001");
-			expect(task?.source).toBe("completed");
+			expect(task?.id).toBe("BACK-1");
+			expect(task?.source).toBe("local");
 		});
 
 		it("should resolve an exact legacy task ID without guessing", async () => {

--- a/src/test/local-branch-tasks.test.ts
+++ b/src/test/local-branch-tasks.test.ts
@@ -118,7 +118,7 @@ describe("Local branch task discovery", () => {
 			expect(remoteState).toEqual([
 				expect.objectContaining({
 					id: "BACK-PREFIXED",
-					branch: "feature",
+					branch: "origin/feature",
 					path: legacyPath,
 				}),
 			]);

--- a/src/test/local-branch-tasks.test.ts
+++ b/src/test/local-branch-tasks.test.ts
@@ -93,7 +93,6 @@ describe("Local branch task discovery", () => {
 			const legacyPath = "backlog/tasks/back-prefixed - Legacy.md";
 			const mockGit = {
 				resolveCommit: async (ref: string) => `commit:${ref}`,
-				listTreeEntries: async () => [{ path: legacyPath, objectId: "legacy-blob" }],
 				listFilesInTree: async () => [legacyPath],
 				getBranchLastModifiedMap: async () => new Map([[legacyPath, new Date("2026-07-10")]]),
 			} as unknown as GitOperations;
@@ -114,13 +113,13 @@ describe("Local branch task discovery", () => {
 			expect(localIndex.has("BACK-PREFIXED")).toBe(true);
 			expect(remoteIndex.has("BACK-PREFIXED")).toBe(true);
 			expect(localState).toEqual([
-				expect.objectContaining({ id: "BACK-PREFIXED", objectId: "legacy-blob", tree: "commit:feature" }),
+				expect.objectContaining({ id: "BACK-PREFIXED", branch: "feature", path: legacyPath }),
 			]);
 			expect(remoteState).toEqual([
 				expect.objectContaining({
 					id: "BACK-PREFIXED",
-					objectId: "legacy-blob",
-					tree: "commit:origin/feature",
+					branch: "feature",
+					path: legacyPath,
 				}),
 			]);
 		});

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -168,6 +168,55 @@ describe("MCP task tools (MVP)", () => {
 		expect(archivedTasks.map((task) => task.id)).toContain("BACK-1");
 	});
 
+	it("refreshes branch identities before a long-lived MCP mutation", async () => {
+		const config = await loadConfig(mcpServer);
+		await mcpServer.filesystem.saveConfig({
+			...config,
+			checkActiveBranches: true,
+			remoteOperations: false,
+			prefixes: { ...config.prefixes, task: "back" },
+		});
+		const localTask: Task = {
+			id: "BACK-1",
+			title: "Local identity",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-08-01",
+			labels: [],
+			dependencies: [],
+		};
+		await mcpServer.filesystem.saveTask(localTask);
+		await $`git add .`.cwd(TEST_DIR).quiet();
+		await $`git commit -m "Add local identity"`.cwd(TEST_DIR).quiet();
+
+		const initialView = await mcpServer.testInterface.callTool({
+			params: { name: "task_view", arguments: { id: "BACK-1" } },
+		});
+		expect(initialView.isError).not.toBe(true);
+
+		await $`git switch -c late-mcp-collision`.cwd(TEST_DIR).quiet();
+		await Bun.write(
+			join(mcpServer.filesystem.tasksDir, "back-1 - Late-MCP-collision.md"),
+			serializeTask({ ...localTask, title: "Late MCP collision" }),
+		);
+		await $`git add .`.cwd(TEST_DIR).quiet();
+		await $`git commit -m "Add late MCP collision"`.cwd(TEST_DIR).quiet();
+		await $`git switch main`.cwd(TEST_DIR).quiet();
+
+		const lateView = await mcpServer.testInterface.callTool({
+			params: { name: "task_view", arguments: { id: "BACK-1" } },
+		});
+		expect(lateView.isError).toBe(true);
+		expect(getText(lateView.content)).toContain("is ambiguous");
+
+		const editResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_edit", arguments: { id: "BACK-1", title: "Wrong target" } },
+		});
+		expect(editResult.isError).toBe(true);
+		expect(getText(editResult.content)).toContain("is ambiguous");
+		expect((await mcpServer.filesystem.loadTask("BACK-1"))?.title).toBe("Local identity");
+	});
+
 	it("assigns default tail ordinals for task_create and preserves explicit ordinals", async () => {
 		const first = await mcpServer.testInterface.callTool({
 			params: {

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -7,7 +7,12 @@ import { McpServer } from "../mcp/server.ts";
 import { registerTaskTools } from "../mcp/tools/tasks/index.ts";
 import type { JsonSchema } from "../mcp/validation/validators.ts";
 import type { Task } from "../types/index.ts";
-import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+import {
+	commitSamePathBranchTaskVariant,
+	createUniqueTestDir,
+	initializeTestProject,
+	safeCleanup,
+} from "./test-utils.ts";
 
 // Helper to extract text from MCP content (handles union types)
 const getText = (content: unknown[] | undefined, index = 0): string => {
@@ -124,6 +129,43 @@ describe("MCP task tools (MVP)", () => {
 		});
 		expect(viewResult.isError).toBe(true);
 		expect(getText(viewResult.content)).toContain("is ambiguous");
+	});
+
+	it("archives the local task when merge policy selects a same-path padded ID variant", async () => {
+		const config = await loadConfig(mcpServer);
+		await mcpServer.filesystem.saveConfig({
+			...config,
+			checkActiveBranches: true,
+			remoteOperations: false,
+			taskResolutionStrategy: "most_progressed",
+			prefixes: { ...config.prefixes, task: "back" },
+		});
+
+		const localTask: Task = {
+			id: "BACK-1",
+			title: "Local task version",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-07-30",
+			labels: [],
+			dependencies: [],
+			description: "Local task version",
+		};
+		await commitSamePathBranchTaskVariant(mcpServer, localTask, {
+			...localTask,
+			id: "BACK-001",
+			title: "Progressed branch version",
+			status: "Done",
+		});
+
+		const archiveResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_archive", arguments: { id: "BACK-1" } },
+		});
+
+		expect(archiveResult.isError).not.toBe(true);
+		expect(await mcpServer.filesystem.loadTask("BACK-1")).toBeNull();
+		const archivedTasks = await mcpServer.filesystem.listArchivedTasks();
+		expect(archivedTasks.map((task) => task.id)).toContain("BACK-1");
 	});
 
 	it("assigns default tail ordinals for task_create and preserves explicit ordinals", async () => {

--- a/src/test/server-tasks-spa-fallback.test.ts
+++ b/src/test/server-tasks-spa-fallback.test.ts
@@ -114,7 +114,7 @@ async function restartWithActiveBranchCollision(
 	await startServer();
 }
 
-async function restartWithActiveRemoteCollision(): Promise<void> {
+async function restartWithActiveRemoteCollision(useSamePath = false): Promise<void> {
 	await server?.stop();
 	server = null;
 
@@ -138,11 +138,18 @@ async function restartWithActiveRemoteCollision(): Promise<void> {
 	await $`git push -u origin main`.cwd(TEST_DIR).quiet();
 
 	await $`git switch -c remote-update`.cwd(TEST_DIR).quiet();
-	await $`git rm -- ${relative(TEST_DIR, mainTaskPath)}`.cwd(TEST_DIR).quiet();
-	await Bun.write(
-		join(filesystem.tasksDir, "back-1 - Remote-path-collision.md"),
-		serializeTask({ ...mainTask, title: "Remote path collision" }),
-	);
+	if (useSamePath) {
+		await Bun.write(
+			mainTaskPath,
+			serializeTask({ ...mainTask, id: "BACK-001", title: "Remote same-path version", status: "Done" }),
+		);
+	} else {
+		await $`git rm -- ${relative(TEST_DIR, mainTaskPath)}`.cwd(TEST_DIR).quiet();
+		await Bun.write(
+			join(filesystem.tasksDir, "back-1 - Remote-path-collision.md"),
+			serializeTask({ ...mainTask, title: "Remote path collision" }),
+		);
+	}
 	await $`git add backlog`.cwd(TEST_DIR).quiet();
 	await $`git commit -m "Move task on remote main"`.cwd(TEST_DIR).quiet();
 	await $`git push origin HEAD:main`.cwd(TEST_DIR).quiet();
@@ -548,6 +555,14 @@ describe("BacklogServer task SPA fallback", () => {
 		expect((await response.json()) as { error: string }).toEqual({
 			error: "Task ID BACK-1 is ambiguous. Repair duplicate task IDs before opening it.",
 		});
+	});
+
+	it("returns the local task when active origin/main has a padded version at the same path", async () => {
+		await restartWithActiveRemoteCollision(true);
+
+		const response = await request("/api/task/BACK-1");
+		expect(response.status).toBe(200);
+		expect(((await response.json()) as Task).title).toBe("Main collision task");
 	});
 
 	it("returns the local legacy task when an active branch changes the same task path", async () => {

--- a/src/test/server-tasks-spa-fallback.test.ts
+++ b/src/test/server-tasks-spa-fallback.test.ts
@@ -14,6 +14,7 @@ let filesystem: FileSystem;
 let server: BacklogServer | null = null;
 let serverPort = 0;
 let auxiliaryWorktreeDir: string | null = null;
+let remoteRepoDir: string | null = null;
 
 const routedTask: Task = {
 	id: "BACK-001.02",
@@ -69,6 +70,7 @@ async function startServer(): Promise<void> {
 async function restartWithActiveBranchCollision(
 	branchTaskId: "BACK-1" | "BACK-001",
 	includeBranchOnlyTask = false,
+	useSamePath = branchTaskId === "BACK-1",
 ): Promise<void> {
 	await server?.stop();
 	server = null;
@@ -89,8 +91,9 @@ async function restartWithActiveBranchCollision(
 	await $`git commit -m "Add main task"`.cwd(TEST_DIR).quiet();
 	await $`git switch -c collision-shadow`.cwd(TEST_DIR).quiet();
 
-	if (branchTaskId === "BACK-1") {
-		await Bun.write(mainTaskPath, serializeTask({ ...mainTask, title: "Exact branch collision" }));
+	if (useSamePath) {
+		const title = branchTaskId === "BACK-1" ? "Exact branch collision" : "Padded same-path version";
+		await Bun.write(mainTaskPath, serializeTask({ ...mainTask, id: branchTaskId, title }));
 	} else {
 		await $`git rm -- ${relative(TEST_DIR, mainTaskPath)}`.cwd(TEST_DIR).quiet();
 		await Bun.write(
@@ -108,6 +111,43 @@ async function restartWithActiveBranchCollision(
 	await $`git add backlog`.cwd(TEST_DIR).quiet();
 	await $`git commit -m "Add branch collision"`.cwd(TEST_DIR).quiet();
 	await $`git switch main`.cwd(TEST_DIR).quiet();
+	await startServer();
+}
+
+async function restartWithActiveRemoteCollision(): Promise<void> {
+	await server?.stop();
+	server = null;
+
+	const config = await filesystem.loadConfig();
+	if (!config) {
+		throw new Error("Expected test config");
+	}
+	await filesystem.saveConfig({ ...config, checkActiveBranches: true, remoteOperations: true });
+	const mainTask = { ...routedTask, id: "BACK-1", title: "Main collision task" };
+	const mainTaskPath = await filesystem.saveTask(mainTask);
+
+	await $`git init -b main`.cwd(TEST_DIR).quiet();
+	await $`git config user.name "Test User"`.cwd(TEST_DIR).quiet();
+	await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+	await $`git add backlog`.cwd(TEST_DIR).quiet();
+	await $`git commit -m "Add main task"`.cwd(TEST_DIR).quiet();
+
+	remoteRepoDir = createUniqueTestDir("server-task-collision-remote");
+	await $`git init --bare -b main ${remoteRepoDir}`.cwd(TEST_DIR).quiet();
+	await $`git remote add origin ${remoteRepoDir}`.cwd(TEST_DIR).quiet();
+	await $`git push -u origin main`.cwd(TEST_DIR).quiet();
+
+	await $`git switch -c remote-update`.cwd(TEST_DIR).quiet();
+	await $`git rm -- ${relative(TEST_DIR, mainTaskPath)}`.cwd(TEST_DIR).quiet();
+	await Bun.write(
+		join(filesystem.tasksDir, "back-1 - Remote-path-collision.md"),
+		serializeTask({ ...mainTask, title: "Remote path collision" }),
+	);
+	await $`git add backlog`.cwd(TEST_DIR).quiet();
+	await $`git commit -m "Move task on remote main"`.cwd(TEST_DIR).quiet();
+	await $`git push origin HEAD:main`.cwd(TEST_DIR).quiet();
+	await $`git switch main`.cwd(TEST_DIR).quiet();
+	await $`git branch -D remote-update`.cwd(TEST_DIR).quiet();
 	await startServer();
 }
 
@@ -185,6 +225,10 @@ describe("BacklogServer task SPA fallback", () => {
 			await $`git worktree remove --force ${auxiliaryWorktreeDir}`.cwd(TEST_DIR).quiet().nothrow();
 			await safeCleanup(auxiliaryWorktreeDir);
 			auxiliaryWorktreeDir = null;
+		}
+		if (remoteRepoDir) {
+			await safeCleanup(remoteRepoDir);
+			remoteRepoDir = null;
 		}
 		await safeCleanup(TEST_DIR);
 	});
@@ -478,8 +522,26 @@ describe("BacklogServer task SPA fallback", () => {
 		expect(((await response.json()) as Task).title).toBe("Main collision task");
 	});
 
+	it("returns the local task when an active branch uses a padded ID at the same task path", async () => {
+		await restartWithActiveBranchCollision("BACK-001", false, true);
+
+		const response = await request("/api/task/BACK-1");
+		expect(response.status).toBe(200);
+		expect(((await response.json()) as Task).title).toBe("Main collision task");
+	});
+
 	it("fails closed when an active branch uses the same normalized ID at a different task path", async () => {
 		await restartWithActiveBranchCollision("BACK-001");
+
+		const response = await request("/api/task/BACK-1");
+		expect(response.status).toBe(409);
+		expect((await response.json()) as { error: string }).toEqual({
+			error: "Task ID BACK-1 is ambiguous. Repair duplicate task IDs before opening it.",
+		});
+	});
+
+	it("fails closed when active origin/main uses the same ID at a different task path", async () => {
+		await restartWithActiveRemoteCollision();
 
 		const response = await request("/api/task/BACK-1");
 		expect(response.status).toBe(409);

--- a/src/test/server-tasks-spa-fallback.test.ts
+++ b/src/test/server-tasks-spa-fallback.test.ts
@@ -433,7 +433,7 @@ describe("BacklogServer task SPA fallback", () => {
 	});
 
 	it("coalesces one full reload when concurrent reads observe a changed ref snapshot", async () => {
-		await restartWithActiveBranchCollision("BACK-1");
+		await restartWithActiveBranchCollision("BACK-001");
 		const contentStore = await (
 			server as unknown as { getContentStoreInstance: () => Promise<ContentStore> }
 		).getContentStoreInstance();
@@ -470,60 +470,49 @@ describe("BacklogServer task SPA fallback", () => {
 		}
 	});
 
-	for (const branchTaskId of ["BACK-1", "BACK-001"] as const) {
-		it(`fails closed when active branch collision-shadow contains ${branchTaskId}`, async () => {
-			await restartWithActiveBranchCollision(branchTaskId);
+	it("returns the local task when an active branch changes the same task path", async () => {
+		await restartWithActiveBranchCollision("BACK-1");
 
-			const response = await request("/api/task/BACK-1");
-			expect(response.status).toBe(409);
-			expect((await response.json()) as { error: string }).toEqual({
-				error: "Task ID BACK-1 is ambiguous. Repair duplicate task IDs before opening it.",
-			});
+		const response = await request("/api/task/BACK-1");
+		expect(response.status).toBe(200);
+		expect(((await response.json()) as Task).title).toBe("Main collision task");
+	});
+
+	it("fails closed when an active branch uses the same normalized ID at a different task path", async () => {
+		await restartWithActiveBranchCollision("BACK-001");
+
+		const response = await request("/api/task/BACK-1");
+		expect(response.status).toBe(409);
+		expect((await response.json()) as { error: string }).toEqual({
+			error: "Task ID BACK-1 is ambiguous. Repair duplicate task IDs before opening it.",
 		});
-	}
+	});
 
-	it("fails closed when an active branch changes an exact legacy task ID", async () => {
+	it("returns the local legacy task when an active branch changes the same task path", async () => {
 		await restartWithActiveLegacyCollision();
 
 		const response = await request("/api/task/BACK-PREFIXED");
-		expect(response.status).toBe(409);
-		expect((await response.json()) as { error: string }).toEqual({
-			error: "Task ID BACK-PREFIXED is ambiguous. Repair duplicate task IDs before opening it.",
-		});
-	});
-
-	it("opens an unchanged task inherited by an active branch", async () => {
-		await restartWithActiveBranchCollision("BACK-1");
-
-		const response = await request("/api/task/BACK-2");
 		expect(response.status).toBe(200);
-		expect(((await response.json()) as Task).title).toBe("Inherited unchanged task");
+		expect(((await response.json()) as Task).title).toBe("Local legacy task");
 	});
 
-	it("uses live current-worktree content when comparing an active branch", async () => {
+	it("reopens the local task after a browser save with an inherited active branch", async () => {
 		await restartWithActiveBranchCollision("BACK-1");
-		expect((await request("/api/task/BACK-1")).status).toBe(409);
 
-		const mainTask = await filesystem.loadTask("BACK-1");
-		expect(mainTask?.filePath).toBeDefined();
-		if (!mainTask?.filePath) {
-			throw new Error("Expected current-branch task path");
-		}
-		const branchContent = await (
-			server as unknown as { core: { git: { showFile: (ref: string, path: string) => Promise<string> } } }
-		).core.git.showFile("collision-shadow", relative(TEST_DIR, mainTask.filePath).replaceAll("\\", "/"));
-		await Bun.write(mainTask.filePath, branchContent);
+		const saved = await request("/api/tasks/BACK-2", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Saved through browser API" }),
+		});
+		expect(saved.status).toBe(200);
 
-		const identical = await request("/api/task/BACK-1", {}, 5000);
-		expect(identical.status).toBe(200);
-
-		await Bun.write(mainTask.filePath, serializeTask({ ...mainTask, title: "Different current-worktree content" }));
-		const changed = await request("/api/task/BACK-1", {}, 5000);
-		expect(changed.status).toBe(409);
+		const reopened = await request("/api/task/BACK-2", {}, 5000);
+		expect(reopened.status).toBe(200);
+		expect(((await reopened.json()) as Task).title).toBe("Saved through browser API");
 	});
 
 	it("uses the current config when active-branch collision checks are toggled", async () => {
-		await restartWithActiveBranchCollision("BACK-1", true);
+		await restartWithActiveBranchCollision("BACK-001", true);
 
 		const initialCollision = await request("/api/task/BACK-1");
 		expect(initialCollision.status).toBe(409);
@@ -600,7 +589,7 @@ describe("BacklogServer task SPA fallback", () => {
 		if (!cachedConfig) throw new Error("Expected cached test config");
 		const customStatuses = ["Queued", "Working", "Complete"];
 		await filesystem.saveConfig({ ...cachedConfig, statuses: customStatuses });
-		await restartWithActiveBranchCollision("BACK-1");
+		await restartWithActiveBranchCollision("BACK-001");
 		expect((await request("/api/task/BACK-1")).status).toBe(409);
 
 		const activeServer = server as unknown as {
@@ -749,7 +738,7 @@ describe("BacklogServer task SPA fallback", () => {
 	});
 
 	it("drops a cached collision after the active branch is removed", async () => {
-		await restartWithActiveBranchCollision("BACK-1");
+		await restartWithActiveBranchCollision("BACK-001");
 		expect((await request("/api/task/BACK-1")).status).toBe(409);
 
 		await $`git branch -D collision-shadow`.cwd(TEST_DIR).quiet();
@@ -760,7 +749,7 @@ describe("BacklogServer task SPA fallback", () => {
 	});
 
 	it("rebuilds cached collision entries after an active branch task changes", async () => {
-		await restartWithActiveBranchCollision("BACK-1");
+		await restartWithActiveBranchCollision("BACK-001");
 		expect((await request("/api/task/BACK-1")).status).toBe(409);
 
 		await replaceCollisionBranchTask("BACK-100", "Branch replacement");
@@ -774,7 +763,7 @@ describe("BacklogServer task SPA fallback", () => {
 	});
 
 	it("retries a branch scan when a ref moves after its tree was indexed", async () => {
-		await restartWithActiveBranchCollision("BACK-1");
+		await restartWithActiveBranchCollision("BACK-001");
 		expect((await request("/api/task/BACK-1")).status).toBe(409);
 
 		const collisionCommit = (await $`git rev-parse collision-shadow`.cwd(TEST_DIR).quiet()).text().trim();
@@ -782,20 +771,20 @@ describe("BacklogServer task SPA fallback", () => {
 			server as unknown as {
 				core: {
 					git: {
-						listTreeEntries: (ref: string, path: string) => Promise<Array<{ path: string; objectId: string }>>;
+						listFilesInTree: (ref: string, path: string) => Promise<string[]>;
 					};
 				};
 			}
 		).core.git;
-		const originalListTreeEntries = coreGit.listTreeEntries.bind(coreGit);
+		const originalListFilesInTree = coreGit.listFilesInTree.bind(coreGit);
 		let movedDuringScan = false;
-		coreGit.listTreeEntries = async (ref, path) => {
-			const entries = await originalListTreeEntries(ref, path);
+		coreGit.listFilesInTree = async (ref, path) => {
+			const files = await originalListFilesInTree(ref, path);
 			if (!movedDuringScan && ref === collisionCommit) {
 				movedDuringScan = true;
 				await replaceCollisionBranchTask("BACK-100", "Moved during scan");
 			}
-			return entries;
+			return files;
 		};
 
 		try {
@@ -808,7 +797,7 @@ describe("BacklogServer task SPA fallback", () => {
 			expect(replacement.status).toBe(200);
 			expect(((await replacement.json()) as Task).title).toBe("Moved during scan");
 		} finally {
-			coreGit.listTreeEntries = originalListTreeEntries;
+			coreGit.listFilesInTree = originalListFilesInTree;
 		}
 	});
 });

--- a/src/test/task-identity-index.test.ts
+++ b/src/test/task-identity-index.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { TaskIdentityIndex, type TaskIdentityRecord } from "../core/task-identity-index.ts";
+import type { Task } from "../types/index.ts";
+
+const context = {
+	repositoryRoot: "/repo",
+	projectRoot: "/repo",
+	backlogDirectory: "backlog",
+};
+
+function task(title: string): Task {
+	return {
+		id: "BACK-1",
+		title,
+		status: "To Do",
+		assignee: [],
+		createdDate: "2026-08-01",
+		labels: [],
+		dependencies: [],
+	};
+}
+
+function index(records: TaskIdentityRecord[]): TaskIdentityIndex {
+	return new TaskIdentityIndex(records, context, ["To Do", "In Progress", "Done"], "most_progressed");
+}
+
+describe("TaskIdentityIndex", () => {
+	it("prefers a live record over an equal-time archive independent of scan order", () => {
+		const active: TaskIdentityRecord = {
+			id: "BACK-001",
+			type: "task",
+			branch: "feature/active",
+			path: "backlog/tasks/back-1 - Shared.md",
+			lastModified: new Date("2026-08-01T10:00:00Z"),
+			task: task("Active"),
+		};
+		const archived: TaskIdentityRecord = {
+			id: "BACK-1",
+			type: "archived",
+			branch: "feature/archive",
+			path: "backlog/archive/tasks/back-1 - Shared.md",
+			lastModified: new Date("2026-08-01T10:00:00Z"),
+		};
+
+		for (const records of [
+			[active, archived],
+			[archived, active],
+		]) {
+			const identityIndex = index(records);
+			expect(identityIndex.getTasks().map((candidate) => candidate.title)).toEqual(["Active"]);
+			expect(identityIndex.getOccupiedIds()).toContain("BACK-001");
+		}
+	});
+
+	it("selects equal task versions deterministically independent of scan order", () => {
+		const branchA: TaskIdentityRecord = {
+			id: "BACK-1",
+			type: "task",
+			branch: "branch-a",
+			path: "backlog/tasks/back-1 - Shared.md",
+			lastModified: new Date("2026-08-01T10:00:00Z"),
+			task: task("Branch A"),
+		};
+		const branchB: TaskIdentityRecord = {
+			...branchA,
+			branch: "branch-b",
+			task: task("Branch B"),
+		};
+
+		expect(index([branchA, branchB]).getTasks()[0]?.title).toBe("Branch A");
+		expect(index([branchB, branchA]).getTasks()[0]?.title).toBe("Branch A");
+	});
+
+	it("hides and frees an identity when every record is archived", () => {
+		const identityIndex = index([
+			{
+				id: "BACK-001",
+				type: "archived",
+				branch: "branch-a",
+				path: "backlog/archive/tasks/back-1 - Shared.md",
+				lastModified: new Date("2026-08-01T10:00:00Z"),
+			},
+			{
+				id: "BACK-1",
+				type: "archived",
+				branch: "branch-b",
+				path: "backlog/archive/tasks/back-1 - Shared.md",
+				lastModified: new Date("2026-08-01T11:00:00Z"),
+			},
+		]);
+
+		expect(identityIndex.getTasks()).toEqual([]);
+		expect(identityIndex.getOccupiedIds()).toEqual([]);
+	});
+});

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -8,8 +8,11 @@ import { randomUUID } from "node:crypto";
 import { rm } from "node:fs/promises";
 import net from "node:net";
 import { join } from "node:path";
+import { $ } from "bun";
 import type { Core } from "../core/backlog.ts";
 import { initializeProject as initializeProjectShared } from "../core/init.ts";
+import { serializeTask } from "../markdown/serializer.ts";
+import type { Task } from "../types/index.ts";
 
 /**
  * Creates a unique test directory name to avoid conflicts in parallel execution
@@ -20,6 +23,27 @@ export function createUniqueTestDir(prefix: string): string {
 	const timestamp = Date.now().toString(36); // Base36 timestamp
 	const pid = process.pid.toString(36); // Process ID for additional uniqueness
 	return join(process.cwd(), "tmp", `${prefix}-${timestamp}-${pid}-${uuid}`);
+}
+
+export async function commitSamePathBranchTaskVariant(
+	core: Core,
+	localTask: Task,
+	branchTask: Task,
+	distinctBranchPath?: string,
+): Promise<void> {
+	const taskPath = await core.filesystem.saveTask(localTask);
+	await $`git add .`.cwd(core.filesystem.rootDir).quiet();
+	await $`git commit -m "Add local task"`.cwd(core.filesystem.rootDir).quiet();
+
+	await $`git switch -c progressed-task-variant`.cwd(core.filesystem.rootDir).quiet();
+	if (distinctBranchPath) {
+		await $`git rm -- ${taskPath}`.cwd(core.filesystem.rootDir).quiet();
+	}
+	const branchTaskPath = distinctBranchPath ?? taskPath;
+	await Bun.write(branchTaskPath, serializeTask(branchTask));
+	await $`git add -- ${branchTaskPath}`.cwd(core.filesystem.rootDir).quiet();
+	await $`git commit -m "Progress padded task variant"`.cwd(core.filesystem.rootDir).quiet();
+	await $`git switch main`.cwd(core.filesystem.rootDir).quiet();
 }
 
 /**


### PR DESCRIPTION
## Summary

Treat task records with the same padding-insensitive canonical ID and normalized repository-relative logical path as versions of one task. Keep the current working copy authoritative, while failing closed when the same canonical ID identifies distinct live paths.

A shared identity index now drives task loading, lifecycle state, detail resolution, statistics, and ID allocation. Long-lived reads and mutations refresh when relevant branch refs or configuration change, lifecycle ties are deterministic, any active or completed variant keeps an ID occupied, and identities whose variants are all archived are hidden and reusable.

## Related Issue or Task

Fixes #818
Fixes #783

Backlog task: BACK-557

## Task Checklist

- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## User-facing behavior

Saving or updating a task remains safe when another active branch contains a version of the same canonical task at the same logical path: Backlog.md uses the current working copy. If the same canonical ID points to distinct live paths, task detail and mutation surfaces report ambiguity instead of choosing one, including when the collision appears after a long-lived process initialized.

Active, completed, and archived records use the same deterministic identity model across task lists, All Tasks/statistics, detail reads, mutations, and allocation. Equal timestamps cannot make scan order free a live ID, branch hydration preserves every distinct logical identity, and an ID becomes reusable only when every known variant is archived. Numeric ID padding remains cosmetic for identity and occupancy without changing configured output spelling.

## Testing

- `bun test`: 1,808 passed, 4 skipped, 0 failed across 202 files (7,657 assertions)
- Focused identity, Core, MCP, statistics, browser/server, lifecycle, allocation, nested-path, and branch tests: 135 passed, 0 failed after review corrections
- `bunx tsc --noEmit`
- `bun run check .`: 342 files checked, no fixes
- `git diff --check`
