### PR TITLE
BACK-559 - Make Core the sole browser task boundary

### DIFF
--- a/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
+++ b/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:12'
-updated_date: '2026-08-01 20:26'
+updated_date: '2026-08-01 20:44'
 labels:
   - web-ui
   - performance
@@ -51,6 +51,8 @@ Make Core the sole browser task read and mutation boundary for list, detail, upd
 3. Route Core task list/detail/update/complete/archive/reorder and duplicate preview through the ContentStore snapshot. Persist already-resolved exact local paths, update the coherent post-write/post-transition snapshot before publication, and preserve updated-date, status callback, auto-commit, Git staging/commit, BACK-557 same-path identity, and fail-closed collision behavior.
 4. Remove direct browser task-corpus filesystem access from list/detail/update/complete/reorder/duplicate handlers. Return all changed reorder tasks, batch persistence publication into one WebSocket reconciliation, apply response tasks optimistically without a redundant foreground refresh, and reject stale responses after newer reconciliation.
 5. Verify focused Core, ContentStore, task-loader, server/browser, watcher, lifecycle, duplicate-repair, reorder, and identity suites. Run an ephemeral 20-active/430-completed before/after fixture, simplify the design, commit an immutable head, run full bun test, bunx tsc --noEmit, bun run check ., bun run build, and git diff --check, then prepare the exact-head handoff for the coordinator’s fresh independent reviewer. Keep BACK-559 In Progress until that reviewer approves.
+
+6. Fresh-review correction: add RED regressions for exact-path complete/archive/update auto-commit, exact-path watcher deletion after frontmatter-ID change, moved-first atomic reorder reconciliation, and ambiguous reorder 409/no-write. Trace each failure to its current boundary, apply only the four narrow fixes, rerun focused/full/performance gates, and return a new immutable head for another fresh review.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -65,4 +67,10 @@ Implementation complete in isolated worktree. ContentStore now owns TaskCorpusSn
 Ephemeral issue #807 fixture (same machine, 20 active + 430 completed, origin/main 928d85c1 versus this worktree): repeated detail x10 improved 722.5ms -> 658.1ms; repeated update x5 improved 1736.7ms -> 371.2ms (~78.6% reduction). No durable benchmark files were added. Focused post-fix verification: 122 pass, 0 fail across reorder, callbacks, Core, server boundary, auto-commit, and publication suites. Full repository rerun pending.
 
 Final implementation verification: bun test passed 1826, skipped 4, failed 0 across 203 files (327.35s); bunx tsc --noEmit passed; bun run check . passed; bun run build passed; git diff --check passed. BACK-559 intentionally remains In Progress with acceptance criteria unchecked pending the coordinator’s fresh independent reviewer.
+
+Fresh review of 278316d7 identified four blockers: lifecycle/update auto-commit still re-resolve by ID after an exact mutation target exists; watcher deletion keys only by the filename-derived ID after frontmatter identity changes; web reorder applies changedTasks one-by-one so a moved-first result invalidates the request object before sibling updates; ambiguous reorder errors fall through to HTTP 500. Correction started with task remaining In Progress.
+
+Fresh-review corrections implemented with RED-to-GREEN coverage. Core complete/archive now rename the already-resolved exact source path and stage that exact move; update auto-commit uses the path returned by saveTask instead of re-resolving by ID. Task watcher rename/deletion reconciliation replaces and removes by exact watched path, including frontmatter identity changes, while preserving existing moved-file recovery. Reorder response tasks are applied as one batch after one stale-request check. Ambiguous reorder targets return HTTP 409 before writes. Focused correction assertions: 11 pass, 0 fail; broader boundary run exposed one existing rename-recovery regression, which was corrected and reverified with 5 focused watcher tests plus TypeScript. Ephemeral 20-active/430-completed rerun against origin/main 928d85c1: detail x10 636.7ms -> 612.5ms; update x5 1612.1ms -> 348.6ms (~78.4% reduction). Full final gates pending.
+
+Fresh post-correction final verification: bun test passed 1831, skipped 4, failed 0 across 203 files (298.21s); bunx tsc --noEmit passed; bun run check . passed across 343 files; bun run build passed. The correction remains intentionally In Progress with acceptance criteria and Definition of Done unchecked pending fresh independent review.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
+++ b/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-559
 title: Make Core the sole browser task boundary
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-07-30 17:12'
-updated_date: '2026-08-01 20:44'
+updated_date: '2026-08-01 21:02'
 labels:
   - web-ui
   - performance
@@ -26,21 +26,21 @@ Make Core the sole browser task read and mutation boundary for list, detail, upd
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Browser task list, detail, update, complete, reorder, and duplicate-repair handlers make zero direct task-corpus list/load/save calls through core.filesystem; Core is their sole task boundary.
-- [ ] #2 Core exposes separate read and mutation resolution paths over one coherent active/completed/branch identity snapshot: detail reads include completed-only tasks, while mutations accept only unambiguous local active targets and fail before writes otherwise.
-- [ ] #3 Active/active, active/completed, distinct-path cross-branch, zero-padded, cross-prefix, and filename/frontmatter collisions fail closed with browser 409 responses and no file mutation, while BACK-557 same-path branch versions remain one identity.
-- [ ] #4 ContentStore and watchers atomically install coherent visible-task and identity state before publishing creation, deletion, completion, archive, malformed-sibling recovery, and branch-promotion events.
-- [ ] #5 Duplicate-repair preview reuses one Core-owned active/completed snapshot for duplicate detection, occupied-ID allocation, and fingerprint preparation.
-- [ ] #6 Browser updates preserve updated-date, status callbacks, auto-commit, Git staging and commit behavior; completed tasks remain excluded from the active board.
-- [ ] #7 A board reorder returns and applies every changed task, performs no redundant foreground board refresh, emits one WebSocket reconciliation, and preserves mutation callback and auto-commit behavior.
-- [ ] #8 An ephemeral same-machine fixture with 20 active and 430 completed tasks records objective before and after evidence meeting the issue #807 performance objective without adding durable benchmark infrastructure.
+- [x] #1 Browser task list, detail, update, complete, reorder, and duplicate-repair handlers make zero direct task-corpus list/load/save calls through core.filesystem; Core is their sole task boundary.
+- [x] #2 Core exposes separate read and mutation resolution paths over one coherent active/completed/branch identity snapshot: detail reads include completed-only tasks, while mutations accept only unambiguous local active targets and fail before writes otherwise.
+- [x] #3 Active/active, active/completed, distinct-path cross-branch, zero-padded, cross-prefix, and filename/frontmatter collisions fail closed with browser 409 responses and no file mutation, while BACK-557 same-path branch versions remain one identity.
+- [x] #4 ContentStore and watchers atomically install coherent visible-task and identity state before publishing creation, deletion, completion, archive, malformed-sibling recovery, and branch-promotion events.
+- [x] #5 Duplicate-repair preview reuses one Core-owned active/completed snapshot for duplicate detection, occupied-ID allocation, and fingerprint preparation.
+- [x] #6 Browser updates preserve updated-date, status callbacks, auto-commit, Git staging and commit behavior; completed tasks remain excluded from the active board.
+- [x] #7 A board reorder returns and applies every changed task, performs no redundant foreground board refresh, emits one WebSocket reconciliation, and preserves mutation callback and auto-commit behavior.
+- [x] #8 An ephemeral same-machine fixture with 20 active and 430 completed tasks records objective before and after evidence meeting the issue #807 performance objective without adding durable benchmark infrastructure.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -73,4 +73,12 @@ Fresh review of 278316d7 identified four blockers: lifecycle/update auto-commit 
 Fresh-review corrections implemented with RED-to-GREEN coverage. Core complete/archive now rename the already-resolved exact source path and stage that exact move; update auto-commit uses the path returned by saveTask instead of re-resolving by ID. Task watcher rename/deletion reconciliation replaces and removes by exact watched path, including frontmatter identity changes, while preserving existing moved-file recovery. Reorder response tasks are applied as one batch after one stale-request check. Ambiguous reorder targets return HTTP 409 before writes. Focused correction assertions: 11 pass, 0 fail; broader boundary run exposed one existing rename-recovery regression, which was corrected and reverified with 5 focused watcher tests plus TypeScript. Ephemeral 20-active/430-completed rerun against origin/main 928d85c1: detail x10 636.7ms -> 612.5ms; update x5 1612.1ms -> 348.6ms (~78.4% reduction). Full final gates pending.
 
 Fresh post-correction final verification: bun test passed 1831, skipped 4, failed 0 across 203 files (298.21s); bunx tsc --noEmit passed; bun run check . passed across 343 files; bun run build passed. The correction remains intentionally In Progress with acceptance criteria and Definition of Done unchecked pending fresh independent review.
+
+Exact approved implementation head ef9c48d37d8e547b2bd443b7c9cb5e2f5b5e6ae3 finalization verification: the single exact-head full-suite rerun passed 1831, skipped 4, failed 0 across 203 files (344.71s). A previously observed minute-boundary updated-date assertion failure did not reproduce in this exact-head rerun; its isolated assertion also passed, so it is classified as a non-reproduced timing flake outside BACK-559 feature scope. Exact-head bunx tsc --noEmit, bun run check . (343 files), bun run build, and git diff-tree --check all passed. Independent review approved the corrected implementation.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made Core the sole browser task boundary over one ContentStore-owned active/completed/branch identity snapshot, with explicit read versus mutation resolution, exact-path lifecycle persistence, atomic watcher identity publication, single-snapshot duplicate repair, and complete batched reorder reconciliation. Verified collision fail-closed/no-write behavior, callbacks and auto-commit, completed-only reads, lifecycle/watchers, and browser boundary behavior. The ephemeral 20-active/430-completed fixture improved detail x10 from 636.7ms to 612.5ms and update x5 from 1612.1ms to 348.6ms (~78.4%). Final exact-head verification passed 1831 tests with 4 skips and 0 failures, plus TypeScript, Biome, build, and diff checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
+++ b/backlog/tasks/back-559 - Eliminate-repeated-task-corpus-scans-from-browser-updates.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-559
-title: Eliminate repeated task-corpus scans from browser updates
-status: To Do
-assignee: []
+title: Make Core the sole browser task boundary
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-07-30 17:12'
+updated_date: '2026-08-01 20:26'
 labels:
   - web-ui
   - performance
@@ -17,17 +19,21 @@ ordinal: 204000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Browser task mutations repeatedly parse the complete active and completed task corpus. With 20 active and 430 completed tasks, a status update regressed from roughly 3 ms in v1.47.0 to roughly 607 ms on current main, while duplicate repair preview adds about 202 ms and the board can request a second refresh. Resolve task identity once per mutation, reuse one active/completed snapshot for duplicate repair, and avoid redundant board refresh work while preserving fail-closed identity behavior.
+Issue #807 exposed repeated task-corpus scans during browser mutations and refreshes, but the architectural cause is that browser handlers resolve task identity through Core and also call Core.filesystem task list/load/save operations directly. This duplicates active/completed/branch identity resolution, bypasses the ContentStore lifecycle, and lets browser behavior drift from BACK-557 fail-closed semantics.
+
+Make Core the sole browser task read and mutation boundary for list, detail, update, complete, reorder, and duplicate operations. Core must provide separate read and mutation resolution over one coherent active/completed/branch identity snapshot. ContentStore and its watchers own coherent loading, identity-index updates, persistence publication, and lifecycle transitions. Preserve the valid issue #807 latency work: one snapshot per mutation or preview, duplicate-repair reuse, complete reorder responses, one WebSocket reconciliation, and no redundant foreground refresh. This complete architecture direction was explicitly approved by Alex; PR #828 and commit e2499879 are rejected evidence only and are not implementation bases.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One ordinary browser task status update performs at most one active/completed identity scan, persists the change, and returns the updated task.
-- [ ] #2 Duplicate repair preview loads active and completed tasks once and reuses that snapshot for duplicate detection, existing-ID allocation input, and fingerprint preparation.
-- [ ] #3 One board drag applies the returned task immediately and does not cause two duplicate-plan builds; the existing WebSocket refresh still reconciles external changes.
-- [ ] #4 Fail-closed behavior remains for active/active, active/completed, zero-padded, cross-prefix, and filename/frontmatter ID collisions, and ambiguous mutations alter no file.
-- [ ] #5 Completed tasks remain excluded from the active board, and current auto-commit, Git staging and commit, updated-date, and status callback behavior remains unchanged.
-- [ ] #6 An ephemeral same-machine fixture with 20 active and 430 completed tasks records before and after status-update, duplicate-preview, and drag-path measurements with at least a 70 percent reduction in the combined mutation and refresh median; no durable benchmark framework is added.
+- [ ] #1 Browser task list, detail, update, complete, reorder, and duplicate-repair handlers make zero direct task-corpus list/load/save calls through core.filesystem; Core is their sole task boundary.
+- [ ] #2 Core exposes separate read and mutation resolution paths over one coherent active/completed/branch identity snapshot: detail reads include completed-only tasks, while mutations accept only unambiguous local active targets and fail before writes otherwise.
+- [ ] #3 Active/active, active/completed, distinct-path cross-branch, zero-padded, cross-prefix, and filename/frontmatter collisions fail closed with browser 409 responses and no file mutation, while BACK-557 same-path branch versions remain one identity.
+- [ ] #4 ContentStore and watchers atomically install coherent visible-task and identity state before publishing creation, deletion, completion, archive, malformed-sibling recovery, and branch-promotion events.
+- [ ] #5 Duplicate-repair preview reuses one Core-owned active/completed snapshot for duplicate detection, occupied-ID allocation, and fingerprint preparation.
+- [ ] #6 Browser updates preserve updated-date, status callbacks, auto-commit, Git staging and commit behavior; completed tasks remain excluded from the active board.
+- [ ] #7 A board reorder returns and applies every changed task, performs no redundant foreground board refresh, emits one WebSocket reconciliation, and preserves mutation callback and auto-commit behavior.
+- [ ] #8 An ephemeral same-machine fixture with 20 active and 430 completed tasks records objective before and after evidence meeting the issue #807 performance objective without adding durable benchmark infrastructure.
 <!-- AC:END -->
 
 ## Definition of Done
@@ -36,3 +42,27 @@ Browser task mutations repeatedly parse the complete active and completed task c
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RED regression coverage at the public and shared-model boundaries: instrument every browser task route to prove zero task-corpus filesystem calls; prove completed-only detail reads; prove unchanged-filename frontmatter-ID, active/completed, distinct-path branch, zero-padded, and cross-prefix collisions fail closed with 409 and no writes; cover watcher creation/deletion/branch promotion, malformed-sibling recovery, listener-time completion/archive identity, callbacks, auto-commit, and reorder publication.
+2. Introduce one internal TaskCorpusSnapshot loaded by Core and owned atomically by ContentStore, containing visible active tasks, local active tasks, local completed tasks, branch identity records, and the TaskIdentityIndex. Give ContentStore explicit read resolution (active or completed) and mutation resolution (unambiguous working-copy active only), with freshness always rebuilding the complete identity snapshot rather than refreshing only active records or checking filenames alone.
+3. Route Core task list/detail/update/complete/archive/reorder and duplicate preview through the ContentStore snapshot. Persist already-resolved exact local paths, update the coherent post-write/post-transition snapshot before publication, and preserve updated-date, status callback, auto-commit, Git staging/commit, BACK-557 same-path identity, and fail-closed collision behavior.
+4. Remove direct browser task-corpus filesystem access from list/detail/update/complete/reorder/duplicate handlers. Return all changed reorder tasks, batch persistence publication into one WebSocket reconciliation, apply response tasks optimistically without a redundant foreground refresh, and reject stale responses after newer reconciliation.
+5. Verify focused Core, ContentStore, task-loader, server/browser, watcher, lifecycle, duplicate-repair, reorder, and identity suites. Run an ephemeral 20-active/430-completed before/after fixture, simplify the design, commit an immutable head, run full bun test, bunx tsc --noEmit, bun run check ., bun run build, and git diff --check, then prepare the exact-head handoff for the coordinator’s fresh independent reviewer. Keep BACK-559 In Progress until that reviewer approves.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Architecture evidence on origin/main 928d85c1: browser list parent resolution, detail, update, and complete handlers call task-corpus operations through core.filesystem before delegating to Core. Core.getTask separately lists active tasks, calls filesystem.loadTask for active/completed collision detection, and consults a Core-owned TaskIdentityIndex, while ContentStore stores only the visible task array and active-directory watcher events publish visible state without the matching identity state. Reorder calls getTask once per ordered ID and update persistence reloads tasks after save. Duplicate preview scans active/completed multiple times.
+
+Rejected evidence e2499879 is not an implementation base. Its useful direction is a ContentStore-owned TaskCorpusSnapshot and exact-path persistence, but its resolveTask method returned not-found for completed-only identity results, refreshTask used filename-list equality before targeted active parsing and could miss a changed frontmatter ID on an unchanged filename, and lifecycle/watcher fixes were layered after initial implementation. The clean design will make read versus mutation resolution explicit and install one complete snapshot before every publication.
+
+Implementation complete in isolated worktree. ContentStore now owns TaskCorpusSnapshot (visible active, local active/completed, branch identity index) with explicit read and mutation resolution. Core routes browser detail/update/complete/reorder/duplicate behavior through this snapshot; server handlers no longer call task-corpus filesystem list/load/save directly. Lifecycle and watcher publications install identity and visible state together. Reorder returns all changed tasks, batches store publication into one debounced WebSocket reconciliation, and the web client applies all response tasks while rejecting stale responses.
+
+Ephemeral issue #807 fixture (same machine, 20 active + 430 completed, origin/main 928d85c1 versus this worktree): repeated detail x10 improved 722.5ms -> 658.1ms; repeated update x5 improved 1736.7ms -> 371.2ms (~78.6% reduction). No durable benchmark files were added. Focused post-fix verification: 122 pass, 0 fail across reorder, callbacks, Core, server boundary, auto-commit, and publication suites. Full repository rerun pending.
+
+Final implementation verification: bun test passed 1826, skipped 4, failed 0 across 203 files (327.35s); bunx tsc --noEmit passed; bun run check . passed; bun run build passed; git diff --check passed. BACK-559 intentionally remains In Progress with acceptance criteria unchecked pending the coordinator’s fresh independent reviewer.
+<!-- SECTION:NOTES:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -58,14 +58,7 @@ import {
 	stringArraysEqual,
 	validateDependencies,
 } from "../utils/task-builders.ts";
-import {
-	AmbiguousTaskIdError,
-	getDraftPath,
-	getTaskFilename,
-	getTaskPath,
-	normalizeTaskId,
-	taskIdsEqual,
-} from "../utils/task-path.ts";
+import { AmbiguousTaskIdError, getDraftPath, getTaskPath, normalizeTaskId, taskIdsEqual } from "../utils/task-path.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { formatValidTaskTypeValues, matchesTaskTypeFilter, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
@@ -1406,14 +1399,11 @@ export class Core {
 			delete task.updatedDate;
 		}
 
-		await this.fs.saveTask(task);
+		const filePath = await this.fs.saveTask(task);
 		// Keep any in-process ContentStore in sync for immediate UI/search freshness.
 
 		if (await this.shouldAutoCommit(autoCommit)) {
-			const filePath = await getTaskPath(task.id, this);
-			if (filePath) {
-				await this.git.addAndCommitTaskFile(task.id, filePath, "update");
-			}
+			await this.git.addAndCommitTaskFile(task.id, filePath, "update");
 		}
 
 		// Fire status change callback if status changed
@@ -2358,15 +2348,16 @@ export class Core {
 
 		// Get paths before moving the file
 		const taskPath = taskToArchive.filePath ?? (await getTaskPath(normalizedTaskId, this));
-		const taskFilename = await getTaskFilename(normalizedTaskId, this);
+		const taskFilename = taskPath ? basename(taskPath) : null;
 
 		if (!taskPath || !taskFilename) return false;
 
 		const fromPath = taskPath;
 		const toPath = join(await this.fs.getArchiveTasksDir(), taskFilename);
 
-		const success = await this.fs.archiveTask(normalizedTaskId);
-		if (!success) {
+		try {
+			await moveFile(fromPath, toPath);
+		} catch {
 			return false;
 		}
 		this.contentStore?.transitionTask(normalizedTaskId);
@@ -2472,18 +2463,20 @@ export class Core {
 		const fromPath = taskPath;
 		const toPath = join(completedDir, taskFilename);
 
-		const success = await this.fs.completeTask(taskId);
-		if (success) {
-			this.contentStore?.transitionTask(task.id, { ...task, filePath: toPath, source: "completed" });
+		try {
+			await moveFile(fromPath, toPath);
+		} catch {
+			return false;
 		}
+		this.contentStore?.transitionTask(task.id, { ...task, filePath: toPath, source: "completed" });
 
-		if (success && (await this.shouldAutoCommit(autoCommit))) {
+		if (await this.shouldAutoCommit(autoCommit)) {
 			// Stage the file move for proper Git tracking
 			const repoRoot = await this.git.stageFileMove(fromPath, toPath);
 			await this.git.commitChanges(`backlog: Complete task ${normalizeTaskId(taskId)}`, repoRoot);
 		}
 
-		return success;
+		return true;
 	}
 
 	async getTerminalStatusTasksByAge(olderThanDays: number): Promise<Task[]> {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -58,7 +58,6 @@ import {
 	stringArraysEqual,
 	validateDependencies,
 } from "../utils/task-builders.ts";
-import { resolveTaskById } from "../utils/task-id.ts";
 import {
 	AmbiguousTaskIdError,
 	getDraftPath,
@@ -72,7 +71,7 @@ import { formatValidTaskTypeValues, matchesTaskTypeFilter, resolveTaskTypeValue 
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
 import { isTerminalStatus } from "../utils/terminal-status.ts";
 import { migrateConfig, needsMigration } from "./config-migration.ts";
-import { ContentStore } from "./content-store.ts";
+import { ContentStore, type TaskCorpusSnapshot } from "./content-store.ts";
 import {
 	applyDuplicateTaskIdRepair,
 	type DuplicateRepairPlan,
@@ -210,7 +209,6 @@ export class Core {
 	private contentStore?: ContentStore;
 	private searchService?: SearchService;
 	private readonly enableWatchers: boolean;
-	private taskIdentityIndex?: TaskIdentityIndex;
 	private activeBranchFingerprint: string | null = null;
 	private activeBranchFingerprintPromise: Promise<string> | null = null;
 	private activeBranchRefreshPromise: Promise<void> | null = null;
@@ -273,7 +271,10 @@ export class Core {
 	}
 
 	async previewDuplicateTaskIdRepair(options: { includeBranches?: boolean } = {}): Promise<DuplicateRepairPlan> {
-		return await previewDuplicateTaskIdRepair(this, options);
+		const hadStore = this.contentStore !== undefined;
+		const store = await this.getContentStore();
+		if (hadStore) await store.refreshLocalTaskCorpus();
+		return await previewDuplicateTaskIdRepair(this, options, store.getTaskCorpusSnapshot());
 	}
 
 	async repairDuplicateTaskIds(expectedFingerprint: string): Promise<DuplicateRepairResult> {
@@ -307,7 +308,7 @@ export class Core {
 	async getContentStore(): Promise<ContentStore> {
 		if (!this.contentStore) {
 			// Use loadTasks as the task loader to include cross-branch tasks
-			this.contentStore = new ContentStore(this.fs, () => this.loadTasks(), this.enableWatchers);
+			this.contentStore = new ContentStore(this.fs, () => this.loadContentStoreCorpus(), this.enableWatchers);
 		}
 		await this.contentStore.ensureInitialized();
 		return this.contentStore;
@@ -371,11 +372,11 @@ export class Core {
 	}
 
 	/** Refresh the existing cross-branch store only when relevant config or refs changed. */
-	async refreshTasksForTaskRead(): Promise<void> {
+	async refreshTasksForTaskRead(): Promise<boolean> {
 		while (true) {
 			const fingerprint = await this.getActiveBranchFingerprint();
 			if (fingerprint === this.activeBranchFingerprint) {
-				return;
+				return false;
 			}
 
 			if (!this.activeBranchRefreshPromise) {
@@ -394,6 +395,7 @@ export class Core {
 			}
 
 			await this.activeBranchRefreshPromise;
+			return true;
 		}
 	}
 
@@ -617,43 +619,14 @@ export class Core {
 	}
 
 	async getTask(taskId: string): Promise<Task | null> {
-		const localTasks = await this.fs.listTasks();
-		const localResolution = resolveTaskById(localTasks, taskId);
-		if (localResolution.status === "invalid") {
-			return null;
-		}
-		if (localResolution.status === "ambiguous") {
-			throw new AmbiguousTaskIdError(
-				taskId,
-				localResolution.tasks.map((task) => task.filePath ?? task.id),
-			);
-		}
-
-		// Also fail closed when an active task collides with a completed file.
-		await this.fs.loadTask(taskId);
-
-		await this.refreshTasksForTaskRead();
 		const store = await this.getContentStore();
-		const identityResolution = this.taskIdentityIndex?.resolve(taskId);
-		if (identityResolution?.status === "ambiguous") {
+		const branchRefreshed = await this.refreshTasksForTaskRead();
+		if (!branchRefreshed) await store.refreshLocalTaskCorpus();
+		const identityResolution = store.resolveTaskForRead(taskId);
+		if (identityResolution.status === "ambiguous") {
 			throw new AmbiguousTaskIdError(taskId, identityResolution.candidates);
 		}
-		const storeResolution = resolveTaskById(store.getTasks(), taskId);
-		if (storeResolution.status === "ambiguous") {
-			throw new AmbiguousTaskIdError(
-				taskId,
-				storeResolution.tasks.map((task) => task.filePath ?? `${task.branch ?? "unknown branch"}:${task.id}`),
-			);
-		}
-		if (localResolution.status === "found") {
-			return localResolution.task;
-		}
-		if (identityResolution?.status === "found") {
-			return identityResolution.task;
-		}
-
-		if (storeResolution.status === "found") return storeResolution.task;
-		return null;
+		return identityResolution.status === "found" ? identityResolution.task : null;
 	}
 
 	async getTaskWithSubtasks(taskId: string, localTasks?: Task[]): Promise<Task | null> {
@@ -671,9 +644,11 @@ export class Core {
 	}
 
 	private async loadLocalTaskForMutation(taskId: string): Promise<Task | null> {
-		const resolvedTask = await this.getTask(taskId);
-		if (!resolvedTask || !isLocalEditableTask(resolvedTask) || resolvedTask.branch) return null;
-		return await this.fs.loadTask(resolvedTask.id);
+		const store = await this.getContentStore();
+		await store.refreshTasks();
+		const resolution = store.resolveTaskForMutation(taskId);
+		if (resolution.status === "ambiguous") throw new AmbiguousTaskIdError(taskId, resolution.candidates);
+		return resolution.status === "found" ? { ...resolution.task } : null;
 	}
 
 	async getTaskContent(taskId: string): Promise<string | null> {
@@ -725,7 +700,6 @@ export class Core {
 			this.contentStore.dispose();
 			this.contentStore = undefined;
 		}
-		this.taskIdentityIndex = undefined;
 		this.activeBranchFingerprint = null;
 		this.activeBranchFingerprintPromise = null;
 		this.activeBranchRefreshPromise = null;
@@ -1416,7 +1390,10 @@ export class Core {
 		normalizeAssignee(task);
 
 		// Load original task to detect status changes for callbacks
-		const originalTask = await this.fs.loadTask(task.id);
+		const cachedResolution = this.contentStore?.isInitialized()
+			? this.contentStore.resolveTaskForMutation(task.id)
+			: undefined;
+		const originalTask = cachedResolution?.status === "found" ? cachedResolution.task : await this.fs.loadTask(task.id);
 		const oldStatus = originalTask?.status ?? "";
 		const newStatus = task.status ?? "";
 		const statusChanged = oldStatus !== newStatus;
@@ -1431,12 +1408,6 @@ export class Core {
 
 		await this.fs.saveTask(task);
 		// Keep any in-process ContentStore in sync for immediate UI/search freshness.
-		if (this.contentStore) {
-			const savedTask = await this.fs.loadTask(task.id);
-			if (savedTask) {
-				this.contentStore.upsertTask(savedTask);
-			}
-		}
 
 		if (await this.shouldAutoCommit(autoCommit)) {
 			const filePath = await getTaskPath(task.id, this);
@@ -2041,8 +2012,7 @@ export class Core {
 		}
 
 		await this.updateTask(task, autoCommit);
-		const refreshed = await this.fs.loadTask(taskId);
-		return refreshed ?? task;
+		return task;
 	}
 
 	async updateDraft(task: Task, autoCommit?: boolean): Promise<void> {
@@ -2242,10 +2212,11 @@ export class Core {
 	}
 
 	async updateTasksBulk(tasks: Task[], commitMessage?: string, autoCommit?: boolean): Promise<void> {
-		// Update all tasks without committing individually
-		for (const task of tasks) {
-			await this.updateTask(task, false); // Don't auto-commit each one
-		}
+		const updateAll = async () => {
+			for (const task of tasks) await this.updateTask(task, false);
+		};
+		if (this.contentStore) await this.contentStore.batchTaskUpdates(updateAll);
+		else await updateAll();
 
 		// Commit all changes at once if auto-commit is enabled
 		if (await this.shouldAutoCommit(autoCommit)) {
@@ -2284,13 +2255,13 @@ export class Core {
 			seen.add(id);
 		}
 
-		// Load all tasks from the ordered list - use getTask to include cross-branch tasks from the store
-		const loadedTasks = await Promise.all(
-			orderedTaskIds.map(async (id) => {
-				const task = await this.getTask(id);
-				return task;
-			}),
-		);
+		const store = await this.getContentStore();
+		await store.refreshTasks();
+		const loadedTasks = orderedTaskIds.map((id) => {
+			const resolution = store.resolveTaskForMutation(id);
+			if (resolution.status === "ambiguous") throw new AmbiguousTaskIdError(id, resolution.candidates);
+			return resolution.status === "found" ? resolution.task : null;
+		});
 
 		// Filter out any tasks that couldn't be loaded (may have been moved/deleted)
 		const validTasks = loadedTasks.filter((t): t is Task => t !== null);
@@ -2398,6 +2369,7 @@ export class Core {
 		if (!success) {
 			return false;
 		}
+		this.contentStore?.transitionTask(normalizedTaskId);
 
 		const activeTasks = await this.fs.listTasks();
 		const sanitizedTasks = this.sanitizeArchivedTaskLinks(activeTasks, normalizedTaskId);
@@ -2501,6 +2473,9 @@ export class Core {
 		const toPath = join(completedDir, taskFilename);
 
 		const success = await this.fs.completeTask(taskId);
+		if (success) {
+			this.contentStore?.transitionTask(task.id, { ...task, filePath: toPath, source: "completed" });
+		}
 
 		if (success && (await this.shouldAutoCommit(autoCommit))) {
 			// Stage the file move for proper Git tracking
@@ -3072,15 +3047,43 @@ export class Core {
 		abortSignal?: AbortSignal,
 		options?: { includeCompleted?: boolean },
 	): Promise<Task[]> {
-		return await this.loadTasksWithStableBranchSnapshot(progressCallback, abortSignal, options, 0);
+		return (await this.loadTasksWithStableBranchSnapshot(progressCallback, abortSignal, options, 0)).tasks;
+	}
+
+	private async loadTaskCorpusSnapshot(): Promise<TaskCorpusSnapshot> {
+		return await this.loadTasksWithStableBranchSnapshot(
+			undefined,
+			undefined,
+			{ includeCompleted: true, visibleCompleted: false },
+			0,
+		);
+	}
+
+	private async loadContentStoreCorpus(): Promise<TaskCorpusSnapshot> {
+		if (Object.hasOwn(this, "loadTasks")) {
+			const [activeTasks, completedTasks, config] = await Promise.all([
+				this.loadTasks(),
+				this.fs.listCompletedTasks(),
+				this.fs.loadConfig(),
+			]);
+			const identityIndex = await this.buildTaskIdentityIndex(
+				activeTasks,
+				completedTasks,
+				[],
+				config?.statuses ?? [...DEFAULT_STATUSES],
+				config?.taskResolutionStrategy ?? "most_progressed",
+			);
+			return { tasks: identityIndex.getTasks(false), activeTasks, completedTasks, identityIndex };
+		}
+		return await this.loadTaskCorpusSnapshot();
 	}
 
 	private async loadTasksWithStableBranchSnapshot(
 		progressCallback: ((msg: string) => void) | undefined,
 		abortSignal: AbortSignal | undefined,
-		options: { includeCompleted?: boolean } | undefined,
+		options: { includeCompleted?: boolean; visibleCompleted?: boolean } | undefined,
 		snapshotAttempt: number,
-	): Promise<Task[]> {
+	): Promise<TaskCorpusSnapshot> {
 		const config = await this.fs.loadConfig();
 		this.git.setConfig(config);
 		const snapshotBefore = await this.getActiveBranchFingerprint(config);
@@ -3153,7 +3156,7 @@ export class Core {
 			statuses,
 			resolutionStrategy,
 		);
-		const filteredTasks = identityIndex.getTasks(includeCompleted);
+		const filteredTasks = identityIndex.getTasks(options?.visibleCompleted ?? includeCompleted);
 
 		const snapshotAfter = await this.getActiveBranchFingerprint();
 		if (snapshotBefore !== snapshotAfter) {
@@ -3162,8 +3165,12 @@ export class Core {
 			}
 			return await this.loadTasksWithStableBranchSnapshot(progressCallback, abortSignal, options, snapshotAttempt + 1);
 		}
-		this.taskIdentityIndex = identityIndex;
 		this.activeBranchFingerprint = snapshotAfter;
-		return filteredTasks;
+		return {
+			tasks: filteredTasks,
+			activeTasks: localTasks,
+			completedTasks,
+			identityIndex,
+		};
 	}
 }

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -827,13 +827,14 @@ export class ContentStore {
 		return true;
 	}
 
-	private publishWatchedTask(task: Task): void {
+	private publishWatchedTask(task: Task, replacedPath?: string): void {
 		const id = normalizeTaskId(task.id);
 		this.nextContentItemGeneration("tasks", id);
 		this.nextContentItemVersion("tasks", id, this.currentRoot());
 		this.activeTasks = this.activeTasks.filter(
 			(candidate) =>
 				candidate.filePath !== task.filePath &&
+				candidate.filePath !== replacedPath &&
 				(candidate.filePath !== undefined || task.filePath !== undefined || !taskIdsEqual(candidate.id, task.id)),
 		);
 		this.activeTasks.push(task);
@@ -844,13 +845,19 @@ export class ContentStore {
 		this.notify("tasks");
 	}
 
-	private removeWatchedTask(id: string): void {
+	private removeWatchedTask(id: string, watchedPath?: string): void {
 		const normalizedId = normalizeTaskId(id);
-		const before = this.activeTasks.length;
-		this.activeTasks = this.activeTasks.filter((task) => !taskIdsEqual(task.id, normalizedId));
-		if (before === this.activeTasks.length) return;
-		this.nextContentItemGeneration("tasks", normalizedId);
-		this.nextContentItemVersion("tasks", normalizedId, this.currentRoot());
+		const removedTasks = this.activeTasks.filter((task) =>
+			watchedPath ? task.filePath === watchedPath : taskIdsEqual(task.id, normalizedId),
+		);
+		if (removedTasks.length === 0) return;
+		this.activeTasks = this.activeTasks.filter((task) =>
+			watchedPath ? task.filePath !== watchedPath : !taskIdsEqual(task.id, normalizedId),
+		);
+		for (const removedId of new Set([normalizedId, ...removedTasks.map((task) => normalizeTaskId(task.id))])) {
+			this.nextContentItemGeneration("tasks", removedId);
+			this.nextContentItemVersion("tasks", removedId, this.currentRoot());
+		}
 		if (this.taskIdentityIndex) {
 			this.taskIdentityIndex = this.taskIdentityIndex.withWorkingCopyCorpus(this.activeTasks, this.completedTasks);
 			this.replaceVisibleTasks(this.taskIdentityIndex.getTasks(false));
@@ -942,17 +949,17 @@ export class ContentStore {
 								return { state: "incomplete" };
 							}
 						},
-						current: () => this.tasks.get(normalizedTaskId),
+						current: () => this.activeTasks.find((task) => task.filePath === fullPath),
 						hasChanged: (previous, next) => this.hasTaskChanged(previous, next),
-						publish: (task) => this.publishWatchedTask(task),
-						remove: () => this.removeWatchedTask(normalizedTaskId),
+						publish: (task) => this.publishWatchedTask(task, fullPath),
+						remove: () => this.removeWatchedTask(normalizedTaskId, fullPath),
 					});
 					return;
 				}
 
 				await this.reconcileOrSchedule(`task:${normalizedTaskId}`, epoch, async () => {
 					if (!(await Bun.file(fullPath).exists())) {
-						this.removeWatchedTask(normalizedTaskId);
+						this.removeWatchedTask(normalizedTaskId, fullPath);
 						return false;
 					}
 					try {

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -10,11 +10,22 @@ import { normalizePriorityValue } from "../utils/priority-config.ts";
 import { normalizeTaskId, normalizeTaskIdentity, taskIdsEqual } from "../utils/task-path.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
 import { matchesTaskTypeFilter } from "../utils/task-type-config.ts";
+import type { TaskIdentityIndex, TaskIdentityResolution } from "./task-identity-index.ts";
+
+export interface TaskCorpusSnapshot {
+	tasks: Task[];
+	activeTasks: Task[];
+	completedTasks: Task[];
+	identityIndex?: TaskIdentityIndex;
+}
+
+type TaskLoaderResult = Task[] | TaskCorpusSnapshot;
 
 interface ContentSnapshot {
 	tasks: Task[];
 	documents: Document[];
 	decisions: Decision[];
+	taskCorpus?: TaskCorpusSnapshot;
 }
 
 type ContentStoreEventType = "ready" | "tasks" | "documents" | "decisions";
@@ -71,6 +82,9 @@ export class ContentStore {
 	private readonly decisions = new Map<string, Decision>();
 
 	private cachedTasks: Task[] = [];
+	private activeTasks: Task[] = [];
+	private completedTasks: Task[] = [];
+	private taskIdentityIndex?: TaskIdentityIndex;
 	private cachedDocuments: Document[] = [];
 	private cachedDecisions: Decision[] = [];
 
@@ -108,6 +122,9 @@ export class ContentStore {
 	private boundBacklogDir: string | null = null;
 	private closed = false;
 	private readonly deferredRechecks = new Map<string, DeferredRecheck>();
+	private taskBatchDepth = 0;
+	private pendingTaskNotification = false;
+	private localTaskRefreshPromise: Promise<void> | null = null;
 
 	private attachWatcherErrorHandler(watcher: FSWatcher, context: string): void {
 		watcher.on("error", (error) => {
@@ -119,7 +136,7 @@ export class ContentStore {
 
 	constructor(
 		private readonly filesystem: FileSystem,
-		private readonly taskLoader?: () => Promise<Task[]>,
+		private readonly taskLoader?: () => Promise<TaskLoaderResult>,
 		private readonly enableWatchers = false,
 	) {
 		this.publishedRoot = this.currentRoot();
@@ -158,6 +175,10 @@ export class ContentStore {
 		return this.getSnapshot();
 	}
 
+	isInitialized(): boolean {
+		return this.initialized;
+	}
+
 	async refreshTasks(): Promise<void> {
 		this.assertOpen();
 		if (!this.initialized) {
@@ -168,6 +189,41 @@ export class ContentStore {
 		await this.enqueueRoot(epoch, async () => {
 			await this.refreshTasksFromDisk(undefined, epoch);
 		});
+	}
+
+	async refreshLocalTaskCorpus(): Promise<void> {
+		if (!this.initialized) {
+			await this.ensureInitialized();
+			return;
+		}
+		if (!this.localTaskRefreshPromise) {
+			const refresh = (async () => {
+				const [activeTasks, completedTasks] = await Promise.all([
+					this.filesystem.listTasks(),
+					this.filesystem.listCompletedTasks(),
+				]);
+				const previousFingerprint = this.taskIdentityIndex?.getFingerprint();
+				this.activeTasks = activeTasks;
+				this.completedTasks = completedTasks;
+				if (this.taskIdentityIndex) {
+					this.taskIdentityIndex = this.taskIdentityIndex.withWorkingCopyCorpus(activeTasks, completedTasks);
+					const tasks = this.taskIdentityIndex.getTasks(false);
+					const changed = this.hasTaskCollectionChanged(tasks);
+					const identityChanged = previousFingerprint !== this.taskIdentityIndex.getFingerprint();
+					this.replaceVisibleTasks(tasks);
+					if (changed || identityChanged) this.publishTaskChange();
+				} else {
+					const changed = this.hasTaskCollectionChanged(activeTasks);
+					this.replaceVisibleTasks(activeTasks);
+					if (changed) this.publishTaskChange();
+				}
+			})();
+			this.localTaskRefreshPromise = refresh;
+			void refresh.finally(() => {
+				if (this.localTaskRefreshPromise === refresh) this.localTaskRefreshPromise = null;
+			});
+		}
+		await this.localTaskRefreshPromise;
 	}
 
 	getTasks(filter?: TaskListFilter): Task[] {
@@ -208,6 +264,30 @@ export class ContentStore {
 		return tasks.slice();
 	}
 
+	getTaskCorpusSnapshot(): TaskCorpusSnapshot {
+		if (!this.initialized) throw new Error("ContentStore not initialized. Call ensureInitialized() first.");
+		return {
+			tasks: this.cachedTasks.slice(),
+			activeTasks: this.activeTasks.slice(),
+			completedTasks: this.completedTasks.slice(),
+			identityIndex: this.taskIdentityIndex,
+		};
+	}
+
+	resolveTaskForRead(taskId: string): TaskIdentityResolution {
+		if (!this.initialized) throw new Error("ContentStore not initialized. Call ensureInitialized() first.");
+		if (this.taskIdentityIndex) return this.taskIdentityIndex.resolveForRead(taskId);
+		const task = this.cachedTasks.find((candidate) => taskIdsEqual(candidate.id, taskId));
+		return task ? { status: "found", task } : { status: "not-found" };
+	}
+
+	resolveTaskForMutation(taskId: string): TaskIdentityResolution {
+		if (!this.initialized) throw new Error("ContentStore not initialized. Call ensureInitialized() first.");
+		if (this.taskIdentityIndex) return this.taskIdentityIndex.resolveForMutation(taskId);
+		const task = this.cachedTasks.find((candidate) => taskIdsEqual(candidate.id, taskId));
+		return task ? { status: "found", task } : { status: "not-found" };
+	}
+
 	upsertTask(task: Task, owner?: PublicationOwner): void {
 		if (!this.canPublishContent()) {
 			return;
@@ -237,11 +317,67 @@ export class ContentStore {
 			this.pendingTaskPublications.set(normalizedId, { root: publicationRoot, task });
 			return;
 		}
-		this.tasks.set(task.id, task);
-		this.cachedTasks = sortByTaskId(Array.from(this.tasks.values()));
-		if (this.initialized) {
-			this.notify("tasks");
+		if (task.branch && this.taskIdentityIndex) {
+			this.taskIdentityIndex = this.taskIdentityIndex.withRecord({
+				id: task.id,
+				type: "task",
+				branch: task.branch,
+				path: task.filePath ?? `${task.branch}:${task.id}`,
+				lastModified: task.lastModified ?? (task.updatedDate ? new Date(task.updatedDate) : new Date(0)),
+				task,
+			});
+			this.replaceVisibleTasks(this.taskIdentityIndex.getTasks(false));
+			this.publishTaskChange();
+			return;
 		}
+		this.activeTasks = this.activeTasks.filter(
+			(candidate) =>
+				candidate.filePath !== task.filePath &&
+				(candidate.filePath !== undefined || task.filePath !== undefined || !taskIdsEqual(candidate.id, task.id)),
+		);
+		this.activeTasks.push(task);
+		if (this.taskIdentityIndex) {
+			this.taskIdentityIndex = this.taskIdentityIndex.withWorkingCopyCorpus(this.activeTasks, this.completedTasks);
+			this.replaceVisibleTasks(this.taskIdentityIndex.getTasks(false));
+		} else {
+			this.tasks.set(task.id, task);
+			this.cachedTasks = sortByTaskId(Array.from(this.tasks.values()));
+		}
+		this.publishTaskChange();
+	}
+
+	async batchTaskUpdates<T>(operation: () => Promise<T>): Promise<T> {
+		this.taskBatchDepth += 1;
+		try {
+			return await operation();
+		} finally {
+			this.taskBatchDepth -= 1;
+			if (this.taskBatchDepth === 0 && this.pendingTaskNotification) {
+				this.pendingTaskNotification = false;
+				if (this.initialized) this.notify("tasks");
+			}
+		}
+	}
+
+	private publishTaskChange(): void {
+		if (!this.initialized) return;
+		if (this.taskBatchDepth > 0) this.pendingTaskNotification = true;
+		else this.notify("tasks");
+	}
+
+	transitionTask(taskId: string, completedTask?: Task): void {
+		const previousActiveCount = this.activeTasks.length;
+		this.activeTasks = this.activeTasks.filter((task) => !taskIdsEqual(task.id, taskId));
+		this.completedTasks = this.completedTasks.filter((task) => !taskIdsEqual(task.id, taskId));
+		if (completedTask) this.completedTasks.push({ ...completedTask, source: "completed" });
+		if (previousActiveCount === this.activeTasks.length && !completedTask) return;
+		if (this.taskIdentityIndex) {
+			this.taskIdentityIndex = this.taskIdentityIndex.withWorkingCopyCorpus(this.activeTasks, this.completedTasks);
+			this.replaceVisibleTasks(this.taskIdentityIndex.getTasks(false));
+		} else {
+			this.replaceVisibleTasks(this.activeTasks);
+		}
+		this.publishTaskChange();
 	}
 
 	getDocuments(): Document[] {
@@ -368,7 +504,7 @@ export class ContentStore {
 			// Otherwise fall back to filesystem-only loading
 			const epoch = this.rootWatcherEpoch;
 			const attemptLoaded = await this.loadCurrentContent(epoch, (snapshot) => {
-				this.replaceTasks(snapshot.tasks);
+				this.installTaskCorpus(snapshot.taskCorpus ?? this.asTaskCorpus(snapshot.tasks));
 				this.replaceDocuments(snapshot.documents);
 				this.replaceDecisions(snapshot.decisions);
 			});
@@ -511,7 +647,7 @@ export class ContentStore {
 			if (!this.isPublicationOwnerCurrent(transitionOwner)) return;
 
 			const loaded = await this.loadCurrentContent(transitionEpoch, (snapshot) => {
-				this.replaceTasks(snapshot.tasks);
+				this.installTaskCorpus(snapshot.taskCorpus ?? this.asTaskCorpus(snapshot.tasks));
 				this.replaceDocuments(snapshot.documents);
 				this.replaceDecisions(snapshot.decisions);
 			});
@@ -633,7 +769,7 @@ export class ContentStore {
 			documents: new Map(this.contentItemVersions.documents),
 			decisions: new Map(this.contentItemVersions.decisions),
 		};
-		const [tasks, documents, decisions] = await Promise.all([
+		const [taskCorpus, documents, decisions] = await Promise.all([
 			this.loadTasksWithLoader(),
 			this.filesystem.listDocuments(),
 			this.filesystem.listDecisions(),
@@ -648,17 +784,23 @@ export class ContentStore {
 			return false;
 		}
 
+		const mergedTasks = this.mergeConcurrentChanges(
+			taskCorpus.tasks,
+			before.tasks,
+			this.tasksForPublicationRoot(targetRoot),
+			(task) => normalizeTaskId(task.id),
+			itemVersions.tasks,
+			this.contentItemVersions.tasks,
+			this.contentItemPublicationRoots.tasks,
+			targetRoot,
+		);
 		publish({
-			tasks: this.mergeConcurrentChanges(
-				tasks,
-				before.tasks,
-				this.tasksForPublicationRoot(targetRoot),
-				(task) => normalizeTaskId(task.id),
-				itemVersions.tasks,
-				this.contentItemVersions.tasks,
-				this.contentItemPublicationRoots.tasks,
-				targetRoot,
-			),
+			tasks: mergedTasks,
+			taskCorpus: {
+				...taskCorpus,
+				tasks: mergedTasks,
+				activeTasks: taskCorpus.identityIndex ? taskCorpus.activeTasks : mergedTasks,
+			},
 			documents: this.mergeConcurrentChanges(
 				documents,
 				before.documents,
@@ -689,17 +831,30 @@ export class ContentStore {
 		const id = normalizeTaskId(task.id);
 		this.nextContentItemGeneration("tasks", id);
 		this.nextContentItemVersion("tasks", id, this.currentRoot());
-		this.tasks.set(id, task);
-		this.cachedTasks = sortByTaskId(Array.from(this.tasks.values()));
+		this.activeTasks = this.activeTasks.filter(
+			(candidate) =>
+				candidate.filePath !== task.filePath &&
+				(candidate.filePath !== undefined || task.filePath !== undefined || !taskIdsEqual(candidate.id, task.id)),
+		);
+		this.activeTasks.push(task);
+		if (this.taskIdentityIndex) {
+			this.taskIdentityIndex = this.taskIdentityIndex.withWorkingCopyCorpus(this.activeTasks, this.completedTasks);
+			this.replaceVisibleTasks(this.taskIdentityIndex.getTasks(false));
+		} else this.replaceVisibleTasks(this.activeTasks);
 		this.notify("tasks");
 	}
 
 	private removeWatchedTask(id: string): void {
 		const normalizedId = normalizeTaskId(id);
-		if (!this.tasks.delete(normalizedId)) return;
+		const before = this.activeTasks.length;
+		this.activeTasks = this.activeTasks.filter((task) => !taskIdsEqual(task.id, normalizedId));
+		if (before === this.activeTasks.length) return;
 		this.nextContentItemGeneration("tasks", normalizedId);
 		this.nextContentItemVersion("tasks", normalizedId, this.currentRoot());
-		this.cachedTasks = sortByTaskId(Array.from(this.tasks.values()));
+		if (this.taskIdentityIndex) {
+			this.taskIdentityIndex = this.taskIdentityIndex.withWorkingCopyCorpus(this.activeTasks, this.completedTasks);
+			this.replaceVisibleTasks(this.taskIdentityIndex.getTasks(false));
+		} else this.replaceVisibleTasks(this.activeTasks);
 		this.notify("tasks");
 	}
 
@@ -756,7 +911,6 @@ export class ContentStore {
 						readEventPath: async () => {
 							if (!(await Bun.file(fullPath).exists())) return null;
 							const task = { ...normalizeTaskIdentity(parseTask(await Bun.file(fullPath).text())), filePath: fullPath };
-							if (!taskIdsEqual(task.id, normalizedTaskId)) throw new Error("Task identity mismatch");
 							return task;
 						},
 						findIdentity: async () => {
@@ -778,7 +932,7 @@ export class ContentStore {
 							);
 							if (local.state !== "absent" || !this.taskLoader) return local;
 							try {
-								const matches = (await this.loadTasksWithLoader()).filter((task) =>
+								const matches = (await this.loadTasksWithLoader()).activeTasks.filter((task) =>
 									taskIdsEqual(task.id, normalizedTaskId),
 								);
 								if (matches.length === 0) return { state: "absent" };
@@ -803,7 +957,10 @@ export class ContentStore {
 					}
 					try {
 						const task = { ...normalizeTaskIdentity(parseTask(await Bun.file(fullPath).text())), filePath: fullPath };
-						if (!taskIdsEqual(task.id, normalizedTaskId)) return true;
+						if (!taskIdsEqual(task.id, normalizedTaskId)) {
+							this.publishWatchedTask(task);
+							return false;
+						}
 						const previous = this.tasks.get(normalizedTaskId);
 						if (previous && !this.hasTaskChanged(previous, task)) return true;
 						this.publishWatchedTask(task);
@@ -815,7 +972,16 @@ export class ContentStore {
 			});
 		});
 		this.attachWatcherErrorHandler(watcher, "tasks");
-		return { stop: () => watcher.close() };
+		const completedWatcher = watch(this.filesystem.completedDir, { recursive: false }, () => {
+			void this.enqueueRoot(epoch, async () => this.refreshTasksFromDisk(undefined, epoch));
+		});
+		this.attachWatcherErrorHandler(completedWatcher, "completed tasks");
+		return {
+			stop: () => {
+				watcher.close();
+				completedWatcher.close();
+			},
+		};
 	}
 
 	private createDecisionWatcher(epoch: number): WatchHandle {
@@ -1012,13 +1178,22 @@ export class ContentStore {
 		);
 	}
 
-	private replaceTasks(tasks: Task[]): void {
-		this.invalidateContentItemGenerations("tasks");
+	private replaceVisibleTasks(tasks: Task[]): void {
 		this.tasks.clear();
-		for (const task of tasks) {
-			this.tasks.set(task.id, task);
-		}
+		for (const task of tasks) this.tasks.set(task.id, task);
 		this.cachedTasks = sortByTaskId(Array.from(this.tasks.values()));
+	}
+
+	private asTaskCorpus(tasks: Task[]): TaskCorpusSnapshot {
+		return { tasks, activeTasks: tasks, completedTasks: [] };
+	}
+
+	private installTaskCorpus(corpus: TaskCorpusSnapshot, visibleTasks = corpus.tasks): void {
+		this.invalidateContentItemGenerations("tasks");
+		this.activeTasks = corpus.activeTasks.slice();
+		this.completedTasks = corpus.completedTasks.slice();
+		this.taskIdentityIndex = corpus.identityIndex;
+		this.replaceVisibleTasks(visibleTasks);
 	}
 
 	private replaceDocuments(documents: Document[]): void {
@@ -1051,7 +1226,8 @@ export class ContentStore {
 		this.filesystem.saveTask = (async (task: Task): Promise<string> => {
 			const owner: PublicationOwner = { root: this.currentRoot() };
 			const result = await originalSaveTask.call(this.filesystem, task);
-			await this.handleTaskWrite(task.id, owner);
+			const savedTask = { ...normalizeTaskIdentity(parseTask(await Bun.file(result).text())), filePath: result };
+			await this.updateTaskFromDisk(task.id, owner, savedTask);
 			return result;
 		}) as FileSystem["saveTask"];
 
@@ -1073,15 +1249,6 @@ export class ContentStore {
 			this.filesystem.saveDocument = originalSaveDocument;
 			this.filesystem.saveDecision = originalSaveDecision;
 		};
-	}
-
-	private async handleTaskWrite(taskId: string, owner: PublicationOwner): Promise<void> {
-		if (!this.canPublishContent() || !this.isPublicationOwnerCurrent(owner)) {
-			return;
-		}
-		await this.enqueuePublication(owner, async () => {
-			await this.updateTaskFromDisk(taskId, owner);
-		});
 	}
 
 	private async handleDocumentWrite(documentId: string, owner: PublicationOwner): Promise<void> {
@@ -1265,13 +1432,14 @@ export class ContentStore {
 			const targetRoot = this.currentRoot();
 			const generation = this.nextContentRefreshGeneration("tasks");
 			const before = { items: this.cachedTasks.slice(), versions: new Map(this.contentItemVersions.tasks) };
-			let tasks: Task[];
+			let corpus: TaskCorpusSnapshot;
 			try {
-				tasks = await this.loadTasksWithLoader();
+				const loaded = await this.loadTasksWithLoader();
+				corpus = Array.isArray(loaded) ? this.asTaskCorpus(loaded) : loaded;
 			} catch {
 				return true;
 			}
-			if (expectedId && !tasks.some((task) => taskIdsEqual(task.id, expectedId))) return true;
+			if (expectedId && !corpus.activeTasks.some((task) => taskIdsEqual(task.id, expectedId))) return true;
 			if (
 				!this.isRootWatcherCurrent(epoch) ||
 				targetRoot !== this.currentRoot() ||
@@ -1279,7 +1447,7 @@ export class ContentStore {
 			)
 				return false;
 			const merged = this.mergeConcurrentChanges(
-				tasks,
+				corpus.tasks,
 				before.items,
 				this.cachedTasks,
 				(task) => normalizeTaskId(task.id),
@@ -1288,8 +1456,9 @@ export class ContentStore {
 				this.contentItemPublicationRoots.tasks,
 				targetRoot,
 			);
-			if (!this.hasTaskCollectionChanged(merged)) return false;
-			this.replaceTasks(merged);
+			const identityChanged = this.taskIdentityIndex?.getFingerprint() !== corpus.identityIndex?.getFingerprint();
+			if (!this.hasTaskCollectionChanged(merged) && !identityChanged) return false;
+			this.installTaskCorpus(corpus, merged);
 			this.notify("tasks");
 			return false;
 		});
@@ -1434,34 +1603,22 @@ export class ContentStore {
 	private async updateTaskFromDisk(
 		taskId: string,
 		owner: PublicationOwner = { root: this.currentRoot() },
+		exactTask?: Task,
 	): Promise<void> {
+		if (!this.canPublishContent() || !this.isPublicationOwnerCurrent(owner)) return;
 		const normalizedTaskId = normalizeTaskId(taskId);
-		const generation = this.nextContentItemGeneration("tasks", normalizedTaskId);
 		const epoch = this.rootWatcherEpoch;
 		await this.reconcileOrSchedule(`task:${normalizedTaskId}`, epoch, async () => {
-			if (
-				!this.isPublicationOwnerCurrent(owner) ||
-				!this.isContentItemGenerationCurrent("tasks", normalizedTaskId, generation)
-			)
-				return false;
-			let task: Task | null;
-			try {
-				task = await this.filesystem.loadTask(taskId);
-			} catch {
-				return true;
+			let task: Task | null | undefined = exactTask;
+			if (!task) {
+				try {
+					task = await this.filesystem.loadTask(taskId);
+				} catch {
+					return true;
+				}
 			}
 			if (!task || !taskIdsEqual(task.id, normalizedTaskId)) return true;
-			const previous = this.tasks.get(normalizedTaskId);
-			if (previous && !this.hasTaskChanged(previous, task)) return false;
-			if (
-				!this.isPublicationOwnerCurrent(owner) ||
-				!this.isContentItemGenerationCurrent("tasks", normalizedTaskId, generation)
-			)
-				return false;
-			this.nextContentItemVersion("tasks", normalizedTaskId, owner.root);
-			this.tasks.set(normalizedTaskId, task);
-			this.cachedTasks = sortByTaskId(Array.from(this.tasks.values()));
-			if (this.initialized) this.notify("tasks");
+			this.upsertTask(task, owner);
 			return false;
 		});
 	}
@@ -1652,11 +1809,12 @@ export class ContentStore {
 		});
 	}
 
-	private async loadTasksWithLoader(): Promise<Task[]> {
+	private async loadTasksWithLoader(): Promise<TaskCorpusSnapshot> {
 		if (this.taskLoader) {
-			return await this.taskLoader();
+			const loaded = await this.taskLoader();
+			return Array.isArray(loaded) ? this.asTaskCorpus(loaded) : loaded;
 		}
-		return await this.filesystem.listTasks();
+		return this.asTaskCorpus(await this.filesystem.listTasks());
 	}
 }
 

--- a/src/core/duplicate-task-repair.ts
+++ b/src/core/duplicate-task-repair.ts
@@ -1,10 +1,11 @@
 import { link, lstat, mkdtemp, rename, rmdir, unlink } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
-import { EntityType, type Task } from "../types/index.ts";
+import type { Task } from "../types/index.ts";
 import { type DuplicateGroup, detectDuplicateTaskIds } from "../utils/duplicate-detection.ts";
 import { escapeRegex, generateNextId, generateNextSubtaskId, idForFilename } from "../utils/prefix-config.ts";
 import { canonicalTaskId, isNumericTaskId } from "../utils/task-id.ts";
 import type { Core } from "./backlog.ts";
+import type { TaskCorpusSnapshot } from "./content-store.ts";
 import { type BranchTaskStateEntry, loadLocalBranchTasks, loadRemoteTasks } from "./task-loader.ts";
 
 export type DuplicateTaskLocation = "active" | "completed";
@@ -90,11 +91,10 @@ function withLocation(task: Task, location: DuplicateTaskLocation, rootDir: stri
 	};
 }
 
-export async function findLocalDuplicateTaskIds(core: Core): Promise<DuplicateGroup[]> {
-	const [activeTasks, completedTasks] = await Promise.all([
-		core.filesystem.listTasks(),
-		core.filesystem.listCompletedTasks(),
-	]);
+export async function findLocalDuplicateTaskIds(core: Core, snapshot?: TaskCorpusSnapshot): Promise<DuplicateGroup[]> {
+	const [activeTasks, completedTasks] = snapshot
+		? [snapshot.activeTasks, snapshot.completedTasks]
+		: await Promise.all([core.filesystem.listTasks(), core.filesystem.listCompletedTasks()]);
 	return detectDuplicateTaskIds([
 		...activeTasks.map((task) => withLocation(task, "active", core.filesystem.rootDir)),
 		...completedTasks.map((task) => withLocation(task, "completed", core.filesystem.rootDir)),
@@ -229,28 +229,19 @@ function validateGroupParent(group: DuplicateGroup): { parentId?: string; blocke
 }
 
 async function allocateRepairId(
-	core: Core,
+	_core: Core,
 	parentId: string | undefined,
 	existingIds: string[],
 	plannedIds: string[],
 	taskPrefix: string,
 	zeroPaddedIds?: number,
 ): Promise<string> {
-	const generatedId = await core.generateNextId(EntityType.Task, parentId);
 	const occupiedIds = [...existingIds, ...plannedIds];
-	if (!occupiedIds.some((occupiedId) => canonicalTaskId(occupiedId) === canonicalTaskId(generatedId))) {
-		return generatedId;
-	}
-
-	let nextId: string;
-	if (!parentId) {
-		nextId = generateNextId(occupiedIds, taskPrefix, zeroPaddedIds);
-	} else {
-		const generatedParent = generatedId.slice(0, generatedId.lastIndexOf("."));
-		nextId = generateNextSubtaskId(occupiedIds, generatedParent, taskPrefix, zeroPaddedIds);
-	}
+	const nextId = parentId
+		? generateNextSubtaskId(occupiedIds, canonicalTaskId(parentId), taskPrefix, zeroPaddedIds)
+		: generateNextId(occupiedIds, taskPrefix, zeroPaddedIds);
 	if (occupiedIds.some((occupiedId) => canonicalTaskId(occupiedId) === canonicalTaskId(nextId))) {
-		throw new Error(`Could not allocate an unused repair ID after ${generatedId}.`);
+		throw new Error(`Could not allocate an unused repair ID after ${nextId}.`);
 	}
 	return nextId;
 }
@@ -392,14 +383,15 @@ async function findReferenceReviews(core: Core, groupIds: string[]): Promise<Dup
 export async function previewDuplicateTaskIdRepair(
 	core: Core,
 	options: { includeBranches?: boolean } = {},
+	snapshot?: TaskCorpusSnapshot,
 ): Promise<DuplicateRepairPlan> {
-	const groups = await findLocalDuplicateTaskIds(core);
+	const groups = await findLocalDuplicateTaskIds(core, snapshot);
 	const crossBranchFindings = options.includeBranches ? await findCrossBranchDuplicateTaskIds(core) : [];
 	const blockedReasons: string[] = [];
 	const changes: DuplicateRepairChange[] = [];
 	const [activeTasks, completedTasks, config] = await Promise.all([
-		core.filesystem.listTasks(),
-		core.filesystem.listCompletedTasks(),
+		snapshot ? Promise.resolve(snapshot.activeTasks) : core.filesystem.listTasks(),
+		snapshot ? Promise.resolve(snapshot.completedTasks) : core.filesystem.listCompletedTasks(),
 		core.filesystem.loadConfig(),
 	]);
 	const existingIds = [...activeTasks, ...completedTasks].map((task) => task.id);

--- a/src/core/task-identity-index.ts
+++ b/src/core/task-identity-index.ts
@@ -147,14 +147,16 @@ function liveRecords(identity: TaskIdentity): TaskIdentityRecord[] {
 
 export class TaskIdentityIndex {
 	private readonly groups = new Map<string, TaskIdentityGroup>();
+	private readonly records: TaskIdentityRecord[];
 
 	constructor(
 		records: TaskIdentityRecord[],
-		context: TaskIdentityPathContext,
+		private readonly context: TaskIdentityPathContext,
 		private readonly statuses: string[],
 		private readonly resolutionStrategy: "most_recent" | "most_progressed",
 	) {
-		for (const record of records) {
+		this.records = records.slice();
+		for (const record of this.records) {
 			const canonicalId = canonicalTaskId(record.id);
 			const path = normalizeRecordPath(record, context);
 			const group = this.groups.get(canonicalId) ?? { id: canonicalId, identities: new Map() };
@@ -165,8 +167,49 @@ export class TaskIdentityIndex {
 		}
 	}
 
-	private getGroup(taskId: string): TaskIdentityGroup | undefined {
-		return [...this.groups.values()].find((group) => taskIdsEqual(group.id, taskId));
+	withWorkingCopyCorpus(activeTasks: Task[], completedTasks: Task[]): TaskIdentityIndex {
+		const records = this.records.filter((record) => !record.workingCopy);
+		for (const task of activeTasks) {
+			records.push({
+				id: task.id,
+				type: "task",
+				branch: "local",
+				path: task.filePath ?? task.id,
+				lastModified: task.lastModified ?? (task.updatedDate ? new Date(task.updatedDate) : new Date(0)),
+				task: { ...task, source: "local" },
+				workingCopy: true,
+			});
+		}
+		for (const task of completedTasks) {
+			records.push({
+				id: task.id,
+				type: "completed",
+				branch: "local",
+				path: task.filePath ?? task.id,
+				lastModified: task.lastModified ?? (task.updatedDate ? new Date(task.updatedDate) : new Date(0)),
+				task: { ...task, source: "completed" },
+				workingCopy: true,
+			});
+		}
+		return new TaskIdentityIndex(records, this.context, this.statuses, this.resolutionStrategy);
+	}
+
+	withRecord(record: TaskIdentityRecord): TaskIdentityIndex {
+		return new TaskIdentityIndex([...this.records, record], this.context, this.statuses, this.resolutionStrategy);
+	}
+
+	private getGroups(taskId: string): TaskIdentityGroup[] {
+		return [...this.groups.values()].filter((group) => taskIdsEqual(group.id, taskId));
+	}
+
+	private candidatesAcrossGroups(groups: TaskIdentityGroup[]): string[] {
+		const candidates = new Set<string>();
+		for (const group of groups) {
+			for (const identity of group.identities.values()) {
+				for (const record of liveRecords(identity)) candidates.add(record.path);
+			}
+		}
+		return [...candidates].sort((left, right) => left.localeCompare(right));
 	}
 
 	private ambiguousCandidates(group: TaskIdentityGroup): string[] {
@@ -211,13 +254,41 @@ export class TaskIdentityIndex {
 		return tasks;
 	}
 
-	resolve(taskId: string): TaskIdentityResolution {
-		const group = this.getGroup(taskId);
-		if (!group) return { status: "not-found" };
+	resolveForRead(taskId: string): TaskIdentityResolution {
+		const groups = this.getGroups(taskId);
+		if (groups.length === 0) return { status: "not-found" };
+		if (groups.length > 1) return { status: "ambiguous", candidates: this.candidatesAcrossGroups(groups) };
+		const group = groups[0] as TaskIdentityGroup;
 		const candidates = this.ambiguousCandidates(group);
 		if (candidates.length > 0) return { status: "ambiguous", candidates };
-		const tasks = this.getTasks(false).filter((task) => taskIdsEqual(task.id, taskId));
+		const tasks = this.getTasks(true).filter((task) => taskIdsEqual(task.id, taskId));
 		return tasks[0] ? { status: "found", task: tasks[0] } : { status: "not-found" };
+	}
+
+	resolveForMutation(taskId: string): TaskIdentityResolution {
+		const groups = this.getGroups(taskId);
+		if (groups.length === 0) return { status: "not-found" };
+		if (groups.length > 1) return { status: "ambiguous", candidates: this.candidatesAcrossGroups(groups) };
+		const group = groups[0] as TaskIdentityGroup;
+		const candidates = this.ambiguousCandidates(group);
+		if (candidates.length > 0) return { status: "ambiguous", candidates };
+		const workingTasks = [...group.identities.values()]
+			.flatMap((identity) => identity.records)
+			.filter((record) => record.workingCopy && record.type === "task" && record.task)
+			.sort((left, right) => recordKey(left).localeCompare(recordKey(right)));
+		const selected = workingTasks[0]?.task;
+		return selected ? { status: "found", task: { ...selected, source: "local" } } : { status: "not-found" };
+	}
+
+	resolve(taskId: string): TaskIdentityResolution {
+		return this.resolveForMutation(taskId);
+	}
+
+	getFingerprint(): string {
+		return this.records
+			.map((record) => `${recordKey(record)}\0${record.type}\0${record.workingCopy ? "1" : "0"}`)
+			.sort((left, right) => left.localeCompare(right))
+			.join("\n");
 	}
 
 	getOccupiedIds(): string[] {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1575,6 +1575,9 @@ export class BacklogServer {
 			return Response.json({ success: true, task: updatedTask, changedTasks });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to reorder task";
+			if (isAmbiguousTaskIdError(error)) {
+				return Response.json({ error: message }, { status: 409 });
+			}
 			// Cross-branch and validation errors are client errors (400), not server errors (500)
 			const isCrossBranchError = message.includes("exists in branch");
 			const isValidationError = message.includes("not found") || message.includes("Missing required");

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,5 @@
 import net from "node:net";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import type { Server, ServerWebSocket } from "bun";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -21,7 +21,7 @@ import {
 import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
 import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import { formatValidStatuses, getCanonicalStatuses, getValidStatuses } from "../utils/status.ts";
-import { resolveTaskById } from "../utils/task-id.ts";
+import { isValidTaskId } from "../utils/task-id.ts";
 import { isAmbiguousTaskIdError } from "../utils/task-path.ts";
 import { getVersion } from "../utils/version.ts";
 
@@ -189,6 +189,7 @@ export class BacklogServer {
 	private contentStore: ContentStore | null = null;
 	private searchService: SearchService | null = null;
 	private unsubscribeContentStore?: () => void;
+	private taskBroadcastTimer?: ReturnType<typeof setTimeout>;
 	private storeReadyBroadcasted = false;
 
 	constructor(projectPath: string) {
@@ -256,11 +257,15 @@ export class BacklogServer {
 	}
 
 	private broadcastTasksUpdated() {
-		for (const ws of this.sockets) {
-			try {
-				ws.send("tasks-updated");
-			} catch {}
-		}
+		if (this.taskBroadcastTimer) clearTimeout(this.taskBroadcastTimer);
+		this.taskBroadcastTimer = setTimeout(() => {
+			this.taskBroadcastTimer = undefined;
+			for (const ws of this.sockets) {
+				try {
+					ws.send("tasks-updated");
+				} catch {}
+			}
+		}, 75);
 	}
 
 	private broadcastConfigUpdated() {
@@ -485,6 +490,7 @@ export class BacklogServer {
 	}
 
 	async stop(): Promise<void> {
+		if (this.taskBroadcastTimer) clearTimeout(this.taskBroadcastTimer);
 		if (this._stopping) return;
 		this._stopping = true;
 
@@ -662,31 +668,10 @@ export class BacklogServer {
 		// Resolve parent task ID if provided
 		let parentTaskId: string | undefined;
 		if (parent) {
-			const store = await this.getContentStoreInstance();
-			let parentTask: Task | undefined;
+			let parentTask: Task | null;
 			try {
-				const localTask = await this.core.filesystem.loadTask(parent);
-				if (localTask) {
-					store.upsertTask(localTask);
-					parentTask = localTask;
-				} else {
-					const parentResolution = resolveTaskById(store.getTasks(), parent);
-					if (parentResolution.status === "ambiguous") {
-						return Response.json(
-							{ error: `Parent task ${parent} is ambiguous. Repair duplicate task IDs before using it.` },
-							{ status: 409 },
-						);
-					}
-					parentTask = parentResolution.status === "found" ? parentResolution.task : undefined;
-					if (!parentTask) {
-						const fallbackId = ensurePrefix(parent);
-						const fallback = await this.core.filesystem.loadTask(fallbackId);
-						if (fallback) {
-							store.upsertTask(fallback);
-							parentTask = fallback;
-						}
-					}
-				}
+				parentTask = await this.core.getTask(parent);
+				if (!parentTask) parentTask = await this.core.getTask(ensurePrefix(parent));
 			} catch (error) {
 				if (isAmbiguousTaskIdError(error)) {
 					return Response.json({ error: error.message }, { status: 409 });
@@ -907,37 +892,16 @@ export class BacklogServer {
 	}
 
 	private async handleGetTask(taskId: string): Promise<Response> {
-		const localTasks = await this.core.filesystem.listTasks();
-		const localResolution = resolveTaskById(localTasks, taskId);
-		if (localResolution.status === "invalid") {
-			return Response.json({ error: `Invalid task ID: ${taskId}` }, { status: 400 });
-		}
-		let localTask: Task | null;
-		try {
-			// loadTask checks active and completed task paths together, so a collision
-			// cannot be hidden by whichever directory happens to be read first.
-			localTask = await this.core.filesystem.loadTask(taskId);
-		} catch (error) {
-			if (isAmbiguousTaskIdError(error)) {
-				return Response.json({ error: error.message }, { status: 409 });
-			}
-			throw error;
-		}
-
-		const store = await this.getContentStoreInstance();
+		if (!isValidTaskId(taskId)) return Response.json({ error: `Invalid task ID: ${taskId}` }, { status: 400 });
 		let resolvedTask: Task | null;
 		try {
 			resolvedTask = await this.core.getTask(taskId);
 		} catch (error) {
 			if (!isAmbiguousTaskIdError(error)) throw error;
-			return Response.json(
-				{ error: `Task ID ${taskId} is ambiguous. Repair duplicate task IDs before opening it.` },
-				{ status: 409 },
-			);
-		}
-		if (localTask) {
-			store.upsertTask(localTask);
-			return Response.json(localTask);
+			const message = error.candidates.some((candidate) => !isAbsolute(candidate))
+				? `Task ID ${taskId} is ambiguous. Repair duplicate task IDs before opening it.`
+				: error.message;
+			return Response.json({ error: message }, { status: 409 });
 		}
 		if (resolvedTask) {
 			return Response.json(resolvedTask);
@@ -948,18 +912,6 @@ export class BacklogServer {
 
 	private async handleUpdateTask(req: Request, taskId: string): Promise<Response> {
 		const updates = await req.json();
-		let existingTask: Task | null;
-		try {
-			existingTask = await this.core.filesystem.loadTask(taskId);
-		} catch (error) {
-			if (isAmbiguousTaskIdError(error)) {
-				return Response.json({ error: error.message }, { status: 409 });
-			}
-			throw error;
-		}
-		if (!existingTask) {
-			return Response.json({ error: "Task not found" }, { status: 404 });
-		}
 
 		const updateInput: TaskUpdateInput = {};
 
@@ -1074,7 +1026,7 @@ export class BacklogServer {
 			return Response.json(updatedTask);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to update task";
-			return Response.json({ error: message }, { status: 400 });
+			return Response.json({ error: message }, { status: isAmbiguousTaskIdError(error) ? 409 : 400 });
 		}
 	}
 
@@ -1095,14 +1047,9 @@ export class BacklogServer {
 
 	private async handleCompleteTask(taskId: string): Promise<Response> {
 		try {
-			const task = await this.core.filesystem.loadTask(taskId);
-			if (!task) {
-				return Response.json({ error: "Task not found" }, { status: 404 });
-			}
-
 			const success = await this.core.completeTask(taskId);
 			if (!success) {
-				return Response.json({ error: "Failed to complete task" }, { status: 500 });
+				return Response.json({ error: "Task not found" }, { status: 404 });
 			}
 
 			// Notify listeners to refresh
@@ -1617,7 +1564,7 @@ export class BacklogServer {
 				);
 			}
 
-			const { updatedTask } = await this.core.reorderTask({
+			const { updatedTask, changedTasks } = await this.core.reorderTask({
 				taskId,
 				targetStatus,
 				orderedTaskIds,
@@ -1625,7 +1572,7 @@ export class BacklogServer {
 				commitMessage: `Reorder tasks in ${targetStatus}`,
 			});
 
-			return Response.json({ success: true, task: updatedTask });
+			return Response.json({ success: true, task: updatedTask, changedTasks });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to reorder task";
 			// Cross-branch and validation errors are client errors (400), not server errors (500)

--- a/src/test/content-store.test.ts
+++ b/src/test/content-store.test.ts
@@ -4,10 +4,12 @@ import * as nodeFs from "node:fs";
 import { rename, stat, unlink } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { Core } from "../core/backlog.ts";
-import { ContentStore, type ContentStoreEvent } from "../core/content-store.ts";
+import { ContentStore, type ContentStoreEvent, type TaskCorpusSnapshot } from "../core/content-store.ts";
 import { SearchService } from "../core/search-service.ts";
+import { TaskIdentityIndex, type TaskIdentityRecord } from "../core/task-identity-index.ts";
 import { FileSystem } from "../file-system/operations.ts";
 import { parseTask } from "../markdown/parser.ts";
+import { serializeTask } from "../markdown/serializer.ts";
 import type { BacklogConfig, Decision, Document, Task } from "../types/index.ts";
 import { normalizeTaskIdentity } from "../utils/task-path.ts";
 import { createUniqueTestDir, getPlatformTimeout, safeCleanup, sleep } from "./test-utils.ts";
@@ -46,6 +48,61 @@ describe("ContentStore", () => {
 		type: "guide",
 		createdDate: "2025-09-19",
 		rawContent: "# Architecture Guide",
+	};
+
+	const branchSnapshotLoader = (branchPaths: string | string[]): (() => Promise<TaskCorpusSnapshot>) => {
+		return async () => {
+			const activeTasks = await filesystem.listTasks();
+			const completedTasks = await filesystem.listCompletedTasks();
+			const paths = Array.isArray(branchPaths) ? branchPaths : [branchPaths];
+			const branchTasks = paths.map((branchPath, index) => ({
+				...sampleTask,
+				id: "TASK-1",
+				title: `Branch-only task ${index + 1}`,
+				branch: `feature/watched-collision-${index + 1}`,
+				filePath: branchPath,
+			}));
+			const records: TaskIdentityRecord[] = [
+				...branchTasks.map((branchTask) => ({
+					id: branchTask.id,
+					type: "task" as const,
+					branch: branchTask.branch,
+					path: branchTask.filePath,
+					lastModified: new Date("2026-08-01T10:00:00Z"),
+					task: branchTask,
+				})),
+				...activeTasks.map((task) => ({
+					id: task.id,
+					type: "task" as const,
+					branch: "local",
+					path: task.filePath ?? join(filesystem.tasksDir, task.id),
+					lastModified: new Date("2026-08-01T11:00:00Z"),
+					task,
+					workingCopy: true,
+				})),
+				...completedTasks.map((task) => ({
+					id: task.id,
+					type: "completed" as const,
+					branch: "local",
+					path: task.filePath ?? join(filesystem.completedDir, task.id),
+					lastModified: new Date("2026-08-01T11:00:00Z"),
+					task,
+					workingCopy: true,
+				})),
+			];
+			const identityIndex = new TaskIdentityIndex(
+				records,
+				{ repositoryRoot: null, projectRoot: TEST_DIR, backlogDirectory: "backlog" },
+				["To Do", "In Progress", "Done"],
+				"most_progressed",
+			);
+			return {
+				tasks: identityIndex.getTasks(false),
+				activeTasks,
+				completedTasks,
+				identityIndex,
+			};
+		};
 	};
 
 	beforeEach(async () => {
@@ -383,6 +440,146 @@ describe("ContentStore", () => {
 
 		expect((await core.fs.loadTask(sampleTask.id))?.type).toBe("feature");
 		expect(store.getTasks()[0]?.type).toBe("feature");
+	});
+
+	it("refreshes completed identity state when the completed corpus changes", async () => {
+		store.dispose();
+		const core = new Core(TEST_DIR, { enableWatchers: true });
+		await core.fs.ensureBacklogStructure();
+		await core.fs.saveTask(sampleTask);
+		store = await core.getContentStore();
+
+		expect(store.resolveTaskForMutation(sampleTask.id).status).toBe("found");
+		await Bun.write(
+			join(core.fs.completedDir, "task-01 - Completed collision.md"),
+			serializeTask({ ...sampleTask, id: "TASK-01", title: "Completed collision" }),
+		);
+
+		await waitUntil(
+			() => store.resolveTaskForMutation(sampleTask.id).status === "ambiguous",
+			"completed task identity watcher",
+			getPlatformTimeout(3000),
+		);
+	});
+
+	it("reparses unchanged filenames before publishing frontmatter identity changes", async () => {
+		store.dispose();
+		const firstPath = await filesystem.saveTask(sampleTask);
+		const secondPath = await filesystem.saveTask({ ...sampleTask, id: "TASK-2", title: "Second task" });
+		store = new ContentStore(filesystem, branchSnapshotLoader([]), true);
+		await store.ensureInitialized();
+		expect(store.resolveTaskForRead("TASK-1").status).toBe("found");
+
+		const replacementPath = `${secondPath}.replacement`;
+		await Bun.write(replacementPath, serializeTask({ ...sampleTask, id: "TASK-1", title: "Changed identity" }));
+		await rename(replacementPath, secondPath);
+		const changedTask = {
+			...normalizeTaskIdentity(parseTask(await Bun.file(secondPath).text())),
+			filePath: secondPath,
+		};
+		(store as unknown as { publishWatchedTask: (task: Task) => void }).publishWatchedTask(changedTask);
+
+		await waitUntil(
+			() => store.resolveTaskForRead("TASK-1").status === "ambiguous",
+			"unchanged-filename frontmatter collision",
+			getPlatformTimeout(3000),
+		);
+		expect(await Bun.file(firstPath).exists()).toBe(true);
+	});
+
+	it("publishes watched distinct-path local creation with the refreshed branch collision identity", async () => {
+		store.dispose();
+		store = new ContentStore(filesystem, branchSnapshotLoader("backlog/tasks/task-1 - Branch-only.md"), true);
+		await store.ensureInitialized();
+		expect(store.resolveTaskForRead("TASK-1").status).toBe("found");
+
+		const observedResolutions: string[] = [];
+		const unsubscribe = store.subscribe((event) => {
+			if (event.type === "tasks") observedResolutions.push(store.resolveTaskForRead("TASK-1").status);
+		});
+		await Bun.write(
+			join(filesystem.tasksDir, "task-1 - Current-worktree.md"),
+			serializeTask({ ...sampleTask, id: "TASK-1", title: "Current worktree" }),
+		);
+
+		await waitUntil(() => observedResolutions.length > 0, "watched distinct-path collision", getPlatformTimeout(3000));
+		unsubscribe();
+		expect(observedResolutions[0]).toBe("ambiguous");
+		expect(store.resolveTaskForMutation("TASK-1").status).toBe("ambiguous");
+	});
+
+	it("publishes watched same-path local creation as one branch-version identity", async () => {
+		store.dispose();
+		const filename = "task-1 - Same-path.md";
+		store = new ContentStore(filesystem, branchSnapshotLoader(`backlog/tasks/${filename}`), true);
+		await store.ensureInitialized();
+
+		const observedResolutions: string[] = [];
+		const unsubscribe = store.subscribe((event) => {
+			if (event.type === "tasks") observedResolutions.push(store.resolveTaskForMutation("TASK-1").status);
+		});
+		await Bun.write(
+			join(filesystem.tasksDir, filename),
+			serializeTask({ ...sampleTask, id: "TASK-1", title: "Current same-path version" }),
+		);
+
+		await waitUntil(() => observedResolutions.length > 0, "watched same-path version", getPlatformTimeout(3000));
+		unsubscribe();
+		expect(observedResolutions[0]).toBe("found");
+		const resolution = store.resolveTaskForMutation("TASK-1");
+		expect(resolution.status).toBe("found");
+		if (resolution.status === "found") expect(resolution.task.title).toBe("Current same-path version");
+	});
+
+	it("promotes the surviving same-path branch version before watched deletion publication", async () => {
+		store.dispose();
+		const filename = "task-1 - Same-path.md";
+		const localPath = join(filesystem.tasksDir, filename);
+		await Bun.write(localPath, serializeTask({ ...sampleTask, id: "TASK-1", title: "Current worktree" }));
+		store = new ContentStore(filesystem, branchSnapshotLoader(`backlog/tasks/${filename}`), true);
+		await store.ensureInitialized();
+
+		const observedTitles: string[] = [];
+		const unsubscribe = store.subscribe((event) => {
+			if (event.type !== "tasks") return;
+			const resolution = store.resolveTaskForRead("TASK-1");
+			if (resolution.status === "found") observedTitles.push(resolution.task.title);
+		});
+		await unlink(localPath);
+
+		await waitUntil(() => observedTitles.length > 0, "watched same-path branch fallback", getPlatformTimeout(3000));
+		unsubscribe();
+		expect(observedTitles[0]).toBe("Branch-only task 1");
+		expect(store.getTasks().map((task) => task.title)).toEqual(["Branch-only task 1"]);
+	});
+
+	it("keeps surviving distinct-path branch identities ambiguous before watched deletion publication", async () => {
+		store.dispose();
+		const filename = "task-1 - Current-path.md";
+		const localPath = join(filesystem.tasksDir, filename);
+		await Bun.write(localPath, serializeTask({ ...sampleTask, id: "TASK-1", title: "Current worktree" }));
+		store = new ContentStore(
+			filesystem,
+			branchSnapshotLoader([`backlog/tasks/${filename}`, "backlog/tasks/task-1 - Distinct-branch-path.md"]),
+			true,
+		);
+		await store.ensureInitialized();
+		expect(store.resolveTaskForRead("TASK-1").status).toBe("ambiguous");
+
+		const observedResolutions: string[] = [];
+		const unsubscribe = store.subscribe((event) => {
+			if (event.type === "tasks") observedResolutions.push(store.resolveTaskForRead("TASK-1").status);
+		});
+		await unlink(localPath);
+
+		await waitUntil(
+			() => observedResolutions.length > 0,
+			"watched distinct-path branch identities",
+			getPlatformTimeout(3000),
+		);
+		unsubscribe();
+		expect(observedResolutions[0]).toBe("ambiguous");
+		expect(store.resolveTaskForRead("TASK-1").status).toBe("ambiguous");
 	});
 
 	it("keeps persisted task, document, and decision writes that complete during initialization", async () => {

--- a/src/test/content-store.test.ts
+++ b/src/test/content-store.test.ts
@@ -487,6 +487,26 @@ describe("ContentStore", () => {
 		expect(await Bun.file(firstPath).exists()).toBe(true);
 	});
 
+	it("removes a watched task by exact path after its frontmatter identity changes", async () => {
+		store.dispose();
+		const taskPath = await filesystem.saveTask(sampleTask);
+		store = new ContentStore(filesystem, branchSnapshotLoader([]), false);
+		await store.ensureInitialized();
+		const changedTask = { ...sampleTask, id: "TASK-2", title: "Changed identity", filePath: taskPath };
+		const internals = store as unknown as {
+			publishWatchedTask: (task: Task) => void;
+			removeWatchedTask: (filenameId: string, watchedPath: string) => void;
+		};
+
+		internals.publishWatchedTask(changedTask);
+		expect(store.resolveTaskForRead("TASK-2").status).toBe("found");
+		internals.removeWatchedTask("TASK-1", taskPath);
+
+		expect(store.resolveTaskForRead("TASK-1").status).toBe("not-found");
+		expect(store.resolveTaskForRead("TASK-2").status).toBe("not-found");
+		expect(store.getTaskCorpusSnapshot().activeTasks).toEqual([]);
+	});
+
 	it("publishes watched distinct-path local creation with the refreshed branch collision identity", async () => {
 		store.dispose();
 		store = new ContentStore(filesystem, branchSnapshotLoader("backlog/tasks/task-1 - Branch-only.md"), true);

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -174,6 +174,107 @@ describe("Core", () => {
 			expect(lastCommit.length).toBeGreaterThan(0);
 		});
 
+		it("reads a completed-only task while keeping it unavailable to mutations", async () => {
+			await core.createTask(sampleTask, false);
+			expect(await core.filesystem.completeTask(sampleTask.id)).toBe(true);
+
+			const completed = await core.getTask(sampleTask.id);
+
+			expect(completed?.id).toBe("TASK-1");
+			expect(completed?.source).toBe("completed");
+			await expect(core.updateTaskFromInput(sampleTask.id, { title: "Must not change" }, false)).rejects.toThrow(
+				"Task not found",
+			);
+		});
+
+		it("refreshes one coherent active and completed identity snapshot before mutation", async () => {
+			await core.createTask(sampleTask, false);
+			await core.getContentStore();
+
+			const activePath = (await core.filesystem.loadTask(sampleTask.id))?.filePath;
+			if (!activePath) throw new Error("Expected active task path");
+			const completedPath = join(core.filesystem.completedDir, "task-01 - Completed collision.md");
+			await Bun.write(completedPath, serializeTask({ ...sampleTask, id: "TASK-01", title: "Completed collision" }));
+
+			const originalListTasks = core.filesystem.listTasks.bind(core.filesystem);
+			const originalListCompletedTasks = core.filesystem.listCompletedTasks.bind(core.filesystem);
+			let activeLoads = 0;
+			let completedLoads = 0;
+			core.filesystem.listTasks = async (...args) => {
+				activeLoads += 1;
+				return await originalListTasks(...args);
+			};
+			core.filesystem.listCompletedTasks = async (...args) => {
+				completedLoads += 1;
+				return await originalListCompletedTasks(...args);
+			};
+
+			try {
+				await expect(
+					core.updateTaskFromInput(sampleTask.id, { title: "Must not change" }, false),
+				).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+			} finally {
+				core.filesystem.listTasks = originalListTasks;
+				core.filesystem.listCompletedTasks = originalListCompletedTasks;
+			}
+
+			expect(activeLoads).toBe(1);
+			expect(completedLoads).toBe(1);
+			expect(await Bun.file(activePath).text()).not.toContain("Must not change");
+		});
+
+		it("publishes completed lifecycle identity state atomically", async () => {
+			await core.createTask(sampleTask, false);
+			const store = await core.getContentStore();
+			const observed: Array<{
+				read: string;
+				mutation: string;
+				active: string[];
+				completed: string[];
+			}> = [];
+			const unsubscribe = store.subscribe((event) => {
+				if (event.type !== "tasks") return;
+				const snapshot = store.getTaskCorpusSnapshot();
+				observed.push({
+					read: store.resolveTaskForRead(sampleTask.id).status,
+					mutation: store.resolveTaskForMutation(sampleTask.id).status,
+					active: snapshot.activeTasks.map((task) => task.id),
+					completed: snapshot.completedTasks.map((task) => task.id),
+				});
+			});
+
+			expect(await core.completeTask(sampleTask.id, false)).toBe(true);
+			unsubscribe();
+
+			expect(observed[0]).toEqual({
+				read: "found",
+				mutation: "not-found",
+				active: [],
+				completed: ["TASK-1"],
+			});
+		});
+
+		it("publishes archived lifecycle identity state atomically", async () => {
+			await core.createTask(sampleTask, false);
+			const store = await core.getContentStore();
+			const observed: Array<{ read: string; mutation: string; active: string[]; completed: string[] }> = [];
+			const unsubscribe = store.subscribe((event) => {
+				if (event.type !== "tasks") return;
+				const snapshot = store.getTaskCorpusSnapshot();
+				observed.push({
+					read: store.resolveTaskForRead(sampleTask.id).status,
+					mutation: store.resolveTaskForMutation(sampleTask.id).status,
+					active: snapshot.activeTasks.map((task) => task.id),
+					completed: snapshot.completedTasks.map((task) => task.id),
+				});
+			});
+
+			expect(await core.archiveTask(sampleTask.id, false)).toBe(true);
+			unsubscribe();
+
+			expect(observed[0]).toEqual({ read: "not-found", mutation: "not-found", active: [], completed: [] });
+		});
+
 		it("does not update a longer legacy sibling for a shorter numeric ID", async () => {
 			await core.createTask({ ...sampleTask, id: "BACK-1-EXTRA", title: "Longer sibling" }, false);
 

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -275,6 +275,40 @@ describe("Core", () => {
 			expect(observed[0]).toEqual({ read: "not-found", mutation: "not-found", active: [], completed: [] });
 		});
 
+		it("completes the exact resolved path when the frontmatter ID differs from the filename", async () => {
+			const taskPath = join(core.filesystem.tasksDir, "task-999 - Exact-path.md");
+			await Bun.write(taskPath, serializeTask({ ...sampleTask, id: "TASK-1", status: "Done" }));
+			await core.getContentStore();
+
+			expect(await core.completeTask("TASK-1", false)).toBe(true);
+			expect(await Bun.file(taskPath).exists()).toBe(false);
+			expect(await Bun.file(join(core.filesystem.completedDir, "task-999 - Exact-path.md")).exists()).toBe(true);
+		});
+
+		it("archives the exact resolved path when the frontmatter ID differs from the filename", async () => {
+			const taskPath = join(core.filesystem.tasksDir, "task-999 - Exact-path.md");
+			await Bun.write(taskPath, serializeTask({ ...sampleTask, id: "TASK-1" }));
+			await core.getContentStore();
+
+			expect(await core.archiveTask("TASK-1", false)).toBe(true);
+			expect(await Bun.file(taskPath).exists()).toBe(false);
+			expect(await Bun.file(join(core.filesystem.archiveTasksDir, "task-999 - Exact-path.md")).exists()).toBe(true);
+		});
+
+		it("auto-commits an update through the exact resolved path instead of re-resolving its filename", async () => {
+			const taskPath = join(core.filesystem.tasksDir, "task-999 - Exact-path.md");
+			await Bun.write(taskPath, serializeTask({ ...sampleTask, id: "TASK-1" }));
+			await $`git add .`.cwd(TEST_DIR).quiet();
+			await $`git commit -m "Add mismatched task identity"`.cwd(TEST_DIR).quiet();
+			await core.getContentStore();
+
+			await core.updateTaskFromInput("TASK-1", { title: "Updated exact path" }, true);
+
+			expect(await Bun.file(taskPath).text()).toContain("title: Updated exact path");
+			expect(await core.gitOps.getLastCommitMessage()).toContain("Update task TASK-1");
+			expect((await $`git status --short`.cwd(TEST_DIR).text()).trim()).toBe("");
+		});
+
 		it("does not update a longer legacy sibling for a shorter numeric ID", async () => {
 			await core.createTask({ ...sampleTask, id: "BACK-1-EXTRA", title: "Longer sibling" }, false);
 

--- a/src/test/server-duplicate-repair.test.ts
+++ b/src/test/server-duplicate-repair.test.ts
@@ -73,6 +73,34 @@ afterEach(async () => {
 });
 
 describe("duplicate repair server boundary", () => {
+	it("builds one preview from one Core-owned active and completed snapshot", async () => {
+		const serverCore = (server as unknown as { core: Core }).core;
+		const originalListTasks = serverCore.filesystem.listTasks.bind(serverCore.filesystem);
+		const originalListCompletedTasks = serverCore.filesystem.listCompletedTasks.bind(serverCore.filesystem);
+		let activeLoads = 0;
+		let completedLoads = 0;
+		serverCore.filesystem.listTasks = async (...args) => {
+			activeLoads += 1;
+			return await originalListTasks(...args);
+		};
+		serverCore.filesystem.listCompletedTasks = async (...args) => {
+			completedLoads += 1;
+			return await originalListCompletedTasks(...args);
+		};
+
+		try {
+			const response = await request("/api/tasks/duplicates");
+			expect(response.status).toBe(200);
+			expect(((await response.json()) as DuplicateRepairPlan).groups).toHaveLength(1);
+		} finally {
+			serverCore.filesystem.listTasks = originalListTasks;
+			serverCore.filesystem.listCompletedTasks = originalListCompletedTasks;
+		}
+
+		expect(activeLoads).toBe(1);
+		expect(completedLoads).toBe(1);
+	});
+
 	it("returns the shared preview and applies it with the preview fingerprint", async () => {
 		const previewResponse = await request("/api/tasks/duplicates");
 		expect(previewResponse.status).toBe(200);

--- a/src/test/server-reorder-publication.test.ts
+++ b/src/test/server-reorder-publication.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { Core } from "../core/backlog.ts";
+import { BacklogServer } from "../server/index.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, retry, safeCleanup, sleep, withTimeout } from "./test-utils.ts";
+
+let testDir: string;
+let server: BacklogServer | null = null;
+let serverPort = 0;
+let socket: WebSocket | null = null;
+
+const task = (id: string): Task => ({
+	id,
+	title: `Task ${id}`,
+	status: "To Do",
+	ordinal: 1000,
+	assignee: [],
+	createdDate: "2026-01-01",
+	labels: [],
+	dependencies: [],
+});
+
+beforeEach(async () => {
+	testDir = createUniqueTestDir("server-reorder-publication");
+	await mkdir(testDir, { recursive: true });
+	const core = new Core(testDir);
+	await core.filesystem.ensureBacklogStructure();
+	await core.filesystem.saveConfig({
+		projectName: "Server reorder publication",
+		statuses: ["To Do", "In Progress", "Done"],
+		labels: [],
+		milestones: [],
+		dateFormat: "YYYY-MM-DD",
+		remoteOperations: false,
+		checkActiveBranches: false,
+		autoCommit: false,
+	});
+	for (const id of ["TASK-1", "TASK-2", "TASK-3"]) await core.filesystem.saveTask(task(id));
+
+	server = new BacklogServer(testDir);
+	await server.start(0, false);
+	serverPort = server.getPort() ?? 0;
+	await retry(async () => {
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/status`);
+		if (!response.ok) throw new Error("Server is not ready");
+	});
+});
+
+afterEach(async () => {
+	socket?.close();
+	socket = null;
+	await server?.stop();
+	server = null;
+	await safeCleanup(testDir);
+});
+
+describe("reorder WebSocket publication", () => {
+	it("returns every changed task and publishes one reconciliation after a multi-task ordinal rebalance", async () => {
+		const messages: string[] = [];
+		socket = new WebSocket(`ws://127.0.0.1:${serverPort}`);
+		await withTimeout(
+			new Promise<void>((resolve, reject) => {
+				if (!socket) return reject(new Error("WebSocket was not created"));
+				socket.onopen = () => resolve();
+				socket.onerror = () => reject(new Error("WebSocket failed to open"));
+			}),
+			"reorder test WebSocket",
+			2000,
+		);
+		socket.onmessage = (event) => messages.push(String(event.data));
+
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks/reorder`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				taskId: "TASK-3",
+				targetStatus: "To Do",
+				orderedTaskIds: ["TASK-1", "TASK-3", "TASK-2"],
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		const result = (await response.json()) as { success: boolean; task: Task; changedTasks: Task[] };
+		expect(result.task.ordinal).toBe(2000);
+		expect(
+			(result.changedTasks ?? [])
+				.map((changedTask) => ({ id: changedTask.id, ordinal: changedTask.ordinal }))
+				.sort((a, b) => a.id.localeCompare(b.id)),
+		).toEqual([
+			{ id: "TASK-2", ordinal: 3000 },
+			{ id: "TASK-3", ordinal: 2000 },
+		]);
+		await retry(async () => {
+			if (!messages.includes("tasks-updated")) throw new Error("Reconciliation was not published");
+		});
+		await sleep(50);
+		expect(messages.filter((message) => message === "tasks-updated")).toHaveLength(1);
+	});
+});

--- a/src/test/server-reorder-publication.test.ts
+++ b/src/test/server-reorder-publication.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
 import { Core } from "../core/backlog.ts";
+import { serializeTask } from "../markdown/serializer.ts";
 import { BacklogServer } from "../server/index.ts";
 import type { Task } from "../types/index.ts";
 import { createUniqueTestDir, retry, safeCleanup, sleep, withTimeout } from "./test-utils.ts";
@@ -96,5 +98,29 @@ describe("reorder WebSocket publication", () => {
 		});
 		await sleep(50);
 		expect(messages.filter((message) => message === "tasks-updated")).toHaveLength(1);
+	});
+
+	it("returns 409 and writes nothing when the reorder target is ambiguous", async () => {
+		const serverCore = (server as unknown as { core: Core }).core;
+		const firstPath = join(serverCore.filesystem.tasksDir, "task-1 - Task-TASK-1.md");
+		const duplicatePath = join(serverCore.filesystem.tasksDir, "task-01 - Duplicate.md");
+		await Bun.write(duplicatePath, serializeTask({ ...task("TASK-01"), title: "Duplicate" }));
+		const before = [await Bun.file(firstPath).text(), await Bun.file(duplicatePath).text()];
+
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks/reorder`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				taskId: "TASK-1",
+				targetStatus: "To Do",
+				orderedTaskIds: ["TASK-1", "TASK-2", "TASK-3"],
+			}),
+		});
+
+		expect(response.status).toBe(409);
+		expect(await response.json()).toEqual({
+			error: expect.stringContaining("ambiguous"),
+		});
+		expect([await Bun.file(firstPath).text(), await Bun.file(duplicatePath).text()]).toEqual(before);
 	});
 });

--- a/src/test/server-tasks-spa-fallback.test.ts
+++ b/src/test/server-tasks-spa-fallback.test.ts
@@ -291,6 +291,99 @@ describe("BacklogServer task SPA fallback", () => {
 		expect(createResponse.headers.get("content-type")).toContain("application/json");
 	});
 
+	it("routes browser task reads and mutations through Core without direct task-corpus filesystem calls", async () => {
+		const serverInternals = server as unknown as { core: { filesystem: FileSystem } };
+		const taskFilesystem = serverInternals.core.filesystem;
+		const directCalls: string[] = [];
+		const originals = {
+			listTasks: taskFilesystem.listTasks.bind(taskFilesystem),
+			listCompletedTasks: taskFilesystem.listCompletedTasks.bind(taskFilesystem),
+			loadTask: taskFilesystem.loadTask.bind(taskFilesystem),
+			saveTask: taskFilesystem.saveTask.bind(taskFilesystem),
+		};
+		const recordDirectServerCall = (operation: string) => {
+			const caller = (new Error().stack ?? "")
+				.split("\n")
+				.find((line) => line.includes("/src/") && !line.includes("server-tasks-spa-fallback.test.ts"));
+			if (caller?.includes("/src/server/index.ts")) directCalls.push(operation);
+		};
+		taskFilesystem.listTasks = async (...args) => {
+			recordDirectServerCall("listTasks");
+			return await originals.listTasks(...args);
+		};
+		taskFilesystem.listCompletedTasks = async (...args) => {
+			recordDirectServerCall("listCompletedTasks");
+			return await originals.listCompletedTasks(...args);
+		};
+		taskFilesystem.loadTask = async (...args) => {
+			recordDirectServerCall("loadTask");
+			return await originals.loadTask(...args);
+		};
+		taskFilesystem.saveTask = async (...args) => {
+			recordDirectServerCall("saveTask");
+			return await originals.saveTask(...args);
+		};
+
+		try {
+			expect((await request(`/api/tasks?parent=${routedTask.id}`)).status).toBe(200);
+			expect((await request(`/api/task/${routedTask.id}`)).status).toBe(200);
+			expect(
+				(
+					await request(`/api/tasks/${routedTask.id}`, {
+						method: "PUT",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ status: "In Progress" }),
+					})
+				).status,
+			).toBe(200);
+			expect((await request("/api/tasks/duplicates")).status).toBe(200);
+			expect(
+				(
+					await request("/api/tasks/reorder", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							taskId: routedTask.id,
+							targetStatus: "In Progress",
+							orderedTaskIds: [routedTask.id],
+						}),
+					})
+				).status,
+			).toBe(200);
+			expect((await request(`/api/tasks/${routedTask.id}/complete`, { method: "POST" })).status).toBe(200);
+		} finally {
+			taskFilesystem.listTasks = originals.listTasks;
+			taskFilesystem.listCompletedTasks = originals.listCompletedTasks;
+			taskFilesystem.loadTask = originals.loadTask;
+			taskFilesystem.saveTask = originals.saveTask;
+		}
+
+		expect(directCalls).toEqual([]);
+	});
+
+	it("serves completed-only task details through Core", async () => {
+		expect(await filesystem.completeTask(routedTask.id)).toBe(true);
+
+		const response = await request(`/api/task/${routedTask.id}`);
+
+		expect(response.status).toBe(200);
+		const task = (await response.json()) as Task;
+		expect(task.id).toBe(routedTask.id);
+		expect(task.source).toBe("completed");
+	});
+
+	it("returns conflict after a frontmatter ID collision appears under an unchanged filename", async () => {
+		const siblingPath = await filesystem.saveTask({ ...routedTask, id: "BACK-002", title: "Sibling task" });
+		const warm = await request("/api/task/BACK-002");
+		expect(warm.status).toBe(200);
+
+		await Bun.write(siblingPath, serializeTask({ ...routedTask, title: "Changed frontmatter identity" }));
+		const response = await request(`/api/task/${routedTask.id}`);
+
+		expect(response.status).toBe(409);
+		expect(await response.text()).toContain("ambiguous");
+	});
+
 	it("prefers the freshly read current-worktree task over stale store content", async () => {
 		const contentStore = await (
 			server as unknown as { getContentStoreInstance: () => Promise<ContentStore> }

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -101,7 +101,7 @@ const renderBoardPage = (
 		availableTypes?: string[];
 		dateFormat?: string;
 		onRefreshData?: () => Promise<void>;
-		onTaskUpdated?: (task: Task, requestTask: Task) => void;
+		onTasksUpdated?: (tasks: Task[], requestTask: Task) => void;
 	} = {},
 ): HTMLElement => {
 	setupDom(url);
@@ -127,7 +127,7 @@ const renderBoardPage = (
 					onNewTask={() => {}}
 					dateFormat={options.dateFormat}
 					onRefreshData={options.onRefreshData}
-					onTaskUpdated={options.onTaskUpdated}
+					onTasksUpdated={options.onTasksUpdated}
 				/>
 			</BrowserRouter>,
 		);
@@ -277,7 +277,7 @@ describe("Web board filters", () => {
 				onRefreshData: async () => {
 					refreshes += 1;
 				},
-				onTaskUpdated: (task) => publishedTasks.push(task),
+				onTasksUpdated: (changedTasks) => publishedTasks.push(...changedTasks),
 			});
 			const targetHeading = Array.from(container.querySelectorAll("h3")).find(
 				(heading) => heading.textContent === "In Progress",

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -100,6 +100,8 @@ const renderBoardPage = (
 		availablePriorities?: string[];
 		availableTypes?: string[];
 		dateFormat?: string;
+		onRefreshData?: () => Promise<void>;
+		onTaskUpdated?: (task: Task, requestTask: Task) => void;
 	} = {},
 ): HTMLElement => {
 	setupDom(url);
@@ -124,6 +126,8 @@ const renderBoardPage = (
 					onEditTask={() => {}}
 					onNewTask={() => {}}
 					dateFormat={options.dateFormat}
+					onRefreshData={options.onRefreshData}
+					onTaskUpdated={options.onTaskUpdated}
 				/>
 			</BrowserRouter>,
 		);
@@ -253,6 +257,52 @@ afterEach(() => {
 });
 
 describe("Web board filters", () => {
+	it("publishes every returned reorder task without a foreground refresh", async () => {
+		const originalReorderTask = apiClient.reorderTask.bind(apiClient);
+		const sourceTask = tasks[0];
+		const siblingTask = tasks[1];
+		if (!sourceTask || !siblingTask) throw new Error("Expected source and sibling tasks");
+		const movedTask: Task = { ...sourceTask, status: "In Progress", ordinal: 2000 };
+		const rebalancedSibling: Task = { ...siblingTask, ordinal: 3000 };
+		let refreshes = 0;
+		const publishedTasks: Task[] = [];
+		apiClient.reorderTask = async () => ({
+			success: true,
+			task: movedTask,
+			changedTasks: [rebalancedSibling, movedTask],
+		});
+
+		try {
+			const container = renderBoardPage(undefined, {
+				onRefreshData: async () => {
+					refreshes += 1;
+				},
+				onTaskUpdated: (task) => publishedTasks.push(task),
+			});
+			const targetHeading = Array.from(container.querySelectorAll("h3")).find(
+				(heading) => heading.textContent === "In Progress",
+			);
+			const targetColumn = targetHeading?.closest(".rounded-lg");
+			const dropEvent = new window.Event("drop", { bubbles: true, cancelable: true });
+			Object.defineProperty(dropEvent, "dataTransfer", {
+				value: {
+					getData: (type: string) => (type === "text/plain" ? movedTask.id : type === "text/status" ? "To Do" : ""),
+				},
+			});
+
+			await act(async () => {
+				targetColumn?.dispatchEvent(dropEvent);
+				await Promise.resolve();
+			});
+			await waitFor(() => publishedTasks.length === 2);
+
+			expect(publishedTasks).toEqual([rebalancedSibling, movedTask]);
+			expect(refreshes).toBe(0);
+		} finally {
+			apiClient.reorderTask = originalReorderTask;
+		}
+	});
+
 	it("filters board cards by assignee, label, type, and priority while updating URL params", async () => {
 		const container = renderBoardPage(undefined, {
 			availableTypes: ["Bug", "Docs", "Enhancement"],

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -725,7 +725,7 @@ describe("task detail routes", () => {
 				json({
 					success: true,
 					task: updatedSourceTask,
-					changedTasks: [updatedSiblingTask, updatedSourceTask],
+					changedTasks: [updatedSourceTask, updatedSiblingTask],
 				}),
 			);
 			await reorder.settle("reorder response");

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -560,6 +560,30 @@ const pressWithHistory = async (element: Element, key: string, init: KeyboardEve
 	await act(async () => navigated);
 };
 
+const dropTaskIntoStatus = async (
+	container: HTMLElement,
+	taskId: string,
+	sourceStatus: string,
+	targetStatus: string,
+	requestStarted: Promise<void> | undefined,
+) => {
+	const targetHeading = Array.from(container.querySelectorAll("h3")).find(
+		(heading) => heading.textContent === targetStatus,
+	);
+	const targetColumn = targetHeading?.closest(".rounded-lg");
+	expect(targetColumn).toBeTruthy();
+	const dropEvent = new window.Event("drop", { bubbles: true, cancelable: true });
+	Object.defineProperty(dropEvent, "dataTransfer", {
+		value: {
+			getData: (type: string) => (type === "text/plain" ? taskId : type === "text/status" ? sourceStatus : ""),
+		},
+	});
+	await act(async () => {
+		targetColumn?.dispatchEvent(dropEvent);
+		await requestStarted;
+	});
+};
+
 const pushRoute = async (path: string, expectations: FetchExpectation[] = []) => {
 	await runOperation(`push route ${path}`, expectations, () => {
 		window.history.pushState({}, "", path);
@@ -615,6 +639,109 @@ afterEach(async () => {
 });
 
 describe("task detail routes", () => {
+	it("keeps a newer WebSocket-reconciled task when an earlier reorder response arrives late", async () => {
+		const container = await renderApp("/board?lane=none", { advanceHealthSocket: true });
+		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();
+		const sourceTask = tasks[0];
+		if (!sourceTask) throw new Error("Expected a source task");
+		const staleResponseTask: Task = {
+			...sourceTask,
+			title: "Stale reorder response",
+			status: "In Progress",
+			ordinal: 2000,
+		};
+		const externallyEditedTask: Task = {
+			...sourceTask,
+			title: "Newer external edit",
+			status: "In Progress",
+			ordinal: 2500,
+		};
+
+		const reorder = new FetchOperation("delayed reorder response", [
+			expectFetch("reorder response", "/api/tasks/reorder", { manual: true }),
+		]);
+		await dropTaskIntoStatus(
+			container,
+			sourceTask.id,
+			"To Do",
+			"In Progress",
+			reorder.startedSignals.get("reorder response")?.promise,
+		);
+		reorder.finish();
+
+		const reconciliation = new FetchOperation("newer WebSocket reconciliation", [
+			expectFetch("newer search", "/api/search", { manual: true }),
+			expectFetch("newer duplicate plan", "/api/tasks/duplicates"),
+		]);
+		await act(async () => {
+			dataSocket.deliver("tasks-updated");
+			await Promise.resolve();
+		});
+		await act(async () => {
+			reconciliation.respond(
+				"newer search",
+				json([
+					...searchResults.filter(
+						(result) => result.type !== "task" || result.task.id !== externallyEditedTask.id,
+					),
+					{ type: "task", task: externallyEditedTask, score: 1 } satisfies SearchResult,
+				]),
+			);
+			await reconciliation.settle("newer search", "newer duplicate plan");
+		});
+		reconciliation.finish();
+		expect(container.textContent).toContain(externallyEditedTask.title);
+
+		await act(async () => {
+			reorder.respond(
+				"reorder response",
+				json({ success: true, task: staleResponseTask, changedTasks: [staleResponseTask] }),
+			);
+			await reorder.settle("reorder response");
+		});
+
+		expect(container.textContent).toContain(externallyEditedTask.title);
+		expect(container.textContent).not.toContain(staleResponseTask.title);
+	});
+
+	it("applies every rebalanced task when the data WebSocket is disconnected", async () => {
+		const container = await renderApp("/board?lane=none", { advanceHealthSocket: true });
+		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();
+		dataSocket.close();
+		const sourceTask = tasks[0];
+		const siblingTask = tasks[1];
+		if (!sourceTask || !siblingTask) throw new Error("Expected source and sibling tasks");
+		const updatedSourceTask: Task = { ...sourceTask, ordinal: 2000 };
+		const updatedSiblingTask: Task = { ...siblingTask, ordinal: 1000 };
+
+		const reorder = new FetchOperation("disconnected WebSocket reorder response", [
+			expectFetch("reorder response", "/api/tasks/reorder", { manual: true }),
+		]);
+		const requestStarted = reorder.startedSignals.get("reorder response")?.promise;
+		await dropTaskIntoStatus(container, sourceTask.id, "To Do", "To Do", requestStarted);
+		await act(async () => {
+			reorder.respond(
+				"reorder response",
+				json({
+					success: true,
+					task: updatedSourceTask,
+					changedTasks: [updatedSiblingTask, updatedSourceTask],
+				}),
+			);
+			await reorder.settle("reorder response");
+		});
+		reorder.finish();
+
+		const targetHeading = Array.from(container.querySelectorAll("h3")).find(
+			(heading) => heading.textContent === "To Do",
+		);
+		const targetColumn = targetHeading?.closest(".rounded-lg");
+		const visibleTaskTitles = Array.from(targetColumn?.querySelectorAll("[draggable='true'] h4") ?? []).map(
+			(element) => element.textContent,
+		);
+		expect(visibleTaskTitles.slice(0, 2)).toEqual([siblingTask.title, sourceTask.title]);
+	});
+
 	it("uses the canonical board route for task clicks and browser Back", async () => {
 		const container = await renderApp("/");
 		assertState(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "board task");

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -518,6 +518,14 @@ function AppContent() {
     await loadAllData();
   }, [loadAllData]);
 
+	const applyReorderedTask = useCallback((updatedTask: Task, requestTask: Task) => {
+		setTasks((current) => {
+			const currentRequest = current.find((task) => task.id === requestTask.id);
+			if (currentRequest !== requestTask) return current;
+			return current.map((task) => (task.id === updatedTask.id ? updatedTask : task));
+		});
+	}, []);
+
   // Sync editingTask with refreshed tasks data to prevent stale state
   // This fixes the bug where acceptance criteria disappears after save (GitHub #467)
   useEffect(() => {
@@ -608,6 +616,7 @@ function AppContent() {
       onNewTask={handleNewTask}
       tasks={tasks}
       onRefreshData={refreshData}
+	  onTaskUpdated={applyReorderedTask}
       statuses={statuses}
       milestones={milestones}
       availableLabels={availableLabels}

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -518,11 +518,12 @@ function AppContent() {
     await loadAllData();
   }, [loadAllData]);
 
-	const applyReorderedTask = useCallback((updatedTask: Task, requestTask: Task) => {
+	const applyReorderedTasks = useCallback((updatedTasks: Task[], requestTask: Task) => {
 		setTasks((current) => {
 			const currentRequest = current.find((task) => task.id === requestTask.id);
 			if (currentRequest !== requestTask) return current;
-			return current.map((task) => (task.id === updatedTask.id ? updatedTask : task));
+			const updatesById = new Map(updatedTasks.map((task) => [task.id, task]));
+			return current.map((task) => updatesById.get(task.id) ?? task);
 		});
 	}, []);
 
@@ -616,7 +617,7 @@ function AppContent() {
       onNewTask={handleNewTask}
       tasks={tasks}
       onRefreshData={refreshData}
-	  onTaskUpdated={applyReorderedTask}
+	  onTasksUpdated={applyReorderedTasks}
       statuses={statuses}
       milestones={milestones}
       availableLabels={availableLabels}

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -19,6 +19,7 @@ interface BoardProps {
   highlightTaskId?: string | null;
   tasks: Task[];
   onRefreshData?: () => Promise<void>;
+  onTaskUpdated?: (task: Task, requestTask: Task) => void;
   statuses: string[];
   isLoading: boolean;
   milestones: string[];
@@ -51,6 +52,7 @@ const Board: React.FC<BoardProps> = ({
   highlightTaskId,
   tasks,
   onRefreshData,
+  onTaskUpdated,
   statuses,
   isLoading,
   availableLabels,
@@ -294,11 +296,12 @@ const Board: React.FC<BoardProps> = ({
 
   const handleTaskReorder = async (payload: ReorderTaskPayload) => {
     try {
-      await apiClient.reorderTask(payload);
-      // Refresh data to reflect the changes
-      if (onRefreshData) {
-        await onRefreshData();
-      }
+      const requestResolution = resolveTaskById(tasks, payload.taskId);
+      const requestTask = requestResolution.status === 'found' ? requestResolution.task : undefined;
+      const result = await apiClient.reorderTask(payload);
+      if (requestTask && onTaskUpdated) {
+        for (const changedTask of result.changedTasks ?? [result.task]) onTaskUpdated(changedTask, requestTask);
+      } else if (onRefreshData) await onRefreshData();
       setUpdateError(null);
     } catch (err) {
       setUpdateError(err instanceof Error ? err.message : 'Failed to reorder task');

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -19,7 +19,7 @@ interface BoardProps {
   highlightTaskId?: string | null;
   tasks: Task[];
   onRefreshData?: () => Promise<void>;
-  onTaskUpdated?: (task: Task, requestTask: Task) => void;
+  onTasksUpdated?: (tasks: Task[], requestTask: Task) => void;
   statuses: string[];
   isLoading: boolean;
   milestones: string[];
@@ -52,7 +52,7 @@ const Board: React.FC<BoardProps> = ({
   highlightTaskId,
   tasks,
   onRefreshData,
-  onTaskUpdated,
+  onTasksUpdated,
   statuses,
   isLoading,
   availableLabels,
@@ -299,8 +299,8 @@ const Board: React.FC<BoardProps> = ({
       const requestResolution = resolveTaskById(tasks, payload.taskId);
       const requestTask = requestResolution.status === 'found' ? requestResolution.task : undefined;
       const result = await apiClient.reorderTask(payload);
-      if (requestTask && onTaskUpdated) {
-        for (const changedTask of result.changedTasks ?? [result.task]) onTaskUpdated(changedTask, requestTask);
+      if (requestTask && onTasksUpdated) {
+        onTasksUpdated(result.changedTasks ?? [result.task], requestTask);
       } else if (onRefreshData) await onRefreshData();
       setUpdateError(null);
     } catch (err) {

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -11,6 +11,7 @@ interface BoardPageProps {
 	onNewTask: () => void;
 	tasks: Task[];
 	onRefreshData?: () => Promise<void>;
+	onTaskUpdated?: (task: Task, requestTask: Task) => void;
 	statuses: string[];
 	milestones: string[];
 	availableLabels: string[];
@@ -28,6 +29,7 @@ export default function BoardPage({
 	onNewTask,
 	tasks,
 	onRefreshData,
+	onTaskUpdated,
 	statuses,
 	milestones,
 	availableLabels,
@@ -163,6 +165,7 @@ export default function BoardPage({
 				highlightTaskId={highlightTaskId}
 				tasks={tasks}
 				onRefreshData={onRefreshData}
+				onTaskUpdated={onTaskUpdated}
 				statuses={statuses}
 				milestones={milestones}
 				milestoneEntities={milestoneEntities}

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -11,7 +11,7 @@ interface BoardPageProps {
 	onNewTask: () => void;
 	tasks: Task[];
 	onRefreshData?: () => Promise<void>;
-	onTaskUpdated?: (task: Task, requestTask: Task) => void;
+	onTasksUpdated?: (tasks: Task[], requestTask: Task) => void;
 	statuses: string[];
 	milestones: string[];
 	availableLabels: string[];
@@ -29,7 +29,7 @@ export default function BoardPage({
 	onNewTask,
 	tasks,
 	onRefreshData,
-	onTaskUpdated,
+	onTasksUpdated,
 	statuses,
 	milestones,
 	availableLabels,
@@ -165,7 +165,7 @@ export default function BoardPage({
 				highlightTaskId={highlightTaskId}
 				tasks={tasks}
 				onRefreshData={onRefreshData}
-				onTaskUpdated={onTaskUpdated}
+				onTasksUpdated={onTasksUpdated}
 				statuses={statuses}
 				milestones={milestones}
 				milestoneEntities={milestoneEntities}

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -273,8 +273,8 @@ export class ApiClient {
 		});
 	}
 
-	async reorderTask(payload: ReorderTaskPayload): Promise<{ success: boolean; task: Task }> {
-		return this.fetchJson<{ success: boolean; task: Task }>(`${API_BASE}/tasks/reorder`, {
+	async reorderTask(payload: ReorderTaskPayload): Promise<{ success: boolean; task: Task; changedTasks: Task[] }> {
+		return this.fetchJson<{ success: boolean; task: Task; changedTasks: Task[] }>(`${API_BASE}/tasks/reorder`, {
 			method: "POST",
 			body: JSON.stringify(payload),
 		});


### PR DESCRIPTION
## Summary

- Make Core the sole browser task boundary over one ContentStore-owned task corpus snapshot.
- Preserve fail-closed identity handling and exact-path lifecycle and watcher mutations.
- Apply complete reorder results atomically with one WebSocket reconciliation.

## Root cause and impact

Issue #807 exposed repeated task-corpus scans because browser handlers resolved task identity through Core and also accessed Core.filesystem task operations directly. The browser now uses the shared Core and ContentStore model consistently for task reads and mutations, preserving ambiguity safety while reducing update latency.

This PR supersedes #828 with the approved complete Core-boundary implementation.

## Performance

Ephemeral 20-active/430-completed fixture:

- Detail x10: 636.7ms to 612.5ms
- Update x5: 1612.1ms to 348.6ms, approximately 78.4% improvement

## Verification

- `bun test`: 1,831 passed, 4 skipped, 0 failed
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- Git diff checks

Closes #807