### PR TITLE
BACK-573 - Clear shared loading ownership after terminal browser initialization errors

### DIFF
--- a/backlog/tasks/back-573 - Clear-shared-loading-ownership-after-terminal-browser-initialization-errors.md
+++ b/backlog/tasks/back-573 - Clear-shared-loading-ownership-after-terminal-browser-initialization-errors.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-573
 title: Clear shared loading ownership after terminal browser initialization errors
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-03 21:28'
+updated_date: '2026-08-03 21:34'
 labels: []
 dependencies: []
 type: bug
@@ -18,15 +20,38 @@ Follow up on BACK-571. After a terminal shared browser initialization error, pro
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 After a terminal shared initialization error, protocol-only loading ownership/state is cleared so the failed attempt is no longer treated as an active load.
-- [ ] #2 A WebSocket close that occurs after that terminal error does not trigger a reload or any duplicate corpus/data request.
-- [ ] #3 The browser continues to show the original terminal error with its retry affordance after the socket close; it is not replaced by loading, empty, or another error state.
-- [ ] #4 Focused regression coverage exercises terminal error followed by socket close and proves both the absence of a second request and preservation of the visible retryable error.
+- [x] #1 After a terminal shared initialization error, protocol-only loading ownership/state is cleared so the failed attempt is no longer treated as an active load.
+- [x] #2 A WebSocket close that occurs after that terminal error does not trigger a reload or any duplicate corpus/data request.
+- [x] #3 The browser continues to show the original terminal error with its retry affordance after the socket close; it is not replaced by loading, empty, or another error state.
+- [x] #4 Focused regression coverage exercises terminal error followed by socket close and proves both the absence of a second request and preservation of the visible retryable error.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Trace the shared browser loading protocol and its terminal error/socket-close lifecycle from merged BACK-571.
+2. Add a focused browser regression that sends a protocol loading frame, then terminal error and WebSocket close, asserting no follow-up data request and the retained retryable error.
+3. Make the smallest state-ownership change that clears protocol-only loading on terminal error while retaining existing success, retry, active-request, and passive-client behavior.
+4. Run focused browser tests, then TypeScript, Biome, build, and the broader test suite; record objective evidence and finalize the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the minimal browser protocol ownership reset on terminal loading errors. Added a TDD regression for loading → terminal error → socket close, asserting no follow-up request and retention of the original retryable error. Focused browser protocol/UI tests, TypeScript, and Biome pass.
+
+Validation passed: bun test src/test/web-task-detail-deeplink.test.tsx src/test/web-side-navigation-loading.test.tsx src/test/browser-loading-state.test.ts; bunx tsc --noEmit; bun run check .; bun run build; and bun test --reporter=dot.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Cleared protocol-only loading ownership on terminal browser initialization errors so socket close cannot reload or replace the retryable error. Added regression coverage for loading → error → socket close, proving zero follow-up requests and preserved retry UI; verified with focused and full test suites, TypeScript, Biome, and build.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -772,6 +772,31 @@ describe("task detail routes", () => {
 		recovery.finish();
 	});
 
+	it("preserves a terminal shared error when the data socket closes", async () => {
+		const container = await renderApp("/board?lane=none");
+		const dataSocket = getAppDataWebSocket();
+		const error = "corpus failed";
+		await act(async () => {
+			dataSocket.deliver(JSON.stringify({ type: "loading", message: "Loading local tasks..." }));
+			dataSocket.deliver(JSON.stringify({ type: "error", message: error }));
+			await Promise.resolve();
+		});
+		expect(container.textContent).toContain("Failed to load tasks");
+		expect(container.textContent).toContain(error);
+		expect(container.textContent).toContain("Retry");
+
+		const duplicate = new FetchOperation("terminal shared error socket close", []);
+		await act(async () => {
+			dataSocket.disconnect();
+			await Promise.resolve();
+		});
+		expect(duplicate.calls).toHaveLength(0);
+		expect(container.textContent).toContain("Failed to load tasks");
+		expect(container.textContent).toContain(error);
+		expect(container.textContent).toContain("Retry");
+		duplicate.finish();
+	});
+
 	it("keeps a newer WebSocket-reconciled task when an earlier reorder response arrives late", async () => {
 		const container = await renderApp("/board?lane=none", { advanceHealthSocket: true });
 		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -581,6 +581,7 @@ function AppContent() {
 		setLoadingMessage(null);
 		if (shouldRefresh) void refreshData();
 	  } else if (loadingState?.type === 'error') {
+		protocolOnlyLoadingRef.current = false;
 		setIsLoading(false);
 		setLoadingMessage(null);
 		setLoadError(new Error(loadingState.message));


### PR DESCRIPTION
## Summary
- clear protocol-only loading ownership after a terminal browser loading error
- retain the existing close recovery only for genuinely interrupted protocol-owned loads
- cover error followed by socket close with zero follow-up requests and preserved retry UI

## Validation
- `bun test src/test/web-task-detail-deeplink.test.tsx src/test/web-side-navigation-loading.test.tsx src/test/browser-loading-state.test.ts`
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- `bun test --reporter=dot`