### PR TITLE
BACK-576 - Multi-assignee parity for task create

### DIFF
--- a/backlog/tasks/back-576 - Multi-assignee-parity-for-task-create.md
+++ b/backlog/tasks/back-576 - Multi-assignee-parity-for-task-create.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-576
 title: Multi-assignee parity for task create
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 17:25'
+updated_date: '2026-08-07 18:24'
 labels:
   - bug
 dependencies: []
@@ -24,16 +26,45 @@ The result is that the documented multi-assignee capability works on edit but no
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Comma-separated assignees parse into separate assignees on `task create`
-- [ ] #2 Comma-separated assignees parse into separate assignees on the draft creation path
-- [ ] #3 Repeated -a flags collect into multiple assignees on `task create`
-- [ ] #4 Repeated -a flags collect into multiple assignees on `task edit`
-- [ ] #5 Tests cover comma-separated and repeated-flag input on both create and edit
+- [x] #1 Comma-separated assignees parse into separate assignees on `task create`
+- [x] #2 Comma-separated assignees parse into separate assignees on the draft creation path
+- [x] #3 Repeated -a flags collect into multiple assignees on `task create`
+- [x] #4 Repeated -a flags collect into multiple assignees on `task edit`
+- [x] #5 Tests cover comma-separated and repeated-flag input on both create and edit
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Make -a/--assignee repeatable on task create, task edit, and draft create by registering createMultiValueAccumulator (mirroring the #693 label fix shape).
+2. Parse create and draft-create assignees through parseDelimitedStringList so comma-separated values split into separate assignees, matching task edit.
+3. Document repeatability and comma-separated input in the create/edit help schema and option descriptions.
+4. Audit the task-creation wizard and MCP create/edit handlers for the same asymmetry and align them only if a real gap exists.
+5. Add CLI tests: comma-separated and repeated -a on task create, repeated -a on task edit, comma-separated and repeated -a on draft create, plus help-schema assertions.
+6. Verify with bunx tsc --noEmit, bun run check ., scoped tests, and one full bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Made -a/--assignee repeatable on task create, task edit, and draft create using the existing createMultiValueAccumulator, and routed create/draft-create assignees through parseDelimitedStringList so comma-separated values split into separate assignees. This mirrors the #693 label fix shape: comma-separated parsing plus repeatable flags, with the semantics documented in the create/edit help schema and option descriptions.
+
+Audit result: the task-creation wizard already parsed comma-separated assignees (parseListInput in src/commands/task-wizard.ts, shared by create and edit), and MCP task_create/task_edit already accept assignee as a JSON array on both sides. Neither surface had the create/edit asymmetry, so no changes were needed there.
+
+Simplification: the inline label split duplicated in task create and draft create was replaced with parseDelimitedStringList. Behavior is identical because createTaskFromInput already runs normalizeStringList over labels.
+
+Validation: bunx tsc --noEmit; bun run check .; bun test on cli-guidance, cli-init-create, cli-task-view-edit, draft-create-consistency, cli-plain-create-edit, label-filter, task-wizard, cli-task-wizard (91 pass, 0 fail); full bun run test (1902 pass, 5 skip, 0 fail).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Brought task create and draft create to multi-assignee parity with task edit: -a/--assignee is now repeatable on all three commands and comma-separated values split into separate assignees, matching the shape of the #693 label fix. The wizard and MCP create/edit paths were audited and already handled multi-assignee input, so they were left unchanged. Verified with CLI tests covering comma-separated and repeated -a on create, edit, and draft create plus help-schema assertions, typecheck, Biome, and a full bun run test (1902 pass, 5 skip, 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1678,7 +1678,11 @@ addHelpSchema(taskCmd.command("create [title]"), {
 			type: () => statusType({ includeDraft: true }),
 			description: "Project task status; case-insensitive",
 		},
-		{ name: "assignee", type: "Assignee list", description: "One or more @names" },
+		{
+			name: "assignee",
+			type: "Comma-separated strings",
+			description: "Assign one or more @names; repeat -a or use @name1,@name2",
+		},
 		{ name: "labels", type: "Comma-separated strings", description: "Task labels" },
 		{ name: "priority", type: priorityType, description: "Task priority" },
 		{ name: "type", type: taskType, description: "Task type; case-insensitive" },
@@ -1702,7 +1706,11 @@ addHelpSchema(taskCmd.command("create [title]"), {
 })
 	.option("-d, --description <text>", "task description (multi-line: include real newlines inside the quoted string)")
 	.option("--desc <text>", "alias for --description")
-	.option("-a, --assignee <assignee>")
+	.option(
+		"-a, --assignee <assignees>",
+		"assign task to one or more @names (comma-separated or repeatable)",
+		createMultiValueAccumulator(),
+	)
 	.option("-s, --status <status>")
 	.option("-l, --labels <labels>")
 	.option("--priority <priority>", "set task priority (configured priorities)")
@@ -1816,13 +1824,8 @@ addHelpSchema(taskCmd.command("create [title]"), {
 				title: title ?? "",
 				description: options.description || options.desc ? String(options.description || options.desc) : undefined,
 				status: createAsDraft ? "Draft" : options.status ? String(options.status) : undefined,
-				assignee: options.assignee ? [String(options.assignee)] : undefined,
-				labels: options.labels
-					? String(options.labels)
-							.split(",")
-							.map((label: string) => label.trim())
-							.filter(Boolean)
-					: undefined,
+				assignee: parseDelimitedStringList(options.assignee),
+				labels: parseDelimitedStringList(options.labels),
 				dependencies:
 					options.dependsOn || options.dep ? normalizeDependencies(options.dependsOn || options.dep) : undefined,
 				references: parseDelimitedStringList(options.ref),
@@ -2642,6 +2645,11 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		{ name: "status", type: statusType, description: "Project task status; case-insensitive" },
 		{ name: "type", type: taskType, description: "Replacement task type; case-insensitive" },
 		{
+			name: "assignee",
+			type: "Comma-separated strings",
+			description: "Replace all assignees; repeat -a or use @name1,@name2",
+		},
+		{
 			name: "label",
 			type: "Comma-separated strings",
 			description: "Replace all labels; repeat --label or use label1,label2",
@@ -2689,7 +2697,11 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 	.option("-t, --title <title>")
 	.option("-d, --description <text>", "task description (multi-line: include real newlines inside the quoted string)")
 	.option("--desc <text>", "alias for --description")
-	.option("-a, --assignee <assignee>")
+	.option(
+		"-a, --assignee <assignees>",
+		"replace all task assignees with one or more @names (comma-separated or repeatable)",
+		createMultiValueAccumulator(),
+	)
 	.option("-s, --status <status>")
 	.option(
 		"-l, --label <labels>",
@@ -3455,7 +3467,11 @@ draftCmd
 	.command("create <title>")
 	.option("-d, --description <text>", "task description (multi-line: include real newlines inside the quoted string)")
 	.option("--desc <text>", "alias for --description")
-	.option("-a, --assignee <assignee>")
+	.option(
+		"-a, --assignee <assignees>",
+		"assign draft to one or more @names (comma-separated or repeatable)",
+		createMultiValueAccumulator(),
+	)
 	.option("-s, --status <status>")
 	.option("-l, --labels <labels>")
 	.action(async (title: string, options) => {
@@ -3467,13 +3483,8 @@ draftCmd
 				title,
 				description: options.description || options.desc ? String(options.description || options.desc) : undefined,
 				status: "Draft",
-				assignee: options.assignee ? [String(options.assignee)] : undefined,
-				labels: options.labels
-					? String(options.labels)
-							.split(",")
-							.map((label: string) => label.trim())
-							.filter(Boolean)
-					: undefined,
+				assignee: parseDelimitedStringList(options.assignee),
+				labels: parseDelimitedStringList(options.labels),
 			});
 			console.log(`Created draft ${task.id}`);
 			console.log(`File: ${filePath}`);

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -315,6 +315,10 @@ describe("CLI Integration", () => {
 			expect(createHelp).toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
 			expect(createHelp).toContain("priority: one of configured priorities: High, Medium, Low");
 			expect(createHelp).toContain("ordinal: Integer");
+			expect(createHelp).toContain(
+				"assignee: Comma-separated strings - Assign one or more @names; repeat -a or use @name1,@name2",
+			);
+			expect(createHelpCompact).toContain("assign task to one or more @names (comma-separated or repeatable)");
 			expect(createHelpCompact).toContain(
 				"--plan <text> add a plan only for already-started work created directly in an active status (for example, In Progress)",
 			);
@@ -332,6 +336,12 @@ describe("CLI Integration", () => {
 			expect(editHelp).toContain("taskId: Task ID");
 			expect(editHelp).toContain("status: one of configured statuses: To Do, In Progress, Done");
 			expect(editHelp).not.toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
+			expect(editHelp).toContain(
+				"assignee: Comma-separated strings - Replace all assignees; repeat -a or use @name1,@name2",
+			);
+			expect(editHelpCompact).toContain(
+				"replace all task assignees with one or more @names (comma-separated or repeatable)",
+			);
 			expect(editHelp).toContain(
 				"label: Comma-separated strings - Replace all labels; repeat --label or use label1,label2",
 			);

--- a/src/test/cli-init-create.test.ts
+++ b/src/test/cli-init-create.test.ts
@@ -452,6 +452,22 @@ describe("CLI Integration", () => {
 			expect(draft?.title).toBe("CLI Auto Commit Draft");
 		});
 
+		it("should split comma-separated assignees on task create", async () => {
+			await $`bun ${CLI_PATH} task create "Comma assignee task" -a "@alice,@bob"`.cwd(TEST_DIR).quiet();
+
+			const core = new Core(TEST_DIR);
+			const task = await core.filesystem.loadTask("task-1");
+			expect(task?.assignee).toEqual(["@alice", "@bob"]);
+		});
+
+		it("should collect repeated assignee flags on task create", async () => {
+			await $`bun ${CLI_PATH} task create "Repeated assignee task" -a @alice -a @bob,@carol`.cwd(TEST_DIR).quiet();
+
+			const core = new Core(TEST_DIR);
+			const task = await core.filesystem.loadTask("task-1");
+			expect(task?.assignee).toEqual(["@alice", "@bob", "@carol"]);
+		});
+
 		it("should accept dependencies from other active branches", async () => {
 			const core = new Core(TEST_DIR);
 

--- a/src/test/cli-task-view-edit.test.ts
+++ b/src/test/cli-task-view-edit.test.ts
@@ -509,6 +509,52 @@ describe("CLI Integration", () => {
 			expect(updatedTask?.labels).toEqual(["old"]);
 		});
 
+		it("should replace assignees from repeated CLI assignee flags", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-11",
+					title: "Repeated Assignee Replace Test",
+					status: "To Do",
+					assignee: ["@old"],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					rawContent: "Testing repeated assignee replacement",
+				},
+				false,
+			);
+
+			await $`bun ${CLI_PATH} task edit task-11 -a @alice -a @bob,@carol --plain`.cwd(TEST_DIR).quiet();
+
+			const updatedTask = await core.filesystem.loadTask("task-11");
+			expect(updatedTask?.assignee).toEqual(["@alice", "@bob", "@carol"]);
+		});
+
+		it("should split comma-separated assignees on task edit", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-12",
+					title: "Comma Assignee Edit Test",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					rawContent: "Testing comma-separated assignee editing",
+				},
+				false,
+			);
+
+			await $`bun ${CLI_PATH} task edit task-12 -a "@alice,@bob" --plain`.cwd(TEST_DIR).quiet();
+
+			const updatedTask = await core.filesystem.loadTask("task-12");
+			expect(updatedTask?.assignee).toEqual(["@alice", "@bob"]);
+		});
+
 		it("should handle non-existent task gracefully", async () => {
 			const core = new Core(TEST_DIR);
 

--- a/src/test/draft-create-consistency.test.ts
+++ b/src/test/draft-create-consistency.test.ts
@@ -42,6 +42,15 @@ describe("Draft creation consistency", () => {
 		expect(secondDraft?.id).toBe("DRAFT-2");
 	});
 
+	it("splits comma-separated and repeated assignees on draft create", async () => {
+		await $`bun ${CLI_PATH} draft create "Comma assignees" -a "@alice,@bob"`.cwd(TEST_DIR).quiet();
+		await $`bun ${CLI_PATH} draft create "Repeated assignees" -a @alice -a @bob,@carol`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		expect((await core.filesystem.loadDraft("draft-1"))?.assignee).toEqual(["@alice", "@bob"]);
+		expect((await core.filesystem.loadDraft("draft-2"))?.assignee).toEqual(["@alice", "@bob", "@carol"]);
+	});
+
 	it("uses DRAFT IDs in plain output for task create --draft", async () => {
 		const result = await $`bun ${CLI_PATH} task create --draft "Plain sample" --plain`.cwd(TEST_DIR).quiet();
 		const output = result.stdout.toString();


### PR DESCRIPTION
Fixes #848.

`task create -a "@a,@b"` stored a single literal assignee `"@a,@b"` because the create path wrapped the raw flag value while the edit path parsed it; repeated `-a` silently kept only the last value because the option was non-collecting. Same defect class as the labels fix in #693, and the fix mirrors that shape exactly: `-a` is now collecting and comma-parsed on `task create`, `task edit`, and `draft create`, with help schema wording matching the labels convention. The task-creation wizard and MCP handlers were audited and already handled lists correctly.

Also replaces a duplicated inline label-splitting block with the shared `parseDelimitedStringList` helper (verified behavior-identical downstream).

Verification: live scenarios for comma-separated, repeated, deduped, whitespace, and no-flag paths on all three commands; frontmatter round-trips; replace-vs-preserve semantics on edit; new tests confirmed to fail on main; full suite green (1902 pass, run twice). Independently reviewed with no blocking findings.