### PR TITLE
BACK-593 - Auto-link task IDs in web markdown to task deep links

### DIFF
--- a/backlog/tasks/back-593 - Auto-link-task-IDs-in-web-markdown-to-task-deep-links.md
+++ b/backlog/tasks/back-593 - Auto-link-task-IDs-in-web-markdown-to-task-deep-links.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 21:10'
-updated_date: '2026-08-07 22:16'
+updated_date: '2026-08-07 22:36'
 labels:
   - web
 dependencies: []
@@ -95,6 +95,15 @@ Review follow-up (PR #865, five accepted Codex findings):
 
 Review-fix verification: 16 tests in src/test/mermaid-markdown.test.tsx, 4 in src/test/web-dependency-input-links.test.tsx, and a new src/test/web-task-details-modal-unsaved-navigation.test.tsx (4 tests, real DOM + react-router, covering decline-blocks-chip, accept-navigates, decline-blocks-comment-autolink, and no prompt when nothing is unsaved). Full suite 1965 pass, 5 skip, 0 fail across 216 files; bunx tsc --noEmit and bun run check . clean.
 Live browser pass of the P1 flow against this repo: on BACK-544 in edit mode with an unsaved title, clicking the BACK-543 dependency chip prompted once and stayed put with the edit intact; accepting the prompt navigated to BACK-543; a plain anchor to another task was blocked the same way while a same-page hash anchor was allowed without prompting. Re-rendered BACK-593 afterwards to confirm the wider candidate pattern still links only real IDs.
+
+Review round 2 (PR #865, two accepted, two deferred):
+
+Accepted 1 (P1). The navigation guard predicate leaned on isDirty, which tracks only the long-form fields, so a comment draft or create-mode metadata could be lost silently. Unsaved work now also counts the comment draft fields, and in create mode any entered field at all (title, type, priority, milestone, assignees, labels, dependencies, references), since nothing is persisted while creating. Two new tests cover a comment-only draft and create-mode metadata entered before any title.
+Accepted 2 (P2). Backslash joined the preceding path-boundary characters, so backlog\tasks\BACK-123 - Title.md no longer linkifies the embedded ID, matching the forward-slash rejection. One test covers the Windows-style path.
+
+Deferred to BACK-599 (bug, web, low, depends on BACK-260): (a) the identity index covers only the active tasks from /api/search while route resolution covers active plus completed, so completed-task references stay unlinked and an active BACK-1 can link while a completed BACK-01 makes the route ambiguous; the real fix needs the parked BACK-260 decision about completed tasks in the web corpus first. (b) generated task links drop search params and taskModalFrom state, so closing a task opened from a filtered board or list returns to an unfiltered view; App.handleEditTask is the precedent to reuse.
+
+Round 2 verification: 17 tests in src/test/mermaid-markdown.test.tsx, 4 in src/test/web-dependency-input-links.test.tsx, 6 in src/test/web-task-details-modal-unsaved-navigation.test.tsx (adding the comment-only draft and create-mode metadata-only scenarios). Full suite 1968 pass, 5 skip, 0 fail across 216 files; bunx tsc --noEmit and bun run check . clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-593 - Auto-link-task-IDs-in-web-markdown-to-task-deep-links.md
+++ b/backlog/tasks/back-593 - Auto-link-task-IDs-in-web-markdown-to-task-deep-links.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-593
 title: Auto-link task IDs in web markdown to task deep links
-status: To Do
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 21:10'
+updated_date: '2026-08-07 21:23'
 labels:
   - web
 dependencies: []
@@ -28,17 +29,67 @@ Related: BACK-239 covers the same idea for documents and decisions plus backlink
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Bare task IDs that match a known task render as links to /tasks/<id> in web markdown fields (description, plan, notes, comments, final summary, documents, decisions)
-- [ ] #2 Task IDs inside inline code spans and fenced code blocks are not linkified
-- [ ] #3 Non-task tokens such as UTF-8, ISO-8601 and v1.2.3, and longer identifiers whose tail looks like a task ID such as my-task-123, are not linkified
-- [ ] #4 Task IDs inside existing markdown links keep their original link target
-- [ ] #5 Dependency chips in the task details sidebar link to the referenced task
-- [ ] #6 Web component tests cover linking, code-block exclusion, non-task tokens, and dependency chip links
+- [x] #1 Bare task IDs that match a known task render as links to /tasks/<id> in web markdown fields (description, plan, notes, comments, final summary, documents, decisions)
+- [x] #2 Task IDs inside inline code spans and fenced code blocks are not linkified
+- [x] #3 Non-task tokens such as UTF-8, ISO-8601 and v1.2.3, and longer identifiers whose tail looks like a task ID such as my-task-123, are not linkified
+- [x] #4 Task IDs inside existing markdown links keep their original link target
+- [x] #5 Dependency chips in the task details sidebar link to the referenced task
+- [x] #6 Web component tests cover linking, code-block exclusion, non-task tokens, and dependency chip links
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Take over PR #812 by cherry-picking cottrell's two source commits (MermaidMarkdown auto-link, DependencyInput chip links) onto a branch off current main, excluding his colliding back-555 task file.
+2. Move detection from string-level regex over raw markdown to the markdown AST: add a small remark plugin (src/web/utils/task-id-links.ts) that walks mdast text nodes and rewrites task-ID matches into link nodes. Code fences and inline code carry no text children, so they are excluded structurally; link/linkReference subtrees are skipped so existing links keep their target.
+3. Validate candidates against the task corpus the web UI already loads: build a canonical-ID index (canonicalTaskId from src/utils/task-id.ts) in a small TaskIdIndexProvider fed by App state, consumed by MermaidMarkdown. Unknown tokens (UTF-8, ISO-8601, v1.2.3) never link, and no new API call is added.
+4. Add leading/trailing boundary rules so IDs embedded in longer identifiers (my-task-123, BACK-1.md) are not matched.
+5. Keep dependency chips as react-router links, but only when the referenced task exists in the loaded corpus.
+6. Extend src/test/mermaid-markdown.test.tsx and add a DependencyInput test; run tsc, biome, and the full test suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Takeover of PR #812 by David Cottrell (@cottrell). His two source commits were cherry-picked with authorship preserved (`git cherry-pick -x`), so the original work is in the branch history:
+- b834302d "Auto-link task IDs in markdown fields to deep links" (MermaidMarkdown + first two tests)
+- c56de5d9 "Make dependencies chips clickable deep links to /tasks/:id" (DependencyInput)
+His `back-555` task file and the plan/finalize commits were excluded: that ID already belongs to a different task on main.
+
+What survived from the original: the feature idea and its shape (bare IDs become `/tasks/<id>` links, dependency chips become router links), the DependencyInput chip Link, and the two original test cases (kept, with stronger assertions).
+
+What was rewritten and why:
+1. Detection moved from a string rewrite of the raw markdown to a small remark plugin over the mdast (`src/web/utils/task-id-links.ts`). The original counted backticks on the current line, so ``` fenced blocks were still linkified, contradicting the PR own acceptance criterion. In the AST, `code` and `inlineCode` nodes carry no text children, so both forms of code are excluded by construction rather than by guesswork, and `link`/`linkReference` subtrees are skipped so existing links keep their target.
+2. Candidates are now validated against real tasks. `TaskIdIndexProvider` (src/web/contexts/TaskIdIndexContext.tsx) builds a canonical-ID index from the task corpus App already loads and passes to the modal, so no new API call and no extra fetch; `canonicalTaskId` from src/utils/task-id.ts makes `back-123`, `BACK-0123` and `BACK-123` resolve to the same task and the link always uses the canonical ID. Unknown ID-shaped tokens (UTF-8, ISO-8601, BACK-9999) never link.
+3. Boundary rules replace `\b`: a candidate preceded by [A-Za-z0-9_-/.] or followed by an identifier character or a file extension is rejected, so `my-task-123`, `backlog/tasks/TASK-123` and `BACK-1.md` stay plain.
+4. Dependency chips link only when the referenced task is in the loaded corpus; unknown dependencies stay plain text instead of pointing at a route that cannot resolve.
+
+Tradeoffs recorded for review:
+- Auto-links render as plain anchors, like hand-written markdown links in this component, so following one is a full page load rather than a client-side route change. Chips keep client-side navigation. Making markdown links client-side would require a Router in MermaidMarkdown and its tests; not worth it for a localhost UI.
+- When the task corpus is empty (initial load, or MermaidMarkdown rendered outside the provider) nothing is linkified. Failing closed was preferred over emitting links that may not resolve.
+- The provider wrapper in App.tsx was added without re-indenting the 120-line JSX block it wraps, to keep the diff reviewable.
+
+Verification:
+- bunx tsc --noEmit and bun run check . clean.
+- bun test src/test/mermaid-markdown.test.tsx (12 pass) and src/test/web-dependency-input-links.test.tsx (2 pass).
+- Live check against this repo through `backlog browser`: task BACK-593 description rendered BACK-555/BACK-239/back-555 as /tasks/ links while UTF-8, ISO-8601, v1.2.3 and my-task-123 stayed plain; a scratch document confirmed a fenced block and an inline code span containing BACK-239 were not linkified while the same ID in prose was; clicking an auto-link opened the target task, and the BACK-544 dependency chip navigated to BACK-543.
+
+Full verification run: bun run test -> 1955 pass, 5 skip, 0 fail across 215 files; bunx tsc --noEmit clean; bun run check . clean; bun run build produced dist/backlog.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Took over PR #812 (David Cottrell, @cottrell): task IDs written in prose in the Web UI now render as links to /tasks/<id>, and dependency chips in the task details sidebar link to the task they reference. His two source commits were cherry-picked so his authorship stays in the history; the colliding back-555 task file was dropped.
+
+Both defects found in review are fixed. Detection now runs as a small remark plugin over the markdown AST (src/web/utils/task-id-links.ts) instead of a regex over the raw source, so inline code and fenced code blocks are excluded structurally and existing links keep their target. Candidates are validated against the task corpus the Web UI already loads, through a TaskIdIndexProvider fed by App state, so UTF-8, ISO-8601, v1.2.3 and unknown IDs never link, and boundary rules keep ID-shaped tails of longer identifiers (my-task-123, backlog/tasks/TASK-123, BACK-1.md) plain.
+
+Verified with 12 tests in src/test/mermaid-markdown.test.tsx and 2 in src/test/web-dependency-input-links.test.tsx, the full suite (1955 pass, 0 fail), tsc and biome clean, plus a live browser check against this repo: prose IDs linked, a fenced block and an inline code span with the same ID stayed plain, clicking an auto-link opened the target task, and a dependency chip navigated from BACK-544 to BACK-543.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-593 - Auto-link-task-IDs-in-web-markdown-to-task-deep-links.md
+++ b/backlog/tasks/back-593 - Auto-link-task-IDs-in-web-markdown-to-task-deep-links.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 21:10'
-updated_date: '2026-08-07 21:23'
+updated_date: '2026-08-07 22:16'
 labels:
   - web
 dependencies: []
@@ -35,6 +35,7 @@ Related: BACK-239 covers the same idea for documents and decisions plus backlink
 - [x] #4 Task IDs inside existing markdown links keep their original link target
 - [x] #5 Dependency chips in the task details sidebar link to the referenced task
 - [x] #6 Web component tests cover linking, code-block exclusion, non-task tokens, and dependency chip links
+- [x] #7 Following a task link from the task details modal with unsaved edits asks for confirmation before leaving, for both dependency chips and auto-linked IDs in markdown
 <!-- AC:END -->
 
 ## Definition of Done
@@ -82,6 +83,18 @@ Verification:
 - Live check against this repo through `backlog browser`: task BACK-593 description rendered BACK-555/BACK-239/back-555 as /tasks/ links while UTF-8, ISO-8601, v1.2.3 and my-task-123 stayed plain; a scratch document confirmed a fenced block and an inline code span containing BACK-239 were not linkified while the same ID in prose was; clicking an auto-link opened the target task, and the BACK-544 dependency chip navigated to BACK-543.
 
 Full verification run: bun run test -> 1955 pass, 5 skip, 0 fail across 215 files; bunx tsc --noEmit clean; bun run check . clean; bun run build produced dist/backlog.
+
+Review follow-up (PR #865, five accepted Codex findings):
+
+1. P1 unsaved-edit loss. Chip and prose links both left the task without passing the modal unsaved-changes confirmation. Fixed with one guard instead of two: TaskDetailsModal now handles clicks in the capture phase over its content grid, and when the form is in edit or create mode with unsaved changes it asks "Discard unsaved changes and leave this task?" before any in-modal link navigates. Declining cancels the event, which stops the react-router chip Link and the plain markdown anchor alike, so the full page load that would discard edits never starts. Same-page anchors (markdown heading links), new-tab clicks (modifier or target), and non-http schemes are exempt, and preview mode is untouched so inline title editing does not prompt spuriously.
+   Chosen over a beforeunload guard: the capture guard covers exactly the paths these links create, reuses the existing confirmation wording, and does not change reload or tab-close behaviour for the rest of the app. beforeunload remains absent, as before this change.
+2. P2 canonical collisions. buildTaskIdIndex now drops a canonical ID when two loaded tasks share it (BACK-1 and BACK-01), instead of keeping the last writer, matching resolveTaskById refusing to guess between ambiguous IDs.
+3. P2 chip identity. Dependency chips resolve through the shared index and canonicalTaskId instead of strict id equality, so dependencies differing in case or zero padding link to the right task, and ambiguous IDs stay plain. The index now maps canonical ID to the task, so chip label, chip href and markdown href all come from one resolution path.
+4. P2 legacy IDs. The candidate pattern widened to the shapes isValidTaskId accepts, including non-numeric bodies such as TASK-PREFIXED. Corpus validation stays fail-closed, so a wider pattern cannot produce false links; it also swallows whole hyphenated identifiers, which keeps my-task-123 plain for a better reason than before.
+5. P2 Unicode boundaries. Boundary tests use \p{L}\p{N}\p{M} classes against short slices rather than single UTF-16 units, so cafeBACK-123 and BACK-123 followed by a non-ASCII letter stay plain.
+
+Review-fix verification: 16 tests in src/test/mermaid-markdown.test.tsx, 4 in src/test/web-dependency-input-links.test.tsx, and a new src/test/web-task-details-modal-unsaved-navigation.test.tsx (4 tests, real DOM + react-router, covering decline-blocks-chip, accept-navigates, decline-blocks-comment-autolink, and no prompt when nothing is unsaved). Full suite 1965 pass, 5 skip, 0 fail across 216 files; bunx tsc --noEmit and bun run check . clean.
+Live browser pass of the P1 flow against this repo: on BACK-544 in edit mode with an unsaved title, clicking the BACK-543 dependency chip prompted once and stayed put with the edit intact; accepting the prompt navigated to BACK-543; a plain anchor to another task was blocked the same way while a same-page hash anchor was allowed without prompting. Re-rendered BACK-593 afterwards to confirm the wider candidate pattern still links only real IDs.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
@@ -89,7 +102,9 @@ Full verification run: bun run test -> 1955 pass, 5 skip, 0 fail across 215 file
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Took over PR #812 (David Cottrell, @cottrell): task IDs written in prose in the Web UI now render as links to /tasks/<id>, and dependency chips in the task details sidebar link to the task they reference. His two source commits were cherry-picked so his authorship stays in the history; the colliding back-555 task file was dropped.
 
-Both defects found in review are fixed. Detection now runs as a small remark plugin over the markdown AST (src/web/utils/task-id-links.ts) instead of a regex over the raw source, so inline code and fenced code blocks are excluded structurally and existing links keep their target. Candidates are validated against the task corpus the Web UI already loads, through a TaskIdIndexProvider fed by App state, so UTF-8, ISO-8601, v1.2.3 and unknown IDs never link, and boundary rules keep ID-shaped tails of longer identifiers (my-task-123, backlog/tasks/TASK-123, BACK-1.md) plain.
+Detection runs as a small remark plugin over the markdown AST (src/web/utils/task-id-links.ts) instead of a regex over the raw source, so inline code and fenced code blocks are excluded structurally and existing links keep their target. Candidates resolve against the task corpus the Web UI already loads, through a TaskIdIndexProvider fed by App state, so UTF-8, ISO-8601, v1.2.3 and unknown IDs never link; canonical collisions and ID-shaped tails of longer identifiers stay plain. Dependency chips resolve through that same canonical identity, so case and zero-padding differences still link and ambiguous IDs do not.
 
-Verified with 12 tests in src/test/mermaid-markdown.test.tsx and 2 in src/test/web-dependency-input-links.test.tsx, the full suite (1955 pass, 0 fail), tsc and biome clean, plus a live browser check against this repo: prose IDs linked, a fenced block and an inline code span with the same ID stayed plain, clicking an auto-link opened the target task, and a dependency chip navigated from BACK-544 to BACK-543.
+Because these links leave the open task, TaskDetailsModal now confirms before any in-modal link navigates away from unsaved edits, covering both the react-router chips and the plain markdown anchors; same-page anchors and new-tab clicks are exempt.
+
+Verified with 24 tests across three web component test files, the full suite (1965 pass, 5 skip, 0 fail), tsc and biome clean, and live browser passes: prose IDs linked while fenced and inline code stayed plain, an auto-link opened the target task, a dependency chip navigated between tasks, and the unsaved-edit prompt blocked and then allowed navigation as chosen.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/mermaid-markdown.test.tsx
+++ b/src/test/mermaid-markdown.test.tsx
@@ -56,4 +56,21 @@ describe("MermaidMarkdown", () => {
 			"/tasks/BACK-426?view=detail#second-heading",
 		]);
 	});
+
+	it("automatically links task IDs to /tasks/:id", () => {
+		const source = "Related task: TASK-358.8 and BACK-123.";
+		const html = renderToString(<MermaidMarkdown source={source} />);
+
+		expect(html).toContain('href="/tasks/TASK-358.8"');
+		expect(html).toContain('href="/tasks/BACK-123"');
+	});
+
+	it("does not auto-link task IDs inside code backticks or existing links", () => {
+		const source = "Code `TASK-100` and link [TASK-200](/tasks/TASK-200)";
+		const html = renderToString(<MermaidMarkdown source={source} />);
+
+		expect(html).toContain("<code>TASK-100</code>");
+		expect(html).not.toContain('href="/tasks/TASK-100"');
+		expect(html).toContain('href="/tasks/TASK-200"');
+	});
 });

--- a/src/test/mermaid-markdown.test.tsx
+++ b/src/test/mermaid-markdown.test.tsx
@@ -122,6 +122,12 @@ describe("MermaidMarkdown", () => {
 		expect(taskLinks(html)).toEqual([]);
 	});
 
+	it("does not auto-link IDs inside Windows-style paths", () => {
+		const html = renderMarkdown("File backlog\\tasks\\BACK-123 - Title.md stays plain.");
+
+		expect(taskLinks(html)).toEqual([]);
+	});
+
 	it("does not auto-link IDs that match no known task", () => {
 		const html = renderMarkdown("Unknown reference BACK-9999 stays plain.");
 

--- a/src/test/mermaid-markdown.test.tsx
+++ b/src/test/mermaid-markdown.test.tsx
@@ -11,19 +11,22 @@ afterEach(() => {
 	delete (globalThis as { navigator?: Navigator }).navigator;
 });
 
-const knownTasks: Task[] = ["TASK-358.8", "BACK-123", "TASK-100", "TASK-200", "TASK-123", "BACK-1"].map((id) => ({
-	id,
-	title: `Task ${id}`,
-	status: "To Do",
-	assignee: [],
-	createdDate: "2026-07-24",
-	labels: [],
-	dependencies: [],
-}));
+const taskFixtures = (...ids: string[]): Task[] =>
+	ids.map((id) => ({
+		id,
+		title: `Task ${id}`,
+		status: "To Do",
+		assignee: [],
+		createdDate: "2026-07-24",
+		labels: [],
+		dependencies: [],
+	}));
 
-function renderMarkdown(source: string): string {
+const knownTasks = taskFixtures("TASK-358.8", "BACK-123", "TASK-100", "TASK-200", "TASK-123", "BACK-1", "TASK-PREFIXED");
+
+function renderMarkdown(source: string, tasks: Task[] = knownTasks): string {
 	return renderToString(
-		<TaskIdIndexProvider tasks={knownTasks}>
+		<TaskIdIndexProvider tasks={tasks}>
 			<MermaidMarkdown source={source} />
 		</TaskIdIndexProvider>,
 	);
@@ -129,5 +132,30 @@ describe("MermaidMarkdown", () => {
 		const html = renderMarkdown("## Blocked by BACK-123\n\n- depends on TASK-100\n");
 
 		expect(taskLinks(html)).toEqual(["/tasks/BACK-123", "/tasks/TASK-100"]);
+	});
+
+	it("links zero-padded references to the canonical task", () => {
+		const html = renderMarkdown("Padded reference BACK-0123 resolves.");
+
+		expect(taskLinks(html)).toEqual(["/tasks/BACK-123"]);
+	});
+
+	it("links legacy non-numeric task IDs", () => {
+		const html = renderMarkdown("Legacy reference TASK-PREFIXED resolves.");
+
+		expect(taskLinks(html)).toEqual(["/tasks/TASK-PREFIXED"]);
+	});
+
+	it("leaves references plain when two loaded tasks share a canonical ID", () => {
+		const ambiguousTasks = taskFixtures("BACK-1", "BACK-01", "BACK-2");
+		const html = renderMarkdown("Ambiguous BACK-1 and unambiguous BACK-2.", ambiguousTasks);
+
+		expect(taskLinks(html)).toEqual(["/tasks/BACK-2"]);
+	});
+
+	it("does not auto-link IDs embedded in non-ASCII identifiers", () => {
+		const html = renderMarkdown("Tokens caféBACK-123 and BACK-123ä stay plain.");
+
+		expect(taskLinks(html)).toEqual([]);
 	});
 });

--- a/src/test/mermaid-markdown.test.tsx
+++ b/src/test/mermaid-markdown.test.tsx
@@ -1,13 +1,38 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { JSDOM } from "jsdom";
 import { renderToString } from "react-dom/server";
+import type { Task } from "../types/index.ts";
 import MermaidMarkdown from "../web/components/MermaidMarkdown.tsx";
+import { TaskIdIndexProvider } from "../web/contexts/TaskIdIndexContext.tsx";
 
 afterEach(() => {
 	delete (globalThis as { window?: Window & typeof globalThis }).window;
 	delete (globalThis as { document?: Document }).document;
 	delete (globalThis as { navigator?: Navigator }).navigator;
 });
+
+const knownTasks: Task[] = ["TASK-358.8", "BACK-123", "TASK-100", "TASK-200", "TASK-123", "BACK-1"].map((id) => ({
+	id,
+	title: `Task ${id}`,
+	status: "To Do",
+	assignee: [],
+	createdDate: "2026-07-24",
+	labels: [],
+	dependencies: [],
+}));
+
+function renderMarkdown(source: string): string {
+	return renderToString(
+		<TaskIdIndexProvider tasks={knownTasks}>
+			<MermaidMarkdown source={source} />
+		</TaskIdIndexProvider>,
+	);
+}
+
+function taskLinks(html: string): string[] {
+	const rendered = new JSDOM(html).window.document;
+	return Array.from(rendered.querySelectorAll('a[href^="/tasks/"]')).map((link) => link.getAttribute("href") ?? "");
+}
 
 describe("MermaidMarkdown", () => {
 	it("renders angle-bracket type strings without throwing", () => {
@@ -58,19 +83,51 @@ describe("MermaidMarkdown", () => {
 	});
 
 	it("automatically links task IDs to /tasks/:id", () => {
-		const source = "Related task: TASK-358.8 and BACK-123.";
-		const html = renderToString(<MermaidMarkdown source={source} />);
+		const html = renderMarkdown("Related task: TASK-358.8 and BACK-123.");
 
-		expect(html).toContain('href="/tasks/TASK-358.8"');
-		expect(html).toContain('href="/tasks/BACK-123"');
+		expect(taskLinks(html)).toEqual(["/tasks/TASK-358.8", "/tasks/BACK-123"]);
+	});
+
+	it("links task IDs written in lower case to their canonical task", () => {
+		const html = renderMarkdown("See back-123 for context.");
+
+		expect(taskLinks(html)).toEqual(["/tasks/BACK-123"]);
 	});
 
 	it("does not auto-link task IDs inside code backticks or existing links", () => {
-		const source = "Code `TASK-100` and link [TASK-200](/tasks/TASK-200)";
-		const html = renderToString(<MermaidMarkdown source={source} />);
+		const html = renderMarkdown("Code `TASK-100` and link [TASK-200](/tasks/TASK-200?view=detail)");
 
 		expect(html).toContain("<code>TASK-100</code>");
-		expect(html).not.toContain('href="/tasks/TASK-100"');
-		expect(html).toContain('href="/tasks/TASK-200"');
+		expect(taskLinks(html)).toEqual(["/tasks/TASK-200?view=detail"]);
+	});
+
+	it("does not auto-link task IDs inside fenced code blocks", () => {
+		const html = renderMarkdown("Run this:\n\n```bash\nbacklog task view TASK-100\n```\n\nThen open BACK-123.");
+
+		expect(taskLinks(html)).toEqual(["/tasks/BACK-123"]);
+	});
+
+	it("does not auto-link tokens that only look like task IDs", () => {
+		const html = renderMarkdown("Encoding UTF-8, dates in ISO-8601, release v1.2.3, file BACK-1.md.");
+
+		expect(taskLinks(html)).toEqual([]);
+	});
+
+	it("does not auto-link an ID-shaped tail of a longer identifier", () => {
+		const html = renderMarkdown("Branch my-task-123 and path backlog/tasks/TASK-123 stay plain.");
+
+		expect(taskLinks(html)).toEqual([]);
+	});
+
+	it("does not auto-link IDs that match no known task", () => {
+		const html = renderMarkdown("Unknown reference BACK-9999 stays plain.");
+
+		expect(taskLinks(html)).toEqual([]);
+	});
+
+	it("links task IDs inside list items and headings", () => {
+		const html = renderMarkdown("## Blocked by BACK-123\n\n- depends on TASK-100\n");
+
+		expect(taskLinks(html)).toEqual(["/tasks/BACK-123", "/tasks/TASK-100"]);
 	});
 });

--- a/src/test/web-dependency-input-links.test.tsx
+++ b/src/test/web-dependency-input-links.test.tsx
@@ -5,22 +5,23 @@ import { MemoryRouter } from "react-router-dom";
 import type { Task } from "../types/index.ts";
 import DependencyInput from "../web/components/DependencyInput.tsx";
 
-const availableTasks: Task[] = [
-	{
-		id: "BACK-10",
-		title: "Known dependency",
+const taskFixtures = (...ids: string[]): Task[] =>
+	ids.map((id) => ({
+		id,
+		title: `Task ${id}`,
 		status: "To Do",
 		assignee: [],
 		createdDate: "2026-07-24",
 		labels: [],
 		dependencies: [],
-	},
-];
+	}));
 
-function renderChips(dependencies: string[]): Document {
+const availableTasks = taskFixtures("BACK-10");
+
+function renderChips(dependencies: string[], tasks: Task[] = availableTasks): Document {
 	const html = renderToString(
 		<MemoryRouter>
-			<DependencyInput value={dependencies} onChange={() => {}} availableTasks={availableTasks} />
+			<DependencyInput value={dependencies} onChange={() => {}} availableTasks={tasks} />
 		</MemoryRouter>,
 	);
 	return new JSDOM(html).window.document;
@@ -32,7 +33,15 @@ describe("DependencyInput dependency chips", () => {
 		const link = rendered.querySelector('a[href="/tasks/BACK-10"]');
 
 		expect(link).toBeTruthy();
-		expect(link?.textContent).toBe("BACK-10 - Known dependency");
+		expect(link?.textContent).toBe("BACK-10 - Task BACK-10");
+	});
+
+	it("resolves dependencies that differ in case or zero padding", () => {
+		const rendered = renderChips(["back-010"]);
+		const link = rendered.querySelector('a[href="/tasks/BACK-10"]');
+
+		expect(link).toBeTruthy();
+		expect(link?.textContent).toBe("BACK-10 - Task BACK-10");
 	});
 
 	it("keeps dependencies that match no loaded task as plain text", () => {
@@ -40,5 +49,12 @@ describe("DependencyInput dependency chips", () => {
 
 		expect(rendered.querySelectorAll("a").length).toBe(0);
 		expect(rendered.body.textContent).toContain("BACK-9999");
+	});
+
+	it("keeps dependencies plain when two loaded tasks share a canonical ID", () => {
+		const rendered = renderChips(["BACK-1"], taskFixtures("BACK-1", "BACK-01"));
+
+		expect(rendered.querySelectorAll("a").length).toBe(0);
+		expect(rendered.body.textContent).toContain("BACK-1");
 	});
 });

--- a/src/test/web-dependency-input-links.test.tsx
+++ b/src/test/web-dependency-input-links.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { renderToString } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { Task } from "../types/index.ts";
+import DependencyInput from "../web/components/DependencyInput.tsx";
+
+const availableTasks: Task[] = [
+	{
+		id: "BACK-10",
+		title: "Known dependency",
+		status: "To Do",
+		assignee: [],
+		createdDate: "2026-07-24",
+		labels: [],
+		dependencies: [],
+	},
+];
+
+function renderChips(dependencies: string[]): Document {
+	const html = renderToString(
+		<MemoryRouter>
+			<DependencyInput value={dependencies} onChange={() => {}} availableTasks={availableTasks} />
+		</MemoryRouter>,
+	);
+	return new JSDOM(html).window.document;
+}
+
+describe("DependencyInput dependency chips", () => {
+	it("links a dependency chip to the task it references", () => {
+		const rendered = renderChips(["BACK-10"]);
+		const link = rendered.querySelector('a[href="/tasks/BACK-10"]');
+
+		expect(link).toBeTruthy();
+		expect(link?.textContent).toBe("BACK-10 - Known dependency");
+	});
+
+	it("keeps dependencies that match no loaded task as plain text", () => {
+		const rendered = renderChips(["BACK-9999"]);
+
+		expect(rendered.querySelectorAll("a").length).toBe(0);
+		expect(rendered.body.textContent).toContain("BACK-9999");
+	});
+});

--- a/src/test/web-task-details-modal-unsaved-navigation.test.tsx
+++ b/src/test/web-task-details-modal-unsaved-navigation.test.tsx
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import type { Task } from "../types/index.ts";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal";
+import { TaskIdIndexProvider } from "../web/contexts/TaskIdIndexContext.tsx";
+import { ThemeProvider } from "../web/contexts/ThemeContext";
+
+let activeRoot: Root | null = null;
+let activeDom: JSDOM | null = null;
+let currentPath = "";
+
+const dependency: Task = {
+	id: "BACK-2",
+	title: "Dependency task",
+	status: "To Do",
+	assignee: [],
+	createdDate: "2026-08-07",
+	labels: [],
+	dependencies: [],
+};
+
+const task: Task = {
+	id: "BACK-1",
+	title: "Task being edited",
+	status: "To Do",
+	assignee: [],
+	createdDate: "2026-08-07",
+	labels: [],
+	dependencies: ["BACK-2"],
+	references: [],
+	comments: [{ index: 1, body: "Blocked by BACK-2 until it lands.", createdDate: "2026-08-07" }],
+};
+
+const setupDom = () => {
+	activeDom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: "http://localhost",
+	});
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = activeDom.window as unknown as Window & typeof globalThis;
+	globalThis.document = activeDom.window.document as Document;
+	globalThis.navigator = activeDom.window.navigator as Navigator;
+	globalThis.localStorage = activeDom.window.localStorage;
+	globalThis.Element = activeDom.window.Element;
+	globalThis.HTMLElement = activeDom.window.HTMLElement;
+	globalThis.HTMLInputElement = activeDom.window.HTMLInputElement;
+	globalThis.HTMLTextAreaElement = activeDom.window.HTMLTextAreaElement;
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(callback, 0);
+	globalThis.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
+
+	window.matchMedia = () =>
+		({
+			matches: false,
+			media: "",
+			onchange: null,
+			addListener: () => {},
+			removeListener: () => {},
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			dispatchEvent: () => false,
+		}) as MediaQueryList;
+
+	const htmlElementPrototype = window.HTMLElement.prototype as unknown as {
+		attachEvent?: () => void;
+		detachEvent?: () => void;
+	};
+	htmlElementPrototype.attachEvent = () => {};
+	htmlElementPrototype.detachEvent = () => {};
+};
+
+function LocationProbe() {
+	currentPath = useLocation().pathname;
+	return null;
+}
+
+const mountModal = async (): Promise<HTMLElement> => {
+	setupDom();
+	currentPath = "";
+	const container = document.getElementById("root");
+	activeRoot = createRoot(container as HTMLElement);
+	await act(async () => {
+		activeRoot?.render(
+			<MemoryRouter initialEntries={["/tasks/BACK-1"]}>
+				<ThemeProvider>
+					<TaskIdIndexProvider tasks={[task, dependency]}>
+						<LocationProbe />
+						<TaskDetailsModal
+							task={task}
+							isOpen={true}
+							onClose={() => {}}
+							availableTasks={[task, dependency]}
+						/>
+					</TaskIdIndexProvider>
+				</ThemeProvider>
+			</MemoryRouter>,
+		);
+		await Promise.resolve();
+	});
+	return container as HTMLElement;
+};
+
+const click = async (element: Element): Promise<MouseEvent> => {
+	const event = new window.MouseEvent("click", { bubbles: true, cancelable: true });
+	await act(async () => {
+		element.dispatchEvent(event);
+		await Promise.resolve();
+	});
+	return event;
+};
+
+const typeInto = async (element: HTMLInputElement, value: string) => {
+	const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+	await act(async () => {
+		setter?.call(element, value);
+		element.dispatchEvent(new window.Event("input", { bubbles: true }));
+		await Promise.resolve();
+	});
+};
+
+const startEditingWithUnsavedChanges = async (container: HTMLElement) => {
+	const editButton = Array.from(container.querySelectorAll("button")).find(
+		(button) => button.textContent?.trim() === "Edit",
+	);
+	expect(editButton).toBeTruthy();
+	await click(editButton as Element);
+
+	const titleInput = Array.from(container.querySelectorAll("input")).find((input) => input.value === task.title);
+	expect(titleInput).toBeTruthy();
+	await typeInto(titleInput as HTMLInputElement, "Task being edited with unsaved work");
+};
+
+const findLinkByText = (container: HTMLElement, text: string): HTMLAnchorElement => {
+	const link = Array.from(container.querySelectorAll('a[href="/tasks/BACK-2"]')).find(
+		(candidate) => candidate.textContent === text,
+	);
+	expect(link, `link "${text}"`).toBeTruthy();
+	return link as HTMLAnchorElement;
+};
+
+/** Dependency chip: a react-router link that changes the route in place. */
+const findChipLink = (container: HTMLElement) => findLinkByText(container, `${dependency.id} - ${dependency.title}`);
+/** Auto-linked task ID in a comment: a plain anchor that would reload the page. */
+const findCommentLink = (container: HTMLElement) => findLinkByText(container, dependency.id);
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => {
+			activeRoot?.unmount();
+		});
+		activeRoot = null;
+	}
+	activeDom?.window.close();
+	activeDom = null;
+});
+
+describe("Task details modal navigation with unsaved edits", () => {
+	it("keeps the editor open when a dependency chip is clicked and the discard prompt is declined", async () => {
+		const container = await mountModal();
+		await startEditingWithUnsavedChanges(container);
+
+		let prompts = 0;
+		window.confirm = () => {
+			prompts += 1;
+			return false;
+		};
+
+		const event = await click(findChipLink(container));
+
+		expect(prompts).toBe(1);
+		expect(event.defaultPrevented).toBe(true);
+		expect(currentPath).toBe("/tasks/BACK-1");
+	});
+
+	it("navigates from a dependency chip once the discard prompt is accepted", async () => {
+		const container = await mountModal();
+		await startEditingWithUnsavedChanges(container);
+
+		window.confirm = () => true;
+
+		await click(findChipLink(container));
+
+		expect(currentPath).toBe("/tasks/BACK-2");
+	});
+
+	it("blocks an auto-linked task ID in a comment when the discard prompt is declined", async () => {
+		const container = await mountModal();
+		await startEditingWithUnsavedChanges(container);
+
+		window.confirm = () => false;
+
+		const event = await click(findCommentLink(container));
+
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it("lets links through while there is nothing unsaved to lose", async () => {
+		const container = await mountModal();
+
+		let prompts = 0;
+		window.confirm = () => {
+			prompts += 1;
+			return false;
+		};
+
+		await click(findChipLink(container));
+
+		expect(prompts).toBe(0);
+		expect(currentPath).toBe("/tasks/BACK-2");
+	});
+});

--- a/src/test/web-task-details-modal-unsaved-navigation.test.tsx
+++ b/src/test/web-task-details-modal-unsaved-navigation.test.tsx
@@ -75,7 +75,7 @@ function LocationProbe() {
 	return null;
 }
 
-const mountModal = async (): Promise<HTMLElement> => {
+const renderModal = async (modalTask: Task | undefined): Promise<HTMLElement> => {
 	setupDom();
 	currentPath = "";
 	const container = document.getElementById("root");
@@ -87,7 +87,7 @@ const mountModal = async (): Promise<HTMLElement> => {
 					<TaskIdIndexProvider tasks={[task, dependency]}>
 						<LocationProbe />
 						<TaskDetailsModal
-							task={task}
+							task={modalTask}
 							isOpen={true}
 							onClose={() => {}}
 							availableTasks={[task, dependency]}
@@ -101,6 +101,11 @@ const mountModal = async (): Promise<HTMLElement> => {
 	return container as HTMLElement;
 };
 
+/** Existing task, opens in preview mode. */
+const mountModal = () => renderModal(task);
+/** No task, opens in create mode. */
+const mountCreateModal = () => renderModal(undefined);
+
 const click = async (element: Element): Promise<MouseEvent> => {
 	const event = new window.MouseEvent("click", { bubbles: true, cancelable: true });
 	await act(async () => {
@@ -110,8 +115,10 @@ const click = async (element: Element): Promise<MouseEvent> => {
 	return event;
 };
 
-const typeInto = async (element: HTMLInputElement, value: string) => {
-	const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+const typeInto = async (element: HTMLInputElement | HTMLTextAreaElement, value: string) => {
+	const prototype =
+		element.tagName === "TEXTAREA" ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+	const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
 	await act(async () => {
 		setter?.call(element, value);
 		element.dispatchEvent(new window.Event("input", { bubbles: true }));
@@ -119,12 +126,32 @@ const typeInto = async (element: HTMLInputElement, value: string) => {
 	});
 };
 
-const startEditingWithUnsavedChanges = async (container: HTMLElement) => {
+const pressEnter = async (element: Element) => {
+	await act(async () => {
+		element.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+		await Promise.resolve();
+	});
+};
+
+const startEditing = async (container: HTMLElement) => {
 	const editButton = Array.from(container.querySelectorAll("button")).find(
 		(button) => button.textContent?.trim() === "Edit",
 	);
 	expect(editButton).toBeTruthy();
 	await click(editButton as Element);
+};
+
+const declineOnConfirm = () => {
+	const prompts: string[] = [];
+	window.confirm = (message?: string) => {
+		prompts.push(message ?? "");
+		return false;
+	};
+	return prompts;
+};
+
+const startEditingWithUnsavedChanges = async (container: HTMLElement) => {
+	await startEditing(container);
 
 	const titleInput = Array.from(container.querySelectorAll("input")).find((input) => input.value === task.title);
 	expect(titleInput).toBeTruthy();
@@ -182,6 +209,38 @@ describe("Task details modal navigation with unsaved edits", () => {
 		await click(findChipLink(container));
 
 		expect(currentPath).toBe("/tasks/BACK-2");
+	});
+
+	it("protects a comment draft that is the only unsaved work", async () => {
+		const container = await mountModal();
+		await startEditing(container);
+
+		const commentBox = container.querySelector('textarea[placeholder="Add a comment..."]');
+		expect(commentBox).toBeTruthy();
+		await typeInto(commentBox as HTMLTextAreaElement, "Draft comment nobody has submitted yet");
+
+		const prompts = declineOnConfirm();
+		const event = await click(findChipLink(container));
+
+		expect(prompts.length).toBe(1);
+		expect(event.defaultPrevented).toBe(true);
+		expect(currentPath).toBe("/tasks/BACK-1");
+	});
+
+	it("protects create-mode metadata entered before any title", async () => {
+		const container = await mountCreateModal();
+
+		const dependencyInput = container.querySelector("#dependency-input");
+		expect(dependencyInput).toBeTruthy();
+		await typeInto(dependencyInput as HTMLTextAreaElement, dependency.id);
+		await pressEnter(dependencyInput as Element);
+
+		const prompts = declineOnConfirm();
+		const event = await click(findChipLink(container));
+
+		expect(prompts.length).toBe(1);
+		expect(event.defaultPrevented).toBe(true);
+		expect(currentPath).toBe("/tasks/BACK-1");
 	});
 
 	it("blocks an auto-linked task ID in a comment when the discard prompt is declined", async () => {

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -13,6 +13,7 @@ import TaskDetailsModal from './components/TaskDetailsModal';
 import InitializationScreen from './components/InitializationScreen';
 import { SuccessToast } from './components/SuccessToast';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { TaskIdIndexProvider } from './contexts/TaskIdIndexContext';
 import {
 	type Decision,
 	type DecisionSearchResult,
@@ -703,6 +704,7 @@ function AppContent() {
 
   return (
     <ThemeProvider>
+      <TaskIdIndexProvider tasks={tasks}>
       <Routes>
             <Route
             path="/"
@@ -826,6 +828,7 @@ function AppContent() {
           }
         />
       )}
+      </TaskIdIndexProvider>
     </ThemeProvider>
   );
 }

--- a/src/web/components/DependencyInput.tsx
+++ b/src/web/components/DependencyInput.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, type KeyboardEvent } from 'react';
+import { Link } from 'react-router-dom';
 import { type Task } from '../../types';
 
 interface DependencyInputProps {
@@ -117,7 +118,13 @@ const DependencyInput: React.FC<DependencyInputProps> = ({ value, onChange, avai
                   key={index}
                   className="inline-flex items-center gap-1 px-2 py-0.5 text-sm bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200 rounded-md transition-colors duration-200 min-w-0 max-w-full"
                 >
-                  <span className="truncate max-w-[16rem] sm:max-w-[20rem] md:max-w-[24rem]">{getTaskDisplay(taskId)}</span>
+                  <Link
+                    to={`/tasks/${taskId}`}
+                    className="truncate max-w-[16rem] sm:max-w-[20rem] md:max-w-[24rem] hover:underline"
+                    title={getTaskDisplay(taskId)}
+                  >
+                    {getTaskDisplay(taskId)}
+                  </Link>
 	                  {!disabled && (
 	                    <button
 	                      type="button"

--- a/src/web/components/DependencyInput.tsx
+++ b/src/web/components/DependencyInput.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useRef, useEffect, type KeyboardEvent } from 'react';
+import React, { useState, useRef, useEffect, useMemo, type KeyboardEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { type Task } from '../../types';
+import { buildTaskIdIndex, resolveTaskReference } from '../utils/task-id-links';
 
 const CHIP_LABEL_CLASS = 'truncate max-w-[16rem] sm:max-w-[20rem] md:max-w-[24rem]';
 
@@ -20,14 +21,10 @@ const DependencyInput: React.FC<DependencyInputProps> = ({ value, onChange, avai
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputId = 'dependency-input';
 
-  // Get task display text
-  const getTaskDisplay = (taskId: string) => {
-    const task = availableTasks.find(t => t.id === taskId);
-    return task ? `${task.id} - ${task.title}` : taskId;
-  };
-
-  // Only link dependencies that resolve to a loaded task
-  const isKnownTask = (taskId: string) => availableTasks.some(t => t.id === taskId);
+  // Resolve chips through the same canonical identity the markdown auto-links use, so
+  // case and zero-padding differences still resolve and ambiguous IDs stay unlinked
+  const taskIdIndex = useMemo(() => buildTaskIdIndex(availableTasks), [availableTasks]);
+  const resolveDependency = (taskId: string) => resolveTaskReference(taskIdIndex, taskId);
 
   // Filter tasks based on input
   useEffect(() => {
@@ -118,21 +115,24 @@ const DependencyInput: React.FC<DependencyInputProps> = ({ value, onChange, avai
           {/* Display selected dependencies */}
           {value.length > 0 && (
             <div className="flex flex-wrap gap-2 mb-2">
-              {value.map((taskId, index) => (
+              {value.map((taskId, index) => {
+                const dependency = resolveDependency(taskId);
+                const display = dependency ? `${dependency.id} - ${dependency.title}` : taskId;
+                return (
                 <span
                   key={index}
                   className="inline-flex items-center gap-1 px-2 py-0.5 text-sm bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200 rounded-md transition-colors duration-200 min-w-0 max-w-full"
                 >
-                  {isKnownTask(taskId) ? (
+                  {dependency ? (
                     <Link
-                      to={`/tasks/${taskId}`}
+                      to={`/tasks/${dependency.id}`}
                       className={`${CHIP_LABEL_CLASS} hover:underline`}
-                      title={getTaskDisplay(taskId)}
+                      title={display}
                     >
-                      {getTaskDisplay(taskId)}
+                      {display}
                     </Link>
                   ) : (
-                    <span className={CHIP_LABEL_CLASS} title={getTaskDisplay(taskId)}>{getTaskDisplay(taskId)}</span>
+                    <span className={CHIP_LABEL_CLASS} title={display}>{display}</span>
                   )}
 	                  {!disabled && (
 	                    <button
@@ -151,7 +151,8 @@ const DependencyInput: React.FC<DependencyInputProps> = ({ value, onChange, avai
                     </button>
                   )}
                 </span>
-              ))}
+                );
+              })}
             </div>
           )}
           

--- a/src/web/components/DependencyInput.tsx
+++ b/src/web/components/DependencyInput.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect, type KeyboardEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { type Task } from '../../types';
 
+const CHIP_LABEL_CLASS = 'truncate max-w-[16rem] sm:max-w-[20rem] md:max-w-[24rem]';
+
 interface DependencyInputProps {
   value: string[];
   onChange: (values: string[]) => void;
@@ -23,6 +25,9 @@ const DependencyInput: React.FC<DependencyInputProps> = ({ value, onChange, avai
     const task = availableTasks.find(t => t.id === taskId);
     return task ? `${task.id} - ${task.title}` : taskId;
   };
+
+  // Only link dependencies that resolve to a loaded task
+  const isKnownTask = (taskId: string) => availableTasks.some(t => t.id === taskId);
 
   // Filter tasks based on input
   useEffect(() => {
@@ -118,13 +123,17 @@ const DependencyInput: React.FC<DependencyInputProps> = ({ value, onChange, avai
                   key={index}
                   className="inline-flex items-center gap-1 px-2 py-0.5 text-sm bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200 rounded-md transition-colors duration-200 min-w-0 max-w-full"
                 >
-                  <Link
-                    to={`/tasks/${taskId}`}
-                    className="truncate max-w-[16rem] sm:max-w-[20rem] md:max-w-[24rem] hover:underline"
-                    title={getTaskDisplay(taskId)}
-                  >
-                    {getTaskDisplay(taskId)}
-                  </Link>
+                  {isKnownTask(taskId) ? (
+                    <Link
+                      to={`/tasks/${taskId}`}
+                      className={`${CHIP_LABEL_CLASS} hover:underline`}
+                      title={getTaskDisplay(taskId)}
+                    >
+                      {getTaskDisplay(taskId)}
+                    </Link>
+                  ) : (
+                    <span className={CHIP_LABEL_CLASS} title={getTaskDisplay(taskId)}>{getTaskDisplay(taskId)}</span>
+                  )}
 	                  {!disabled && (
 	                    <button
 	                      type="button"

--- a/src/web/components/MermaidMarkdown.tsx
+++ b/src/web/components/MermaidMarkdown.tsx
@@ -8,15 +8,38 @@ interface Props {
 
 const URI_AUTOLINK_PREFIX_REGEX = /^<[A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\u0000-\u0020]*>/;
 const EMAIL_AUTOLINK_PREFIX_REGEX = /^<[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+\.[A-Za-z0-9-]+>/;
+const TASK_ID_REGEX = /\b([a-zA-Z]+-\d+(?:\.\d+)*)\b/g;
 
 function sanitizeMarkdownSource(source: string): string {
-	return source.replace(/<(?=[A-Za-z])/g, (match, offset, fullText) => {
+	let processed = source.replace(/<(?=[A-Za-z])/g, (match, offset, fullText) => {
 		const remaining = fullText.slice(offset);
 		if (URI_AUTOLINK_PREFIX_REGEX.test(remaining) || EMAIL_AUTOLINK_PREFIX_REGEX.test(remaining)) {
 			return match;
 		}
 		return "&lt;";
 	});
+
+	// Auto-link task IDs (e.g., TASK-123, BACK-456, TASK-358.8)
+	processed = processed.replace(TASK_ID_REGEX, (match, _id, offset, fullText) => {
+		const before = fullText.slice(Math.max(0, offset - 2), offset);
+		const after = fullText.slice(offset + match.length, offset + match.length + 2);
+
+		if (before === "](" || before === "(#" || (before.startsWith("[") && after.endsWith("]"))) {
+			return match;
+		}
+
+		// Avoid linking if inside a code block or backticks (odd number of backticks on line)
+		const lines = fullText.slice(0, offset).split("\n");
+		const currentLine = lines[lines.length - 1] || "";
+		const backtickCount = (currentLine.match(/`/g) || []).length;
+		if (backtickCount % 2 !== 0) {
+			return match;
+		}
+
+		return `[${match}](/tasks/${match})`;
+	});
+
+	return processed;
 }
 
 function keepHashLinksInCurrentRoute(url: string, key: string): string {

--- a/src/web/components/MermaidMarkdown.tsx
+++ b/src/web/components/MermaidMarkdown.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import MDEditor from "@uiw/react-md-editor";
+import { useTaskIdIndex } from "../contexts/TaskIdIndexContext";
 import { renderMermaidIn } from "../utils/mermaid";
+import { createTaskIdLinkPlugin } from "../utils/task-id-links";
 
 interface Props {
 	source: string;
@@ -8,38 +10,15 @@ interface Props {
 
 const URI_AUTOLINK_PREFIX_REGEX = /^<[A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\u0000-\u0020]*>/;
 const EMAIL_AUTOLINK_PREFIX_REGEX = /^<[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+\.[A-Za-z0-9-]+>/;
-const TASK_ID_REGEX = /\b([a-zA-Z]+-\d+(?:\.\d+)*)\b/g;
 
 function sanitizeMarkdownSource(source: string): string {
-	let processed = source.replace(/<(?=[A-Za-z])/g, (match, offset, fullText) => {
+	return source.replace(/<(?=[A-Za-z])/g, (match, offset, fullText) => {
 		const remaining = fullText.slice(offset);
 		if (URI_AUTOLINK_PREFIX_REGEX.test(remaining) || EMAIL_AUTOLINK_PREFIX_REGEX.test(remaining)) {
 			return match;
 		}
 		return "&lt;";
 	});
-
-	// Auto-link task IDs (e.g., TASK-123, BACK-456, TASK-358.8)
-	processed = processed.replace(TASK_ID_REGEX, (match, _id, offset, fullText) => {
-		const before = fullText.slice(Math.max(0, offset - 2), offset);
-		const after = fullText.slice(offset + match.length, offset + match.length + 2);
-
-		if (before === "](" || before === "(#" || (before.startsWith("[") && after.endsWith("]"))) {
-			return match;
-		}
-
-		// Avoid linking if inside a code block or backticks (odd number of backticks on line)
-		const lines = fullText.slice(0, offset).split("\n");
-		const currentLine = lines[lines.length - 1] || "";
-		const backtickCount = (currentLine.match(/`/g) || []).length;
-		if (backtickCount % 2 !== 0) {
-			return match;
-		}
-
-		return `[${match}](/tasks/${match})`;
-	});
-
-	return processed;
 }
 
 function keepHashLinksInCurrentRoute(url: string, key: string): string {
@@ -53,6 +32,8 @@ function keepHashLinksInCurrentRoute(url: string, key: string): string {
 export default function MermaidMarkdown({ source }: Props) {
 	const ref = useRef<HTMLDivElement | null>(null);
 	const safeSource = sanitizeMarkdownSource(source);
+	const taskIdIndex = useTaskIdIndex();
+	const remarkPlugins = useMemo(() => [createTaskIdLinkPlugin(taskIdIndex)], [taskIdIndex]);
 
 	useEffect(() => {
 		if (!ref.current) return;
@@ -70,7 +51,11 @@ export default function MermaidMarkdown({ source }: Props) {
 
 	return (
 		<div ref={ref} className="wmde-markdown">
-			<MDEditor.Markdown source={safeSource} urlTransform={keepHashLinksInCurrentRoute} />
+			<MDEditor.Markdown
+				source={safeSource}
+				urlTransform={keepHashLinksInCurrentRoute}
+				remarkPlugins={remarkPlugins}
+			/>
 		</div>
 	);
 }

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -493,7 +493,20 @@ export const TaskDetailsModal: React.FC<Props> = ({
     if (onSaved) void onSaved();
   }, [commentsChanged, onSaved]);
 
-  const hasUnsavedEdits = (mode === "edit" || mode === "create") && isDirty;
+  const hasCommentDraft = commentBody.trim() !== "" || commentAuthor.trim() !== "";
+  // Nothing is persisted while creating, so any entered field is unsaved work.
+  const hasCreateModeEntries =
+    isCreateMode &&
+    (title.trim() !== "" ||
+      taskType.trim() !== "" ||
+      priority.trim() !== "" ||
+      milestone.trim() !== "" ||
+      assignee.length > 0 ||
+      labels.length > 0 ||
+      dependencies.length > 0 ||
+      references.length > 0);
+  const hasUnsavedEdits =
+    (mode === "edit" || mode === "create") && (isDirty || hasCommentDraft || hasCreateModeEntries);
 
   // Links inside the modal (dependency chips, auto-linked task IDs in markdown) leave this
   // task behind, so they ask the same question closing does before the navigation happens.

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -493,6 +493,25 @@ export const TaskDetailsModal: React.FC<Props> = ({
     if (onSaved) void onSaved();
   }, [commentsChanged, onSaved]);
 
+  const hasUnsavedEdits = (mode === "edit" || mode === "create") && isDirty;
+
+  // Links inside the modal (dependency chips, auto-linked task IDs in markdown) leave this
+  // task behind, so they ask the same question closing does before the navigation happens.
+  const confirmNavigationAwayFromEdits = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!hasUnsavedEdits || event.defaultPrevented || event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    const link = (event.target as Element | null)?.closest?.("a[href]") as HTMLAnchorElement | null;
+    if (!link) return;
+    if (link.target && link.target !== "_self") return;
+    const destination = new URL(link.href, window.location.href);
+    if (destination.protocol !== "http:" && destination.protocol !== "https:") return;
+    // Same-page anchors (markdown heading links) do not unload the form.
+    if (destination.pathname === window.location.pathname && destination.search === window.location.search) return;
+    if (window.confirm("Discard unsaved changes and leave this task?")) return;
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   const handleCancelEdit = () => {
     if (isDirty) {
       const confirmDiscard = window.confirm("Discard unsaved changes?");
@@ -918,7 +937,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
         </div>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6" onClickCapture={confirmNavigationAwayFromEdits}>
         {/* Main content */}
         <div className="md:col-span-2 space-y-6">
           {/* Title field for create mode */}

--- a/src/web/contexts/TaskIdIndexContext.tsx
+++ b/src/web/contexts/TaskIdIndexContext.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { type Task } from '../../types';
+import { buildTaskIdIndex, type TaskIdIndex } from '../utils/task-id-links';
+
+const EMPTY_INDEX: TaskIdIndex = new Map();
+
+const TaskIdIndexContext = createContext<TaskIdIndex>(EMPTY_INDEX);
+
+/** Known task IDs, used to auto-link task references in rendered markdown. */
+export const useTaskIdIndex = () => useContext(TaskIdIndexContext);
+
+interface TaskIdIndexProviderProps {
+	tasks: Task[];
+	children: React.ReactNode;
+}
+
+export const TaskIdIndexProvider: React.FC<TaskIdIndexProviderProps> = ({ tasks, children }) => {
+	const index = useMemo(() => buildTaskIdIndex(tasks), [tasks]);
+
+	return <TaskIdIndexContext.Provider value={index}>{children}</TaskIdIndexContext.Provider>;
+};

--- a/src/web/utils/task-id-links.ts
+++ b/src/web/utils/task-id-links.ts
@@ -1,0 +1,98 @@
+import type { Task } from "../../types/index.ts";
+import { canonicalTaskId } from "../../utils/task-id.ts";
+
+/** Canonical task ID -> the ID used in `/tasks/:id` routes. */
+export type TaskIdIndex = Map<string, string>;
+
+export function buildTaskIdIndex(tasks: Task[]): TaskIdIndex {
+	const index: TaskIdIndex = new Map();
+	for (const task of tasks) {
+		index.set(canonicalTaskId(task.id), task.id);
+	}
+	return index;
+}
+
+/** Minimal mdast shape: only the fields this transform reads or writes. */
+type MarkdownNode = {
+	type: string;
+	value?: string;
+	url?: string;
+	children?: MarkdownNode[];
+};
+
+const TASK_ID_CANDIDATE = /[A-Za-z]+-\d+(?:\.\d+)*/g;
+/** A candidate preceded by one of these is part of a longer identifier or path. */
+const PRECEDING_REJECT = /[A-Za-z0-9_\-/.]/;
+/** A candidate followed by an identifier character or a file extension is not an ID reference. */
+const FOLLOWING_REJECT = /^[A-Za-z0-9_-]|^\.[A-Za-z0-9]/;
+/** Text inside these nodes already points somewhere; never rewrite it. */
+const SKIPPED_NODES = new Set(["link", "linkReference", "definition"]);
+
+function splitTaskIds(value: string, index: TaskIdIndex): MarkdownNode[] | null {
+	let parts: MarkdownNode[] | null = null;
+	let cursor = 0;
+
+	TASK_ID_CANDIDATE.lastIndex = 0;
+	let match = TASK_ID_CANDIDATE.exec(value);
+	while (match) {
+		const candidate = match[0];
+		const start = match.index;
+		const end = start + candidate.length;
+		const preceding = start === 0 ? "" : value.charAt(start - 1);
+		const taskId = index.get(canonicalTaskId(candidate));
+
+		if (taskId && !PRECEDING_REJECT.test(preceding) && !FOLLOWING_REJECT.test(value.slice(end, end + 2))) {
+			parts ??= [];
+			if (start > cursor) {
+				parts.push({ type: "text", value: value.slice(cursor, start) });
+			}
+			parts.push({ type: "link", url: `/tasks/${taskId}`, children: [{ type: "text", value: candidate }] });
+			cursor = end;
+		}
+
+		match = TASK_ID_CANDIDATE.exec(value);
+	}
+
+	if (!parts) return null;
+	if (cursor < value.length) {
+		parts.push({ type: "text", value: value.slice(cursor) });
+	}
+	return parts;
+}
+
+function linkTaskIds(node: MarkdownNode, index: TaskIdIndex): void {
+	const children = node.children;
+	if (!children) return;
+
+	const rewritten: MarkdownNode[] = [];
+	let changed = false;
+	for (const child of children) {
+		if (child.type === "text" && typeof child.value === "string") {
+			const parts = splitTaskIds(child.value, index);
+			if (parts) {
+				rewritten.push(...parts);
+				changed = true;
+				continue;
+			}
+		} else if (!SKIPPED_NODES.has(child.type)) {
+			linkTaskIds(child, index);
+		}
+		rewritten.push(child);
+	}
+
+	if (changed) {
+		node.children = rewritten;
+	}
+}
+
+/**
+ * Remark plugin that turns known task IDs in markdown text into `/tasks/:id` links.
+ * Code fences and inline code hold no text children in mdast, so they are excluded by construction.
+ */
+export function createTaskIdLinkPlugin(index: TaskIdIndex) {
+	return () => (tree: MarkdownNode) => {
+		if (index.size > 0) {
+			linkTaskIds(tree, index);
+		}
+	};
+}

--- a/src/web/utils/task-id-links.ts
+++ b/src/web/utils/task-id-links.ts
@@ -40,7 +40,7 @@ type MarkdownNode = {
 /** Covers every ID shape `isValidTaskId` accepts, including legacy non-numeric bodies. */
 const TASK_ID_CANDIDATE = /[A-Za-z]+-[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*/g;
 /** A candidate preceded by one of these is part of a longer identifier or path. */
-const PRECEDING_REJECT = /[\p{L}\p{N}\p{M}_\-/.]$/u;
+const PRECEDING_REJECT = /[\p{L}\p{N}\p{M}_\-/\\.]$/u;
 /** A candidate followed by an identifier character or a file extension is not an ID reference. */
 const FOLLOWING_REJECT = /^[\p{L}\p{N}\p{M}_-]|^\.[\p{L}\p{N}\p{M}]/u;
 /** Text inside these nodes already points somewhere; never rewrite it. */

--- a/src/web/utils/task-id-links.ts
+++ b/src/web/utils/task-id-links.ts
@@ -1,15 +1,32 @@
 import type { Task } from "../../types/index.ts";
 import { canonicalTaskId } from "../../utils/task-id.ts";
 
-/** Canonical task ID -> the ID used in `/tasks/:id` routes. */
-export type TaskIdIndex = Map<string, string>;
+/** Canonical task ID -> the task it identifies. */
+export type TaskIdIndex = Map<string, Task>;
 
+/**
+ * Index tasks by canonical ID. Canonical collisions (BACK-1 and BACK-01 both loaded) are
+ * dropped rather than resolved to the last writer, matching how route resolution refuses
+ * to guess between ambiguous IDs.
+ */
 export function buildTaskIdIndex(tasks: Task[]): TaskIdIndex {
 	const index: TaskIdIndex = new Map();
+	const seen = new Set<string>();
 	for (const task of tasks) {
-		index.set(canonicalTaskId(task.id), task.id);
+		const canonical = canonicalTaskId(task.id);
+		if (seen.has(canonical)) {
+			index.delete(canonical);
+			continue;
+		}
+		seen.add(canonical);
+		index.set(canonical, task);
 	}
 	return index;
+}
+
+/** Resolve a task reference through the same canonical identity the markdown links use. */
+export function resolveTaskReference(index: TaskIdIndex, reference: string): Task | undefined {
+	return index.get(canonicalTaskId(reference));
 }
 
 /** Minimal mdast shape: only the fields this transform reads or writes. */
@@ -20,11 +37,12 @@ type MarkdownNode = {
 	children?: MarkdownNode[];
 };
 
-const TASK_ID_CANDIDATE = /[A-Za-z]+-\d+(?:\.\d+)*/g;
+/** Covers every ID shape `isValidTaskId` accepts, including legacy non-numeric bodies. */
+const TASK_ID_CANDIDATE = /[A-Za-z]+-[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*/g;
 /** A candidate preceded by one of these is part of a longer identifier or path. */
-const PRECEDING_REJECT = /[A-Za-z0-9_\-/.]/;
+const PRECEDING_REJECT = /[\p{L}\p{N}\p{M}_\-/.]$/u;
 /** A candidate followed by an identifier character or a file extension is not an ID reference. */
-const FOLLOWING_REJECT = /^[A-Za-z0-9_-]|^\.[A-Za-z0-9]/;
+const FOLLOWING_REJECT = /^[\p{L}\p{N}\p{M}_-]|^\.[\p{L}\p{N}\p{M}]/u;
 /** Text inside these nodes already points somewhere; never rewrite it. */
 const SKIPPED_NODES = new Set(["link", "linkReference", "definition"]);
 
@@ -38,15 +56,17 @@ function splitTaskIds(value: string, index: TaskIdIndex): MarkdownNode[] | null 
 		const candidate = match[0];
 		const start = match.index;
 		const end = start + candidate.length;
-		const preceding = start === 0 ? "" : value.charAt(start - 1);
-		const taskId = index.get(canonicalTaskId(candidate));
+		// Slices, not single characters, so boundary tests see whole code points.
+		const preceding = value.slice(Math.max(0, start - 2), start);
+		const following = value.slice(end, end + 3);
+		const task = resolveTaskReference(index, candidate);
 
-		if (taskId && !PRECEDING_REJECT.test(preceding) && !FOLLOWING_REJECT.test(value.slice(end, end + 2))) {
+		if (task && !PRECEDING_REJECT.test(preceding) && !FOLLOWING_REJECT.test(following)) {
 			parts ??= [];
 			if (start > cursor) {
 				parts.push({ type: "text", value: value.slice(cursor, start) });
 			}
-			parts.push({ type: "link", url: `/tasks/${taskId}`, children: [{ type: "text", value: candidate }] });
+			parts.push({ type: "link", url: `/tasks/${task.id}`, children: [{ type: "text", value: candidate }] });
 			cursor = end;
 		}
 


### PR DESCRIPTION
Takeover of #812 by @cottrell — his feature and commits carry over with authorship preserved (cherry-picked); the takeover fixes the two review defects found on the original.

Bare task IDs in web markdown now render as links to /tasks/<id>, and dependency chips navigate to their tasks. Two design changes from the original: code exclusion moved from a per-line backtick count to a remark plugin over the mdast, so inline code, fenced blocks, and existing links are excluded structurally; and candidates are validated against a canonical-ID index built from the task corpus the app already loads, so UTF-8, ISO-8601, v1.2.3, tails of longer identifiers, and unknown IDs all stay plain (fail-closed), while case/zero-padding variants resolve to canonical hrefs. Unknown dependency chips render as plain text.

Verification: 14 component tests plus a live browser pass covering every acceptance scenario, including WebSocket-driven index updates (a task created while a page is open becomes linkified without reload). Full suite 1955 pass / 0 fail. Independently reviewed with no blocking findings, including live DOM inspection.