### PR TITLE
Allow clearing defaultEditor via empty value in config set and init

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -824,7 +824,7 @@ addHelpSchema(program.command("init [projectName]"), {
 					options.branchDays ||
 					options.bypassGitHooks ||
 					options.zeroPaddedIds ||
-					options.defaultEditor ||
+					options.defaultEditor !== undefined ||
 					options.webPort ||
 					options.autoOpenBrowser ||
 					options.installClaudeAgent ||
@@ -1029,11 +1029,8 @@ addHelpSchema(program.command("init [projectName]"), {
 					const paddingValue = parseNumber(options.zeroPaddedIds, result.zeroPaddedIds ?? 0);
 					result.zeroPaddedIds = paddingValue > 0 ? paddingValue : undefined;
 					result.defaultEditor =
-						options.defaultEditor ||
-						existingConfig?.defaultEditor ||
-						process.env.EDITOR ||
-						process.env.VISUAL ||
-						undefined;
+						options.defaultEditor ??
+						(existingConfig?.defaultEditor || process.env.EDITOR || process.env.VISUAL || undefined);
 					result.defaultPort = parseNumber(options.webPort, result.defaultPort ?? 6420);
 					result.autoOpenBrowser = parseBoolean(options.autoOpenBrowser, result.autoOpenBrowser ?? true);
 					return result;
@@ -4450,13 +4447,16 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 			// Handle specific config keys
 			switch (key) {
 				case "defaultEditor": {
-					// Validate that the editor command exists
-					const { isEditorAvailable } = await import("./utils/editor.ts");
-					const isAvailable = await isEditorAvailable(value);
-					if (!isAvailable) {
-						console.error(`Editor command not found: ${value}`);
-						console.error("Please ensure the editor is installed and available in your PATH");
-						process.exit(1);
+					// An explicitly empty value means "no editor" and skips executable validation
+					if (value) {
+						// Validate that the editor command exists
+						const { isEditorAvailable } = await import("./utils/editor.ts");
+						const isAvailable = await isEditorAvailable(value);
+						if (!isAvailable) {
+							console.error(`Editor command not found: ${value}`);
+							console.error("Please ensure the editor is installed and available in your PATH");
+							process.exit(1);
+						}
 					}
 					config.defaultEditor = value;
 					break;

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -308,4 +308,73 @@ describe("Config commands", () => {
 		expect(config?.projectName).toBe(originalProjectName ?? "");
 		expect(config?.statuses).toEqual(originalStatuses);
 	});
+
+	it("clears defaultEditor via config set with an explicitly empty value", async () => {
+		// An empty value means "no editor": it must be stored, not rejected as an invalid executable
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Config not loaded");
+		config.defaultEditor = "code --wait";
+		await core.filesystem.saveConfig(config);
+		expect((await core.filesystem.loadConfig())?.defaultEditor).toBe("code --wait");
+
+		const cleared = await $`bun ${CLI_PATH} config set defaultEditor ${""}`.cwd(TEST_DIR).nothrow().quiet();
+		expect(cleared.exitCode).toBe(0);
+
+		core.filesystem.invalidateConfigCache();
+		const reloaded = await core.filesystem.loadConfig();
+		expect(reloaded?.defaultEditor).toBeUndefined();
+	});
+
+	it("honors an explicitly empty --default-editor flag during init instead of discarding it", async () => {
+		// With EDITOR set as a sentinel, a discarded empty flag would fall back to the environment value
+		const initDir = createUniqueTestDir("test-config-commands-init");
+		await mkdir(initDir, { recursive: true });
+		await $`git init`.cwd(initDir).quiet();
+
+		const env = { ...process.env, EDITOR: "backlog-sentinel-editor", VISUAL: "backlog-sentinel-editor" };
+		const result =
+			await $`bun ${CLI_PATH} init "Editorless Project" --defaults --default-editor ${""} --integration-mode none`
+				.cwd(initDir)
+				.env(env)
+				.nothrow()
+				.quiet();
+		expect(result.exitCode).toBe(0);
+
+		const initCore = new Core(initDir);
+		const config = await initCore.filesystem.loadConfig();
+		expect(config?.defaultEditor).toBeUndefined();
+
+		await safeCleanup(initDir);
+	});
+
+	it("clears a configured editor when re-initializing with an explicitly empty --default-editor", async () => {
+		const initDir = createUniqueTestDir("test-config-commands-reinit");
+		await mkdir(initDir, { recursive: true });
+		await $`git init`.cwd(initDir).quiet();
+
+		// First init without the flag: the EDITOR env fallback must still apply
+		const env = { ...process.env, EDITOR: "backlog-sentinel-editor", VISUAL: "backlog-sentinel-editor" };
+		const initial = await $`bun ${CLI_PATH} init "Editor Project" --defaults --integration-mode none`
+			.cwd(initDir)
+			.env(env)
+			.nothrow()
+			.quiet();
+		expect(initial.exitCode).toBe(0);
+
+		const initCore = new Core(initDir);
+		expect((await initCore.filesystem.loadConfig())?.defaultEditor).toBe("backlog-sentinel-editor");
+
+		// Re-init with an explicitly empty flag: clears the editor instead of keeping the existing value
+		const reinit =
+			await $`bun ${CLI_PATH} init "Editor Project" --defaults --default-editor ${""} --integration-mode none`
+				.cwd(initDir)
+				.env(env)
+				.nothrow()
+				.quiet();
+		expect(reinit.exitCode).toBe(0);
+		initCore.filesystem.invalidateConfigCache();
+		expect((await initCore.filesystem.loadConfig())?.defaultEditor).toBeUndefined();
+
+		await safeCleanup(initDir);
+	});
 });


### PR DESCRIPTION
## Summary

There is no way through the CLI to configure a project to have **no** editor:

- `backlog config set defaultEditor ""` is rejected with `Editor command not found` — the value is validated as an executable before storing, so the one value meaning "do not open an editor" cannot be stored.
- `backlog init --default-editor "" ...` silently discards the flag because the empty string is falsy and falls through to the existing-config/`EDITOR`/`VISUAL` fallback chain.

This matters for unattended/agent use, where a blocking editor default such as `code --wait` hangs a non-interactive process.

This PR treats an explicitly empty value as a valid "no editor" setting in both paths:

- `config set defaultEditor` skips the executable-exists validation when the value is empty and stores it (serialization omits the empty value, so `default_editor` is removed from `config.yml`).
- `init --default-editor ""` now counts as "flag provided" (using `??` instead of `||` so the empty string no longer falls through to the env/existing-config fallback). The existing clearing logic in `initializeProject` (`delete config.defaultEditor` when an override is present but empty) then applies, which also makes re-init with `--default-editor ""` clear a previously configured editor.

## Related Issue or Task

Fixes #844

> **📋 Important:** Please discuss the change in an issue before opening a PR.
> - If no issue exists, open one first so maintainers and contributors can agree that the proposal fits the current project scope before implementation.
> - All PRs must have an associated task in the backlog.
> - If no task exists, create one first using: `backlog task create "Your task title"`
> - Follow the [task guidelines](../src/guidelines/agent-guidelines.md) when creating tasks
> - Tasks should be atomic, testable, and well-defined with clear acceptance criteria

## Task Checklist

- [ ] I have created a corresponding task in `backlog/tasks/` — _no task file added; happy for the maintainer to allocate a task ID at review_
- [ ] The task has clear acceptance criteria
- [ ] I have added an implementation plan to the task
- [ ] All acceptance criteria in the task are marked as completed

## Testing

Added three regression tests in `src/test/config-commands.test.ts` (all fail on `main`, pass with this change):

- `clears defaultEditor via config set with an explicitly empty value` — previously exited 1 with `Editor command not found`; now exits 0 and the reloaded config has no editor.
- `honors an explicitly empty --default-editor flag during init instead of discarding it` — with `EDITOR` set to a sentinel value, asserts the initialized config has no editor (a discarded empty flag would have leaked the sentinel into the config).
- `clears a configured editor when re-initializing with an explicitly empty --default-editor` — verifies the `EDITOR` env fallback still applies when the flag is absent, and that re-init with `--default-editor ""` clears it.

- `bun test src/test/config-commands.test.ts`: 16 pass, 0 fail.
- `bunx tsc --noEmit`: clean.
- `bunx biome check .`: clean.
- Full `bun test` (1897 tests, 213 files, macOS arm64): all remaining failures are pre-existing flaky ~5s timeouts in unrelated git/remote/config-watcher tests — reproduced identically on a clean `main` worktree, with run-to-run variance on the same tree.
