### PR TITLE
Serialize the task edit read-modify-write with a per-task lock

### DIFF
--- a/scripts/smoke-parallel-task-locking.sh
+++ b/scripts/smoke-parallel-task-locking.sh
@@ -23,6 +23,7 @@ Runs real parallel smoke tests against the local Backlog.md CLI:
   1. concurrent task creation
   2. concurrent draft promotion
   3. concurrent task demotion
+  4. concurrent task editing (lost-write regression)
 
 Environment overrides:
   BUN_BIN            Bun executable to use (default: bun)
@@ -231,6 +232,42 @@ scenario_parallel_demote() {
 	info "Scenario 3 passed"
 }
 
+scenario_parallel_edit() {
+	local repo_dir="${TMP_ROOT}/edit"
+	local i
+
+	info "Scenario 4: concurrent task editing (${JOB_COUNT} jobs)"
+	init_repo "${repo_dir}"
+
+	pushd "${repo_dir}" >/dev/null
+	run_cli task create "Shared Task" >/dev/null
+	popd >/dev/null
+
+	# All racers exit 0 and print "Updated task" either way — only the final file
+	# content can reveal a lost write, so that is what this scenario asserts on.
+	for i in $(seq 1 "${JOB_COUNT}"); do
+		start_job "${repo_dir}" "edit-${i}" task edit task-1 --add-label "smoke-${i}"
+	done
+	wait_for_jobs
+
+	local task_files=("${repo_dir}"/backlog/tasks/task-1\ -\ *.md)
+	if [[ ${#task_files[@]} -ne 1 ]]; then
+		ls -la "${repo_dir}/backlog/tasks" >&2 || true
+		fail "Expected exactly one task-1 file after parallel edits"
+	fi
+
+	local content
+	content="$(cat "${task_files[0]}")"
+	for i in $(seq 1 "${JOB_COUNT}"); do
+		if ! printf '%s' "${content}" | grep -Eq "smoke-${i}([^0-9]|$)"; then
+			printf '[smoke] Final task file after parallel edits:\n%s\n' "${content}" >&2
+			fail "Label smoke-${i} missing after parallel edits — a concurrent edit was lost"
+		fi
+	done
+
+	info "Scenario 4 passed"
+}
+
 main() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -277,6 +314,7 @@ main() {
 	scenario_parallel_create
 	scenario_parallel_promote
 	scenario_parallel_demote
+	scenario_parallel_edit
 
 	info "All parallel locking smoke tests passed"
 }

--- a/scripts/smoke-parallel-task-locking.sh
+++ b/scripts/smoke-parallel-task-locking.sh
@@ -234,26 +234,36 @@ scenario_parallel_demote() {
 
 scenario_parallel_edit() {
 	local repo_dir="${TMP_ROOT}/edit"
+	local filler_count=100
+	local shared_id="task-$((filler_count + 1))"
 	local i
 
 	info "Scenario 4: concurrent task editing (${JOB_COUNT} jobs)"
 	init_repo "${repo_dir}"
 
+	# The race window of one edit is its ~25ms read-modify-write, which bun startup
+	# variance otherwise hides: one racer has usually finished before the next starts
+	# parsing. A board full of filler tasks stretches every edit's read phase so the
+	# windows genuinely overlap. Without the fillers this scenario passes even on the
+	# broken build (verified: 8/8 labels survive pre-fix with 1 task, 1-2/8 with 100).
 	pushd "${repo_dir}" >/dev/null
+	for i in $(seq 1 "${filler_count}"); do
+		run_cli task create "Filler ${i}" >/dev/null
+	done
 	run_cli task create "Shared Task" >/dev/null
 	popd >/dev/null
 
 	# All racers exit 0 and print "Updated task" either way — only the final file
 	# content can reveal a lost write, so that is what this scenario asserts on.
 	for i in $(seq 1 "${JOB_COUNT}"); do
-		start_job "${repo_dir}" "edit-${i}" task edit task-1 --add-label "smoke-${i}"
+		start_job "${repo_dir}" "edit-${i}" task edit "${shared_id}" --add-label "smoke-${i}"
 	done
 	wait_for_jobs
 
-	local task_files=("${repo_dir}"/backlog/tasks/task-1\ -\ *.md)
+	local task_files=("${repo_dir}"/backlog/tasks/${shared_id}\ -\ *.md)
 	if [[ ${#task_files[@]} -ne 1 ]]; then
 		ls -la "${repo_dir}/backlog/tasks" >&2 || true
-		fail "Expected exactly one task-1 file after parallel edits"
+		fail "Expected exactly one ${shared_id} file after parallel edits"
 	fi
 
 	local content

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2033,16 +2033,26 @@ export class Core {
 			return await this.demoteTaskWithUpdates(task, input, autoCommit);
 		}
 
-		const { mutated } = await this.applyTaskUpdateInput(task, input, async (status) =>
-			this.requireCanonicalStatus(status),
-		);
+		// Serialise the read-modify-write per task. The snapshot is re-read inside the lock so a
+		// writer that waited applies its mutation to current state, not to its pre-wait snapshot —
+		// otherwise the last writer silently overwrites the previous one (both report success).
+		return await this.fs.withTaskLock(task, async () => {
+			const current = await this.loadLocalTaskForMutation(taskId);
+			if (!current) {
+				throw new Error(`Task not found: ${taskId}`);
+			}
 
-		if (!mutated) {
-			return task;
-		}
+			const { mutated } = await this.applyTaskUpdateInput(current, input, async (status) =>
+				this.requireCanonicalStatus(status),
+			);
 
-		await this.updateTask(task, autoCommit);
-		return task;
+			if (!mutated) {
+				return current;
+			}
+
+			await this.updateTask(current, autoCommit);
+			return current;
+		});
 	}
 
 	async updateDraft(task: Task, autoCommit?: boolean): Promise<void> {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -74,6 +74,24 @@ export function isCreateLockError(error: unknown): error is Error {
 	);
 }
 
+export const TASK_LOCK_ERROR_CODE = "ETASKLOCK";
+export const TASK_LOCK_ERROR_MESSAGE = "Another edit of this task is already in progress. Please try again.";
+
+function taskLockError(message: string, cause?: unknown): Error {
+	const error = new Error(message, cause === undefined ? undefined : { cause }) as Error & { code?: string };
+	error.name = "TaskLockError";
+	error.code = TASK_LOCK_ERROR_CODE;
+	return error;
+}
+
+export function isTaskLockError(error: unknown): error is Error {
+	return (
+		error instanceof Error &&
+		(error as Error & { code?: string }).code === TASK_LOCK_ERROR_CODE &&
+		error.name === "TaskLockError"
+	);
+}
+
 export class FileSystem {
 	private resolvedBacklogDir: string;
 	private resolvedBacklogDirName: string;
@@ -286,6 +304,21 @@ export class FileSystem {
 		return error instanceof Error ? error : new Error(String(error));
 	}
 
+	private toTaskLockError(error: unknown): Error {
+		if (isTaskLockError(error)) {
+			return error;
+		}
+
+		const code = (error as NodeJS.ErrnoException | undefined)?.code;
+		if (code === "ELOCKED") {
+			return taskLockError(TASK_LOCK_ERROR_MESSAGE, error);
+		}
+		if (code === "ECOMPROMISED") {
+			return taskLockError("The task edit lock was interrupted. Please try again.", error);
+		}
+		return error instanceof Error ? error : new Error(String(error));
+	}
+
 	private async getGitCommonDir(): Promise<string | null> {
 		try {
 			const config = await this.loadConfig();
@@ -338,14 +371,69 @@ export class FileSystem {
 
 		const backlogDir = await this.getBacklogDir();
 		const lockTarget = await this.getCreateLockTarget(backlogDir);
-		const locksDir = lockTarget.locksDir;
-		const lockDir = join(locksDir, "create");
+		return await this.withLockTarget(
+			lockTarget,
+			join(lockTarget.locksDir, "create"),
+			options,
+			(error) => this.toCreateLockError(error),
+			fn,
+		);
+	}
+
+	// Per-task variant of the create lock: serialises read-modify-write cycles for a single
+	// task so concurrent edits cannot silently overwrite each other. The lock target is the
+	// task file itself — proper-lockfile tracks one lock per target file in-process, so a
+	// shared target would clobber concurrent per-task locks within one process. The lock
+	// directory still lives beside the create lock's (git common dir or backlog dir), and
+	// the same escape hatch applies (USE_GLOBAL_TASK_ID_LOCK=false).
+	async withTaskLock<T>(
+		task: Pick<Task, "id" | "filePath">,
+		fn: () => Promise<T>,
+		options: CreateLockOptions = {},
+	): Promise<T> {
+		if (process.env.USE_GLOBAL_TASK_ID_LOCK?.toLowerCase() === "false") {
+			return await fn();
+		}
+
+		const filePath = typeof task.filePath === "string" && task.filePath.trim().length > 0 ? task.filePath : undefined;
+		if (!filePath) {
+			throw new Error(`Cannot lock task ${task.id} for editing without its file path.`);
+		}
+
+		const backlogDir = await this.getBacklogDir();
+		const lockTarget = await this.getCreateLockTarget(backlogDir);
+		const taskLockTarget: CreateLockTarget = { targetPath: filePath, locksDir: lockTarget.locksDir };
+		return await this.withLockTarget(
+			taskLockTarget,
+			join(lockTarget.locksDir, this.getTaskLockDirName(task.id)),
+			options,
+			(error) => this.toTaskLockError(error),
+			fn,
+		);
+	}
+
+	private getTaskLockDirName(taskId: string): string {
+		const key = taskId
+			.trim()
+			.toLowerCase()
+			.replace(/[^a-z0-9._-]+/g, "-")
+			.replace(/^\.+/, "");
+		return `task-${key.length > 0 ? key : "unknown"}`;
+	}
+
+	private async withLockTarget<T>(
+		lockTarget: CreateLockTarget,
+		lockDir: string,
+		options: CreateLockOptions,
+		toError: (error: unknown) => Error,
+		fn: () => Promise<T>,
+	): Promise<T> {
 		const timeoutMs = options.timeoutMs ?? DEFAULT_CREATE_LOCK_TIMEOUT_MS;
 		const retryDelayMs = options.retryDelayMs ?? DEFAULT_CREATE_LOCK_RETRY_DELAY_MS;
 		const staleMs = Math.max(options.staleMs ?? DEFAULT_CREATE_LOCK_STALE_MS, 2_000);
 		const retries = Math.max(Math.ceil(timeoutMs / retryDelayMs) - 1, 0);
 
-		await mkdir(locksDir, { recursive: true });
+		await mkdir(lockTarget.locksDir, { recursive: true });
 
 		let release: (() => Promise<void>) | undefined;
 		try {
@@ -362,7 +450,7 @@ export class FileSystem {
 				},
 			});
 		} catch (error) {
-			throw this.toCreateLockError(error);
+			throw toError(error);
 		}
 
 		try {
@@ -370,7 +458,7 @@ export class FileSystem {
 			try {
 				await release?.();
 			} catch (error) {
-				throw this.toCreateLockError(error);
+				throw toError(error);
 			}
 			return result;
 		} catch (error) {

--- a/src/test/atomic-task-edit.test.ts
+++ b/src/test/atomic-task-edit.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Core } from "../core/backlog.ts";
+import { TASK_LOCK_ERROR_MESSAGE } from "../file-system/operations.ts";
+import { initializeTestProject, withTimeout } from "./test-utils.ts";
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+	reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe("atomic task editing", () => {
+	let testDir: string;
+	let originalGlobalLockEnv: string | undefined;
+
+	beforeEach(async () => {
+		originalGlobalLockEnv = process.env.USE_GLOBAL_TASK_ID_LOCK;
+		delete process.env.USE_GLOBAL_TASK_ID_LOCK;
+
+		testDir = await mkdtemp(join(tmpdir(), "backlog-atomic-edit-"));
+		const core = new Core(testDir);
+		await initializeTestProject(core, "Atomic Edit Test", false);
+
+		const config = await core.fs.loadConfig();
+		if (config) {
+			config.checkActiveBranches = false;
+			await core.fs.saveConfig(config);
+		}
+	});
+
+	afterEach(async () => {
+		if (originalGlobalLockEnv === undefined) {
+			delete process.env.USE_GLOBAL_TASK_ID_LOCK;
+		} else {
+			process.env.USE_GLOBAL_TASK_ID_LOCK = originalGlobalLockEnv;
+		}
+		await rm(testDir, { recursive: true, force: true });
+	});
+
+	it("preserves every change when concurrent edits target the same task", async () => {
+		const setup = new Core(testDir);
+		await setup.createTaskFromInput({ title: "Shared Task" }, false);
+
+		// Each Core has its own ContentStore, so these race exactly like separate processes:
+		// without serialisation every writer mutates the same pre-write snapshot and all but
+		// one label are lost, even though every caller is told the update succeeded.
+		const writerCount = 6;
+		const edits = Array.from({ length: writerCount }, (_, index) => {
+			const core = new Core(testDir);
+			return core.updateTaskFromInput("task-1", { addLabels: [`label-${index + 1}`] }, false);
+		});
+		await Promise.all(edits);
+
+		const final = await setup.fs.loadTask("task-1");
+		expect(final?.labels ?? []).toEqual(
+			expect.arrayContaining(Array.from({ length: writerCount }, (_, index) => `label-${index + 1}`)),
+		);
+		expect(final?.labels?.length).toBe(writerCount);
+	});
+
+	it("applies an edit that waited on the lock on top of the change that held it", async () => {
+		const setup = new Core(testDir);
+		await setup.createTaskFromInput({ title: "Shared Task" }, false);
+
+		const holder = new Core(testDir);
+		const waiter = new Core(testDir);
+		const holderEntered = createDeferred<void>();
+		const waiterReachedLock = createDeferred<void>();
+		const lockableTask = await holder.fs.loadTask("task-1");
+		if (!lockableTask) {
+			throw new Error("task-1 missing during test setup");
+		}
+
+		// The holder owns the task lock and lands its write while the waiter is blocked.
+		const heldEdit = holder.fs.withTaskLock(lockableTask, async () => {
+			holderEntered.resolve();
+			await waiterReachedLock.promise;
+			const current = await holder.fs.loadTask("task-1");
+			if (!current) {
+				throw new Error("task-1 missing during test setup");
+			}
+			await holder.fs.saveTask({ ...current, labels: ["holder"] });
+		});
+
+		// Signals when the waiter has finished its pre-lock read and is about to block on the
+		// lock. A lock without a re-read inside it would apply the waiter's mutation to that
+		// pre-wait snapshot and lose the holder's label — the negative this test can return.
+		const originalWithTaskLock = waiter.fs.withTaskLock.bind(waiter.fs);
+		waiter.fs.withTaskLock = (async <T>(
+			task: { id: string; filePath?: string },
+			fn: () => Promise<T>,
+			options?: { timeoutMs?: number; retryDelayMs?: number; staleMs?: number },
+		): Promise<T> => {
+			waiterReachedLock.resolve();
+			return await originalWithTaskLock(task, fn, options);
+		}) as typeof waiter.fs.withTaskLock;
+
+		await holderEntered.promise;
+		const waitedEdit = waiter.updateTaskFromInput("task-1", { addLabels: ["waiter"] }, false);
+
+		await heldEdit;
+		const result = await waitedEdit;
+
+		const final = await setup.fs.loadTask("task-1");
+		expect(final?.labels ?? []).toEqual(["holder", "waiter"]);
+		expect(result.labels ?? []).toEqual(["holder", "waiter"]);
+	});
+
+	it("keeps concurrent edits of different tasks independent", async () => {
+		const setup = new Core(testDir);
+		await setup.createTaskFromInput({ title: "Task A" }, false);
+		await setup.createTaskFromInput({ title: "Task B" }, false);
+
+		await Promise.all([
+			new Core(testDir).updateTaskFromInput("task-1", { addLabels: ["alpha"] }, false),
+			new Core(testDir).updateTaskFromInput("task-2", { addLabels: ["beta"] }, false),
+		]);
+
+		const first = await setup.fs.loadTask("task-1");
+		const second = await setup.fs.loadTask("task-2");
+		expect(first?.labels ?? []).toEqual(["alpha"]);
+		expect(second?.labels ?? []).toEqual(["beta"]);
+	});
+
+	it("returns a user-facing error when the task edit lock times out", async () => {
+		const core = new Core(testDir);
+		await core.createTaskFromInput({ title: "Lockable Task" }, false);
+		const lockableTask = await core.fs.loadTask("task-1");
+		if (!lockableTask) {
+			throw new Error("task-1 missing during test setup");
+		}
+		const lockEntered = createDeferred<void>();
+		const releaseLock = createDeferred<void>();
+
+		const heldLock = core.fs.withTaskLock(
+			lockableTask,
+			async () => {
+				lockEntered.resolve();
+				await releaseLock.promise;
+			},
+			{ timeoutMs: 5_000, retryDelayMs: 25, staleMs: 5_000 },
+		);
+		await lockEntered.promise;
+
+		await expect(
+			core.fs.withTaskLock(lockableTask, async () => undefined, {
+				timeoutMs: 100,
+				retryDelayMs: 25,
+				staleMs: 5_000,
+			}),
+		).rejects.toThrow(TASK_LOCK_ERROR_MESSAGE);
+
+		releaseLock.resolve();
+		await heldLock;
+	});
+
+	it("bypasses task-lock serialization when the global lock is disabled by the legacy escape hatch", async () => {
+		process.env.USE_GLOBAL_TASK_ID_LOCK = "false";
+
+		const core = new Core(testDir);
+		const bothEntered = createDeferred<void>();
+		const releaseBoth = createDeferred<void>();
+		let entries = 0;
+		const enter = async (value: string): Promise<string> => {
+			entries += 1;
+			if (entries === 2) bothEntered.resolve();
+			await releaseBoth.promise;
+			return value;
+		};
+
+		const firstOperation = core.fs.withTaskLock({ id: "task-1" }, () => enter("first"));
+		const secondOperation = core.fs.withTaskLock({ id: "task-1" }, () => enter("second"));
+		const outcomesPromise = Promise.allSettled([firstOperation, secondOperation]);
+		let outcomes: PromiseSettledResult<string>[];
+
+		try {
+			await withTimeout(bothEntered.promise, "both operations should enter without serialization", 250);
+			expect(entries).toBe(2);
+		} finally {
+			releaseBoth.resolve();
+			outcomes = await outcomesPromise;
+		}
+
+		expect(outcomes).toEqual([
+			{ status: "fulfilled", value: "first" },
+			{ status: "fulfilled", value: "second" },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

`backlog task edit` performs an unlocked read-modify-write: the task file is parsed into a snapshot, mutated in memory, and the whole file is serialised back. Two concurrent edits of the same task lose one write — **both processes exit 0 and both print `Updated task X`** (measured in #843: 12/12 writes lost when simultaneous; a ~25 ms vulnerable window).

#565 added the `proper-lockfile`-backed lock, scoped to ID allocation at create/promote/demote time. This PR finishes that work for the edit path: a **per-task lock around the whole read → mutate → write** in `updateTaskFromInput`, which the CLI (`task edit`), the MCP server (`update_task` via `editTaskOrDraft`), and the web server (PUT task) all funnel through — one fix point covers every front door.

Design notes:

- New `FileSystem.withTaskLock(task, fn)` beside `withCreateLock`, sharing its mechanics (extracted into a common `withLockTarget`), its lock location (git common dir when present, `backlog/.locks` otherwise — worktree-safe), its timeout/stale defaults, and the `USE_GLOBAL_TASK_ID_LOCK=false` escape hatch. Lock contention surfaces as a user-facing `ETASKLOCK` error after the same 30 s default, matching `ECREATELOCK`.
- **The lock target is the task file itself**, not the shared backlog dir: proper-lockfile tracks one lock per target file in-process, so a shared target with per-task `lockfilePath`s corrupts concurrent locks held by one process (observed as `ERELEASED` when two edits in a single process race). Per-task targets also mean an edit never contends with the create lock.
- **The snapshot is re-read inside the lock.** A lock around only the write would still apply a waiting writer's mutation to its pre-wait snapshot, so the lost write would survive the lock. One regression test asserts against exactly that implementation.
- The mutation input — not the mutated object — crosses the lock boundary, per the same shape as #565's allocation fix. The write itself is unchanged (still `Bun.write`); temp-write-and-rename would harden against crash mid-write and can be a follow-up if you want it.

Not in this PR — the same defect on other write paths, deliberately kept separate per the small-reviewable-units rule: `reorderTask`/`updateTasksBulk` (board drag; archive link-sanitiser — needs a multi-file story), draft edits (`updateDraftFromInput` → `saveDraft`), and the TUI's raw `$EDITOR` write (a lock would span an editor session). Happy to take any of these as follow-ups.

The manifesto already commits to this mitigation: design principle 6 ("Deterministic and reversible where possible. Prefer preview, explicit confirmation, **atomic writes**, and useful recovery evidence") and named risk 3, "Plain-text corruption" ("Mitigation: semantic commands, validation, **atomic writes**, ambiguity checks, and deterministic serialization"). And AGENTS.md asks to "keep behavior consistent across similar stores (defaults, parse errors, **locking**); divergence requires a clear reason" — allocation is locked and edit was not; this removes that divergence.

## Related Issue or Task

Fixes #843

No `backlog/tasks/` entry is included — I didn't want to claim a BACK- id unilaterally. Happy to add one under whatever id you assign.

## Task Checklist

- [ ] I have created a corresponding task in `backlog/tasks/` — see note above; will add on id assignment
- [ ] The task has clear acceptance criteria — see note above
- [ ] I have added an implementation plan to the task — see note above
- [ ] All acceptance criteria in the task are marked as completed — see note above

## Testing

New `src/test/atomic-task-edit.test.ts` (5 tests, green on this branch):

- **`preserves every change when concurrent edits target the same task`** — 6 writers append distinct labels to one task; asserts all 6 labels are present in the final file. Content assertion, because every racer exits 0 either way. **Red on `main`: 1–2 of 6 labels survive (3/3 runs)**; green with the fix.
- **`applies an edit that waited on the lock on top of the change that held it`** — a writer takes its pre-lock snapshot, blocks while the lock holder writes, then must land on the holder's state. The negative this returns: a lock-without-re-read implementation loses the holder's label and fails.
- Concurrent edits of *different* tasks stay independent (the issue's negative control); lock timeout produces the user-facing `ETASKLOCK` message; the legacy escape hatch bypasses serialisation.

`scripts/smoke-parallel-task-locking.sh` gains **scenario 4: concurrent task editing**, reusing the existing harness and asserting on final file content. One subtlety, documented in the script: the board is pre-filled with 100 tasks, because via `bun src/cli.ts` the ~25 ms race window is otherwise hidden by process-startup variance — without the fillers the scenario passes even on the broken build (verified: 8/8 labels survive pre-fix with 1 task, 1–2/8 with 100). Red on `main` ("Label smoke-1 missing after parallel edits — a concurrent edit was lost"), green with the fix. Scenarios 1–3 unchanged and passing in both states.

Full suite: `bun test` — 1899 tests across 214 files. On macOS the git-branch/fs-watcher CLI-integration tests (e.g. `should merge task status from remote branches`, the ContentStore watcher-publish tests) flake on their 5 s timeouts under load; the failing set varies run to run (2–18 failures), and the same files time out identically on **unmodified** `upstream/main` in isolation, so these are pre-existing (upstream's macOS CI runs only a subset of the suite) and are untouched here. All locking, task-edit, create, MCP, and web tests pass; the new tests pass in 3/3 consecutive full-file runs.

`bunx tsc --noEmit` clean · `bunx biome check .` clean.
