### PR TITLE
BACK-584 - Keep vim keys inside the list at navigation boundaries

### DIFF
--- a/backlog/tasks/back-584 - Keep-vim-keys-inside-the-list-at-navigation-boundaries.md
+++ b/backlog/tasks/back-584 - Keep-vim-keys-inside-the-list-at-navigation-boundaries.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-584
 title: Keep vim keys inside the list at navigation boundaries
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 17:25'
+updated_date: '2026-08-07 21:31'
 labels:
   - enhancement
 dependencies: []
@@ -25,18 +27,56 @@ Maintainer decision (confirmed): no new config key. Instead, j and k never enter
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 j at the last row keeps focus in place in the task list, the detail pane, and the board (including empty columns)
-- [ ] #2 k at the first row keeps focus in place on the same three surfaces
-- [ ] #3 ArrowDown at the last row and ArrowUp at the first row still hand focus off to the search input
-- [ ] #4 `/` and Ctrl+F still focus the search input directly
-- [ ] #5 No new configuration key is introduced
-- [ ] #6 Existing navigation tests are updated to the new j/k behavior
-- [ ] #7 Help text and docs that describe the old j/k boundary behavior are updated
+- [x] #1 j at the last row keeps focus in place in the task list, the detail pane, and the board (including empty columns)
+- [x] #2 k at the first row keeps focus in place on the same three surfaces
+- [x] #3 ArrowDown at the last row and ArrowUp at the first row still hand focus off to the search input
+- [x] #4 `/` and Ctrl+F still focus the search input directly
+- [x] #5 No new configuration key is introduced
+- [x] #6 Existing navigation tests are updated to the new j/k behavior
+- [x] #7 Help text and docs that describe the old j/k boundary behavior are updated
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Teach GenericList which key family drove vertical navigation: add a BoundaryNavigationKey type ("arrow" | "vim"), split the up/k and down/j bindings, and pass the kind to onBoundaryNavigation. Lists without a boundary handler (filter popups) keep today's circular wrap for both families.
+2. Replace shouldMoveFromListBoundaryToSearch with one shared resolver in task-viewer-with-search.ts: resolveListBoundaryNavigation(direction, selectedIndex, total, key) -> "move" | "search" | "stay". Arrow keys at a boundary (and in an empty list) resolve to "search"; vim keys resolve to "stay".
+3. Task list: use the resolver in the onBoundaryNavigation callback; consume the key on "stay" so j/k neither wrap nor hand off.
+4. Detail pane: shouldMoveFromDetailBoundaryToSearch takes the key kind; bind up and k separately so k falls through to the built-in scroll (which is already clamped at the top).
+5. Board: split the screen-level up/k and down/j bindings and route both through the resolver, collapsing the empty-column special case into the resolver's empty-list branch.
+6. Tests: resolver + detail helper unit tests; GenericList widget tests driving real key events; a board TUI test with a fake screen covering a populated column and an empty column for j/k vs arrows. No config key, no docs change (nothing user-facing documents the handoff).
+7. Verify: bunx tsc --noEmit, bun run check ., scoped TUI tests, full bun test, plus a real-PTY spot check of the board.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the no-config split: the key family that drove vertical navigation is now carried to every boundary site.
+
+- src/ui/components/generic-list.ts: added BoundaryNavigationKey ("arrow" | "vim"), split the up/k and down/j bindings, and pass the kind to onBoundaryNavigation. Lists without a boundary handler (filter popups, pickers) keep today's circular wrap for both key families, so only the surfaces with a search handoff change.
+- src/ui/task-viewer-with-search.ts: replaced shouldMoveFromListBoundaryToSearch with resolveListBoundaryNavigation(direction, selectedIndex, total, key) -> "move" | "search" | "stay", shared by the task list and the board. Arrow keys at a boundary (and in an empty list) resolve to "search"; vim keys resolve to "stay", and the task-list callback returns true on "stay" so j/k neither wrap nor hand off. shouldMoveFromDetailBoundaryToSearch now takes (scrollOffset, key) and its vestigial direction argument is gone; the detail pane binds up and k separately, and k falls through to the built-in vi scroll which is already clamped at the top.
+- src/ui/board.ts: the two screen-level handlers collapsed into one moveBoardSelection(direction, key) used by four bindings; the empty-column special case is now the resolver's empty-list branch (pendingSearchWrap stays null there because an empty column has no row to return to).
+
+No config key, no new behavior for / and Ctrl+F (their bindings are untouched), and mid-list j/k is unchanged.
+
+Verification evidence:
+- New src/test/tui-vim-boundary-navigation.test.ts drives real key events: a GenericList wired with the viewer's boundary callback (j at the last row and k at the first row keep the selection and record no handoff; arrows at the same rows hand off) and a real renderBoardTui on a fake screen for both a populated column and an empty column (j/k keep focus on the column list; Down/Up move focus to the search textbox).
+- src/test/task-viewer-boundary-navigation.test.ts updated to the new resolver and detail-pane helper, including the empty-list branch.
+- Mutation control: forcing the resolver to return "search" for vim keys fails 3 of the 4 new behavior tests, so they are not vacuous.
+- Real PTY spot check with expect (task list TUI and board TUI in a temp project, markers read off the footer): j past the last row and k at the top of the detail pane never focus search, while Down/Up at the same boundaries do; empty board column behaves the same. Same scripts exit 1 against the pre-fix behavior.
+- bunx tsc --noEmit clean, bun run check . clean, bun run test 1951 pass / 5 skip / 0 fail.
+- AC #7: nothing shipped documents the old j/k boundary behavior (grepped README, ADVANCED-CONFIG, CLI-INSTRUCTIONS, AGENTS, CONTRIBUTING, DEVELOPMENT, src/guidelines, help popup and footers). The only boundary copy is the search-focused footer '[up/down] Back to Tasks/Board' and the help popup's 'arrows Navigate tasks', both arrow-key statements that stay accurate.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+j and k now stay inside the list at navigation boundaries in the task list, the detail pane, and the kanban board (including empty columns), while the arrow keys keep the BACK-399 handoff into the search input and / and Ctrl+F still focus search directly. No configuration key was added: GenericList and the board handlers now report which key family drove the navigation, and a shared resolveListBoundaryNavigation helper decides between moving, handing off to search, and staying put. Verified with new key-event tests over a real GenericList and a real board TUI (populated and empty columns), updated helper tests, a mutation control run proving the tests are not vacuous, a real-PTY expect check of both TUIs, and tsc/biome/full bun test.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/task-viewer-boundary-navigation.test.ts
+++ b/src/test/task-viewer-boundary-navigation.test.ts
@@ -2,32 +2,44 @@ import { describe, expect, it } from "bun:test";
 import {
 	type PendingSearchWrap,
 	resolveFilterExitPane,
+	resolveListBoundaryNavigation,
 	resolveSearchExitTargetIndex,
 	resolveTaskListSelection,
 	shouldMoveFromDetailBoundaryToSearch,
-	shouldMoveFromListBoundaryToSearch,
 } from "../ui/task-viewer-with-search.ts";
 
 describe("task viewer boundary navigation", () => {
-	it("moves from first list row to search on up", () => {
-		expect(shouldMoveFromListBoundaryToSearch("up", 0, 4)).toBe(true);
-		expect(shouldMoveFromListBoundaryToSearch("up", 1, 4)).toBe(false);
+	it("moves from first list row to search on arrow up", () => {
+		expect(resolveListBoundaryNavigation("up", 0, 4, "arrow")).toBe("search");
+		expect(resolveListBoundaryNavigation("up", 1, 4, "arrow")).toBe("move");
 	});
 
-	it("moves from last list row to search on down", () => {
-		expect(shouldMoveFromListBoundaryToSearch("down", 3, 4)).toBe(true);
-		expect(shouldMoveFromListBoundaryToSearch("down", 2, 4)).toBe(false);
+	it("moves from last list row to search on arrow down", () => {
+		expect(resolveListBoundaryNavigation("down", 3, 4, "arrow")).toBe("search");
+		expect(resolveListBoundaryNavigation("down", 2, 4, "arrow")).toBe("move");
 	});
 
-	it("does not move to search when there are no rows", () => {
-		expect(shouldMoveFromListBoundaryToSearch("up", 0, 0)).toBe(false);
-		expect(shouldMoveFromListBoundaryToSearch("down", 0, 0)).toBe(false);
+	it("keeps vim keys inside the list at both boundaries", () => {
+		expect(resolveListBoundaryNavigation("up", 0, 4, "vim")).toBe("stay");
+		expect(resolveListBoundaryNavigation("down", 3, 4, "vim")).toBe("stay");
 	});
 
-	it("moves from detail pane to search only when navigating up at top boundary", () => {
-		expect(shouldMoveFromDetailBoundaryToSearch("up", 0)).toBe(true);
-		expect(shouldMoveFromDetailBoundaryToSearch("up", 2)).toBe(false);
-		expect(shouldMoveFromDetailBoundaryToSearch("down", 0)).toBe(false);
+	it("moves vim keys like arrows away from the boundaries", () => {
+		expect(resolveListBoundaryNavigation("up", 1, 4, "vim")).toBe("move");
+		expect(resolveListBoundaryNavigation("down", 2, 4, "vim")).toBe("move");
+	});
+
+	it("treats an empty list as a boundary for both key families", () => {
+		expect(resolveListBoundaryNavigation("up", 0, 0, "arrow")).toBe("search");
+		expect(resolveListBoundaryNavigation("down", 0, 0, "arrow")).toBe("search");
+		expect(resolveListBoundaryNavigation("up", 0, 0, "vim")).toBe("stay");
+		expect(resolveListBoundaryNavigation("down", 0, 0, "vim")).toBe("stay");
+	});
+
+	it("moves from detail pane to search only on arrow up at the top boundary", () => {
+		expect(shouldMoveFromDetailBoundaryToSearch(0, "arrow")).toBe(true);
+		expect(shouldMoveFromDetailBoundaryToSearch(2, "arrow")).toBe(false);
+		expect(shouldMoveFromDetailBoundaryToSearch(0, "vim")).toBe(false);
 	});
 
 	it("resolves search exit target to last row after top-boundary handoff", () => {

--- a/src/test/tui-vim-boundary-navigation.test.ts
+++ b/src/test/tui-vim-boundary-navigation.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "bun:test";
+import type { ListInterface, ScreenInterface } from "neo-neo-bblessed";
+import type { Task } from "../types/index.ts";
+import { renderBoardTui } from "../ui/board.ts";
+import { GenericList } from "../ui/components/generic-list.ts";
+import { resolveListBoundaryNavigation } from "../ui/task-viewer-with-search.ts";
+import { createScreen } from "../ui/tui.ts";
+import { withTimeout } from "./test-utils.ts";
+
+type EmittingWidget = { emit: (event: string, ch?: string, key?: { name: string; full: string }) => boolean };
+
+function pressKey(widget: EmittingWidget, name: string): void {
+	widget.emit("keypress", "", { name, full: name });
+	widget.emit(`key ${name}`, "", { name, full: name });
+}
+
+function withTty<T>(run: () => T): T {
+	const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+	try {
+		return run();
+	} finally {
+		if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
+		else Reflect.deleteProperty(process.stdout, "isTTY");
+	}
+}
+
+function task(id: string, status = "To Do"): Task {
+	return {
+		id,
+		title: `Task ${id}`,
+		status,
+		assignee: [],
+		createdDate: "2026-08-07 00:00",
+		labels: [],
+		dependencies: [],
+	};
+}
+
+describe("vim keys stay inside the task list at boundaries", () => {
+	function createTaskListHarness(screen: ScreenInterface) {
+		const searchHandoffs: Array<"up" | "down"> = [];
+		// Mirrors the task viewer's boundary callback (src/ui/task-viewer-with-search.ts).
+		const list = new GenericList({
+			parent: screen,
+			items: [{ id: "TASK-1" }, { id: "TASK-2" }],
+			itemRenderer: (item) => item.id,
+			showHelp: false,
+			onBoundaryNavigation: (direction, selectedIndex, total, key) => {
+				const navigation = resolveListBoundaryNavigation(direction, selectedIndex, total, key);
+				if (navigation === "move") return false;
+				if (navigation === "search") searchHandoffs.push(direction);
+				return true;
+			},
+		});
+		return { list, listBox: list.getListBox() as ListInterface & EmittingWidget, searchHandoffs };
+	}
+
+	it("keeps j on the last row and k on the first row inside the list", () => {
+		withTty(() => {
+			const screen = createScreen({ smartCSR: false });
+			try {
+				const { list, listBox, searchHandoffs } = createTaskListHarness(screen);
+
+				pressKey(listBox, "j");
+				expect(list.getSelectedIndex()).toBe(1);
+
+				pressKey(listBox, "j");
+				expect(list.getSelectedIndex()).toBe(1);
+
+				pressKey(listBox, "k");
+				expect(list.getSelectedIndex()).toBe(0);
+
+				pressKey(listBox, "k");
+				expect(list.getSelectedIndex()).toBe(0);
+
+				expect(searchHandoffs).toEqual([]);
+				list.destroy();
+			} finally {
+				screen.destroy();
+			}
+		});
+	});
+
+	it("still hands the arrow keys off to search at the same boundaries", () => {
+		withTty(() => {
+			const screen = createScreen({ smartCSR: false });
+			try {
+				const { list, listBox, searchHandoffs } = createTaskListHarness(screen);
+
+				pressKey(listBox, "up");
+				expect(list.getSelectedIndex()).toBe(0);
+				expect(searchHandoffs).toEqual(["up"]);
+
+				pressKey(listBox, "down");
+				expect(list.getSelectedIndex()).toBe(1);
+
+				pressKey(listBox, "down");
+				expect(list.getSelectedIndex()).toBe(1);
+				expect(searchHandoffs).toEqual(["up", "down"]);
+
+				list.destroy();
+			} finally {
+				screen.destroy();
+			}
+		});
+	});
+});
+
+describe("vim keys stay inside board columns at boundaries", () => {
+	type BoardWidget = { type?: string; items?: unknown[]; selected?: number };
+
+	async function withBoard(
+		run: (context: {
+			screen: ScreenInterface & EmittingWidget;
+			focused: () => BoardWidget | undefined;
+			selectedRow: () => number | undefined;
+		}) => Promise<void> | void,
+	): Promise<void> {
+		const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+		const screen = createScreen({ smartCSR: false }) as ScreenInterface & EmittingWidget;
+		try {
+			const boardPromise = renderBoardTui([task("TASK-1"), task("TASK-2")], ["To Do", "Done"], "horizontal", 20, {
+				screen,
+			});
+			await Bun.sleep(20);
+			const focused = () => (screen as unknown as { focused?: BoardWidget }).focused;
+			await run({ screen, focused, selectedRow: () => focused()?.selected });
+			pressKey(screen, "q");
+			await withTimeout(boardPromise, "board close", 1000);
+		} finally {
+			screen.destroy();
+			if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
+			else Reflect.deleteProperty(process.stdout, "isTTY");
+		}
+	}
+
+	it("keeps j and k inside a populated column and lets arrows reach search", async () => {
+		await withBoard(async ({ screen, focused, selectedRow }) => {
+			expect(focused()?.type).toBe("list");
+			expect(selectedRow()).toBe(0);
+
+			pressKey(screen, "k");
+			expect(focused()?.type).toBe("list");
+			expect(selectedRow()).toBe(0);
+
+			pressKey(screen, "j");
+			expect(selectedRow()).toBe(1);
+
+			pressKey(screen, "j");
+			expect(focused()?.type).toBe("list");
+			expect(selectedRow()).toBe(1);
+
+			pressKey(screen, "down");
+			expect(focused()?.type).toBe("textbox");
+		});
+	});
+
+	it("keeps j and k inside an empty column and lets arrows reach search", async () => {
+		await withBoard(async ({ screen, focused }) => {
+			pressKey(screen, "right");
+			expect(focused()?.type).toBe("list");
+			expect(focused()?.items?.length ?? 0).toBe(0);
+
+			pressKey(screen, "j");
+			expect(focused()?.type).toBe("list");
+
+			pressKey(screen, "k");
+			expect(focused()?.type).toBe("list");
+
+			pressKey(screen, "up");
+			expect(focused()?.type).toBe("textbox");
+		});
+	});
+});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -22,6 +22,7 @@ import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-con
 import { openConfirmPopup } from "./components/confirm-popup.ts";
 import { createFilterHeader, type FilterHeader, type FilterState } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
+import type { BoundaryNavigationKey } from "./components/generic-list.ts";
 import { openHelpPopup } from "./components/help-popup.ts";
 import { openTaskComposer, type TaskComposerOptions } from "./components/task-composer.ts";
 import { formatFooterContent } from "./footer-content.ts";
@@ -30,8 +31,8 @@ import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-
 import { formatTaskTypeBadge } from "./task-type.ts";
 import {
 	createTaskPopup,
+	resolveListBoundaryNavigation,
 	resolveSearchExitTargetIndex,
-	shouldMoveFromListBoundaryToSearch,
 } from "./task-viewer-with-search.ts";
 import { createScreen } from "./tui.ts";
 import { stripBlessedFgTags } from "./utils/strip-tags.ts";
@@ -1113,76 +1114,52 @@ export async function renderBoardTui(
 			}
 		});
 
-		screen.key(["up", "k"], () => {
+		const moveBoardSelection = (direction: "up" | "down", key: BoundaryNavigationKey) => {
 			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 
+			const column = columns[currentCol];
 			if (moveOp) {
-				if (moveOp.targetIndex > 0) {
-					moveOp.targetIndex--;
-					renderView();
-				}
-			} else {
-				const column = columns[currentCol];
-				if (!column) return;
-				const listWidget = column.list;
-				const selected = listWidget.selected ?? 0;
-				const total = column.tasks.length;
-				if (total === 0) {
-					pendingSearchWrap = null;
-					focusFilterControl("search");
-					updateFooter();
-					screen.render();
+				if (direction === "up") {
+					if (moveOp.targetIndex > 0) {
+						moveOp.targetIndex--;
+						renderView();
+					}
 					return;
 				}
-				if (shouldMoveFromListBoundaryToSearch("up", selected, total)) {
-					pendingSearchWrap = "to-last";
-					focusFilterControl("search");
-					updateFooter();
-					screen.render();
-					return;
-				}
-				const nextIndex = selected - 1;
-				selectColumnRow(column, nextIndex, true);
-				screen.render();
-			}
-		});
-
-		screen.key(["down", "j"], () => {
-			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
-
-			if (moveOp) {
-				const column = columns[currentCol];
 				// We need to check the projected length to know if we can move down
 				// The current rendered column has the correct length including the ghost task
 				if (column && moveOp.targetIndex < column.tasks.length - 1) {
 					moveOp.targetIndex++;
 					renderView();
 				}
-			} else {
-				const column = columns[currentCol];
-				if (!column) return;
-				const listWidget = column.list;
-				const selected = listWidget.selected ?? 0;
-				const total = column.tasks.length;
-				if (total === 0) {
-					pendingSearchWrap = null;
-					focusFilterControl("search");
-					updateFooter();
-					screen.render();
-					return;
-				}
-				if (shouldMoveFromListBoundaryToSearch("down", selected, total)) {
-					pendingSearchWrap = "to-first";
-					focusFilterControl("search");
-					updateFooter();
-					screen.render();
-					return;
-				}
-				const nextIndex = selected + 1;
-				selectColumnRow(column, nextIndex, true);
-				screen.render();
+				return;
 			}
-		});
+
+			if (!column) return;
+			const selected = column.list.selected ?? 0;
+			const total = column.tasks.length;
+			const navigation = resolveListBoundaryNavigation(direction, selected, total, key);
+			if (navigation === "stay") return;
+			if (navigation === "search") {
+				if (total === 0) {
+					// An empty column has no row to return to, so leaving search selects nothing.
+					pendingSearchWrap = null;
+				} else {
+					pendingSearchWrap = direction === "up" ? "to-last" : "to-first";
+				}
+				focusFilterControl("search");
+				updateFooter();
+				screen.render();
+				return;
+			}
+			selectColumnRow(column, direction === "up" ? selected - 1 : selected + 1, true);
+			screen.render();
+		};
+
+		screen.key(["up"], () => moveBoardSelection("up", "arrow"));
+		screen.key(["k"], () => moveBoardSelection("up", "vim"));
+		screen.key(["down"], () => moveBoardSelection("down", "arrow"));
+		screen.key(["j"], () => moveBoardSelection("down", "vim"));
 
 		const lanePageAmount = () => {
 			const column = columns[currentCol];

--- a/src/ui/components/generic-list.ts
+++ b/src/ui/components/generic-list.ts
@@ -14,6 +14,12 @@ export interface GenericListItem {
 	id: string;
 }
 
+/**
+ * Key family that drove vertical navigation. Arrow keys may hand focus off at a list
+ * boundary; vim keys stay inside the list.
+ */
+export type BoundaryNavigationKey = "arrow" | "vim";
+
 export interface GenericListOptions<T extends GenericListItem> {
 	parent?: ElementInterface | ScreenInterface;
 	title?: string;
@@ -28,7 +34,12 @@ export interface GenericListOptions<T extends GenericListItem> {
 	// Called whenever the highlighted item changes (live navigation)
 	onHighlight?: (selected: T | null, index: number) => void;
 	// Called before wrapping at list boundaries. Return true to consume navigation.
-	onBoundaryNavigation?: (direction: "up" | "down", selectedIndex: number, total: number) => boolean;
+	onBoundaryNavigation?: (
+		direction: "up" | "down",
+		selectedIndex: number,
+		total: number,
+		key: BoundaryNavigationKey,
+	) => boolean;
 	width?: string | number;
 	height?: string | number;
 	top?: string | number;
@@ -291,22 +302,22 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 		// Custom key bindings
 		const keys = this.options.keys || {};
 
-		// Circular navigation for up/down (including vim-style keys)
-		const moveUp = () => {
+		// Circular navigation for up/down (including vim-style keys), unless a boundary handler consumes it
+		const moveUp = (key: BoundaryNavigationKey) => {
 			const total = this.filteredItems.length;
 			if (total === 0) return;
 			const sel = typeof this.selectedIndex === "number" ? this.selectedIndex : 0;
-			if (sel <= 0 && this.options.onBoundaryNavigation?.("up", sel, total)) {
+			if (sel <= 0 && this.options.onBoundaryNavigation?.("up", sel, total, key)) {
 				return;
 			}
 			this.setHighlightedIndex(sel > 0 ? sel - 1 : total - 1, { render: true });
 		};
 
-		const moveDown = () => {
+		const moveDown = (key: BoundaryNavigationKey) => {
 			const total = this.filteredItems.length;
 			if (total === 0) return;
 			const sel = typeof this.selectedIndex === "number" ? this.selectedIndex : 0;
-			if (sel >= total - 1 && this.options.onBoundaryNavigation?.("down", sel, total)) {
+			if (sel >= total - 1 && this.options.onBoundaryNavigation?.("down", sel, total, key)) {
 				return;
 			}
 			this.setHighlightedIndex(sel < total - 1 ? sel + 1 : 0, { render: true });
@@ -324,8 +335,10 @@ export class GenericList<T extends GenericListItem> implements GenericListContro
 			return height > 0 ? Math.max(1, height - 3) : 5;
 		};
 
-		this.listBox.key(["up", "k"], moveUp);
-		this.listBox.key(["down", "j"], moveDown);
+		this.listBox.key(["up"], () => moveUp("arrow"));
+		this.listBox.key(["k"], () => moveUp("vim"));
+		this.listBox.key(["down"], () => moveDown("arrow"));
+		this.listBox.key(["j"], () => moveDown("vim"));
 		this.listBox.key(["pageup", "C-u"], () => {
 			const sel = typeof this.selectedIndex === "number" ? this.selectedIndex : 0;
 			moveTo(sel - pageAmount());

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -34,7 +34,7 @@ import {
 	type FilterState,
 } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
-import { createGenericList, type GenericList } from "./components/generic-list.ts";
+import { type BoundaryNavigationKey, createGenericList, type GenericList } from "./components/generic-list.ts";
 import { openHelpPopup } from "./components/help-popup.ts";
 import { formatFooterContent } from "./footer-content.ts";
 import { formatHeading } from "./heading.ts";
@@ -74,28 +74,30 @@ export type TaskListBoundaryDirection = "up" | "down";
 export type PendingSearchWrap = "to-first" | "to-last" | null;
 type PaneFocus = "list" | "detail";
 
-export function shouldMoveFromListBoundaryToSearch(
+/** What vertical navigation should do next: keep moving, hand focus to search, or stay put. */
+export type ListBoundaryNavigation = "move" | "search" | "stay";
+
+/**
+ * Resolves vertical navigation in the task list and in board columns. Arrow keys hand focus
+ * to the search input at a boundary (and from an empty list), while vim keys stay inside the
+ * list so j/k never leave it.
+ */
+export function resolveListBoundaryNavigation(
 	direction: TaskListBoundaryDirection,
 	selectedIndex: number,
 	totalTasks: number,
-): boolean {
-	if (totalTasks <= 0) {
-		return false;
+	key: BoundaryNavigationKey,
+): ListBoundaryNavigation {
+	const atBoundary = totalTasks <= 0 || (direction === "up" ? selectedIndex <= 0 : selectedIndex >= totalTasks - 1);
+	if (!atBoundary) {
+		return "move";
 	}
-	if (direction === "up") {
-		return selectedIndex <= 0;
-	}
-	return selectedIndex >= totalTasks - 1;
+	return key === "arrow" ? "search" : "stay";
 }
 
-export function shouldMoveFromDetailBoundaryToSearch(
-	direction: TaskListBoundaryDirection,
-	scrollOffset: number,
-): boolean {
-	if (direction !== "up") {
-		return false;
-	}
-	return scrollOffset <= 0;
+/** The detail pane hands focus back to search only when the up arrow is pressed at the top. */
+export function shouldMoveFromDetailBoundaryToSearch(scrollOffset: number, key: BoundaryNavigationKey): boolean {
+	return key === "arrow" && scrollOffset <= 0;
 }
 
 export function resolveSearchExitTargetIndex(
@@ -893,12 +895,16 @@ export async function viewTaskEnhanced(
 			onHighlight: (selected: Task | null) => {
 				void applySelection(selected);
 			},
-			onBoundaryNavigation: (direction, selectedIndex, total) => {
-				if (!shouldMoveFromListBoundaryToSearch(direction, selectedIndex, total)) {
+			onBoundaryNavigation: (direction, selectedIndex, total, key) => {
+				const navigation = resolveListBoundaryNavigation(direction, selectedIndex, total, key);
+				if (navigation === "move") {
 					return false;
 				}
-				pendingSearchWrap = direction === "up" ? "to-last" : "to-first";
-				filterHeader.focusSearch();
+				if (navigation === "search") {
+					pendingSearchWrap = direction === "up" ? "to-last" : "to-first";
+					filterHeader.focusSearch();
+				}
+				// "stay" consumes the key so vim navigation neither wraps nor leaves the list.
 				return true;
 			},
 			showHelp: false,
@@ -950,14 +956,18 @@ export async function viewTaskEnhanced(
 				return height > 0 ? Math.max(1, height - 3) : 0;
 			};
 
-			boxInstance.key(["up", "k"], () => {
-				if (!shouldMoveFromDetailBoundaryToSearch("up", scrollable.getScroll?.() ?? 0)) {
+			// Returning true leaves the key to the built-in scroll handling, which is clamped at the top.
+			const moveUpFromDetail = (key: BoundaryNavigationKey) => {
+				if (!shouldMoveFromDetailBoundaryToSearch(scrollable.getScroll?.() ?? 0, key)) {
 					return true;
 				}
 				pendingSearchWrap = null;
 				filterHeader.focusSearch();
 				return false;
-			});
+			};
+
+			boxInstance.key(["up"], () => moveUpFromDetail("arrow"));
+			boxInstance.key(["k"], () => moveUpFromDetail("vim"));
 
 			boxInstance.key(["pageup", "b"], () => {
 				const delta = pageAmount();


### PR DESCRIPTION
Closes #768. Supersedes #770's config-key approach per maintainer decision.

At list/board boundaries, `j`/`k` previously handed focus to the search input (deliberate in BACK-399, surprising for vim users). Decided behavior, no new config key: `j`/`k` now stop at boundaries (no wrap, no handoff) while the arrow keys keep the search handoff, on the task list, the detail pane, and the board including empty columns; `/` and Ctrl+F are unchanged.

Implementation splits the shared bindings into arrow/vim families with one shared boundary resolver; the board's two screen handlers collapse into one (net −23 lines in board.ts). Filter popups and pickers keep circular wrap for both families.

Verification: behavior tests driven by real key events with a mutation control (forcing vim to hand off fails 5 tests), plus real-PTY passes on all surfaces whose control scripts fail against pre-fix main. Full suite 1951 pass / 0 fail. Independently reviewed with no blocking findings, including a fork-source analysis confirming no double-scroll in the detail pane and intact picker wrapping.