### PR TITLE
BACK-561 - Normalize acceptance criteria metadata for Done tasks

### DIFF
--- a/backlog/tasks/back-469 - TUI-theme-adaptive-rendering-remove-hardcoded-colors-add-scroll-improvements.md
+++ b/backlog/tasks/back-469 - TUI-theme-adaptive-rendering-remove-hardcoded-colors-add-scroll-improvements.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-02-21 08:42'
-updated_date: '2026-08-01 22:01'
+updated_date: '2026-08-02 07:28'
 labels:
   - ui
   - board
@@ -67,13 +67,13 @@ Comprehensive TUI improvement for terminal theme compatibility and quality of li
 - [x] #4 No hardcoded fg: "white" or bg: "black" in TUI text/container styles (backdrop overlays excluded)
 - [x] #5 Semantic colors use "gray" instead of "white" for neutral/muted elements
 - [x] #6 Code paths styled with cyan instead of gray for cross-theme visibility
-- [ ] #7 PGUP/PGDN/Home/End work in standalone viewer, popup viewer, board lanes, and generic list
-- [ ] #8 Ctrl+D/Ctrl+U work in board lanes and generic list
-- [ ] #9 Scrollbar indicators on scrollable content areas (except task list pane)
-- [ ] #10 Status/priority filter selectors allow full down-arrow navigation before exiting
+- [x] #7 PGUP/PGDN/Home/End work in standalone viewer, popup viewer, board lanes, and generic list
+- [x] #8 Ctrl+D/Ctrl+U work in board lanes and generic list
+- [x] #9 Scrollbar indicators on scrollable content areas (except task list pane)
+- [x] #10 Status/priority filter selectors allow full down-arrow navigation before exiting
 - [x] #11 All tests pass
-- [ ] #12 Screenshot tool auto-captures board, tasklist, detail, and filters views in Terminal and Ghostty
-- [ ] #13 Screenshot compare command generates static PNG, animated APNG, and GIF comparisons
+- [x] #12 Screenshot tool auto-captures board, tasklist, detail, and filters views in Terminal and Ghostty
+- [x] #13 Screenshot compare command generates static PNG, animated APNG, and GIF comparisons
 <!-- AC:END -->
 
 ## Definition of Done

--- a/backlog/tasks/back-561 - Normalize-acceptance-criteria-metadata-for-Done-tasks.md
+++ b/backlog/tasks/back-561 - Normalize-acceptance-criteria-metadata-for-Done-tasks.md
@@ -1,0 +1,57 @@
+---
+id: BACK-561
+title: Normalize acceptance criteria metadata for Done tasks
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-02 07:26'
+updated_date: '2026-08-02 16:13'
+labels: []
+dependencies: []
+type: chore
+ordinal: 206000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Normalize task metadata under an explicit maintainer direction. Check every acceptance criterion on every task already in the configured terminal Done status without per-criterion re-verification. Do not change non-terminal tasks, task content beyond acceptance-criterion checkbox state, or code behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Every task already in the configured terminal Done status has all current acceptance criteria checked under the recorded maintainer override
+- [x] #2 No non-terminal task is modified by the bulk normalization
+- [x] #3 The change affects task metadata only and introduces no code behavior changes
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Enumerate all tasks in the configured terminal Done status through canonical CLI JSON, covering active and completed locations.
+2. Read each Done task through the CLI, count its current acceptance criteria, and check every criterion under Alex's explicit maintainer override without per-criterion re-verification.
+3. Confirm non-terminal tasks and all non-checkbox content remain unchanged, run backlog doctor, inspect the full diff, and finalize this cleanup task with the override recorded.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Maintainer override: Alex explicitly directed checking every acceptance criterion on tasks already in terminal Done status without re-verifying each criterion individually. The canonical CLI enumeration and checkbox mutations were performed under that direction.
+
+Validation: backlog doctor reported no duplicate IDs across active or completed tasks; canonical Done search and list enumerations matched; all 311 acceptance criteria on the 55 pre-existing Done tasks are checked. Diff inspection confirmed only six checkbox changes on a Done task plus this cleanup task's own metadata. No TypeScript, formatting, runtime behavior, or test files changed, so the conditional code checks did not apply and no full code suite was run.
+
+Final doctor rerun also surfaced a pre-existing cross-branch BACK-555 diagnostic across other worktrees; no duplicate IDs were found within this branch's active or completed task locations, and the diagnostic did not affect this cleanup.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Normalized terminal Done task metadata under Alex's explicit maintainer override. Checked all 311 acceptance criteria across 55 pre-existing Done tasks without individual re-verification; six previously unchecked boxes changed. Verified with matching canonical Done enumerations, zero remaining unchecked criteria, backlog doctor, git diff --check, and scoped diff inspection.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary

Normalize acceptance-criteria checkbox metadata for every task already in the configured terminal Done status under the explicit maintainer override.

- Checked all 311 acceptance criteria across 55 pre-existing Done tasks without individual criterion re-verification.
- Six previously unchecked criteria changed, all on BACK-469.
- No non-terminal task or code behavior changed.

## Related Issue or Task

Backlog task: BACK-561

## Task Checklist

- [x] I have created a corresponding task in backlog/tasks/
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Verification

- Canonical Done search and task-list JSON enumerations matched.
- Post-finalization enumeration: 56 Done tasks, 314 acceptance criteria, 0 unchecked.
- backlog doctor found no duplicate IDs within this branch active or completed locations; a final run also reported a pre-existing cross-branch BACK-555 diagnostic.
- git diff --check passed.
- No full code suite was run because this is a markdown metadata-only cleanup.