### PR TITLE
BACK-574 - Allow clearing defaultEditor

### DIFF
--- a/backlog/tasks/back-574 - Allow-clearing-defaultEditor.md
+++ b/backlog/tasks/back-574 - Allow-clearing-defaultEditor.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-574
 title: Allow clearing defaultEditor
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-07 17:25'
+updated_date: '2026-08-07 17:38'
 labels:
   - bug
 dependencies: []
@@ -26,15 +28,56 @@ Reference fix: a fork by iRonin has a clean, tested fix in commit 4541e71 on bra
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Setting an empty value via `config set defaultEditor ""` clears the key from config.yml
-- [ ] #2 `init --default-editor ""` clears a previously configured editor
-- [ ] #3 Non-empty defaultEditor values are still validated before being stored
-- [ ] #4 Tests cover both clear paths (config set and init)
+- [x] #1 Setting an empty value via `config set defaultEditor ""` clears the key from config.yml
+- [x] #2 `init --default-editor ""` clears a previously configured editor
+- [x] #3 Non-empty defaultEditor values are still validated before being stored
+- [x] #4 Tests cover both clear paths (config set and init)
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reuse iRonin's existing fix from commit 4541e71 (branch fix/allow-empty-default-editor on iRonin/Backlog.md), cherry-picked with authorship preserved.
+2. config set defaultEditor: skip the isEditorAvailable executable check when the value is empty, so an empty string is stored; config serialization (src/file-system/operations.ts) already omits default_editor when falsy, which clears the key from config.yml.
+3. init --default-editor: change the isNonInteractive check from truthiness to 'options.defaultEditor !== undefined' and the fallback chain in applyAdvancedOptionOverrides from || to ??, so an explicitly empty flag is treated as provided rather than falling through to existingConfig/EDITOR/VISUAL. The existing clear-on-empty logic in src/core/init.ts (hasDefaultEditorOverride + delete config.defaultEditor) then removes the key.
+4. Keep validation for non-empty values unchanged.
+5. Verify the commit still applies to current main and re-check the touched sites for drift.
+6. Tests: 3 cases in src/test/config-commands.test.ts covering config set clear, init --default-editor "" with sentinel EDITOR/VISUAL, and re-init clearing a previously configured editor.
+7. Verify with bunx tsc --noEmit, bun run check ., scoped config tests, and the full suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reused iRonin's fix: cherry-picked commit 4541e71 (from withdrawn PR #850) with original authorship preserved (CK @ iRonin.IT). The cherry-pick applied cleanly onto current origin/main (5088d9ee) with no conflicts and no adaptation; its parent (fad58c9a) is only a few commits behind main, so the touched sites had not drifted. Verified both pre-images matched current main byte-for-byte before applying.
+
+Changes (src/cli.ts):
+- config set defaultEditor now runs the isEditorAvailable executable check only for non-empty values; an empty value is stored as "" and the config serializer (src/file-system/operations.ts:1636) omits default_editor when falsy, so the key disappears from config.yml.
+- init: the isNonInteractive guard uses options.defaultEditor !== undefined instead of truthiness, and the fallback chain uses ?? so an explicitly empty --default-editor is treated as provided rather than falling through to existingConfig/EDITOR/VISUAL. The pre-existing clear-on-empty logic in src/core/init.ts (hasDefaultEditorOverride + delete config.defaultEditor) then removes the key. --default-editor has no default value, so the !== undefined guard cannot spuriously force non-interactive mode.
+
+No new abstraction was needed: both clear paths reuse behavior that already existed (falsy-omitting serialization and the init override-clearing logic); only the two guards that discarded the empty value changed.
+
+Verification evidence:
+- AC1: scripted repro in a temp git project. After init with --default-editor "code --wait", config.yml line 7 read default_editor: "code --wait"; after 'config set defaultEditor ""' the line is gone and 'config get defaultEditor' prints 'defaultEditor is not set'.
+- AC2: scripted repro with EDITOR/VISUAL=sentinel-editor. First init (no flag) wrote default_editor: "sentinel-editor"; re-init with --default-editor "" removed the line; re-init with --default-editor "cat" wrote default_editor: "cat", so the env fallback and non-empty flag still work.
+- AC3: 'config set defaultEditor definitely-not-a-real-editor-xyz' still exits 1 with 'Editor command not found' and does not write the value; 'config set defaultEditor cat' exits 0 and stores it.
+- AC4: 3 new tests in src/test/config-commands.test.ts. Confirmed load-bearing: with src/cli.ts reverted to 5088d9ee all 3 fail (init cases receive 'backlog-sentinel-editor' instead of undefined), and all 16 tests in the file pass with the fix.
+- DoD1: bunx tsc --noEmit clean.
+- DoD2: biome check clean over 357 files. Note: 'bun run check' reports 0 files when run from a worktree under .claude/ because biome.json excludes '!**/.claude' and matches the absolute path; verified by temporarily removing that one pattern, then restoring biome.json unchanged.
+- DoD3: full 'bun run test' green: 1892 pass, 5 skip, 0 fail, 8023 expect() calls across 213 files.
+
+Observation left for review, not changed: 'config set defaultEditor ""' prints 'Set defaultEditor = ' with a trailing blank. That message is shared by every config key, so making it clearer for empty values would be a generic change outside this task's scope.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Allowed an explicitly empty defaultEditor to mean 'no editor' in both CLI paths, by cherry-picking iRonin's fix (commit 4541e71, authorship preserved). 'config set defaultEditor ""' now skips the executable check and clears default_editor from config.yml; 'init --default-editor ""' is treated as provided (!== undefined / ??) instead of falling through to the existing config or EDITOR/VISUAL, so the pre-existing clear-on-empty logic in src/core/init.ts removes the key. Non-empty values are still validated and rejected when the executable is missing. Verified with 3 new tests in src/test/config-commands.test.ts (confirmed failing against pre-fix src/cli.ts), scripted end-to-end repros of all three issue #844 cases, clean bunx tsc --noEmit and biome check, and a full green bun run test (1892 pass, 5 skip, 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-574 - Allow-clearing-defaultEditor.md
+++ b/backlog/tasks/back-574 - Allow-clearing-defaultEditor.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-574
 title: Allow clearing defaultEditor
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 17:25'
-updated_date: '2026-08-07 17:38'
+updated_date: '2026-08-07 17:50'
 labels:
   - bug
 dependencies: []
@@ -74,6 +74,8 @@ Verification evidence:
 - DoD3: full 'bun run test' green: 1892 pass, 5 skip, 0 fail, 8023 expect() calls across 213 files.
 
 Observation left for review, not changed: 'config set defaultEditor ""' prints 'Set defaultEditor = ' with a trailing blank. That message is shared by every config key, so making it clearer for empty values would be a generic change outside this task's scope.
+
+Post-review finalization: rebased onto origin/main at b79fa3a3 (picked up 1034279f biome .claude anchor fix, 5088d9ee docs, and BACK-585). Rebase was clean with no conflicts and no task-file collisions; iRonin's authorship is preserved on the cherry-picked commit. Re-verified after the rebase: bunx tsc --noEmit clean; 'bun run check' now works natively in agent worktrees thanks to 1034279f and reports 357 files checked with no fixes; src/test/config-commands.test.ts 16/16 pass; full 'bun run test' green at 1892 pass, 5 skip, 0 fail across 213 files. Review returned approve with zero blocking findings.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -824,7 +824,7 @@ addHelpSchema(program.command("init [projectName]"), {
 					options.branchDays ||
 					options.bypassGitHooks ||
 					options.zeroPaddedIds ||
-					options.defaultEditor ||
+					options.defaultEditor !== undefined ||
 					options.webPort ||
 					options.autoOpenBrowser ||
 					options.installClaudeAgent ||
@@ -1029,11 +1029,8 @@ addHelpSchema(program.command("init [projectName]"), {
 					const paddingValue = parseNumber(options.zeroPaddedIds, result.zeroPaddedIds ?? 0);
 					result.zeroPaddedIds = paddingValue > 0 ? paddingValue : undefined;
 					result.defaultEditor =
-						options.defaultEditor ||
-						existingConfig?.defaultEditor ||
-						process.env.EDITOR ||
-						process.env.VISUAL ||
-						undefined;
+						options.defaultEditor ??
+						(existingConfig?.defaultEditor || process.env.EDITOR || process.env.VISUAL || undefined);
 					result.defaultPort = parseNumber(options.webPort, result.defaultPort ?? 6420);
 					result.autoOpenBrowser = parseBoolean(options.autoOpenBrowser, result.autoOpenBrowser ?? true);
 					return result;
@@ -4450,13 +4447,16 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 			// Handle specific config keys
 			switch (key) {
 				case "defaultEditor": {
-					// Validate that the editor command exists
-					const { isEditorAvailable } = await import("./utils/editor.ts");
-					const isAvailable = await isEditorAvailable(value);
-					if (!isAvailable) {
-						console.error(`Editor command not found: ${value}`);
-						console.error("Please ensure the editor is installed and available in your PATH");
-						process.exit(1);
+					// An explicitly empty value means "no editor" and skips executable validation
+					if (value) {
+						// Validate that the editor command exists
+						const { isEditorAvailable } = await import("./utils/editor.ts");
+						const isAvailable = await isEditorAvailable(value);
+						if (!isAvailable) {
+							console.error(`Editor command not found: ${value}`);
+							console.error("Please ensure the editor is installed and available in your PATH");
+							process.exit(1);
+						}
 					}
 					config.defaultEditor = value;
 					break;

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -308,4 +308,73 @@ describe("Config commands", () => {
 		expect(config?.projectName).toBe(originalProjectName ?? "");
 		expect(config?.statuses).toEqual(originalStatuses);
 	});
+
+	it("clears defaultEditor via config set with an explicitly empty value", async () => {
+		// An empty value means "no editor": it must be stored, not rejected as an invalid executable
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Config not loaded");
+		config.defaultEditor = "code --wait";
+		await core.filesystem.saveConfig(config);
+		expect((await core.filesystem.loadConfig())?.defaultEditor).toBe("code --wait");
+
+		const cleared = await $`bun ${CLI_PATH} config set defaultEditor ${""}`.cwd(TEST_DIR).nothrow().quiet();
+		expect(cleared.exitCode).toBe(0);
+
+		core.filesystem.invalidateConfigCache();
+		const reloaded = await core.filesystem.loadConfig();
+		expect(reloaded?.defaultEditor).toBeUndefined();
+	});
+
+	it("honors an explicitly empty --default-editor flag during init instead of discarding it", async () => {
+		// With EDITOR set as a sentinel, a discarded empty flag would fall back to the environment value
+		const initDir = createUniqueTestDir("test-config-commands-init");
+		await mkdir(initDir, { recursive: true });
+		await $`git init`.cwd(initDir).quiet();
+
+		const env = { ...process.env, EDITOR: "backlog-sentinel-editor", VISUAL: "backlog-sentinel-editor" };
+		const result =
+			await $`bun ${CLI_PATH} init "Editorless Project" --defaults --default-editor ${""} --integration-mode none`
+				.cwd(initDir)
+				.env(env)
+				.nothrow()
+				.quiet();
+		expect(result.exitCode).toBe(0);
+
+		const initCore = new Core(initDir);
+		const config = await initCore.filesystem.loadConfig();
+		expect(config?.defaultEditor).toBeUndefined();
+
+		await safeCleanup(initDir);
+	});
+
+	it("clears a configured editor when re-initializing with an explicitly empty --default-editor", async () => {
+		const initDir = createUniqueTestDir("test-config-commands-reinit");
+		await mkdir(initDir, { recursive: true });
+		await $`git init`.cwd(initDir).quiet();
+
+		// First init without the flag: the EDITOR env fallback must still apply
+		const env = { ...process.env, EDITOR: "backlog-sentinel-editor", VISUAL: "backlog-sentinel-editor" };
+		const initial = await $`bun ${CLI_PATH} init "Editor Project" --defaults --integration-mode none`
+			.cwd(initDir)
+			.env(env)
+			.nothrow()
+			.quiet();
+		expect(initial.exitCode).toBe(0);
+
+		const initCore = new Core(initDir);
+		expect((await initCore.filesystem.loadConfig())?.defaultEditor).toBe("backlog-sentinel-editor");
+
+		// Re-init with an explicitly empty flag: clears the editor instead of keeping the existing value
+		const reinit =
+			await $`bun ${CLI_PATH} init "Editor Project" --defaults --default-editor ${""} --integration-mode none`
+				.cwd(initDir)
+				.env(env)
+				.nothrow()
+				.quiet();
+		expect(reinit.exitCode).toBe(0);
+		initCore.filesystem.invalidateConfigCache();
+		expect((await initCore.filesystem.loadConfig())?.defaultEditor).toBeUndefined();
+
+		await safeCleanup(initDir);
+	});
 });


### PR DESCRIPTION
Fixes #844.

`defaultEditor` could not be cleared once set: `config set defaultEditor ""` was rejected because executable validation ran before storage, and `init --default-editor ""` was silently discarded by truthiness fallbacks. The only workaround was hand-editing config.yml, and the shipped default `code --wait` can hang unattended processes.

This applies the fix contributed by @iRonin (from withdrawn PR #850, commit authorship preserved): `config set` skips executable validation for the empty value (the serializer already omits empty values, removing the key), and the init fallback chain treats `""` as provided so a previously configured editor is cleared. Non-empty values are still validated.

Verification: three regression tests using sentinel `EDITOR`/`VISUAL` values (confirmed to fail without the fix), scripted end-to-end repros of all three issue scenarios, and a full-suite run after rebasing onto current main (1892 pass, 0 fail). Independently reviewed with no blocking findings.