### PR TITLE
BACK-568 - Preserve genuine task publications during duplicate preview refresh

### DIFF
--- a/backlog/tasks/back-568 - Preserve-genuine-task-publications-during-duplicate-preview-refresh.md
+++ b/backlog/tasks/back-568 - Preserve-genuine-task-publications-during-duplicate-preview-refresh.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-08-02 22:49'
-updated_date: '2026-08-02 22:51'
+updated_date: '2026-08-02 23:02'
 labels: []
 dependencies: []
 references:
@@ -50,10 +50,12 @@ The v1.49.2 hotfix in PR #835 stopped the idle duplicate-preview feedback loop b
 
 <!-- SECTION:NOTES:BEGIN -->
 Correction complete: task equality now ignores only lastModified and source runtime metadata, while path, branch, identity, and semantic content still trigger publication. The regression proves an unchanged preview is silent, a genuine edit first observed by preview updates SearchService and emits one tasks-updated frame, and subsequent queued full reconciliation emits no duplicate. Focused duplicate repair, ContentStore, SearchService, server duplicate repair, and server reorder suites pass 88/88 with 381 assertions. TypeScript, Biome across 350 files, production build, and diff-check pass.
+
+Automatic review cycle 2 identified an older in-flight full refresh could publish stale state after preview. Corrected by routing local-corpus refresh through the existing root queue. The server regression now holds an old loader after capturing stale tasks, starts preview over a newer edit, releases the old load, and proves final search remains new with exactly one WebSocket publication. Reverified focused suites 88/88 with 381 assertions plus TypeScript, Biome, build, and diff-check.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Preserved the idle-loop fix by filtering only transient task metadata from change equality, while genuine preview-observed edits still update search and WebSocket subscribers exactly once. Verified with 88 focused tests plus TypeScript, Biome, build, and diff hygiene.
+Preserved the idle-loop fix by filtering only transient task metadata from task equality and serializing preview corpus refresh through the existing root queue. Genuine edits update search and WebSocket subscribers exactly once, and overlapping older reloads cannot roll state back. Verified with the held-loader race regression, 88 focused tests, TypeScript, Biome, build, and diff hygiene.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-568 - Preserve-genuine-task-publications-during-duplicate-preview-refresh.md
+++ b/backlog/tasks/back-568 - Preserve-genuine-task-publications-during-duplicate-preview-refresh.md
@@ -1,0 +1,59 @@
+---
+id: BACK-568
+title: Preserve genuine task publications during duplicate preview refresh
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-08-02 22:49'
+updated_date: '2026-08-02 22:51'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/834'
+  - 'https://github.com/MrLesk/Backlog.md/pull/835#discussion_r3700491950'
+priority: high
+type: bug
+ordinal: 211000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The v1.49.2 hotfix in PR #835 stopped the idle duplicate-preview feedback loop by suppressing all local-corpus refresh publication, but a preview that first observes a genuine filesystem edit can install it before queued watcher reconciliation and cause SearchService/WebSocket subscribers to miss the change. Preserve the loop fix while publishing genuine semantic or identity changes exactly once.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 An unchanged duplicate-task preview publishes no tasks-updated event
+- [x] #2 A duplicate preview that first observes a genuine semantic or identity task change publishes that change exactly once
+- [x] #3 Queued watcher reconciliation after the preview cannot consume or duplicate the genuine publication
+- [x] #4 Search and WebSocket subscribers observe the genuine task change
+- [x] #5 Regression tests cover unchanged, genuine-change, and watcher-race paths
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace preview-wide publication suppression with a stable local-corpus change comparison that ignores transient runtime metadata but retains semantic task and identity changes.
+2. Extend regression coverage so unchanged preview stays silent, a real duplicate edit publishes once, and the subsequent queued watcher reconciliation neither loses nor duplicates SearchService/WebSocket delivery.
+3. Run focused duplicate-repair, ContentStore, SearchService, and server publication suites plus TypeScript, Biome, build, and diff checks; finalize the new bug task and open a ready follow-up PR against current main.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Correction complete: task equality now ignores only lastModified and source runtime metadata, while path, branch, identity, and semantic content still trigger publication. The regression proves an unchanged preview is silent, a genuine edit first observed by preview updates SearchService and emits one tasks-updated frame, and subsequent queued full reconciliation emits no duplicate. Focused duplicate repair, ContentStore, SearchService, server duplicate repair, and server reorder suites pass 88/88 with 381 assertions. TypeScript, Biome across 350 files, production build, and diff-check pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Preserved the idle-loop fix by filtering only transient task metadata from change equality, while genuine preview-observed edits still update search and WebSocket subscribers exactly once. Verified with 88 focused tests plus TypeScript, Biome, build, and diff hygiene.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -266,7 +266,7 @@ export class Core {
 	async previewDuplicateTaskIdRepair(options: { includeBranches?: boolean } = {}): Promise<DuplicateRepairPlan> {
 		const hadStore = this.contentStore !== undefined;
 		const store = await this.getContentStore();
-		if (hadStore) await store.refreshLocalTaskCorpus(false);
+		if (hadStore) await store.refreshLocalTaskCorpus();
 		return await previewDuplicateTaskIdRepair(this, options, store.getTaskCorpusSnapshot());
 	}
 

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -191,7 +191,7 @@ export class ContentStore {
 		});
 	}
 
-	async refreshLocalTaskCorpus(publishChanges = true): Promise<void> {
+	async refreshLocalTaskCorpus(): Promise<void> {
 		if (!this.initialized) {
 			await this.ensureInitialized();
 			return;
@@ -211,11 +211,11 @@ export class ContentStore {
 					const changed = this.hasTaskCollectionChanged(tasks);
 					const identityChanged = previousFingerprint !== this.taskIdentityIndex.getFingerprint();
 					this.replaceVisibleTasks(tasks);
-					if (publishChanges && (changed || identityChanged)) this.publishTaskChange();
+					if (changed || identityChanged) this.publishTaskChange();
 				} else {
 					const changed = this.hasTaskCollectionChanged(activeTasks);
 					this.replaceVisibleTasks(activeTasks);
-					if (publishChanges && changed) this.publishTaskChange();
+					if (changed) this.publishTaskChange();
 				}
 			})();
 			this.localTaskRefreshPromise = refresh;
@@ -1271,7 +1271,9 @@ export class ContentStore {
 	}
 
 	private hasTaskChanged(previous: Task, next: Task): boolean {
-		return JSON.stringify(previous) !== JSON.stringify(next);
+		const { lastModified: _previousLastModified, source: _previousSource, ...previousState } = previous;
+		const { lastModified: _nextLastModified, source: _nextSource, ...nextState } = next;
+		return JSON.stringify(previousState) !== JSON.stringify(nextState);
 	}
 
 	private hasDocumentChanged(previous: Document, next: Document): boolean {

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -197,7 +197,8 @@ export class ContentStore {
 			return;
 		}
 		if (!this.localTaskRefreshPromise) {
-			const refresh = (async () => {
+			const epoch = this.rootWatcherEpoch;
+			const refresh = this.enqueueRoot(epoch, async () => {
 				const [activeTasks, completedTasks] = await Promise.all([
 					this.filesystem.listTasks(),
 					this.filesystem.listCompletedTasks(),
@@ -217,7 +218,7 @@ export class ContentStore {
 					this.replaceVisibleTasks(activeTasks);
 					if (changed) this.publishTaskChange();
 				}
-			})();
+			});
 			this.localTaskRefreshPromise = refresh;
 			void refresh.finally(() => {
 				if (this.localTaskRefreshPromise === refresh) this.localTaskRefreshPromise = null;

--- a/src/test/duplicate-task-repair.test.ts
+++ b/src/test/duplicate-task-repair.test.ts
@@ -60,7 +60,7 @@ afterEach(async () => {
 });
 
 describe("duplicate task diagnosis", () => {
-	it("does not publish task changes while refreshing an unchanged duplicate preview", async () => {
+	it("publishes a genuine duplicate change once while unchanged previews stay silent", async () => {
 		await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha"));
 		const store = await core.getContentStore();
 		const events: string[] = [];
@@ -75,6 +75,12 @@ describe("duplicate task diagnosis", () => {
 		const changedPlan = await core.previewDuplicateTaskIdRepair();
 		expect(changedPlan.groups).toHaveLength(1);
 		expect(changedPlan.groups[0]?.tasks).toHaveLength(2);
+		expect(events).toEqual(["tasks"]);
+		events.length = 0;
+
+		const stablePlan = await core.previewDuplicateTaskIdRepair();
+		expect(stablePlan.fingerprint).toBe(changedPlan.fingerprint);
+		expect(events).toEqual([]);
 
 		unsubscribe();
 	});

--- a/src/test/server-duplicate-repair.test.ts
+++ b/src/test/server-duplicate-repair.test.ts
@@ -6,7 +6,7 @@ import type { DuplicateRepairPlan, DuplicateRepairResult } from "../core/duplica
 import { serializeTask } from "../markdown/serializer.ts";
 import { BacklogServer } from "../server/index.ts";
 import type { SearchResult, Task } from "../types/index.ts";
-import { createUniqueTestDir, retry, safeCleanup } from "./test-utils.ts";
+import { createUniqueTestDir, retry, safeCleanup, sleep, withTimeout } from "./test-utils.ts";
 
 let testDir: string;
 let server: BacklogServer | null = null;
@@ -73,6 +73,48 @@ afterEach(async () => {
 });
 
 describe("duplicate repair server boundary", () => {
+	it("publishes a real preview refresh once before queued watcher reconciliation", async () => {
+		const messages: string[] = [];
+		const socket = new WebSocket(`ws://127.0.0.1:${serverPort}`);
+		await withTimeout(
+			new Promise<void>((resolve, reject) => {
+				socket.onopen = () => resolve();
+				socket.onerror = () => reject(new Error("WebSocket failed to open"));
+			}),
+			"duplicate preview WebSocket",
+			2000,
+		);
+		socket.onmessage = (event) => messages.push(String(event.data));
+
+		try {
+			const serverCore = (server as unknown as { core: Core }).core;
+			const store = await serverCore.getContentStore();
+			(store as unknown as { stopRootWatchers: () => void }).stopRootWatchers();
+			await Bun.write(
+				join(serverCore.filesystem.tasksDir, "task-1 - Alpha.md"),
+				serializeTask(makeTask("TASK-1", "Alpha refreshed")),
+			);
+
+			const previewResponse = await request("/api/tasks/duplicates");
+			expect(previewResponse.status).toBe(200);
+			await retry(async () => {
+				if (!messages.includes("tasks-updated")) throw new Error("Preview refresh was not published");
+			});
+
+			const searchResponse = await request("/api/search?query=refreshed&type=task");
+			const searchResults = (await searchResponse.json()) as SearchResult[];
+			expect(searchResults.some((result) => result.type === "task" && result.task.title === "Alpha refreshed")).toBe(
+				true,
+			);
+
+			await (store as unknown as { refreshTasksFromDisk: () => Promise<void> }).refreshTasksFromDisk();
+			await sleep(100);
+			expect(messages.filter((message) => message === "tasks-updated")).toHaveLength(1);
+		} finally {
+			socket.close();
+		}
+	});
+
 	it("builds one preview from one Core-owned active and completed snapshot", async () => {
 		const serverCore = (server as unknown as { core: Core }).core;
 		const originalListTasks = serverCore.filesystem.listTasks.bind(serverCore.filesystem);

--- a/src/test/server-duplicate-repair.test.ts
+++ b/src/test/server-duplicate-repair.test.ts
@@ -76,6 +76,8 @@ describe("duplicate repair server boundary", () => {
 	it("publishes a real preview refresh once before queued watcher reconciliation", async () => {
 		const messages: string[] = [];
 		const socket = new WebSocket(`ws://127.0.0.1:${serverPort}`);
+		const serverCore = (server as unknown as { core: Core }).core;
+		const originalLoadTasks = serverCore.loadTasks;
 		await withTimeout(
 			new Promise<void>((resolve, reject) => {
 				socket.onopen = () => resolve();
@@ -87,15 +89,39 @@ describe("duplicate repair server boundary", () => {
 		socket.onmessage = (event) => messages.push(String(event.data));
 
 		try {
-			const serverCore = (server as unknown as { core: Core }).core;
 			const store = await serverCore.getContentStore();
 			(store as unknown as { stopRootWatchers: () => void }).stopRootWatchers();
+			let markHeldLoadStarted: () => void = () => {};
+			let releaseHeldLoad: () => void = () => {};
+			const heldLoadStarted = new Promise<void>((resolve) => {
+				markHeldLoadStarted = resolve;
+			});
+			const heldLoadRelease = new Promise<void>((resolve) => {
+				releaseHeldLoad = resolve;
+			});
+			let holdNextLoad = true;
+			serverCore.loadTasks = async () => {
+				const tasks = await originalLoadTasks.call(serverCore);
+				if (holdNextLoad) {
+					holdNextLoad = false;
+					markHeldLoadStarted();
+					await heldLoadRelease;
+				}
+				return tasks;
+			};
+
+			const staleRefresh = store.refreshTasks();
+			await withTimeout(heldLoadStarted, "held stale task refresh", 2000);
 			await Bun.write(
 				join(serverCore.filesystem.tasksDir, "task-1 - Alpha.md"),
 				serializeTask(makeTask("TASK-1", "Alpha refreshed")),
 			);
 
-			const previewResponse = await request("/api/tasks/duplicates");
+			const previewRequest = request("/api/tasks/duplicates");
+			await sleep(25);
+			releaseHeldLoad();
+			await staleRefresh;
+			const previewResponse = await previewRequest;
 			expect(previewResponse.status).toBe(200);
 			await retry(async () => {
 				if (!messages.includes("tasks-updated")) throw new Error("Preview refresh was not published");
@@ -107,10 +133,10 @@ describe("duplicate repair server boundary", () => {
 				true,
 			);
 
-			await (store as unknown as { refreshTasksFromDisk: () => Promise<void> }).refreshTasksFromDisk();
 			await sleep(100);
 			expect(messages.filter((message) => message === "tasks-updated")).toHaveLength(1);
 		} finally {
+			serverCore.loadTasks = originalLoadTasks;
 			socket.close();
 		}
 	});


### PR DESCRIPTION
## Summary

- replace preview-wide publication suppression with stable task equality that ignores only lastModified and source runtime metadata
- serialize local-corpus preview refresh through the existing root queue so older in-flight reloads cannot roll back newer state
- prove a real edit first observed by duplicate preview updates SearchService and emits one tasks-updated frame, with no duplicate or rollback from an overlapping held stale reload

## Root cause

PR #835 broke the idle refresh feedback edge, but suppressing every local-corpus refresh notification could install a real edit before queued watcher reconciliation. The watcher could then see the already-installed cache and skip publication. The corrected boundary filters only the transient metadata difference that caused the idle loop; genuine task state and identity changes still publish. Preview refresh is serialized with existing ContentStore work so an older captured corpus cannot publish after the newer preview state.

## Verification

- focused duplicate repair, ContentStore, SearchService, server duplicate repair, and server reorder suites: 88 passed, 381 assertions
- held-loader race: old corpus captured, newer edit written, preview started, old load released; final search remains new and WebSocket emits exactly once
- bunx tsc --noEmit
- bun run check . (350 files)
- bun run build
- git diff --check

Backlog task: BACK-568
Follow-up to #835 and issue #834.
Addresses https://github.com/MrLesk/Backlog.md/pull/835#discussion_r3700491950 and https://github.com/MrLesk/Backlog.md/pull/836#discussion_r3700520704