### PR TITLE
BACK-586 - Clear references and documentation through the CLI

### DIFF
--- a/backlog/tasks/back-586 - Clear-references-and-documentation-through-the-CLI.md
+++ b/backlog/tasks/back-586 - Clear-references-and-documentation-through-the-CLI.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-586
 title: Clear references and documentation through the CLI
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 19:41'
+updated_date: '2026-08-07 19:52'
 labels:
   - bug
 dependencies: []
@@ -22,17 +24,48 @@ Fix GitHub issue #861: `task edit --ref ""` and `task edit --doc ""` exit 0 and 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 task edit --clear-refs removes all references and --clear-docs removes all documentation from an existing task
-- [ ] #2 Empty --ref or --doc values are rejected with a non-zero exit and an error naming --clear-refs or --clear-docs, and the task is left unchanged
-- [ ] #3 --clear-refs cannot be combined with --ref and --clear-docs cannot be combined with --doc; invalid input does not mutate the task
-- [ ] #4 The interactive-TTY edit wizard predicate includes the new flags so --clear-refs/--clear-docs apply directly instead of opening the wizard
-- [ ] #5 MCP task_edit treats blank-only references/documentation arrays as a no-op while an explicit empty array clears the list, matching the labels convention
-- [ ] #6 CLI help documents --clear-refs and --clear-docs, and regression tests cover clearing, empty-value rejection, conflict rejection, the interactive-TTY path, and the MCP blank-only vs explicit-empty behavior
+- [x] #1 task edit --clear-refs removes all references and --clear-docs removes all documentation from an existing task
+- [x] #2 Empty --ref or --doc values are rejected with a non-zero exit and an error naming --clear-refs or --clear-docs, and the task is left unchanged
+- [x] #3 --clear-refs cannot be combined with --ref and --clear-docs cannot be combined with --doc; invalid input does not mutate the task
+- [x] #4 The interactive-TTY edit wizard predicate includes the new flags so --clear-refs/--clear-docs apply directly instead of opening the wizard
+- [x] #5 MCP task_edit treats blank-only references/documentation arrays as a no-op while an explicit empty array clears the list, matching the labels convention
+- [x] #6 CLI help documents --clear-refs and --clear-docs, and regression tests cover clearing, empty-value rejection, conflict rejection, the interactive-TTY path, and the MCP blank-only vs explicit-empty behavior
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add --clear-refs and --clear-docs to task edit: Commander options, the addHelpSchema option list, and the hasEditFieldFlags interactive-wizard predicate.
+2. Consolidate the clearable-list validation used by --clear-deps into one shared cli.ts helper and reuse it for references and documentation, keeping the existing dependency error text byte-identical.
+3. Reject empty --ref/--doc occurrences and clear/setter conflicts before the edit runs, so no false-success output can occur.
+4. Make buildTaskUpdateInput treat references and documentation like dependencies: blank-only arrays are a no-op, an explicit empty array clears (shared resolveClearableList helper).
+5. Add CLI regression coverage (clear, empty rejection, conflict rejection, interactive-TTY path, help output) and MCP coverage for blank-only vs explicit empty arrays.
+6. Run bunx tsc --noEmit, bun run check ., the focused test files, and the full bun test suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added task edit --clear-refs and --clear-docs mirroring the --clear-deps shape from PR #840 (BACK-572): Commander options, addHelpSchema entries, hasEditFieldFlags membership so an interactive TTY applies the flags instead of opening the wizard, conflict rejection against the same-field setter, and rejection of empty --ref/--doc occurrences with an error naming the clear flag.
+
+Simplification instead of literal duplication: the dependency validation block was consolidated into one cli.ts helper (validateClearableListInput) now shared by dependencies, references, and documentation. The existing --clear-deps error strings are byte-identical, so BACK-572 regression tests stay green. Likewise buildTaskUpdateInput now uses one sanitizeClearableStringArray helper for dependencies, references, and documentation, which gives references and documentation the labels convention: a blank-only array is a no-op, an explicit empty array clears.
+
+No core change was needed: Core.updateTask already treats an explicit empty references/documentation list as a clear.
+
+Interaction note for issue #856 (out of scope here): when incremental --add-ref/--remove-ref land, they must be added to the same validateClearableListInput conflict check so --clear-refs/--clear-docs stay mutually exclusive with them, and to hasEditFieldFlags.
+
+Validation: bunx tsc --noEmit clean; bun run check . clean (357 files); bun test src/test/cli-refs-docs.test.ts (23 pass); bun test src/test/mcp-refs-docs.test.ts src/test/cli-dependency.test.ts (11 pass); bun test src/test/mcp-tasks.test.ts src/test/references.test.ts src/test/documentation.test.ts (51 pass); full bun run test 1910 pass / 5 skip / 0 fail across 213 files. Live repro of issue #861 in a scratch project confirmed: empty --ref/--doc now exit 1 with the clear-flag error and leave the task JSON unchanged, --clear-refs then --clear-docs move references and documentation to [].
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added task edit --clear-refs and --clear-docs and stopped empty --ref/--doc values from reporting a false success, mirroring the --clear-deps fix from PR #840. Empty setter values and clear/setter conflicts now exit 1 with an error naming the clear flag, the interactive-TTY predicate recognizes both flags, and MCP task_edit treats blank-only reference/documentation arrays as a no-op while an explicit empty array clears. Verified with new CLI and MCP regression tests, a live reproduction of issue #861, bunx tsc --noEmit, bun run check ., and the full suite (1910 pass, 5 skip).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -467,9 +467,32 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.dep !== undefined ||
 			options.clearDeps ||
 			options.ref !== undefined ||
+			options.clearRefs ||
 			options.doc !== undefined ||
+			options.clearDocs ||
 			options.modifiedFile !== undefined,
 	);
+}
+
+/**
+ * Validate a clearable list option pair such as --ref/--clear-refs.
+ * Returns an error message when the clear flag conflicts with a setter or a setter value is blank.
+ */
+function validateClearableListInput(input: {
+	rawValues: string[];
+	cleared: boolean;
+	isBlank: (value: string) => boolean;
+	setterFlags: string;
+	clearFlag: string;
+	subject: string;
+}): string | undefined {
+	if (input.cleared && input.rawValues.length > 0) {
+		return `Cannot combine ${input.clearFlag} with ${input.setterFlags}. Use ${input.clearFlag} by itself.`;
+	}
+	if (input.rawValues.some(input.isBlank)) {
+		return `Cannot use an empty value with ${input.setterFlags}. Use ${input.clearFlag} to remove all ${input.subject}.`;
+	}
+	return undefined;
 }
 
 async function resolveCliMilestoneInput(core: Core, milestone: string): Promise<string> {
@@ -2674,6 +2697,16 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			type: "Boolean",
 			description: "Remove all task dependencies; cannot combine with dependency flags",
 		},
+		{
+			name: "clear-refs",
+			type: "Boolean",
+			description: "Remove all references; cannot combine with --ref",
+		},
+		{
+			name: "clear-docs",
+			type: "Boolean",
+			description: "Remove all documentation; cannot combine with --doc",
+		},
 		{ name: "plan", type: "Markdown", description: "Replacement implementation plan" },
 		{
 			name: "append-plan",
@@ -2805,6 +2838,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
 		return [...soFar, value];
 	})
+	.option("--clear-refs", "remove all references (cannot combine with --ref)")
 	.option(
 		"--modified-file <path>",
 		"set modified file paths from project root (can be used multiple times)",
@@ -2817,6 +2851,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
 		return [...soFar, value];
 	})
+	.option("--clear-docs", "remove all documentation (cannot combine with --doc)")
 	.action(async (taskId: string | undefined, options) => {
 		const shouldUseWizard = hasInteractiveTTY && !hasEditFieldFlags(options);
 		if (!shouldUseWizard && !taskId) {
@@ -3022,15 +3057,36 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			.filter((value) => value.length > 0);
 
 		const combinedDependencies = [...toStringArray(options.dependsOn), ...toStringArray(options.dep)];
-		if (options.clearDeps && combinedDependencies.length > 0) {
-			console.error("Cannot combine --clear-deps with --depends-on or --dep. Use --clear-deps by itself.");
-			process.exitCode = 1;
-			return;
-		}
-		if (combinedDependencies.some((value) => normalizeDependencies([value]).length === 0)) {
-			console.error(
-				"Cannot use an empty value with --depends-on or --dep. Use --clear-deps to remove all task dependencies.",
-			);
+		const rawReferences = toStringArray(options.ref);
+		const rawDocumentation = toStringArray(options.doc);
+		const isBlankListValue = (value: string) => parseDelimitedStringList(value) === undefined;
+		const clearableListError =
+			validateClearableListInput({
+				rawValues: combinedDependencies,
+				cleared: Boolean(options.clearDeps),
+				isBlank: (value) => normalizeDependencies([value]).length === 0,
+				setterFlags: "--depends-on or --dep",
+				clearFlag: "--clear-deps",
+				subject: "task dependencies",
+			}) ??
+			validateClearableListInput({
+				rawValues: rawReferences,
+				cleared: Boolean(options.clearRefs),
+				isBlank: isBlankListValue,
+				setterFlags: "--ref",
+				clearFlag: "--clear-refs",
+				subject: "references",
+			}) ??
+			validateClearableListInput({
+				rawValues: rawDocumentation,
+				cleared: Boolean(options.clearDocs),
+				isBlank: isBlankListValue,
+				setterFlags: "--doc",
+				clearFlag: "--clear-docs",
+				subject: "documentation",
+			});
+		if (clearableListError) {
+			console.error(clearableListError);
 			process.exitCode = 1;
 			return;
 		}
@@ -3087,11 +3143,15 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		} else if (options.clearDeps) {
 			editArgs.dependencies = [];
 		}
-		if (normalizedReferences && normalizedReferences.length > 0) {
+		if (normalizedReferences) {
 			editArgs.references = normalizedReferences;
+		} else if (options.clearRefs) {
+			editArgs.references = [];
 		}
-		if (normalizedDocumentation && normalizedDocumentation.length > 0) {
+		if (normalizedDocumentation) {
 			editArgs.documentation = normalizedDocumentation;
+		} else if (options.clearDocs) {
+			editArgs.documentation = [];
 		}
 		if (normalizedModifiedFiles && normalizedModifiedFiles.length > 0) {
 			editArgs.modifiedFiles = normalizedModifiedFiles;

--- a/src/test/cli-refs-docs.test.ts
+++ b/src/test/cli-refs-docs.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { $ } from "bun";
 import { Core } from "../index.ts";
 import { getTestCliPath } from "./test-cli.ts";
@@ -10,6 +11,19 @@ let TEST_DIR: string;
 
 describe("CLI --ref and --doc flags", () => {
 	const cliPath = getTestCliPath();
+
+	// Runs the CLI with stdio reported as a TTY so interactive-only behavior (the edit wizard) applies.
+	async function runCliWithInteractiveTty(cwd: string, args: string[]) {
+		const entryPath = join(cwd, "interactive-cli-entry.ts");
+		await writeFile(
+			entryPath,
+			`Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+await import(${JSON.stringify(pathToFileURL(cliPath).href)});
+`,
+		);
+		return await $`bun ${entryPath} ${args}`.cwd(cwd).quiet().nothrow();
+	}
 
 	beforeEach(async () => {
 		TEST_DIR = createUniqueTestDir("test-cli-refs-docs");
@@ -175,6 +189,102 @@ describe("CLI --ref and --doc flags", () => {
 			expect(result.exitCode).toBe(0);
 			const out = result.stdout.toString();
 			expect(out).toContain("Modified files: src/api.ts, src/ui.ts");
+		});
+	});
+
+	describe("task edit with --clear-refs and --clear-docs", () => {
+		async function createTaskWithRefsAndDocs() {
+			await $`bun ${cliPath} task create "Feature" --ref a --ref b --doc doc-a --doc doc-b`.cwd(TEST_DIR).quiet();
+		}
+
+		it("clears references with --clear-refs", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const result = await $`bun ${cliPath} task edit 1 --clear-refs --plain`.cwd(TEST_DIR).quiet();
+
+			expect(result.exitCode).toBe(0);
+			const task = await new Core(TEST_DIR).filesystem.loadTask("TASK-1");
+			expect(task?.references).toEqual([]);
+			expect(task?.documentation).toEqual(["doc-a", "doc-b"]);
+		});
+
+		it("clears documentation with --clear-docs", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const result = await $`bun ${cliPath} task edit 1 --clear-docs --plain`.cwd(TEST_DIR).quiet();
+
+			expect(result.exitCode).toBe(0);
+			const task = await new Core(TEST_DIR).filesystem.loadTask("TASK-1");
+			expect(task?.documentation).toEqual([]);
+			expect(task?.references).toEqual(["a", "b"]);
+		});
+
+		it("clears references with --clear-refs in an interactive terminal", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const result = await runCliWithInteractiveTty(TEST_DIR, ["task", "edit", "1", "--clear-refs"]);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toContain("Updated task TASK-1");
+			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.references).toEqual([]);
+		});
+
+		it("clears documentation with --clear-docs in an interactive terminal", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const result = await runCliWithInteractiveTty(TEST_DIR, ["task", "edit", "1", "--clear-docs"]);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toContain("Updated task TASK-1");
+			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.documentation).toEqual([]);
+		});
+
+		it("rejects empty and conflicting reference edits without changing references", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const empty = await $`bun ${cliPath} task edit 1 --ref ""`.cwd(TEST_DIR).quiet().nothrow();
+			expect(empty.exitCode).toBe(1);
+			expect(empty.stderr.toString()).toContain("Cannot use an empty value with --ref");
+			expect(empty.stdout.toString()).not.toContain("Updated task");
+
+			const emptyAlongsideValue = await $`bun ${cliPath} task edit 1 --ref "" --ref c`.cwd(TEST_DIR).quiet().nothrow();
+			expect(emptyAlongsideValue.exitCode).toBe(1);
+			expect(emptyAlongsideValue.stderr.toString()).toContain("Cannot use an empty value with --ref");
+
+			const conflicting = await $`bun ${cliPath} task edit 1 --clear-refs --ref c`.cwd(TEST_DIR).quiet().nothrow();
+			expect(conflicting.exitCode).toBe(1);
+			expect(conflicting.stderr.toString()).toContain("Cannot combine --clear-refs with --ref");
+
+			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.references).toEqual(["a", "b"]);
+		});
+
+		it("rejects empty and conflicting documentation edits without changing documentation", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const empty = await $`bun ${cliPath} task edit 1 --doc ""`.cwd(TEST_DIR).quiet().nothrow();
+			expect(empty.exitCode).toBe(1);
+			expect(empty.stderr.toString()).toContain("Cannot use an empty value with --doc");
+			expect(empty.stdout.toString()).not.toContain("Updated task");
+
+			const emptyAlongsideValue = await $`bun ${cliPath} task edit 1 --doc "" --doc doc-c`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(emptyAlongsideValue.exitCode).toBe(1);
+			expect(emptyAlongsideValue.stderr.toString()).toContain("Cannot use an empty value with --doc");
+
+			const conflicting = await $`bun ${cliPath} task edit 1 --clear-docs --doc doc-c`.cwd(TEST_DIR).quiet().nothrow();
+			expect(conflicting.exitCode).toBe(1);
+			expect(conflicting.stderr.toString()).toContain("Cannot combine --clear-docs with --doc");
+
+			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.documentation).toEqual(["doc-a", "doc-b"]);
+		});
+
+		it("documents --clear-refs and --clear-docs in task edit help", async () => {
+			const result = await $`bun ${cliPath} task edit --help`.cwd(TEST_DIR).quiet();
+
+			expect(result.stdout.toString()).toContain("--clear-refs");
+			expect(result.stdout.toString()).toContain("--clear-docs");
 		});
 	});
 

--- a/src/test/mcp-refs-docs.test.ts
+++ b/src/test/mcp-refs-docs.test.ts
@@ -116,4 +116,51 @@ describe("MCP task references and documentation", () => {
 		expect(task?.references).toEqual(["ref-1.ts", "ref-3.ts"]);
 		expect(task?.documentation).toEqual(["doc-1.md", "doc-3.md"]);
 	});
+
+	it("does not clear references or documentation from blank-only task_edit arrays", async () => {
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Blank input",
+					references: ["ref-1.ts"],
+					documentation: ["doc-1.md"],
+				},
+			},
+		});
+
+		const blankEdit = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					references: ["", "   "],
+					documentation: ["", "   "],
+				},
+			},
+		});
+
+		expect(getText(blankEdit.content)).toContain("References: ref-1.ts");
+		expect(getText(blankEdit.content)).toContain("Documentation: doc-1.md");
+		let task = await mcpServer.getTask("task-1");
+		expect(task?.references).toEqual(["ref-1.ts"]);
+		expect(task?.documentation).toEqual(["doc-1.md"]);
+
+		const clearEdit = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					references: [],
+					documentation: [],
+				},
+			},
+		});
+
+		expect(getText(clearEdit.content)).not.toContain("References:");
+		expect(getText(clearEdit.content)).not.toContain("Documentation:");
+		task = await mcpServer.getTask("task-1");
+		expect(task?.references).toEqual([]);
+		expect(task?.documentation).toEqual([]);
+	});
 });

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -8,6 +8,14 @@ function sanitizeStringArray(values: string[] | undefined): string[] | undefined
 	return trimmed.length > 0 ? trimmed : undefined;
 }
 
+/**
+ * Resolve a clearable list field: blank-only values are a no-op, an explicit empty array clears the list.
+ */
+function sanitizeClearableStringArray(values: string[] | undefined): string[] | undefined {
+	if (values === undefined) return undefined;
+	return sanitizeStringArray(values) ?? (values.length === 0 ? [] : undefined);
+}
+
 function sanitizeAppend(values: string[] | undefined): string[] | undefined {
 	const sanitized = sanitizeStringArray(values);
 	if (!sanitized) {
@@ -80,16 +88,12 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		updateInput.assignee = assignee;
 	}
 
-	if (args.dependencies !== undefined) {
-		const dependencies = sanitizeStringArray(args.dependencies);
-		if (dependencies) {
-			updateInput.dependencies = dependencies;
-		} else if (args.dependencies.length === 0) {
-			updateInput.dependencies = [];
-		}
+	const dependencies = sanitizeClearableStringArray(args.dependencies);
+	if (dependencies) {
+		updateInput.dependencies = dependencies;
 	}
 
-	const references = sanitizeStringArray(args.references);
+	const references = sanitizeClearableStringArray(args.references);
 	if (references) {
 		updateInput.references = references;
 	}
@@ -104,7 +108,7 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		updateInput.removeReferences = removeReferences;
 	}
 
-	const documentation = sanitizeStringArray(args.documentation);
+	const documentation = sanitizeClearableStringArray(args.documentation);
 	if (documentation) {
 		updateInput.documentation = documentation;
 	}


### PR DESCRIPTION
Fixes #861.

`task edit --ref ""` and `--doc ""` exited 0 and printed "Updated task TASK-1" while changing nothing (false success), and neither list had a clear operation. This mirrors the merged #840 dependencies convention exactly: `--clear-refs` and `--clear-docs` flags, per-occurrence empty-value rejection naming the matching clear flag, clear-vs-setter conflict rejection, inclusion in the interactive-TTY predicate (the #840 P1 lesson, covered by faked-TTY regression tests), and the MCP blank-array convention (blank-only arrays are a no-op, explicit `[]` clears).

Rather than duplicating #840's validation twice more, the logic is consolidated into one shared validator and one shared sanitizer now serving dependencies, references, and documentation — error strings byte-identical, and the pre-existing dependency test files pass unmodified.

Out of scope by design: #856's incremental `--add-ref`/`--remove-ref` (the task notes record that those must join the same conflict check when they land).

Verification: live repro of the issue's exact sequence (bug confirmed on main first, all six rejection paths verified byte-unchanged on disk), non-vacuous TTY tests, full suite 1910 pass / 0 fail. Independently reviewed with no blocking findings.