### PR TITLE
BACK-572 - Clear task dependencies through the CLI

### DIFF
--- a/backlog/tasks/back-572 - Clear-task-dependencies-through-the-CLI.md
+++ b/backlog/tasks/back-572 - Clear-task-dependencies-through-the-CLI.md
@@ -4,8 +4,9 @@ title: Clear task dependencies through the CLI
 status: Done
 assignee:
   - '@codex'
+  - '@claude'
 created_date: '2026-08-03 20:16'
-updated_date: '2026-08-03 20:27'
+updated_date: '2026-08-07 17:29'
 labels: []
 dependencies: []
 references:
@@ -48,6 +49,12 @@ Fix GitHub issue #839: task edit currently ignores an empty dependency value, re
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented --clear-deps with matching conflict and empty-value validation. Verified with bun test src/test/cli-dependency.test.ts, bunx tsc --noEmit, bun run check ., and bun test (1880 passed, 5 skipped).
+
+Review follow-up (PR #840): fixed three defects in the --clear-deps change.
+1. hasEditFieldFlags() in src/cli.ts did not list --clear-deps, so in an interactive TTY 'task edit X --clear-deps' (without --plain) opened the edit wizard and never cleared dependencies; the flag is now part of the predicate.
+2. Empty dependency values were only rejected when the combined normalized list was empty, so '--depends-on "" --dep TASK-1' silently accepted the empty occurrence; each raw --depends-on/--dep occurrence is now validated individually.
+3. MCP task_edit treated a blank-only dependency array such as ["   "] as a full clear; buildTaskUpdateInput now mirrors the labels convention (blank-only is a no-op, explicit [] still clears).
+Coverage: CLI regression test runs the edit through a faked-TTY entry point without --plain, a CLI case for an empty value alongside a valid one, and an MCP test mirroring the existing blank-only labels test.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-572 - Clear-task-dependencies-through-the-CLI.md
+++ b/backlog/tasks/back-572 - Clear-task-dependencies-through-the-CLI.md
@@ -1,0 +1,57 @@
+---
+id: BACK-572
+title: Clear task dependencies through the CLI
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-03 20:16'
+updated_date: '2026-08-03 20:27'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/839'
+priority: medium
+type: bug
+ordinal: 214000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fix GitHub issue #839: task edit currently ignores an empty dependency value, reports success without changing the task, and offers no supported way to remove dependencies. Add a clear, consistent CLI workflow without allowing silent no-op edits.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 task edit --clear-deps removes all dependencies from an existing task
+- [x] #2 --clear-deps cannot be combined with --depends-on or --dep and does not mutate the task on invalid input
+- [x] #3 Empty --depends-on or --dep is rejected instead of reporting a successful no-op
+- [x] #4 CLI help and regression tests document and verify dependency clearing
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a clear-dependencies edit input that follows the existing clear-* validation pattern.
+2. Reject empty dependency flag values before constructing an edit, preventing false-success output.
+3. Cover clear, conflicting, and empty-value behavior at the CLI surface; run focused and repository checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented --clear-deps with matching conflict and empty-value validation. Verified with bun test src/test/cli-dependency.test.ts, bunx tsc --noEmit, bun run check ., and bun test (1880 passed, 5 skipped).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added task edit --clear-deps and rejected empty dependency values to prevent false-success edits. Verified by focused CLI regression coverage, type-check, Biome, and the full Bun suite (1880 passed, 5 skipped).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2663,6 +2663,11 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			type: "Boolean",
 			description: "Remove all labels; cannot combine with other label flags",
 		},
+		{
+			name: "clear-deps",
+			type: "Boolean",
+			description: "Remove all task dependencies; cannot combine with dependency flags",
+		},
 		{ name: "plan", type: "Markdown", description: "Replacement implementation plan" },
 		{
 			name: "append-plan",
@@ -2773,6 +2778,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		createMultiValueAccumulator(),
 	)
 	.option("--clear-final-summary", "remove final summary")
+	.option("--clear-deps", "remove all task dependencies (cannot combine with --depends-on or --dep)")
 	.option(
 		"--depends-on <taskIds>",
 		"set task dependencies (comma-separated or use multiple times)",
@@ -3006,7 +3012,19 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			.filter((value) => value.length > 0);
 
 		const combinedDependencies = [...toStringArray(options.dependsOn), ...toStringArray(options.dep)];
+		if (options.clearDeps && combinedDependencies.length > 0) {
+			console.error("Cannot combine --clear-deps with --depends-on or --dep. Use --clear-deps by itself.");
+			process.exitCode = 1;
+			return;
+		}
 		const dependencyValues = combinedDependencies.length > 0 ? normalizeDependencies(combinedDependencies) : undefined;
+		if (combinedDependencies.length > 0 && dependencyValues?.length === 0) {
+			console.error(
+				"Cannot use an empty value with --depends-on or --dep. Use --clear-deps to remove all task dependencies.",
+			);
+			process.exitCode = 1;
+			return;
+		}
 
 		const normalizedReferences = parseDelimitedStringList(options.ref);
 		const normalizedDocumentation = parseDelimitedStringList(options.doc);
@@ -3054,8 +3072,10 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		if (assigneeValues.length > 0) {
 			editArgs.assignee = assigneeValues;
 		}
-		if (dependencyValues && dependencyValues.length > 0) {
+		if (dependencyValues) {
 			editArgs.dependencies = dependencyValues;
+		} else if (options.clearDeps) {
+			editArgs.dependencies = [];
 		}
 		if (normalizedReferences && normalizedReferences.length > 0) {
 			editArgs.references = normalizedReferences;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -465,6 +465,7 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.clearFinalSummary ||
 			options.dependsOn !== undefined ||
 			options.dep !== undefined ||
+			options.clearDeps ||
 			options.ref !== undefined ||
 			options.doc !== undefined ||
 			options.modifiedFile !== undefined,
@@ -3017,14 +3018,14 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			process.exitCode = 1;
 			return;
 		}
-		const dependencyValues = combinedDependencies.length > 0 ? normalizeDependencies(combinedDependencies) : undefined;
-		if (combinedDependencies.length > 0 && dependencyValues?.length === 0) {
+		if (combinedDependencies.some((value) => normalizeDependencies([value]).length === 0)) {
 			console.error(
 				"Cannot use an empty value with --depends-on or --dep. Use --clear-deps to remove all task dependencies.",
 			);
 			process.exitCode = 1;
 			return;
 		}
+		const dependencyValues = combinedDependencies.length > 0 ? normalizeDependencies(combinedDependencies) : undefined;
 
 		const normalizedReferences = parseDelimitedStringList(options.ref);
 		const normalizedDocumentation = parseDelimitedStringList(options.doc);

--- a/src/test/cli-dependency.test.ts
+++ b/src/test/cli-dependency.test.ts
@@ -1,11 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
 
 const CLI_PATH = getTestCliPath();
+
+// Runs the CLI with stdio reported as a TTY so interactive-only behavior (the edit wizard) applies.
+async function runCliWithInteractiveTty(cwd: string, args: string[]) {
+	const entryPath = join(cwd, "interactive-cli-entry.ts");
+	await writeFile(
+		entryPath,
+		`Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+await import(${JSON.stringify(pathToFileURL(CLI_PATH).href)});
+`,
+	);
+	return await $`bun ${entryPath} ${args}`.cwd(cwd).quiet().nothrow();
+}
 
 describe("CLI dependency options", () => {
 	let testDir: string;
@@ -57,6 +72,17 @@ describe("CLI dependency options", () => {
 		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual([]);
 	});
 
+	it("clears dependencies with --clear-deps in an interactive terminal", async () => {
+		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
+		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1`.cwd(testDir).quiet();
+
+		const result = await runCliWithInteractiveTty(testDir, ["task", "edit", "2", "--clear-deps"]);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain("Updated task TASK-2");
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual([]);
+	});
+
 	it("rejects empty and conflicting dependency edits without changing dependencies", async () => {
 		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
 		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1`.cwd(testDir).quiet();
@@ -68,6 +94,13 @@ describe("CLI dependency options", () => {
 		const emptyDep = await $`bun ${CLI_PATH} task edit 2 --dep ""`.cwd(testDir).quiet().nothrow();
 		expect(emptyDep.exitCode).toBe(1);
 		expect(emptyDep.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+
+		const emptyAlongsideValue = await $`bun ${CLI_PATH} task edit 2 --depends-on "" --dep TASK-1`
+			.cwd(testDir)
+			.quiet()
+			.nothrow();
+		expect(emptyAlongsideValue.exitCode).toBe(1);
+		expect(emptyAlongsideValue.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
 
 		const conflicting = await $`bun ${CLI_PATH} task edit 2 --clear-deps --depends-on TASK-1`
 			.cwd(testDir)

--- a/src/test/cli-dependency.test.ts
+++ b/src/test/cli-dependency.test.ts
@@ -47,6 +47,44 @@ describe("CLI dependency options", () => {
 		expect((await core.filesystem.loadTask("TASK-3"))?.dependencies).toEqual(["TASK-1", "TASK-2"]);
 	});
 
+	it("clears dependencies with --clear-deps", async () => {
+		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
+		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1`.cwd(testDir).quiet();
+
+		const result = await $`bun ${CLI_PATH} task edit 2 --clear-deps --plain`.cwd(testDir).quiet();
+
+		expect(result.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual([]);
+	});
+
+	it("rejects empty and conflicting dependency edits without changing dependencies", async () => {
+		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
+		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1`.cwd(testDir).quiet();
+
+		const emptyDependsOn = await $`bun ${CLI_PATH} task edit 2 --depends-on ""`.cwd(testDir).quiet().nothrow();
+		expect(emptyDependsOn.exitCode).toBe(1);
+		expect(emptyDependsOn.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+
+		const emptyDep = await $`bun ${CLI_PATH} task edit 2 --dep ""`.cwd(testDir).quiet().nothrow();
+		expect(emptyDep.exitCode).toBe(1);
+		expect(emptyDep.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+
+		const conflicting = await $`bun ${CLI_PATH} task edit 2 --clear-deps --depends-on TASK-1`
+			.cwd(testDir)
+			.quiet()
+			.nothrow();
+		expect(conflicting.exitCode).toBe(1);
+		expect(conflicting.stderr.toString()).toContain("Cannot combine --clear-deps with --depends-on or --dep");
+
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual(["TASK-1"]);
+	});
+
+	it("documents --clear-deps in task edit help", async () => {
+		const result = await $`bun ${CLI_PATH} task edit --help`.cwd(testDir).quiet();
+
+		expect(result.stdout.toString()).toContain("--clear-deps");
+	});
+
 	it("rejects a dependency that does not exist", async () => {
 		const result = await $`bun ${CLI_PATH} task create "Dependent task" --dep TASK-999`.cwd(testDir).quiet().nothrow();
 

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -852,6 +852,52 @@ describe("MCP task tools (MVP)", () => {
 		expect((await mcpServer.getTask("task-1"))?.labels).toEqual([]);
 	});
 
+	it("does not clear dependencies from blank-only task_edit dependency arrays", async () => {
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Dependency target",
+				},
+			},
+		});
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Dependency blank input",
+					dependencies: ["task-1"],
+				},
+			},
+		});
+
+		const blankEdit = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-2",
+					dependencies: ["", "   "],
+				},
+			},
+		});
+
+		expect(getText(blankEdit.content)).toContain("Dependencies: TASK-1");
+		expect((await mcpServer.getTask("task-2"))?.dependencies).toEqual(["TASK-1"]);
+
+		const clearEdit = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-2",
+					dependencies: [],
+				},
+			},
+		});
+
+		expect(getText(clearEdit.content)).not.toContain("Dependencies:");
+		expect((await mcpServer.getTask("task-2"))?.dependencies).toEqual([]);
+	});
+
 	it("creates, edits, lists, and views tasks with ordinal", async () => {
 		const createdA = await mcpServer.testInterface.callTool({
 			params: {

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -81,7 +81,12 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	}
 
 	if (args.dependencies !== undefined) {
-		updateInput.dependencies = sanitizeStringArray(args.dependencies) ?? [];
+		const dependencies = sanitizeStringArray(args.dependencies);
+		if (dependencies) {
+			updateInput.dependencies = dependencies;
+		} else if (args.dependencies.length === 0) {
+			updateInput.dependencies = [];
+		}
 	}
 
 	const references = sanitizeStringArray(args.references);

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -80,9 +80,8 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		updateInput.assignee = assignee;
 	}
 
-	const dependencies = sanitizeStringArray(args.dependencies);
-	if (dependencies) {
-		updateInput.dependencies = dependencies;
+	if (args.dependencies !== undefined) {
+		updateInput.dependencies = sanitizeStringArray(args.dependencies) ?? [];
 	}
 
 	const references = sanitizeStringArray(args.references);


### PR DESCRIPTION
## Summary
- add `task edit --clear-deps` to remove all task dependencies
- reject empty dependency flag values and conflicting clear/set input to prevent false-success edits
- add CLI regression coverage for clearing, validation, and help output

Fixes #839.

## Validation
- `bun test src/test/cli-dependency.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun test` (1880 passed, 5 skipped)