### PR TITLE
BACK-577 - Include the project name in TUI window titles

### DIFF
--- a/backlog/tasks/back-577 - Include-the-project-name-in-TUI-window-titles.md
+++ b/backlog/tasks/back-577 - Include-the-project-name-in-TUI-window-titles.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-577
 title: Include the project name in TUI window titles
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 17:25'
+updated_date: '2026-08-07 20:09'
 labels:
   - bug
 dependencies: []
@@ -22,16 +24,52 @@ GitHub issue #853. TUI window titles do not identify which project is open, so u
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The board TUI title includes the project name, following the overview TUI pattern
-- [ ] #2 The task viewer TUI title includes the project name, following the same pattern
-- [ ] #3 Titles fall back to a sensible default when the project name is empty
-- [ ] #4 The readyPattern "Backlog Board" in src/test/tui-interactive-editor-handoff.test.ts:409 is updated to match
-- [ ] #5 Restoring the previous terminal title on exit is either included as a small addition or explicitly recorded as out of scope
+- [x] #1 The board TUI title includes the project name, following the overview TUI pattern
+- [x] #2 The task viewer TUI title includes the project name, following the same pattern
+- [x] #3 Titles fall back to a sensible default when the project name is empty
+- [x] #4 The readyPattern "Backlog Board" in src/test/tui-interactive-editor-handoff.test.ts:409 is updated to match
+- [x] #5 Restoring the previous terminal title on exit is either included as a small addition or explicitly recorded as out of scope
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a shared formatTuiTitle(view, projectName) helper in src/ui/tui.ts: returns `${projectName} - ${view}` when the configured name is usable, otherwise `Backlog ${view}` (blank/whitespace and the placeholder 'Untitled Project' both count as unusable).
+2. Board (src/ui/board.ts): add an optional projectName to renderBoardTui options (same shape as dateFormat) and title the screen with formatTuiTitle('Board', projectName). Pass config?.projectName from the board callers (unified-view, simple-unified-view, enhanced-views) that already load config.
+3. Task viewer (src/ui/task-viewer-with-search.ts): capture projectName from the config it already loads and apply formatTuiTitle to all three screen.title assignments (initial, no-results, selected task) so the project stays visible while a task is open.
+4. Overview (src/ui/overview-tui.ts): route its screen title through the same helper so the three surfaces share one rule.
+5. Tests: update the 'Backlog Board' readyPattern in src/test/tui-interactive-editor-handoff.test.ts and add unit coverage for formatTuiTitle (named project, blank, whitespace, Untitled Project).
+6. Verify titles end-to-end via the interactive expect PTY suite (RUN_INTERACTIVE_TUI_TESTS=1) plus bunx tsc --noEmit, bun run check ., and a full bun test.
+7. Terminal-title restore on exit: assess blessed's capability; include only if trivially small, otherwise record it as out of scope in the notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a shared `formatTuiTitle(view, projectName)` helper in src/ui/tui.ts and routed every TUI screen title through it: board ("<project> - Board"), task viewer ("<project> - Tasks", the caller-supplied title such as "Search: foo"/"Drafts", and the selected-task title "<project> - Task BACK-1 - ..."), and overview ("<project> - Overview", unchanged behavior for a named project).
+
+Fallback rule: a blank/whitespace name and the `Untitled Project` placeholder (the config-migration default, also used by the web server) both fall back to "Backlog <view>", which preserves the previous "Backlog Board"/"Backlog Tasks" strings instead of showing a blank or meaningless project name.
+
+The board is a pure render function, so it takes the name through a new optional `projectName` option alongside the existing `dateFormat` option; all three callers (unified-view, simple-unified-view, enhanced-views) already load config and pass `config?.projectName`. The task viewer already loads config itself, so it reads `config?.projectName` directly and needs no new option.
+
+The selected-task title is included deliberately: it overwrites the initial title as soon as a task is open, so titling only the initial screen would have left the tab unidentified in normal use.
+
+Out of scope (AC #5): restoring the previous terminal title on exit, including Ctrl-C. neo-neo-bblessed never captures the original title (the restore branch in Program's exit handler is commented out), so this needs XTerm title-stack escapes (\x1b[22;2t / \x1b[23;2t) pushed per screen and popped on every teardown path, plus a process-level exit hook for hard exits. createScreen is used by every screen (loading screens, popups, tests), so unbalanced push/pop would restore the wrong title and the extra escapes would reach terminals that may not support the stack. That is a separate, riskier change than a title string.
+
+Also not included: the issue also asks for the project name inside the board Filters view; that is not part of this task's acceptance criteria.
+
+Verification: RUN_INTERACTIVE_TUI_TESTS=1 bun test src/test/tui-interactive-editor-handoff.test.ts (4 pass) drives the real CLI through an expect PTY; the captured transcripts contain the actual OSC title writes `\x1b]0;Interactive board - Board\x07` and `\x1b]0;Interactive task-list - Tasks\x07` followed by `\x1b]0;Interactive task-list - Task TASK-1 - Task list interactive editor task\x07`.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+TUI window titles now identify the open project. A single formatTuiTitle(view, projectName) helper in src/ui/tui.ts renders "<project> - <view>" and falls back to "Backlog <view>" for a blank name or the "Untitled Project" placeholder; the board, the task viewer (initial, no-results, and selected-task titles) and the overview all use it, with the board receiving the name through a new optional projectName option passed by its existing callers. Verified by driving the real CLI through an expect PTY (RUN_INTERACTIVE_TUI_TESTS=1, 4 pass), whose transcripts show the OSC titles "Interactive board - Board", "Interactive task-list - Tasks" and "Interactive task-list - Task TASK-1 - ..."; fallbacks covered by new unit tests in src/test/tui-window-title.test.ts. bunx tsc --noEmit, bun run check . and bun test (1913 pass, 5 skip, 0 fail) are clean. Restoring the previous terminal title on exit is recorded as out of scope in the notes.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-577 - Include-the-project-name-in-TUI-window-titles.md
+++ b/backlog/tasks/back-577 - Include-the-project-name-in-TUI-window-titles.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 17:25'
-updated_date: '2026-08-07 20:34'
+updated_date: '2026-08-07 20:56'
 labels:
   - bug
 dependencies: []
@@ -70,6 +70,8 @@ Verification: RUN_INTERACTIVE_TUI_TESTS=1 bun test src/test/tui-interactive-edit
 Follow-up (PR #863 review, P1 accepted): formatTuiTitle now strips control characters. The title is emitted as `ESC ] 0 ; <title> BEL` by the fork's Program.setTitle with no escaping, so a project name from a cloned repo's backlog/config.yml containing BEL or ESC could close the OSC sequence and inject arbitrary escape codes into the user's terminal. A single stripControlCharacters helper in src/ui/tui.ts removes C0 controls, DEL, and C1 controls (0x00-0x1f, 0x7f, 0x80-0x9f) from the composed title, so the caller-supplied view strings (search queries, task titles read from task markdown, which are equally attacker-controlled) are covered by the same strip point; the project name is also cleaned before the blank/'Untitled Project' fallback check so a name made only of control characters still falls back instead of producing ' - Board'. Implemented as a code-point filter rather than a regex because Biome's noControlCharactersInRegex forbids control escapes in regular expressions.
 
 Verification: src/test/tui-window-title.test.ts covers a crafted project name (Acme+BEL+ESC]0;pwned), a crafted view/task title, a C1 character, a control-only name falling back to 'Backlog Board', and the emitted screen.title being control-character free (7 pass). Re-ran RUN_INTERACTIVE_TUI_TESTS=1 PTY suite (4 pass), bunx tsc --noEmit, bun run check ., and bun run test (1916 pass, 5 skip, 0 fail).
+
+Rebased onto main after PR #833 (BACK-565 TUI task composer rewrite) merged. One conflict, in the renderBoardTui options type in src/ui/board.ts: #833 dropped the '@internal Retained while the disabled entrypoint is reverted after BACK-565' comments above createTask/taskComposer, which was the context my 'projectName?: string' line was anchored to. Resolved by keeping main's version of that block verbatim and re-adding only 'projectName?: string' after 'dateFormat?: string'. Everything else re-applied cleanly. Re-grepped after the rebase for screen titles: #833 added no new createScreen or screen.title site (the composer and the help/filter popups are in-screen widgets whose 'title' fields are box labels and task-field values, not terminal titles), so no additional call site needs the helper. Re-verified on the rebased tree: bunx tsc --noEmit, bun run check ., title unit tests (7 pass), RUN_INTERACTIVE_TUI_TESTS=1 PTY suite (4 pass), bun run test (1952 pass, 5 skip, 0 fail).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-577 - Include-the-project-name-in-TUI-window-titles.md
+++ b/backlog/tasks/back-577 - Include-the-project-name-in-TUI-window-titles.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 17:25'
-updated_date: '2026-08-07 20:09'
+updated_date: '2026-08-07 20:34'
 labels:
   - bug
 dependencies: []
@@ -66,6 +66,10 @@ Out of scope (AC #5): restoring the previous terminal title on exit, including C
 Also not included: the issue also asks for the project name inside the board Filters view; that is not part of this task's acceptance criteria.
 
 Verification: RUN_INTERACTIVE_TUI_TESTS=1 bun test src/test/tui-interactive-editor-handoff.test.ts (4 pass) drives the real CLI through an expect PTY; the captured transcripts contain the actual OSC title writes `\x1b]0;Interactive board - Board\x07` and `\x1b]0;Interactive task-list - Tasks\x07` followed by `\x1b]0;Interactive task-list - Task TASK-1 - Task list interactive editor task\x07`.
+
+Follow-up (PR #863 review, P1 accepted): formatTuiTitle now strips control characters. The title is emitted as `ESC ] 0 ; <title> BEL` by the fork's Program.setTitle with no escaping, so a project name from a cloned repo's backlog/config.yml containing BEL or ESC could close the OSC sequence and inject arbitrary escape codes into the user's terminal. A single stripControlCharacters helper in src/ui/tui.ts removes C0 controls, DEL, and C1 controls (0x00-0x1f, 0x7f, 0x80-0x9f) from the composed title, so the caller-supplied view strings (search queries, task titles read from task markdown, which are equally attacker-controlled) are covered by the same strip point; the project name is also cleaned before the blank/'Untitled Project' fallback check so a name made only of control characters still falls back instead of producing ' - Board'. Implemented as a code-point filter rather than a regex because Biome's noControlCharactersInRegex forbids control escapes in regular expressions.
+
+Verification: src/test/tui-window-title.test.ts covers a crafted project name (Acme+BEL+ESC]0;pwned), a crafted view/task title, a C1 character, a control-only name falling back to 'Backlog Board', and the emitted screen.title being control-character free (7 pass). Re-ran RUN_INTERACTIVE_TUI_TESTS=1 PTY suite (4 pass), bunx tsc --noEmit, bun run check ., and bun run test (1916 pass, 5 skip, 0 fail).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/test/tui-interactive-editor-handoff.test.ts
+++ b/src/test/tui-interactive-editor-handoff.test.ts
@@ -406,7 +406,7 @@ describe("interactive TUI editor handoff", () => {
 			scenario: "board",
 			cliArgs: ["board"],
 			taskTitle: "Board interactive editor task",
-			readyPattern: "Backlog Board",
+			readyPattern: "Interactive board - Board",
 		});
 
 		expect(result.editorMarker).toContain("started");
@@ -420,7 +420,7 @@ describe("interactive TUI editor handoff", () => {
 			scenario: "task-list",
 			cliArgs: ["task", "list"],
 			taskTitle: "Task list interactive editor task",
-			readyPattern: "Tasks",
+			readyPattern: "Interactive task-list - Tasks",
 		});
 
 		expect(result.editorMarker).toContain("started");

--- a/src/test/tui-window-title.test.ts
+++ b/src/test/tui-window-title.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { createScreen, formatTuiTitle } from "../ui/tui.ts";
 
+function hasControlCharacters(value: string): boolean {
+	return Array.from(value).some((character) => {
+		const code = character.codePointAt(0) ?? 0;
+		return code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f);
+	});
+}
+
 describe("TUI window titles", () => {
 	it("prefixes the configured project name", () => {
 		expect(formatTuiTitle("Board", "Acme Website")).toBe("Acme Website - Board");
@@ -21,10 +28,42 @@ describe("TUI window titles", () => {
 		expect(formatTuiTitle("Overview", "untitled project")).toBe("Backlog Overview");
 	});
 
+	it("strips control characters from a crafted project name", () => {
+		// The title is written as ESC ] 0 ; <title> BEL, so a BEL or ESC in backlog/config.yml
+		// would otherwise end the sequence and inject escape codes into the terminal.
+		const crafted = formatTuiTitle("Board", "Acme\u0007\u001b]0;pwned");
+		expect(crafted).toBe("Acme]0;pwned - Board");
+		expect(hasControlCharacters(crafted)).toBe(false);
+
+		expect(formatTuiTitle("Board", "Acme\nWebsite")).toBe("AcmeWebsite - Board");
+		expect(formatTuiTitle("Board", "Acme\u009bWebsite")).toBe("AcmeWebsite - Board");
+		expect(formatTuiTitle("Board", "\u0007\u001b\u007f")).toBe("Backlog Board");
+	});
+
+	it("strips control characters from caller-supplied view titles", () => {
+		const craftedTask = formatTuiTitle("Task TASK-1 - Fix\u0007 login\u001b]0;pwned", "Acme Website");
+		expect(craftedTask).toBe("Acme Website - Task TASK-1 - Fix login]0;pwned");
+		expect(hasControlCharacters(craftedTask)).toBe(false);
+
+		const craftedSearch = formatTuiTitle("Search: \u001b]0;pwned\u0007", undefined);
+		expect(craftedSearch).toBe("Backlog Search: ]0;pwned");
+		expect(hasControlCharacters(craftedSearch)).toBe(false);
+	});
+
 	it("applies the title to the terminal screen", () => {
 		const screen = createScreen({ smartCSR: false, title: formatTuiTitle("Board", "Acme Website") });
 		try {
 			expect(screen.title).toBe("Acme Website - Board");
+		} finally {
+			screen.destroy();
+		}
+	});
+
+	it("keeps the emitted screen title free of injected escape sequences", () => {
+		const screen = createScreen({ smartCSR: false, title: formatTuiTitle("Board", "Acme\u0007\u001b]0;pwned") });
+		try {
+			expect(screen.title).toBe("Acme]0;pwned - Board");
+			expect(hasControlCharacters(String(screen.title))).toBe(false);
 		} finally {
 			screen.destroy();
 		}

--- a/src/test/tui-window-title.test.ts
+++ b/src/test/tui-window-title.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { createScreen, formatTuiTitle } from "../ui/tui.ts";
+
+describe("TUI window titles", () => {
+	it("prefixes the configured project name", () => {
+		expect(formatTuiTitle("Board", "Acme Website")).toBe("Acme Website - Board");
+		expect(formatTuiTitle("Tasks", "Acme Website")).toBe("Acme Website - Tasks");
+		expect(formatTuiTitle("Overview", "Acme Website")).toBe("Acme Website - Overview");
+		expect(formatTuiTitle("Task TASK-1 - Fix login", "Acme Website")).toBe("Acme Website - Task TASK-1 - Fix login");
+	});
+
+	it("trims surrounding whitespace from the project name", () => {
+		expect(formatTuiTitle("Board", "  Acme Website  ")).toBe("Acme Website - Board");
+	});
+
+	it("falls back to a generic title when the project name is unusable", () => {
+		expect(formatTuiTitle("Board", undefined)).toBe("Backlog Board");
+		expect(formatTuiTitle("Board", "")).toBe("Backlog Board");
+		expect(formatTuiTitle("Board", "   ")).toBe("Backlog Board");
+		expect(formatTuiTitle("Tasks", "Untitled Project")).toBe("Backlog Tasks");
+		expect(formatTuiTitle("Overview", "untitled project")).toBe("Backlog Overview");
+	});
+
+	it("applies the title to the terminal screen", () => {
+		const screen = createScreen({ smartCSR: false, title: formatTuiTitle("Board", "Acme Website") });
+		try {
+			expect(screen.title).toBe("Acme Website - Board");
+		} finally {
+			screen.destroy();
+		}
+	});
+});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -33,7 +33,7 @@ import {
 	resolveSearchExitTargetIndex,
 	shouldMoveFromListBoundaryToSearch,
 } from "./task-viewer-with-search.ts";
-import { createScreen } from "./tui.ts";
+import { createScreen, formatTuiTitle } from "./tui.ts";
 import { stripBlessedFgTags } from "./utils/strip-tags.ts";
 
 export type ColumnData = {
@@ -278,6 +278,7 @@ export async function renderBoardTui(
 		milestoneEntities?: Milestone[];
 		startupWarning?: string;
 		dateFormat?: string;
+		projectName?: string;
 		createTask?: (input: TaskCreateInput) => Promise<Task>;
 		screen?: ScreenInterface;
 		taskComposer?: (options: TaskComposerOptions) => Promise<Task | null>;
@@ -299,7 +300,7 @@ export async function renderBoardTui(
 	}
 
 	await new Promise<void>((resolve) => {
-		const screen = options?.screen ?? createScreen({ title: "Backlog Board" });
+		const screen = options?.screen ?? createScreen({ title: formatTuiTitle("Board", options?.projectName) });
 		const container = box({
 			parent: screen,
 			width: "100%",

--- a/src/ui/enhanced-views.ts
+++ b/src/ui/enhanced-views.ts
@@ -186,6 +186,7 @@ async function renderBoardTuiWithSwitching(
 	// This is a placeholder - we'll need to modify the actual board.ts
 	return renderBoardTui(tasks, statuses, layout, maxColumnWidth, {
 		dateFormat: config?.dateFormat,
+		projectName: config?.projectName,
 		priorities: config?.priorities,
 		types: config?.types,
 	});

--- a/src/ui/overview-tui.ts
+++ b/src/ui/overview-tui.ts
@@ -2,7 +2,7 @@ import { box } from "neo-neo-bblessed";
 import type { TaskStatistics } from "../core/statistics.ts";
 import { formatPriorityLabel } from "../utils/priority-config.ts";
 import { getStatusIcon } from "./status-icon.ts";
-import { createScreen } from "./tui.ts";
+import { createScreen, formatTuiTitle } from "./tui.ts";
 
 const priorityColors: Record<string, string> = {
 	high: "red",
@@ -36,7 +36,7 @@ export async function renderOverviewTui(statistics: TaskStatistics, projectName:
 	}
 
 	return new Promise<void>((resolve) => {
-		const screen = createScreen({ title: `${projectName} - Overview` });
+		const screen = createScreen({ title: formatTuiTitle("Overview", projectName) });
 
 		// Main container
 		const container = box({

--- a/src/ui/simple-unified-view.ts
+++ b/src/ui/simple-unified-view.ts
@@ -122,6 +122,7 @@ export async function runSimpleUnifiedView(options: SimpleUnifiedViewOptions): P
 				await switchView();
 			},
 			dateFormat: config?.dateFormat,
+			projectName: config?.projectName,
 			priorities: config?.priorities,
 			types: config?.types,
 		});

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -42,7 +42,7 @@ import { createLoadingScreen } from "./loading.ts";
 import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-icon.ts";
 import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-lifecycle.ts";
 import { formatTaskTypeBadge } from "./task-type.ts";
-import { addScrollKeys, createScreen } from "./tui.ts";
+import { addScrollKeys, createScreen, formatTuiTitle } from "./tui.ts";
 
 function getPriorityDisplay(priority?: string): string {
 	switch (normalizePriorityValue(priority)) {
@@ -233,6 +233,7 @@ export async function viewTaskEnhanced(
 	);
 
 	let dateFormat: string | undefined;
+	let projectName: string | undefined;
 
 	if (options.tasks) {
 		// Tasks already provided - use in-memory search (no ContentStore loading)
@@ -243,6 +244,7 @@ export async function viewTaskEnhanced(
 		priorityOptions = getPriorityOptions(config);
 		configuredTaskTypes = getTaskTypeValues(config);
 		dateFormat = config?.dateFormat;
+		projectName = config?.projectName;
 		taskSearchIndex = createTaskSearchIndex(allTasks);
 	} else {
 		// Need to load tasks - show loading screen
@@ -255,6 +257,7 @@ export async function viewTaskEnhanced(
 			priorityOptions = getPriorityOptions(config);
 			configuredTaskTypes = getTaskTypeValues(config);
 			dateFormat = config?.dateFormat;
+			projectName = config?.projectName;
 
 			loadingScreen?.update("Loading tasks from branches...");
 			contentStore = await core.getContentStore();
@@ -318,7 +321,8 @@ export async function viewTaskEnhanced(
 	let selectionRequestId = 0;
 	let noResultsMessage: string | null = null;
 
-	const screen = createScreen({ title: options.title || "Backlog Tasks" });
+	const screenTitle = formatTuiTitle(options.title || "Tasks", projectName);
+	const screen = createScreen({ title: screenTitle });
 
 	// Main container
 	const container = box({
@@ -1011,7 +1015,7 @@ export async function viewTaskEnhanced(
 		};
 
 		if (noResultsMessage) {
-			screen.title = options.title || "Backlog Tasks";
+			screen.title = screenTitle;
 
 			headerDetailBox = box({
 				parent: detailPane,
@@ -1048,7 +1052,7 @@ export async function viewTaskEnhanced(
 			return;
 		}
 
-		screen.title = `Task ${currentSelectedTask.id} - ${currentSelectedTask.title}`;
+		screen.title = formatTuiTitle(`Task ${currentSelectedTask.id} - ${currentSelectedTask.title}`, projectName);
 
 		const detailContent = generateDetailContent(currentSelectedTask, resolveMilestoneLabel, dateFormat);
 

--- a/src/ui/tui.ts
+++ b/src/ui/tui.ts
@@ -85,17 +85,30 @@ export function addScrollKeys(
 	});
 }
 
+/** Remove C0 controls, DEL, and C1 controls so they can never reach the terminal title. */
+function stripControlCharacters(value: string): string {
+	return Array.from(value)
+		.filter((character) => {
+			const code = character.codePointAt(0) ?? 0;
+			return code > 0x1f && code !== 0x7f && !(code >= 0x80 && code <= 0x9f);
+		})
+		.join("");
+}
+
 /**
  * Terminal/window title for a TUI surface, so parallel terminals can be told apart.
  * Uses the configured project name when it identifies the project, and falls back to a
  * generic "Backlog <view>" title for a blank name or the "Untitled Project" placeholder.
+ *
+ * The title is emitted as `ESC ] 0 ; <title> BEL`, so the composed string is stripped of
+ * control characters: both the project name and the view (search queries, task titles)
+ * come from repository files that a clone can control, and an embedded BEL or ESC would
+ * otherwise close the title sequence and inject arbitrary escape codes into the terminal.
  */
 export function formatTuiTitle(view: string, projectName?: string): string {
-	const name = projectName?.trim() ?? "";
-	if (!name || name.toLowerCase() === "untitled project") {
-		return `Backlog ${view}`;
-	}
-	return `${name} - ${view}`;
+	const name = stripControlCharacters(projectName ?? "").trim();
+	const usableName = name && name.toLowerCase() !== "untitled project" ? name : "";
+	return stripControlCharacters(usableName ? `${usableName} - ${view}` : `Backlog ${view}`);
 }
 
 export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterface {

--- a/src/ui/tui.ts
+++ b/src/ui/tui.ts
@@ -85,6 +85,19 @@ export function addScrollKeys(
 	});
 }
 
+/**
+ * Terminal/window title for a TUI surface, so parallel terminals can be told apart.
+ * Uses the configured project name when it identifies the project, and falls back to a
+ * generic "Backlog <view>" title for a blank name or the "Untitled Project" placeholder.
+ */
+export function formatTuiTitle(view: string, projectName?: string): string {
+	const name = projectName?.trim() ?? "";
+	if (!name || name.toLowerCase() === "untitled project") {
+		return `Backlog ${view}`;
+	}
+	return `${name} - ${view}`;
+}
+
 export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterface {
 	const program: ProgramInterface = createProgram({ tput: false });
 	const screen = blessedScreen({ smartCSR: true, program, fullUnicode: true, ...options });

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -494,6 +494,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					milestoneEntities,
 					startupWarning,
 					dateFormat: config?.dateFormat,
+					projectName: config?.projectName,
 					priorities: config?.priorities,
 					types: config?.types,
 					createTask: async (input) => createTaskFromBoard(options.core, input, taskUpdateCallbacks.onTaskAdded),


### PR DESCRIPTION
Fixes #853.

TUI window titles didn't identify the project: the board hardcoded "Backlog Board" and the task viewer defaulted to "Backlog Tasks", so boards for different projects were indistinguishable across terminal tabs, while the overview already used the project-aware pattern. A shared `formatTuiTitle` helper now applies `<project> - <view>` to the board, the task viewer (including the selected-task title that overwrites the initial one in normal use), and the overview, falling back to the old generic strings when the name is blank or the "Untitled Project" placeholder.

Terminal-title restore on exit is recorded as out of scope with rationale (the vendored blessed fork never captures the original title; a title-stack approach needs balanced push/pop across every teardown path) — candidate follow-up.

Verification: real OSC title writes captured from expect-driven PTY runs (patterns tightened so a regression to the old strings fails the test), plus a green full suite. Independently reviewed with no blocking findings.