### PR TITLE
BACK-571 - Show genuine loading indicators in the browser board and sidebar

### DIFF
--- a/backlog/tasks/back-571 - Show-genuine-loading-indicators-in-the-browser-board-and-sidebar.md
+++ b/backlog/tasks/back-571 - Show-genuine-loading-indicators-in-the-browser-board-and-sidebar.md
@@ -1,12 +1,26 @@
 ---
 id: BACK-571
 title: Show genuine loading indicators in the browser board and sidebar
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-03 20:02'
-updated_date: '2026-08-03 20:04'
+updated_date: '2026-08-03 20:40'
 labels: []
 dependencies: []
+modified_files:
+  - src/core/backlog.ts
+  - src/server/index.ts
+  - src/utils/browser-loading-state.ts
+  - src/web/App.tsx
+  - src/web/components/Layout.tsx
+  - src/web/components/SideNavigation.tsx
+  - src/web/components/BoardPage.tsx
+  - src/web/components/Board.tsx
+  - src/test/browser-loading-state.test.ts
+  - src/test/server-loading-progress.test.ts
+  - src/test/web-side-navigation-loading.test.tsx
+  - src/test/web-task-detail-deeplink.test.tsx
 type: enhancement
 ordinal: 213000
 ---
@@ -19,18 +33,39 @@ Follow up on BACK-570 without undoing its asynchronous, idle-stable browser star
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 While shared Core data is loading, the browser displays the existing Core progress callback messages verbatim—the same messages shown by the TUI—rather than generic or browser-only substitutes
-- [ ] #2 Core progress messages reach the browser through the server's existing WebSocket or an equivalent shared progress channel tied to the same in-flight corpus initialization, and the latest phase is retained and sent to browser connections that arrive after loading has started
-- [ ] #3 Progress delivery never starts a second store, corpus scan, or data request and never synthesizes phases from timers or elapsed time
-- [ ] #4 While the shared load is pending, sidebar task, document, and decision counts and collections show the current Core progress message with a genuine loading indicator or skeleton instead of 0, No items, or another loaded-empty presentation
-- [ ] #5 While task data is pending, the Kanban board shows the current Core progress message with a genuine loading state or skeleton and does not present zero cards, empty columns, or Empty as if loading had completed
-- [ ] #6 When loading resolves, the progress presentation clears and the sidebar and Kanban show the actual counts, collections, and task cards
-- [ ] #7 Loaded-empty and load-error states are visually and behaviorally distinct from loading; errors remain visible and retryable, and focused web/server tests cover verbatim progress delivery including late connections, loading, loaded data, loaded-empty, error/retry, stable mounting, and the absence of timer-based fake progress
+- [x] #1 While shared Core data is loading, the browser displays the existing Core progress callback messages verbatim—the same messages shown by the TUI—rather than generic or browser-only substitutes
+- [x] #2 Core progress messages reach the browser through the server's existing WebSocket or an equivalent shared progress channel tied to the same in-flight corpus initialization, and the latest phase is retained and sent to browser connections that arrive after loading has started
+- [x] #3 Progress delivery never starts a second store, corpus scan, or data request and never synthesizes phases from timers or elapsed time
+- [x] #4 While the shared load is pending, sidebar task, document, and decision counts and collections show the current Core progress message with a genuine loading indicator or skeleton instead of 0, No items, or another loaded-empty presentation
+- [x] #5 While task data is pending, the Kanban board shows the current Core progress message with a genuine loading state or skeleton and does not present zero cards, empty columns, or Empty as if loading had completed
+- [x] #6 When loading resolves, the progress presentation clears and the sidebar and Kanban show the actual counts, collections, and task cards
+- [x] #7 Loaded-empty and load-error states are visually and behaviorally distinct from loading; errors remain visible and retryable, and focused web/server tests cover verbatim progress delivery including late connections, loading, loaded data, loaded-empty, error/retry, stable mounting, and the absence of timer-based fake progress
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add focused failing Core/server tests that prove the existing shared ContentStore initialization forwards Core progress verbatim, retains the latest phase for late WebSocket connections, publishes completion/error/retry states, and remains a single deduplicated load.
+2. Bridge the existing Core loadTasks progress callback through BacklogServer’s current WebSocket while allowing the browser shell/socket to connect during the same in-flight services promise; retain only the latest loading state and reset it correctly for retry.
+3. Add focused React tests and update the existing App/Layout/sidebar/Kanban state path so pending data shows the verbatim Core phase with genuine indicators, loaded-empty renders only after success, and failures are distinct and retryable without remounting the shell.
+4. Run targeted tests, then typecheck, Biome, build, and the appropriate full suite; simplify the final diff, finalize BACK-571 through the CLI, and publish a ready PR titled exactly “BACK-571 - Show genuine loading indicators in the browser board and sidebar”.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented one retained browser loading-state channel on BacklogServer around the existing deduplicated servicesReadyPromise and Core-backed ContentStore initialization. Core's existing progress callback is forwarded verbatim; WebSocket connections receive the retained phase immediately, the first socket still starts the same shared initialization, failures remain retained without auto-retrying, and an HTTP retry reuses the same store initialization path. React keeps the shell mounted and distinguishes pending skeleton/progress, loaded-empty, loaded data, and retryable error states. Validation: focused loading/reorder/UI tests 33 pass; full bun test 1,883 pass, 5 expected skips, 0 fail; bunx tsc --noEmit, bun run check ., and bun run build pass. Rendered browser QA verified the exact Core phase in sidebar and Kanban, no premature empty presentation, late-connection retention, loaded cards/counts, and sidebar collapse/expand.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Bridged the existing Core corpus progress callback through a retained WebSocket loading state and updated the mounted browser sidebar and Kanban to show genuine phase/skeleton, loaded-empty, loaded-data, and retryable error presentations. Verified by focused protocol/server/React coverage, rendered browser interaction, 1,883 passing repository tests, typecheck, Biome, and production build.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-571 - Show-genuine-loading-indicators-in-the-browser-board-and-sidebar.md
+++ b/backlog/tasks/back-571 - Show-genuine-loading-indicators-in-the-browser-board-and-sidebar.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-03 20:02'
-updated_date: '2026-08-03 20:58'
+updated_date: '2026-08-03 21:15'
 labels: []
 dependencies: []
 modified_files:
@@ -57,6 +57,8 @@ Follow up on BACK-570 without undoing its asynchronous, idle-stable browser star
 2. Bridge the existing Core loadTasks progress callback through BacklogServer’s current WebSocket while allowing the browser shell/socket to connect during the same in-flight services promise; retain only the latest loading state and reset it correctly for retry.
 3. Add focused React tests and update the existing App/Layout/sidebar/Kanban state path so pending data shows the verbatim Core phase with genuine indicators, loaded-empty renders only after success, and failures are distinct and retryable without remounting the shell.
 4. Run targeted tests, then typecheck, Biome, build, and the appropriate full suite; simplify the final diff, finalize BACK-571 through the CLI, and publish a ready PR titled exactly “BACK-571 - Show genuine loading indicators in the browser board and sidebar”.
+
+5. Address the approved second Codex review cycle only: clear protocol-only ownership when any HTTP data request overlaps the phase, expose a collapsed-sidebar corpus error/retry affordance on non-board routes, and reconcile protocol-only loading when the data WebSocket closes. Add focused regressions, rerun full validation, push the final head, and await fresh Codex and independent review before merge.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -65,10 +67,14 @@ Follow up on BACK-570 without undoing its asynchronous, idle-stable browser star
 Implemented one retained browser loading-state channel on BacklogServer around the existing deduplicated servicesReadyPromise and Core-backed ContentStore initialization. Core's existing progress callback is forwarded verbatim; WebSocket connections receive the retained phase immediately, the first socket still starts the same shared initialization, failures remain retained without auto-retrying, and an HTTP retry reuses the same store initialization path. React keeps the shell mounted and distinguishes pending skeleton/progress, loaded-empty, loaded data, and retryable error states. Validation: focused loading/reorder/UI tests 33 pass; full bun test 1,883 pass, 5 expected skips, 0 fail; bunx tsc --noEmit, bun run check ., and bun run build pass. Rendered browser QA verified the exact Core phase in sidebar and Kanban, no premature empty presentation, late-connection retention, loaded cards/counts, and sidebar collapse/expand.
 
 Codex review follow-up: scoped the Core progress callback to ContentStore initialization only, preventing later watcher/manual refreshes from emitting unterminated browser loading phases. Added passive-client reconciliation on shared retry completion while tracking active data-request ownership so a tab with an in-flight request does not start a duplicate. Added focused regressions for both findings. Final validation: focused suite 88 pass, full bun test 1,885 pass with 5 expected skips and 0 failures; typecheck, Biome, and build pass.
+
+Alex approved the three second-cycle Codex P2 findings for implementation; task reopened while the narrowly scoped fixes and final review gates are completed.
+
+Second Codex review follow-up completed within the approved scope: any overlapping HTTP data request now owns and clears protocol-only loading to prevent a later loaded frame from duplicating the refresh; collapsed sidebar mode exposes a visible retryable corpus error affordance; and unexpected WebSocket closure reconciles passive protocol-only loading through the existing refresh path while cleanup closures remain inert. Added focused regressions for all three findings. Final validation: focused Core/server/React suite 91 pass, full bun test 1,888 pass with 5 expected skips and 0 failures; bunx tsc --noEmit, bun run check ., and bun run build pass.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Bridged the existing Core corpus progress callback through a retained WebSocket loading state scoped strictly to shared initialization, and updated the mounted browser sidebar and Kanban to show genuine phase/skeleton, loaded-empty, loaded-data, and retryable error presentations. Passive tabs now reconcile once after another tab's successful retry without duplicating an active request. Verified by focused protocol/Core/server/React coverage, rendered browser interaction, 1,885 passing repository tests, typecheck, Biome, and production build.
+Bridged the existing Core corpus progress callback through a retained WebSocket loading state scoped strictly to shared initialization, and updated the mounted browser sidebar and Kanban to show genuine phase/skeleton, loaded-empty, loaded-data, and retryable error presentations. Hardened multi-tab and disconnect behavior so overlapping HTTP work does not duplicate refreshes, passive protocol-only loading reconciles after an unexpected socket close, and collapsed navigation retains error/retry access. Verified by focused protocol/Core/server/React coverage, rendered browser interaction, 1,888 passing repository tests, typecheck, Biome, and production build.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-571 - Show-genuine-loading-indicators-in-the-browser-board-and-sidebar.md
+++ b/backlog/tasks/back-571 - Show-genuine-loading-indicators-in-the-browser-board-and-sidebar.md
@@ -5,11 +5,12 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-03 20:02'
-updated_date: '2026-08-03 20:40'
+updated_date: '2026-08-03 20:58'
 labels: []
 dependencies: []
 modified_files:
   - src/core/backlog.ts
+  - src/core/content-store.ts
   - src/server/index.ts
   - src/utils/browser-loading-state.ts
   - src/web/App.tsx
@@ -62,10 +63,12 @@ Follow up on BACK-570 without undoing its asynchronous, idle-stable browser star
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented one retained browser loading-state channel on BacklogServer around the existing deduplicated servicesReadyPromise and Core-backed ContentStore initialization. Core's existing progress callback is forwarded verbatim; WebSocket connections receive the retained phase immediately, the first socket still starts the same shared initialization, failures remain retained without auto-retrying, and an HTTP retry reuses the same store initialization path. React keeps the shell mounted and distinguishes pending skeleton/progress, loaded-empty, loaded data, and retryable error states. Validation: focused loading/reorder/UI tests 33 pass; full bun test 1,883 pass, 5 expected skips, 0 fail; bunx tsc --noEmit, bun run check ., and bun run build pass. Rendered browser QA verified the exact Core phase in sidebar and Kanban, no premature empty presentation, late-connection retention, loaded cards/counts, and sidebar collapse/expand.
+
+Codex review follow-up: scoped the Core progress callback to ContentStore initialization only, preventing later watcher/manual refreshes from emitting unterminated browser loading phases. Added passive-client reconciliation on shared retry completion while tracking active data-request ownership so a tab with an in-flight request does not start a duplicate. Added focused regressions for both findings. Final validation: focused suite 88 pass, full bun test 1,885 pass with 5 expected skips and 0 failures; typecheck, Biome, and build pass.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Bridged the existing Core corpus progress callback through a retained WebSocket loading state and updated the mounted browser sidebar and Kanban to show genuine phase/skeleton, loaded-empty, loaded-data, and retryable error presentations. Verified by focused protocol/server/React coverage, rendered browser interaction, 1,883 passing repository tests, typecheck, Biome, and production build.
+Bridged the existing Core corpus progress callback through a retained WebSocket loading state scoped strictly to shared initialization, and updated the mounted browser sidebar and Kanban to show genuine phase/skeleton, loaded-empty, loaded-data, and retryable error presentations. Passive tabs now reconcile once after another tab's successful retry without duplicating an active request. Verified by focused protocol/Core/server/React coverage, rendered browser interaction, 1,885 passing repository tests, typecheck, Biome, and production build.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -307,11 +307,11 @@ export class Core {
 			// Use loadTasks as the task loader to include cross-branch tasks
 			this.contentStore = new ContentStore(
 				this.fs,
-				() => this.loadContentStoreCorpus(progressCallback),
+				(callback) => this.loadContentStoreCorpus(callback),
 				this.enableWatchers,
 			);
 		}
-		await this.contentStore.ensureInitialized();
+		await this.contentStore.ensureInitialized(progressCallback);
 		return this.contentStore;
 	}
 

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -302,10 +302,14 @@ export class Core {
 		return Math.max(...ordinals) + DEFAULT_ORDINAL_STEP;
 	}
 
-	async getContentStore(): Promise<ContentStore> {
+	async getContentStore(progressCallback?: (message: string) => void): Promise<ContentStore> {
 		if (!this.contentStore) {
 			// Use loadTasks as the task loader to include cross-branch tasks
-			this.contentStore = new ContentStore(this.fs, () => this.loadContentStoreCorpus(), this.enableWatchers);
+			this.contentStore = new ContentStore(
+				this.fs,
+				() => this.loadContentStoreCorpus(progressCallback),
+				this.enableWatchers,
+			);
 		}
 		await this.contentStore.ensureInitialized();
 		return this.contentStore;
@@ -3111,19 +3115,19 @@ export class Core {
 		return (await this.loadTasksWithStableBranchSnapshot(progressCallback, abortSignal, options, 0)).tasks;
 	}
 
-	private async loadTaskCorpusSnapshot(): Promise<TaskCorpusSnapshot> {
+	private async loadTaskCorpusSnapshot(progressCallback?: (message: string) => void): Promise<TaskCorpusSnapshot> {
 		return await this.loadTasksWithStableBranchSnapshot(
-			undefined,
+			progressCallback,
 			undefined,
 			{ includeCompleted: true, visibleCompleted: false },
 			0,
 		);
 	}
 
-	private async loadContentStoreCorpus(): Promise<TaskCorpusSnapshot> {
+	private async loadContentStoreCorpus(progressCallback?: (message: string) => void): Promise<TaskCorpusSnapshot> {
 		if (Object.hasOwn(this, "loadTasks")) {
 			const [activeTasks, completedTasks, config] = await Promise.all([
-				this.loadTasks(),
+				this.loadTasks(progressCallback),
 				this.fs.listCompletedTasks(),
 				this.fs.loadConfig(),
 			]);
@@ -3136,7 +3140,7 @@ export class Core {
 			);
 			return { tasks: identityIndex.getTasks(false), activeTasks, completedTasks, identityIndex };
 		}
-		return await this.loadTaskCorpusSnapshot();
+		return await this.loadTaskCorpusSnapshot(progressCallback);
 	}
 
 	private async loadTasksWithStableBranchSnapshot(

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -20,6 +20,7 @@ export interface TaskCorpusSnapshot {
 }
 
 type TaskLoaderResult = Task[] | TaskCorpusSnapshot;
+type ProgressCallback = (message: string) => void;
 
 interface ContentSnapshot {
 	tasks: Task[];
@@ -136,7 +137,7 @@ export class ContentStore {
 
 	constructor(
 		private readonly filesystem: FileSystem,
-		private readonly taskLoader?: () => Promise<TaskLoaderResult>,
+		private readonly taskLoader?: (progressCallback?: ProgressCallback) => Promise<TaskLoaderResult>,
 		private readonly enableWatchers = false,
 	) {
 		this.publishedRoot = this.currentRoot();
@@ -158,14 +159,14 @@ export class ContentStore {
 		};
 	}
 
-	async ensureInitialized(): Promise<ContentSnapshot> {
+	async ensureInitialized(progressCallback?: ProgressCallback): Promise<ContentSnapshot> {
 		this.assertOpen();
 		if (this.initialized) {
 			return this.getSnapshot();
 		}
 
 		if (!this.initializing) {
-			this.initializing = this.loadInitialData().catch((error) => {
+			this.initializing = this.loadInitialData(progressCallback).catch((error) => {
 				this.initializing = null;
 				throw error;
 			});
@@ -489,7 +490,7 @@ export class ContentStore {
 		return [...tasks.values()];
 	}
 
-	private async loadInitialData(): Promise<void> {
+	private async loadInitialData(progressCallback?: ProgressCallback): Promise<void> {
 		let ready = false;
 		for (let attempt = 0; attempt < 12 && !ready; attempt += 1) {
 			if (this.closed) {
@@ -504,11 +505,15 @@ export class ContentStore {
 			// Use custom task loader if provided (e.g., loadTasks for cross-branch support)
 			// Otherwise fall back to filesystem-only loading
 			const epoch = this.rootWatcherEpoch;
-			const attemptLoaded = await this.loadCurrentContent(epoch, (snapshot) => {
-				this.installTaskCorpus(snapshot.taskCorpus ?? this.asTaskCorpus(snapshot.tasks));
-				this.replaceDocuments(snapshot.documents);
-				this.replaceDecisions(snapshot.decisions);
-			});
+			const attemptLoaded = await this.loadCurrentContent(
+				epoch,
+				(snapshot) => {
+					this.installTaskCorpus(snapshot.taskCorpus ?? this.asTaskCorpus(snapshot.tasks));
+					this.replaceDocuments(snapshot.documents);
+					this.replaceDecisions(snapshot.decisions);
+				},
+				progressCallback,
+			);
 			if (!attemptLoaded || !this.isPublicationOwnerCurrent(owner)) {
 				continue;
 			}
@@ -757,7 +762,11 @@ export class ContentStore {
 		}
 	}
 
-	private async loadCurrentContent(epoch: number, publish: (snapshot: ContentSnapshot) => void): Promise<boolean> {
+	private async loadCurrentContent(
+		epoch: number,
+		publish: (snapshot: ContentSnapshot) => void,
+		progressCallback?: ProgressCallback,
+	): Promise<boolean> {
 		const targetRoot = this.currentRoot();
 		const generations: Record<ContentCollection, number> = {
 			tasks: this.nextContentRefreshGeneration("tasks"),
@@ -771,7 +780,7 @@ export class ContentStore {
 			decisions: new Map(this.contentItemVersions.decisions),
 		};
 		const [taskCorpus, documents, decisions] = await Promise.all([
-			this.loadTasksWithLoader(),
+			this.loadTasksWithLoader(progressCallback),
 			this.filesystem.listDocuments(),
 			this.filesystem.listDecisions(),
 		]);
@@ -1822,9 +1831,9 @@ export class ContentStore {
 		});
 	}
 
-	private async loadTasksWithLoader(): Promise<TaskCorpusSnapshot> {
+	private async loadTasksWithLoader(progressCallback?: ProgressCallback): Promise<TaskCorpusSnapshot> {
 		if (this.taskLoader) {
-			const loaded = await this.taskLoader();
+			const loaded = await this.taskLoader(progressCallback);
 			return Array.isArray(loaded) ? this.asTaskCorpus(loaded) : loaded;
 		}
 		return this.asTaskCorpus(await this.filesystem.listTasks());

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,6 +18,7 @@ import {
 	type TaskUpdateInput,
 } from "../types/index.ts";
 import { launchBrowser } from "../utils/browser-launch.ts";
+import type { BrowserLoadingState } from "../utils/browser-loading-state.ts";
 import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
 import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import { formatValidStatuses, getCanonicalStatuses, getValidStatuses } from "../utils/status.ts";
@@ -189,6 +190,7 @@ export class BacklogServer {
 	private contentStore: ContentStore | null = null;
 	private searchService: SearchService | null = null;
 	private servicesReadyPromise: Promise<void> | null = null;
+	private browserLoadingState: BrowserLoadingState = { type: "loading", message: null };
 	private unsubscribeContentStore?: () => void;
 	private taskBroadcastTimer?: ReturnType<typeof setTimeout>;
 	private storeReadyBroadcasted = false;
@@ -207,17 +209,26 @@ export class BacklogServer {
 
 	private async ensureServicesReady(): Promise<void> {
 		if (!this.servicesReadyPromise) {
-			const readyPromise = this.initializeServices().catch((error) => {
-				if (this.servicesReadyPromise === readyPromise) this.servicesReadyPromise = null;
-				throw error;
-			});
+			this.publishBrowserLoadingState({ type: "loading", message: null });
+			const readyPromise = this.initializeServices()
+				.then(() => this.publishBrowserLoadingState({ type: "loaded" }))
+				.catch((error) => {
+					if (this.servicesReadyPromise === readyPromise) this.servicesReadyPromise = null;
+					this.publishBrowserLoadingState({
+						type: "error",
+						message: error instanceof Error ? error.message : String(error),
+					});
+					throw error;
+				});
 			this.servicesReadyPromise = readyPromise;
 		}
 		await this.servicesReadyPromise;
 	}
 
 	private async initializeServices(): Promise<void> {
-		const store = await this.core.getContentStore();
+		const store = await this.core.getContentStore((message) => {
+			this.publishBrowserLoadingState({ type: "loading", message });
+		});
 		this.contentStore = store;
 
 		if (!this.unsubscribeContentStore) {
@@ -284,6 +295,16 @@ export class BacklogServer {
 		for (const ws of this.sockets) {
 			try {
 				ws.send("config-updated");
+			} catch {}
+		}
+	}
+
+	private publishBrowserLoadingState(state: BrowserLoadingState) {
+		this.browserLoadingState = state;
+		const message = JSON.stringify(state);
+		for (const ws of this.sockets) {
+			try {
+				ws.send(message);
 			} catch {}
 		}
 	}
@@ -442,6 +463,10 @@ export class BacklogServer {
 				websocket: {
 					open: (ws: ServerWebSocket) => {
 						this.sockets.add(ws);
+						ws.send(JSON.stringify(this.browserLoadingState));
+						if (this.browserLoadingState.type === "loading") {
+							void this.ensureServicesReady().catch(() => {});
+						}
 					},
 					message(ws: ServerWebSocket) {
 						ws.send("pong");
@@ -516,6 +541,7 @@ export class BacklogServer {
 		this.searchService = null;
 		this.contentStore = null;
 		this.servicesReadyPromise = null;
+		this.browserLoadingState = { type: "loading", message: null };
 		this.storeReadyBroadcasted = false;
 
 		// Proactively close WebSocket connections
@@ -602,7 +628,6 @@ export class BacklogServer {
 	private async handleRequest(req: Request, server: Server<unknown>): Promise<Response> {
 		// Handle WebSocket upgrade
 		if (req.headers.get("upgrade") === "websocket") {
-			await this.ensureServicesReady();
 			const success = server.upgrade(req, { data: undefined });
 			if (success) {
 				return new Response(null, { status: 101 }); // WebSocket upgrade response

--- a/src/test/browser-loading-state.test.ts
+++ b/src/test/browser-loading-state.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { parseBrowserLoadingState } from "../utils/browser-loading-state.ts";
+
+describe("browser loading state protocol", () => {
+	it("preserves Core progress messages verbatim", () => {
+		const message = "Applying latest task states from branch scans...";
+		expect(parseBrowserLoadingState(JSON.stringify({ type: "loading", message }))).toEqual({
+			type: "loading",
+			message,
+		});
+	});
+
+	it("leaves existing WebSocket publications outside the loading protocol", () => {
+		expect(parseBrowserLoadingState("tasks-updated")).toBeNull();
+		expect(parseBrowserLoadingState('{"type":"loading","message":42}')).toBeNull();
+	});
+});

--- a/src/test/server-loading-progress.test.ts
+++ b/src/test/server-loading-progress.test.ts
@@ -10,6 +10,7 @@ const sockets: WebSocket[] = [];
 
 type ServerInternals = {
 	core: {
+		getContentStore: () => Promise<{ refreshTasks: () => Promise<void> }>;
 		loadTasks: (
 			progressCallback?: (message: string) => void,
 			abortSignal?: AbortSignal,
@@ -116,6 +117,10 @@ describe("browser corpus loading progress", () => {
 		await waitForState(first.states, { type: "loaded" });
 		await waitForState(late.states, { type: "loaded" });
 		expect(loadCalls).toBe(1);
+
+		await (await internals(server).core.getContentStore()).refreshTasks();
+		expect(first.states.filter((state) => state.type === "loading" && state.message === phase)).toHaveLength(1);
+		expect(loadCalls).toBe(2);
 	});
 
 	it("publishes a distinct failure and retries the same shared initialization", async () => {

--- a/src/test/server-loading-progress.test.ts
+++ b/src/test/server-loading-progress.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { FileSystem } from "../file-system/operations.ts";
+import { BacklogServer } from "../server/index.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, retry, safeCleanup, withTimeout } from "./test-utils.ts";
+
+let testDir: string;
+let server: BacklogServer | null = null;
+const sockets: WebSocket[] = [];
+
+type ServerInternals = {
+	core: {
+		loadTasks: (
+			progressCallback?: (message: string) => void,
+			abortSignal?: AbortSignal,
+			options?: { includeCompleted?: boolean },
+		) => Promise<Task[]>;
+	};
+};
+
+type LoadingState =
+	| { type: "loading"; message: string | null }
+	| { type: "loaded" }
+	| { type: "error"; message: string };
+
+const internals = (instance: BacklogServer): ServerInternals => instance as unknown as ServerInternals;
+
+const openSocket = async (port: number): Promise<{ socket: WebSocket; states: LoadingState[] }> => {
+	const states: LoadingState[] = [];
+	const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+	sockets.push(socket);
+	socket.onmessage = (event) => {
+		try {
+			states.push(JSON.parse(String(event.data)) as LoadingState);
+		} catch {}
+	};
+	await withTimeout(
+		new Promise<void>((resolve, reject) => {
+			socket.onopen = () => resolve();
+			socket.onerror = () => reject(new Error("WebSocket failed to open"));
+		}),
+		"loading progress WebSocket",
+		2000,
+	);
+	return { socket, states };
+};
+
+const waitForState = async (states: LoadingState[], expected: LoadingState): Promise<void> => {
+	await retry(async () => {
+		if (!states.some((state) => JSON.stringify(state) === JSON.stringify(expected))) {
+			throw new Error(`Missing ${JSON.stringify(expected)} in ${JSON.stringify(states)}`);
+		}
+	});
+};
+
+beforeEach(async () => {
+	testDir = createUniqueTestDir("server-loading-progress");
+	const filesystem = new FileSystem(testDir);
+	await filesystem.ensureBacklogStructure();
+	await filesystem.saveConfig({
+		projectName: "Server loading progress",
+		statuses: ["To Do", "In Progress", "Done"],
+		labels: [],
+		milestones: [],
+		dateFormat: "YYYY-MM-DD",
+		remoteOperations: false,
+		checkActiveBranches: false,
+	});
+});
+
+afterEach(async () => {
+	for (const socket of sockets.splice(0)) socket.close();
+	await server?.stop();
+	server = null;
+	await safeCleanup(testDir);
+});
+
+describe("browser corpus loading progress", () => {
+	it("forwards Core progress verbatim to current and late sockets without duplicating the shared load", async () => {
+		let loadCalls = 0;
+		let reportPhase: () => void = () => {};
+		let releaseLoad: () => void = () => {};
+		const phaseReady = new Promise<void>((resolve) => {
+			reportPhase = resolve;
+		});
+		const heldLoad = new Promise<void>((resolve) => {
+			releaseLoad = resolve;
+		});
+		const phase = "Loading tasks from 7 local branches...";
+
+		server = new BacklogServer(testDir);
+		internals(server).core.loadTasks = async (progressCallback) => {
+			loadCalls += 1;
+			await phaseReady;
+			progressCallback?.(phase);
+			await heldLoad;
+			return [];
+		};
+		await server.start(0, false);
+		const port = server.getPort() ?? 0;
+
+		const searchResponse = fetch(`http://127.0.0.1:${port}/api/search`);
+		const first = await openSocket(port);
+		await waitForState(first.states, { type: "loading", message: null });
+		expect(first.states.filter((state) => state.type === "loading" && state.message !== null)).toEqual([]);
+
+		reportPhase();
+		await waitForState(first.states, { type: "loading", message: phase });
+
+		const late = await openSocket(port);
+		await waitForState(late.states, { type: "loading", message: phase });
+		expect(loadCalls).toBe(1);
+
+		releaseLoad();
+		expect((await searchResponse).status).toBe(200);
+		await waitForState(first.states, { type: "loaded" });
+		await waitForState(late.states, { type: "loaded" });
+		expect(loadCalls).toBe(1);
+	});
+
+	it("publishes a distinct failure and retries the same shared initialization", async () => {
+		let loadCalls = 0;
+		let failFirstLoad = true;
+		server = new BacklogServer(testDir);
+		internals(server).core.loadTasks = async (progressCallback) => {
+			loadCalls += 1;
+			progressCallback?.(failFirstLoad ? "Checking active branches..." : "Loading local tasks...");
+			if (failFirstLoad) {
+				failFirstLoad = false;
+				throw new Error("corpus failed");
+			}
+			return [];
+		};
+		await server.start(0, false);
+		const port = server.getPort() ?? 0;
+
+		const firstResponsePromise = fetch(`http://127.0.0.1:${port}/api/search`);
+		const client = await openSocket(port);
+		const firstResponse = await firstResponsePromise;
+		expect(firstResponse.status).toBe(500);
+		await waitForState(client.states, { type: "loading", message: "Checking active branches..." });
+		await waitForState(client.states, { type: "error", message: "corpus failed" });
+
+		const [retry, concurrentRetry] = await Promise.all([
+			fetch(`http://127.0.0.1:${port}/api/search`),
+			fetch(`http://127.0.0.1:${port}/api/search?type=document`),
+		]);
+		expect(retry.status).toBe(200);
+		expect(concurrentRetry.status).toBe(200);
+		await waitForState(client.states, { type: "loading", message: "Loading local tasks..." });
+		await waitForState(client.states, { type: "loaded" });
+		expect(loadCalls).toBe(2);
+	});
+});

--- a/src/test/web-side-navigation-loading.test.tsx
+++ b/src/test/web-side-navigation-loading.test.tsx
@@ -86,6 +86,18 @@ describe("SideNavigation task loading", () => {
 		expect(failed).not.toContain("No decisions");
 	});
 
+	it("keeps a retryable load failure visible when the sidebar is collapsed", () => {
+		storage.set("sideNavCollapsed", "true");
+		try {
+			const failed = renderNavigation(false, 0, new Error("corpus failed"));
+			expect(failed).toContain('role="alert"');
+			expect(failed).toContain('aria-label="Failed to load navigation. Retry"');
+			expect(failed).toContain("Retry");
+		} finally {
+			storage.delete("sideNavCollapsed");
+		}
+	});
+
 	it("keeps Kanban loading, loaded-empty, and error states distinct", () => {
 		const phase = "Applying latest task states from branch scans...";
 		const loading = renderBoard(true, undefined, phase);

--- a/src/test/web-side-navigation-loading.test.tsx
+++ b/src/test/web-side-navigation-loading.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { renderToString } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
+import BoardPage from "../web/components/BoardPage";
 import SideNavigation from "../web/components/SideNavigation";
 
 const storage = new Map<string, string>();
@@ -15,7 +16,7 @@ globalThis.localStorage = {
 	},
 } as Storage;
 
-const renderNavigation = (isLoading: boolean, taskCount: number, error?: Error): string =>
+const renderNavigation = (isLoading: boolean, taskCount: number, error?: Error, loadingMessage?: string): string =>
 	renderToString(
 		<MemoryRouter>
 			<SideNavigation
@@ -23,6 +24,7 @@ const renderNavigation = (isLoading: boolean, taskCount: number, error?: Error):
 				docs={[]}
 				decisions={[]}
 				isLoading={isLoading}
+				loadingMessage={loadingMessage}
 				error={error}
 				onRetry={async () => {}}
 				onRefreshData={async () => {}}
@@ -30,16 +32,36 @@ const renderNavigation = (isLoading: boolean, taskCount: number, error?: Error):
 		</MemoryRouter>,
 	);
 
+const renderBoard = (isLoading: boolean, error?: Error, loadingMessage?: string): string =>
+	renderToString(
+		<MemoryRouter>
+			<BoardPage
+				onEditTask={() => {}}
+				onNewTask={() => {}}
+				tasks={[]}
+				statuses={["To Do", "Done"]}
+				milestones={[]}
+				availableLabels={[]}
+				milestoneEntities={[]}
+				archivedMilestones={[]}
+				isLoading={isLoading}
+				loadingMessage={loadingMessage}
+				loadError={error}
+				onRefreshData={async () => {}}
+			/>
+		</MemoryRouter>,
+	);
+
 describe("SideNavigation task loading", () => {
 	it("keeps navigation mounted while only the task count is loading", () => {
-		const loading = renderNavigation(true, 0);
+		const phase = "Loading tasks from 7 local branches...";
+		const loading = renderNavigation(true, 0, undefined, phase);
 		expect(loading).toContain("Kanban Board");
 		expect(loading).toContain("All Tasks");
 		expect(loading).toContain('aria-label="Loading task count"');
 		expect(loading).toContain('aria-label="Loading document count"');
 		expect(loading).toContain('aria-label="Loading decision count"');
-		expect(loading).toContain("Loading documents…");
-		expect(loading).toContain("Loading decisions…");
+		expect(loading).toContain(phase);
 		expect(loading).not.toContain("No documents");
 		expect(loading).not.toContain("No decisions");
 
@@ -54,12 +76,32 @@ describe("SideNavigation task loading", () => {
 		expect(loaded).not.toContain('aria-label="Loading task count"');
 	});
 
-	it("keeps the deferred loading presentation and exposes retry after a corpus failure", () => {
-		const failed = renderNavigation(true, 0, new Error("corpus failed"));
+	it("shows a distinct unavailable presentation and exposes retry after a corpus failure", () => {
+		const failed = renderNavigation(false, 0, new Error("corpus failed"));
 		expect(failed).toContain("Failed to load navigation");
 		expect(failed).toContain("Retry");
-		expect(failed).toContain('aria-label="Loading task count"');
+		expect(failed).toContain('aria-label="task count unavailable"');
+		expect(failed).not.toContain('aria-label="Loading task count"');
 		expect(failed).not.toContain("No documents");
 		expect(failed).not.toContain("No decisions");
+	});
+
+	it("keeps Kanban loading, loaded-empty, and error states distinct", () => {
+		const phase = "Applying latest task states from branch scans...";
+		const loading = renderBoard(true, undefined, phase);
+		expect(loading).toContain("Kanban Board");
+		expect(loading).toContain(phase);
+		expect(loading).toContain('role="status"');
+		expect(loading).not.toContain("Empty");
+
+		const loadedEmpty = renderBoard(false);
+		expect(loadedEmpty).toContain("Empty");
+		expect(loadedEmpty).not.toContain(phase);
+
+		const failed = renderBoard(false, new Error("corpus failed"));
+		expect(failed).toContain("Failed to load tasks");
+		expect(failed).toContain("corpus failed");
+		expect(failed).toContain("Retry");
+		expect(failed).not.toContain("Empty");
 	});
 });

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -463,6 +463,8 @@ const renderApp = async (
 	path: string,
 	options: {
 		advanceHealthSocket?: boolean;
+		afterInitialStatus?: (container: HTMLElement) => void | Promise<void>;
+		beforeInitialStatus?: (container: HTMLElement) => void | Promise<void>;
 		manualDuplicatePlan?: boolean;
 		operationRef?: { current?: FetchOperation };
 	} = {},
@@ -500,7 +502,13 @@ const renderApp = async (
 		);
 		await Promise.resolve();
 	});
+	if (options.beforeInitialStatus) {
+		await act(async () => options.beforeInitialStatus?.(container as HTMLElement));
+	}
 	await act(async () => operation.settle("initial status"));
+	if (options.afterInitialStatus) {
+		await act(async () => options.afterInitialStatus?.(container as HTMLElement));
+	}
 	await act(async () => operation.settle("initial search"));
 	if (controlledTimer) {
 		await act(async () => controlledTimer.advance());
@@ -639,6 +647,21 @@ afterEach(async () => {
 });
 
 describe("task detail routes", () => {
+	it("preserves a retained Core phase when initial data loading starts after the socket connects", async () => {
+		const phase = "Loading tasks from local and remote branches...";
+		let observedWhileSearchPending = false;
+		await renderApp("/board", {
+			beforeInitialStatus: async () => {
+				getAppDataWebSocket().deliver(JSON.stringify({ type: "loading", message: phase }));
+				await Promise.resolve();
+			},
+			afterInitialStatus: (rendered) => {
+				observedWhileSearchPending = rendered.textContent?.includes(phase) ?? false;
+			},
+		});
+		expect(observedWhileSearchPending).toBe(true);
+	});
+
 	it("keeps a newer WebSocket-reconciled task when an earlier reorder response arrives late", async () => {
 		const container = await renderApp("/board?lane=none", { advanceHealthSocket: true });
 		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -662,6 +662,60 @@ describe("task detail routes", () => {
 		expect(observedWhileSearchPending).toBe(true);
 	});
 
+	it("reconciles a passive client when another browser retry completes", async () => {
+		const container = await renderApp("/board?lane=none");
+		const dataSocket = getAppDataWebSocket();
+		const phase = "Loading tasks from local branches...";
+
+		await act(async () => {
+			dataSocket.deliver(JSON.stringify({ type: "loading", message: phase }));
+			await Promise.resolve();
+		});
+		expect(container.textContent).toContain(phase);
+
+		const reconciliation = new FetchOperation("passive shared retry completion", [
+			expectFetch("passive config", "/api/config"),
+			expectFetch("passive search", "/api/search"),
+		]);
+		await act(async () => {
+			dataSocket.deliver(JSON.stringify({ type: "loaded" }));
+			await Promise.resolve();
+		});
+		await act(async () => reconciliation.settle("passive config", "passive search"));
+		reconciliation.finish();
+
+		expect(container.textContent).not.toContain(phase);
+		expect(container.querySelector("[aria-label='Loading tasks']")).toBeNull();
+		expect(container.textContent).toContain(tasks[0]?.title ?? "");
+	});
+
+	it("does not duplicate an active data request when shared loading completes", async () => {
+		await renderApp("/board?lane=none");
+		const dataSocket = getAppDataWebSocket();
+		const activeRefresh = new FetchOperation("active refresh during shared completion", [
+			expectFetch("active config", "/api/config"),
+			expectFetch("active search", "/api/search", { manual: true }),
+		]);
+
+		await act(async () => {
+			dataSocket.deliver("tasks-updated");
+			await Promise.resolve();
+		});
+		await activeRefresh.startedSignals.get("active search")?.promise;
+		await act(async () => {
+			dataSocket.deliver(JSON.stringify({ type: "loading", message: "Loading local tasks..." }));
+			dataSocket.deliver(JSON.stringify({ type: "loaded" }));
+			await Promise.resolve();
+		});
+		expect(activeRefresh.calls.filter((call) => call.url === "/api/search")).toHaveLength(1);
+
+		await act(async () => {
+			activeRefresh.respond("active search", json(searchResults));
+			await activeRefresh.settle("active config", "active search");
+		});
+		activeRefresh.finish();
+	});
+
 	it("keeps a newer WebSocket-reconciled task when an earlier reorder response arrives late", async () => {
 		const container = await renderApp("/board?lane=none", { advanceHealthSocket: true });
 		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -327,6 +327,11 @@ class FakeWebSocket {
 		this.onmessage({ data });
 	}
 
+	disconnect() {
+		this.readyState = FakeWebSocket.CLOSED;
+		this.onclose?.();
+	}
+
 	close() {
 		this.readyState = FakeWebSocket.CLOSED;
 	}
@@ -662,6 +667,35 @@ describe("task detail routes", () => {
 		expect(observedWhileSearchPending).toBe(true);
 	});
 
+	it("does not duplicate a completed HTTP refresh when the loaded frame arrives later", async () => {
+		await renderApp("/board");
+		const dataSocket = getAppDataWebSocket();
+		await act(async () => {
+			dataSocket.deliver(JSON.stringify({ type: "loading", message: "Loading local tasks..." }));
+			await Promise.resolve();
+		});
+
+		const overlappingRefresh = new FetchOperation("HTTP refresh overlapping shared loading", [
+			expectFetch("overlapping config", "/api/config"),
+			expectFetch("overlapping search", "/api/search"),
+		]);
+		await act(async () => {
+			dataSocket.deliver("config-updated");
+			await Promise.resolve();
+		});
+		await act(async () => overlappingRefresh.settle("overlapping config", "overlapping search"));
+		overlappingRefresh.finish();
+
+		const duplicate = new FetchOperation("late loaded frame after initial reconciliation", []);
+		await act(async () => {
+			getAppDataWebSocket().deliver(JSON.stringify({ type: "loaded" }));
+			await Promise.resolve();
+		});
+		await Promise.all(duplicate.calls.map((call) => call.settledSignal));
+		expect(duplicate.calls.filter((call) => call.url === "/api/search")).toHaveLength(0);
+		duplicate.finish();
+	});
+
 	it("reconciles a passive client when another browser retry completes", async () => {
 		const container = await renderApp("/board?lane=none");
 		const dataSocket = getAppDataWebSocket();
@@ -714,6 +748,28 @@ describe("task detail routes", () => {
 			await activeRefresh.settle("active config", "active search");
 		});
 		activeRefresh.finish();
+	});
+
+	it("reconciles protocol-only loading when the data socket closes", async () => {
+		const container = await renderApp("/board?lane=none");
+		const dataSocket = getAppDataWebSocket();
+		const phase = "Loading tasks from local branches...";
+		await act(async () => {
+			dataSocket.deliver(JSON.stringify({ type: "loading", message: phase }));
+			await Promise.resolve();
+		});
+		expect(container.textContent).toContain(phase);
+
+		const recovery = new FetchOperation("protocol-only socket close recovery", []);
+		await act(async () => {
+			dataSocket.disconnect();
+			await Promise.resolve();
+		});
+		await Promise.all(recovery.calls.map((call) => call.settledSignal));
+		expect(recovery.calls.filter((call) => call.url === "/api/search")).toHaveLength(1);
+		expect(container.querySelector("[aria-label='Loading tasks']")).toBeNull();
+		expect(container.textContent).toContain(tasks[0]?.title ?? "");
+		recovery.finish();
 	});
 
 	it("keeps a newer WebSocket-reconciled task when an earlier reorder response arrives late", async () => {

--- a/src/utils/browser-loading-state.ts
+++ b/src/utils/browser-loading-state.ts
@@ -1,0 +1,21 @@
+export type BrowserLoadingState =
+	| { type: "loading"; message: string | null }
+	| { type: "loaded" }
+	| { type: "error"; message: string };
+
+export function parseBrowserLoadingState(value: unknown): BrowserLoadingState | null {
+	if (typeof value !== "string" || !value.startsWith("{")) return null;
+
+	try {
+		const state = JSON.parse(value) as Record<string, unknown>;
+		if (state.type === "loaded") return { type: "loaded" };
+		if (state.type === "loading" && (typeof state.message === "string" || state.message === null)) {
+			return { type: "loading", message: state.message };
+		}
+		if (state.type === "error" && typeof state.message === "string") {
+			return { type: "error", message: state.message };
+		}
+	} catch {}
+
+	return null;
+}

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -33,6 +33,7 @@ import { collectArchivedMilestoneKeys, collectMilestoneIds, milestoneKey } from 
 import { getTaskTypeValues } from '../utils/task-type-config';
 import { createUrlPath } from './utils/urlHelpers';
 import { filterKanbanTasks } from './utils/kanban-tasks';
+import { parseBrowserLoadingState } from '../utils/browser-loading-state';
 
 type TaskRouteNavigationState = {
   taskModalFrom?: string;
@@ -201,6 +202,7 @@ function AppContent() {
   const [docs, setDocs] = useState<Document[]>([]);
   const [decisions, setDecisions] = useState<Decision[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadingMessage, setLoadingMessage] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<Error | null>(null);
   const [duplicateRepairPlan, setDuplicateRepairPlan] = useState<DuplicateRepairPlan | null>(null);
   
@@ -297,10 +299,9 @@ function AppContent() {
   const loadAllData = useCallback(async () => {
     const requestId = loadAllDataRequestRef.current + 1;
     loadAllDataRequestRef.current = requestId;
-    let completed = false;
-    try {
-      setIsLoading(true);
-      setLoadError(null);
+		try {
+			setIsLoading(true);
+			setLoadError(null);
       const shellDataPromise = Promise.all([
         apiClient.fetchStatuses(),
         apiClient.fetchConfig(),
@@ -343,15 +344,15 @@ function AppContent() {
       }).catch(() => {
         if (loadAllDataRequestRef.current === requestId) setDuplicateRepairPlan(null);
       });
-      completed = true;
     } catch (error) {
       if (loadAllDataRequestRef.current === requestId) {
         console.error('Failed to load data:', error);
         setLoadError(error instanceof Error ? error : new Error('Failed to load data'));
       }
     } finally {
-      if (loadAllDataRequestRef.current === requestId && completed) {
+      if (loadAllDataRequestRef.current === requestId) {
         setIsLoading(false);
+        setLoadingMessage(null);
       }
     }
   }, [applySearchResults]);
@@ -562,7 +563,18 @@ function AppContent() {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(`${protocol}//${window.location.host}`);
     ws.onmessage = (event) => {
-      if (event.data === "tasks-updated") {
+	  const loadingState = parseBrowserLoadingState(event.data);
+	  if (loadingState?.type === 'loading') {
+		setIsLoading(true);
+		setLoadError(null);
+		setLoadingMessage(loadingState.message);
+	  } else if (loadingState?.type === 'loaded') {
+		setLoadingMessage(null);
+	  } else if (loadingState?.type === 'error') {
+		setIsLoading(false);
+		setLoadingMessage(null);
+		setLoadError(new Error(loadingState.message));
+      } else if (event.data === "tasks-updated") {
         refreshData();
       } else if (event.data === "config-updated") {
         // Reload statuses when config changes
@@ -644,6 +656,8 @@ function AppContent() {
       milestoneEntities={milestoneEntities}
       archivedMilestones={archivedMilestones}
       isLoading={isLoading}
+      loadingMessage={loadingMessage}
+      loadError={loadError}
       hideEmptyColumns={config?.hideEmptyColumns ?? false}
       dateFormat={config?.dateFormat}
       availablePriorities={config?.priorities}
@@ -682,6 +696,7 @@ function AppContent() {
                 docs={docs}
                 decisions={decisions}
                 isLoading={isLoading}
+                loadingMessage={loadingMessage}
                 error={loadError}
                 onRefreshData={refreshData}
                 duplicateRepairPlan={duplicateRepairPlan}

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -301,6 +301,7 @@ function AppContent() {
   const loadAllData = useCallback(async () => {
     const requestId = loadAllDataRequestRef.current + 1;
     loadAllDataRequestRef.current = requestId;
+	protocolOnlyLoadingRef.current = false;
 		pendingDataRequestRef.current = requestId;
 		try {
 			setIsLoading(true);
@@ -566,6 +567,7 @@ function AppContent() {
   useEffect(() => {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(`${protocol}//${window.location.host}`);
+	let disposed = false;
     ws.onmessage = (event) => {
 	  const loadingState = parseBrowserLoadingState(event.data);
 	  if (loadingState?.type === 'loading') {
@@ -589,7 +591,15 @@ function AppContent() {
         loadAllData();
       }
     };
-    return () => ws.close();
+	ws.onclose = () => {
+		if (disposed || !protocolOnlyLoadingRef.current || pendingDataRequestRef.current !== null) return;
+		protocolOnlyLoadingRef.current = false;
+		void refreshData();
+	};
+	return () => {
+		disposed = true;
+		ws.close();
+	};
   }, [refreshData, loadAllData]);
 
   const handleSubmitTask = async (taskData: Partial<Task>) => {

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -210,6 +210,8 @@ function AppContent() {
   const previousOnlineRef = useRef<boolean | null>(null);
   const hasBeenRunningRef = useRef(false);
   const loadAllDataRequestRef = useRef(0);
+  const pendingDataRequestRef = useRef<number | null>(null);
+  const protocolOnlyLoadingRef = useRef(false);
   const location = useLocation();
   const navigate = useNavigate();
   const tasksRouteWithTitle = useMatch('/tasks/:id/:title');
@@ -299,6 +301,7 @@ function AppContent() {
   const loadAllData = useCallback(async () => {
     const requestId = loadAllDataRequestRef.current + 1;
     loadAllDataRequestRef.current = requestId;
+		pendingDataRequestRef.current = requestId;
 		try {
 			setIsLoading(true);
 			setLoadError(null);
@@ -351,6 +354,7 @@ function AppContent() {
       }
     } finally {
       if (loadAllDataRequestRef.current === requestId) {
+				pendingDataRequestRef.current = null;
         setIsLoading(false);
         setLoadingMessage(null);
       }
@@ -565,11 +569,15 @@ function AppContent() {
     ws.onmessage = (event) => {
 	  const loadingState = parseBrowserLoadingState(event.data);
 	  if (loadingState?.type === 'loading') {
+		if (pendingDataRequestRef.current === null) protocolOnlyLoadingRef.current = true;
 		setIsLoading(true);
 		setLoadError(null);
 		setLoadingMessage(loadingState.message);
 	  } else if (loadingState?.type === 'loaded') {
+		const shouldRefresh = protocolOnlyLoadingRef.current && pendingDataRequestRef.current === null;
+		protocolOnlyLoadingRef.current = false;
 		setLoadingMessage(null);
+		if (shouldRefresh) void refreshData();
 	  } else if (loadingState?.type === 'error') {
 		setIsLoading(false);
 		setLoadingMessage(null);

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -22,6 +22,8 @@ interface BoardProps {
   onTasksUpdated?: (tasks: Task[], requestTask: Task) => void;
   statuses: string[];
   isLoading: boolean;
+  loadingMessage?: string | null;
+  loadError?: Error | null;
   milestones: string[];
   availableLabels: string[];
   milestoneEntities: Milestone[];
@@ -55,6 +57,8 @@ const Board: React.FC<BoardProps> = ({
   onTasksUpdated,
   statuses,
   isLoading,
+  loadingMessage,
+  loadError,
   availableLabels,
   milestoneEntities,
   archivedMilestones,
@@ -457,14 +461,6 @@ const Board: React.FC<BoardProps> = ({
     }));
   };
 
-  if (isLoading && statuses.length === 0) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-lg text-gray-600 dark:text-gray-300 transition-colors duration-200">Loading tasks...</div>
-      </div>
-    );
-  }
-
   // Dynamic layout using flexbox:
   // - Columns are flex items with equal growth (flex-1) to divide space evenly
   // - A minimum width keeps columns readable; beyond available space, container scrolls horizontally
@@ -576,7 +572,33 @@ const Board: React.FC<BoardProps> = ({
         </div>
       </div>
 
-      {laneMode === 'milestone' ? (
+      {loadError ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-6 py-10 text-center dark:border-red-800 dark:bg-red-900/20" role="alert">
+          <p className="font-medium text-red-700 dark:text-red-300">Failed to load tasks</p>
+          <p className="mt-1 text-sm text-red-600 dark:text-red-400">{loadError.message}</p>
+          {onRefreshData && (
+            <button
+              type="button"
+              onClick={() => void onRefreshData()}
+              className="mt-4 rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600"
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      ) : isLoading ? (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 px-6 py-10 dark:border-gray-700 dark:bg-gray-800/30" role="status" aria-label="Loading tasks">
+          <div className="mx-auto flex max-w-xl items-center justify-center gap-3 text-gray-600 dark:text-gray-300">
+            <span className="h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500 dark:border-gray-600 dark:border-t-blue-400" aria-hidden="true" />
+            {loadingMessage && <p>{loadingMessage}</p>}
+          </div>
+          <div className="mx-auto mt-6 grid max-w-3xl grid-cols-3 gap-4" aria-hidden="true">
+            {[0, 1, 2].map((column) => (
+              <div key={column} className="h-24 animate-pulse rounded-lg bg-gray-200/70 dark:bg-gray-700/60" />
+            ))}
+          </div>
+        </div>
+      ) : laneMode === 'milestone' ? (
         <div className="space-y-6">
           {visibleLanes.map((lane) => {
             const taskCount = laneTaskCount(lane.key);

--- a/src/web/components/BoardPage.tsx
+++ b/src/web/components/BoardPage.tsx
@@ -18,6 +18,8 @@ interface BoardPageProps {
 	milestoneEntities: Milestone[];
 	archivedMilestones: Milestone[];
 	isLoading: boolean;
+	loadingMessage?: string | null;
+	loadError?: Error | null;
 	hideEmptyColumns?: boolean;
 	dateFormat?: string;
 	availablePriorities?: string[];
@@ -36,6 +38,8 @@ export default function BoardPage({
 	milestoneEntities,
 	archivedMilestones,
 	isLoading,
+	loadingMessage,
+	loadError,
 	hideEmptyColumns,
 	dateFormat,
 	availablePriorities,
@@ -171,6 +175,8 @@ export default function BoardPage({
 				milestoneEntities={milestoneEntities}
 				archivedMilestones={archivedMilestones}
 				isLoading={isLoading}
+				loadingMessage={loadingMessage}
+				loadError={loadError}
 				availableLabels={availableLabels}
 				laneMode={laneMode}
 				onLaneChange={handleLaneChange}

--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -14,6 +14,7 @@ interface LayoutProps {
 	docs: Document[];
 	decisions: Decision[];
 	isLoading: boolean;
+	loadingMessage?: string | null;
 	error?: Error | null;
 	onRefreshData: () => Promise<void>;
 	duplicateRepairPlan?: DuplicateRepairPlan | null;
@@ -27,6 +28,7 @@ export default function Layout({
 	docs,
 	decisions,
 	isLoading,
+	loadingMessage,
 	error,
 	onRefreshData,
 	duplicateRepairPlan = null,
@@ -39,6 +41,7 @@ export default function Layout({
 				docs={docs}
 				decisions={decisions}
 				isLoading={isLoading}
+				loadingMessage={loadingMessage}
 				error={error}
 				onRetry={onRefreshData}
 				onRefreshData={onRefreshData}

--- a/src/web/components/SideNavigation.tsx
+++ b/src/web/components/SideNavigation.tsx
@@ -33,6 +33,39 @@ const hasTaskSearchFilters = (parsedQuery: ReturnType<typeof parseSearchCommandQ
 	);
 };
 
+const LoadingPhase = ({ message, className }: { message?: string | null; className: string }) => (
+	<p className={className} role="status">
+		{message ?? (
+			<span
+				className="inline-block h-3 w-32 animate-pulse rounded bg-gray-300 dark:bg-gray-700"
+				aria-label="Loading content"
+			/>
+		)}
+	</p>
+);
+
+const NavigationCount = ({
+	count,
+	isLoading,
+	error,
+	label,
+}: {
+	count: number;
+	isLoading: boolean;
+	error?: Error | null;
+	label: string;
+}) => {
+	if (isLoading) {
+		return (
+			<span
+				className="inline-block h-3 w-5 animate-pulse rounded bg-gray-300 align-middle dark:bg-gray-700"
+				aria-label={`Loading ${label} count`}
+			/>
+		);
+	}
+	return error ? <span aria-label={`${label} count unavailable`}>—</span> : count;
+};
+
 // Icon components for better semantics and performance
 const Icons = {
 	Tasks: () => (
@@ -227,6 +260,7 @@ interface SideNavigationProps {
 	docs: Document[];
 	decisions: Decision[];
 	isLoading: boolean;
+	loadingMessage?: string | null;
 	error?: Error | null;
 	onRetry?: () => void;
 	onRefreshData: () => Promise<void>;
@@ -237,6 +271,7 @@ const SideNavigation = memo(function SideNavigation({
 	docs, 
 	decisions, 
 	isLoading, 
+	loadingMessage,
 	error, 
 	onRetry
 }: SideNavigationProps) {
@@ -585,9 +620,12 @@ const SideNavigation = memo(function SideNavigation({
 						<div className="flex items-center space-x-3 text-gray-700 dark:text-gray-300">
 							<span className="text-gray-500 dark:text-gray-400"><Icons.Tasks /></span>
 							<span className="text-sm font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400 whitespace-nowrap">
-								Tasks ({isLoading ? <span className="inline-block h-3 w-5 animate-pulse rounded bg-gray-300 align-middle dark:bg-gray-700" aria-label="Loading task count" /> : taskCount})
+								Tasks (<NavigationCount count={taskCount} isLoading={isLoading} error={error} label="task" />)
 							</span>
 						</div>
+						{isLoading && (
+							<LoadingPhase message={loadingMessage} className="mt-2 text-xs text-gray-500 dark:text-gray-400" />
+						)}
 					</div>
 				)}
 
@@ -688,7 +726,7 @@ const SideNavigation = memo(function SideNavigation({
 									</button>
 									<span className="text-gray-500 dark:text-gray-400"><Icons.Document /></span>
 									<span className="text-sm font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400 whitespace-nowrap">
-										Documents ({isLoading ? <span className="inline-block h-3 w-5 animate-pulse rounded bg-gray-300 align-middle dark:bg-gray-700" aria-label="Loading document count" /> : docs.length})
+										Documents (<NavigationCount count={docs.length} isLoading={isLoading} error={error} label="document" />)
 									</span>
 								</div>
 									<button
@@ -707,7 +745,9 @@ const SideNavigation = memo(function SideNavigation({
 							{!isDocsCollapsed && (
 								<div className="space-y-1">
 									{isLoading ? (
-										<p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">Loading documents…</p>
+										<LoadingPhase message={loadingMessage} className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400" />
+									) : error ? (
+										<p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">Documents unavailable</p>
 									) : filteredDocs.length === 0 ? (
 										<p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No documents</p>
 									) : searchQuery.trim() ? (
@@ -751,7 +791,7 @@ const SideNavigation = memo(function SideNavigation({
 									</button>
 									<span className="text-gray-500 dark:text-gray-400"><Icons.Decision /></span>
 									<span className="text-sm font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400 whitespace-nowrap">
-										Decisions ({isLoading ? <span className="inline-block h-3 w-5 animate-pulse rounded bg-gray-300 align-middle dark:bg-gray-700" aria-label="Loading decision count" /> : decisions.length})
+										Decisions (<NavigationCount count={decisions.length} isLoading={isLoading} error={error} label="decision" />)
 									</span>
 								</div>
 								{/* Temporarily hidden - decisions editing not ready */}
@@ -773,7 +813,9 @@ const SideNavigation = memo(function SideNavigation({
 							{!isDecisionsCollapsed && (
 								<div className="space-y-1">
 									{isLoading ? (
-										<p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">Loading decisions…</p>
+										<LoadingPhase message={loadingMessage} className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400" />
+									) : error ? (
+										<p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">Decisions unavailable</p>
 									) : filteredDecisions.length === 0 ? (
 										<p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No decisions</p>
 									) : (

--- a/src/web/components/SideNavigation.tsx
+++ b/src/web/components/SideNavigation.tsx
@@ -598,6 +598,20 @@ const SideNavigation = memo(function SideNavigation({
 
 			<nav className="flex-1 overflow-y-auto">
 				{/* Error State */}
+				{error && isCollapsed && onRetry && (
+					<div className="px-2 py-3" role="alert">
+						<button
+							type="button"
+							onClick={onRetry}
+							className="flex w-full items-center justify-center rounded-md bg-red-50 p-3 font-bold text-red-600 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30"
+							aria-label="Failed to load navigation. Retry"
+							title="Failed to load navigation. Retry"
+						>
+							<span aria-hidden="true">!</span>
+							<span className="sr-only">Retry</span>
+						</button>
+					</div>
+				)}
 				{error && !isCollapsed && (
 					<div className="px-4 py-4">
 						<div className="text-center p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">


### PR DESCRIPTION
## What changed

- forward the existing Core corpus-loading progress callback through a retained WebSocket state
- let the browser shell and socket connect while the same deduplicated ContentStore initialization is in flight
- keep the sidebar and Kanban mounted with genuine progress, skeleton, loaded-empty, loaded-data, and retryable error presentations
- preserve the existing `tasks-updated` and `config-updated` WebSocket messages and BACK-570 startup behavior

## Why

The browser previously rendered generic or loaded-empty UI while the shared Core corpus was still loading. That hid genuine branch-scan progress and could make zero counts or empty columns look authoritative before initialization had completed.

## Impact

Browser clients now see Core's exact progress messages, including clients that connect after a phase starts, without adding another store, corpus scan, request, or timer-based fake progress. Failures stay visible and retry through the existing data refresh path.

## Verification

- `bun test src/test/server-reorder-publication.test.ts src/test/server-loading-progress.test.ts src/test/browser-loading-state.test.ts src/test/web-side-navigation-loading.test.tsx src/test/web-task-detail-deeplink.test.tsx` — 33 pass, 0 fail
- `bun test` — 1,883 pass, 5 expected skips, 0 fail
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- rendered browser QA for initial pending state, retained late-connection phase, loaded data/counts, no premature empty state, and sidebar collapse/expand
