### PR TITLE
BACK-567 - Stop idle browser refresh loop from duplicate task preview

### DIFF
--- a/backlog/tasks/back-567 - Stop-idle-browser-refresh-loop-from-duplicate-task-preview.md
+++ b/backlog/tasks/back-567 - Stop-idle-browser-refresh-loop-from-duplicate-task-preview.md
@@ -1,0 +1,57 @@
+---
+id: BACK-567
+title: Stop idle browser refresh loop from duplicate task preview
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-08-02 22:21'
+updated_date: '2026-08-02 22:37'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/834'
+priority: high
+type: bug
+ordinal: 210000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Backlog.md v1.49.0 and v1.49.1 can enter a browser/server feedback loop while idle: duplicate-task preview refreshes the local identity corpus, publishes tasks-updated despite unchanged files, and triggers another full UI reload. Stop the spurious publication without changing duplicate detection or repair behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 An unchanged duplicate-task preview does not publish a tasks-updated event
+- [x] #2 The browser remains idle after its initial duplicate-task preview when repository task files do not change
+- [x] #3 Duplicate-task preview still observes real task corpus changes
+- [x] #4 Regression tests cover the event-publication boundary
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression that initializes the Core-owned ContentStore, repeats duplicate-task preview without filesystem changes, and asserts no task publication after the initial snapshot while a real corpus change still publishes.
+2. Narrow the ContentStore local-corpus publication gate so semantic task and identity equality suppresses unchanged previews without altering duplicate detection, repair, watcher, or browser behavior.
+3. Run focused duplicate-repair/ContentStore/server tests, TypeScript, Biome, build, full relevant tests, and diff review; then finalize BACK-567 and publish a ready PR linked to issue #834.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fail-first evidence: the initialized Core preview emitted one tasks event for an unchanged corpus, reproducing the WebSocket feedback trigger. The fix refreshes the active/completed identity snapshot for duplicate preview without publishing the read back to task listeners; adding a real duplicate between previews is still detected. Focused duplicate repair, ContentStore, and server duplicate-repair suites pass 79/79 with 348 assertions. TypeScript, Biome across 350 files, production build, and diff-check pass. The initial full bun test run encountered one unrelated default-timeout failure in task-type filtering documentation after 6.46s; the impacted suites in that run passed and the full run continued while the ready hotfix PR was prepared.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Stopped duplicate-task preview from publishing its own local-corpus refresh back through tasks-updated while preserving refreshed duplicate detection. Verified the exact unchanged-preview event regression, real duplicate observation, 79 focused tests, TypeScript, Biome, build, and diff hygiene.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -266,7 +266,7 @@ export class Core {
 	async previewDuplicateTaskIdRepair(options: { includeBranches?: boolean } = {}): Promise<DuplicateRepairPlan> {
 		const hadStore = this.contentStore !== undefined;
 		const store = await this.getContentStore();
-		if (hadStore) await store.refreshLocalTaskCorpus();
+		if (hadStore) await store.refreshLocalTaskCorpus(false);
 		return await previewDuplicateTaskIdRepair(this, options, store.getTaskCorpusSnapshot());
 	}
 

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -191,7 +191,7 @@ export class ContentStore {
 		});
 	}
 
-	async refreshLocalTaskCorpus(): Promise<void> {
+	async refreshLocalTaskCorpus(publishChanges = true): Promise<void> {
 		if (!this.initialized) {
 			await this.ensureInitialized();
 			return;
@@ -211,11 +211,11 @@ export class ContentStore {
 					const changed = this.hasTaskCollectionChanged(tasks);
 					const identityChanged = previousFingerprint !== this.taskIdentityIndex.getFingerprint();
 					this.replaceVisibleTasks(tasks);
-					if (changed || identityChanged) this.publishTaskChange();
+					if (publishChanges && (changed || identityChanged)) this.publishTaskChange();
 				} else {
 					const changed = this.hasTaskCollectionChanged(activeTasks);
 					this.replaceVisibleTasks(activeTasks);
-					if (changed) this.publishTaskChange();
+					if (publishChanges && changed) this.publishTaskChange();
 				}
 			})();
 			this.localTaskRefreshPromise = refresh;

--- a/src/test/duplicate-task-repair.test.ts
+++ b/src/test/duplicate-task-repair.test.ts
@@ -60,6 +60,25 @@ afterEach(async () => {
 });
 
 describe("duplicate task diagnosis", () => {
+	it("does not publish task changes while refreshing an unchanged duplicate preview", async () => {
+		await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha"));
+		const store = await core.getContentStore();
+		const events: string[] = [];
+		const unsubscribe = store.subscribe((event) => events.push(event.type));
+		events.length = 0;
+
+		const unchangedPlan = await core.previewDuplicateTaskIdRepair();
+		expect(unchangedPlan.groups).toEqual([]);
+		expect(events).toEqual([]);
+
+		await writeTask(core.filesystem.tasksDir, "task-01 - Beta.md", makeTask("TASK-01", "Beta"));
+		const changedPlan = await core.previewDuplicateTaskIdRepair();
+		expect(changedPlan.groups).toHaveLength(1);
+		expect(changedPlan.groups[0]?.tasks).toHaveLength(2);
+
+		unsubscribe();
+	});
+
 	it("detects three-way, active/completed, and zero-padded collisions while ignoring archive reuse", async () => {
 		await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha"));
 		await writeTask(core.filesystem.tasksDir, "task-01 - Beta.md", makeTask("TASK-01", "Beta"));


### PR DESCRIPTION
## Summary

- refresh the local active/completed identity snapshot for duplicate preview without publishing that read back to task listeners
- preserve real duplicate detection and all normal watcher/task-read publications
- add a regression for the initialized-store event boundary and real corpus refresh

## Root cause

The browser reload path requests the duplicate-repair preview. That read refreshed the local task corpus and published a task event, which the server broadcast as tasks-updated; the browser then reloaded and requested the preview again. Duplicate preview now refreshes its snapshot silently, breaking the read-to-notification feedback edge.

## Verification

- focused duplicate repair, ContentStore, and server duplicate-repair suites: 79 passed, 348 assertions
- bunx tsc --noEmit
- bun run check . (350 files)
- bun run build
- git diff --check

The initial full bun test run continued during hotfix publication; impacted suites passed, with one unrelated default-timeout failure in task-type filtering documentation to be rerun separately.

Backlog task: BACK-567
Closes #834