### PR TITLE
BACK-585 - Fix the ubuntu CI epoll_ctl test-runner flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.os }}
-          path: test-results.xml
+          # The full profile writes a second JUnit file for the serial DOM pass.
+          path: test-results*.xml
           if-no-files-found: error
       - name: Run interactive TUI regression tests
         if: matrix.os == 'ubuntu-latest'

--- a/backlog/tasks/back-585 - Diagnose-and-fix-the-ubuntu-latest-CI-test-runner-flake.md
+++ b/backlog/tasks/back-585 - Diagnose-and-fix-the-ubuntu-latest-CI-test-runner-flake.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-585
 title: Diagnose and fix the ubuntu-latest CI test-runner flake
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-07 17:44'
+updated_date: '2026-08-07 21:36'
 labels:
   - bug
   - ci
@@ -56,3 +58,47 @@ Seen once and possibly unrelated (runner slowness), worth noting during investig
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Pull failing CI logs (jobs 92944921578, 92944999624) and pin down the exact failure mechanism
+2. Identify repo-side trigger: bunfig [test] preload imports jsdom (via react-dom-preload.ts) for every test file; with --parallel/--isolate each file's fresh realm re-imports jsdom -> undici -> node:assert -> internal:util/colors -> process.stderr WriteStream -> Bun.file(fd).writer() -> epoll_ctl EEXIST on Linux
+3. Reproduce in an ubuntu container with Bun 1.3.14 (minimal synthetic repro + repo suite) to confirm mechanism before fixing
+4. Fix: stop importing jsdom in the global preload for all ~200 files; move DOM/react-dom bootstrap to an explicit first import in the ~15 DOM-dependent web test files
+5. Re-run reproduction after fix (N looped runs) to show the signature disappears; run full local suite, tsc, biome
+6. Document root cause, evidence sample, and CI validation guidance in the task
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root-cause analysis (evidence-based):
+
+1. Failing-log anatomy (jobs 92944921578, 92944999624): while a fresh test file starts, an 'Unhandled error between tests' fires: EEXIST epoll_ctl thrown from new WriteStream (internal:fs/streams:244) <- internal:util/colors refresh <- node:assert <- undici <- jsdom module-scope import chain. The file then aborts whole with 'Cannot call describe() after the test run has completed'.
+2. Why jsdom loads for every file: bunfig [test] preload -> test-preload.ts -> react-dom-preload.ts imports jsdom at module scope. Verified empirically that with --isolate the preload and all modules re-evaluate per test file (fresh realm), so all ~200 realms imported jsdom.
+3. Why it throws: Bun's internal:util/colors refresh() evaluates process.stderr, whose lazy construction (BunProcess.cpp constructStdioWriteStream) builds fs.WriteStream with $fastPath -> Bun.file(2).writer() (FileSink). In Linux workers this registers with the process-wide epoll; /proc probes inside a real --parallel worker show each construction adding a new tfd to the shared epoll table. EEXIST = EPOLL_CTL_ADD for an fd already in the interest list (classic stale-entry pitfall when a dup'd fd is closed without EPOLL_CTL_DEL while fd 2 keeps the description alive).
+4. Why uncatchable: BunProcess.cpp clears the exception and calls reportUncaughtExceptionAtEventLoop, returning undefined - user code cannot try/catch it; the runner counts it as an unhandled error and completes the file's run before its describe() calls execute (hence nameless whole-file failures).
+5. Why Linux-only: epoll EPOLL_CTL_ADD errors EEXIST on duplicates; macOS kqueue EV_ADD is idempotent, Windows uses IOCP.
+6. Why it started 2026-08-03/04: BACK-569 (670c5bd7) added --parallel to the ubuntu run. Workers' stdio are Bun socketpairs (probes: fd 2 flags 04002 = O_RDWR|O_NONBLOCK inside workers) with FileSink pollers; the previous single-process shape writes stderr through a blocking Actions pipe synchronously and never registers stdio in epoll (probes: shell-pipe fd flags 01, blocking). Months of pre-parallel ubuntu CI with the same per-realm jsdom preload never showed the signature.
+7. No matching upstream Bun issue found for this signature (searched epoll_ctl EEXIST WriteStream / describe-after-completed).
+
+Fix (three coordinated changes):
+1. src/test/test-preload.ts no longer imports jsdom/react-dom for every realm; it keeps only git identity env vars. This removes the per-realm process.stderr construction from all non-DOM test files (the milestone files and the rest of the suite no longer touch the vulnerable code path at all) and drops ~200 redundant jsdom+react-dom realm imports.
+2. The 10 web test files that render with react-dom/client now import ./react-dom-preload.ts as their first import. The bootstrap was rewritten to be fully synchronous (require instead of top-level await): Bun continues evaluating sibling imports and the file body while a module is suspended at top-level await (verified with a probe), so the async version would restore DOM globals mid-test. The renderToString-only files (modal-documentation, modal-acceptance-criteria, mermaid-markdown) and mermaid.test.ts pass without the bootstrap (verified) since react-dom/server needs no DOM at import.
+3. scripts/run-ci-tests.ts full profile now runs the 15 jsdom-loading test files in a separate single-process 'bun test --isolate' pass (no --parallel) after the parallel pass, with a separate JUnit outfile; ci.yml uploads test-results*.xml. Rationale: DOM test realms must still construct process.stderr; keeping them out of worker processes puts them in the shape that has never exhibited the failure (blocking stdio, synchronous stderr writes).
+
+PROCESS NOTE - pending maintainer decision: change 3 above (run-ci-tests.ts full profile split into a parallel pass plus a serial single-process pass for the 15 jsdom-loading files, and the one-line ci.yml artifact path widening test-results.xml -> test-results*.xml that supports it) alters how/where tests run in CI. That is a workflow-architecture decision and is NOT settled: it is implemented on branch tasks/back-585-ubuntu-ci-flake as a PROPOSAL for Alex to accept, adjust, or reject. Job topology itself (matrix, jobs, steps, fail-fast) is unchanged; the same single 'Run tests' step invokes the same script with the same flags. Changes 1-2 (preload trim + per-file synchronous DOM bootstrap) are test-code changes that stand on their own and do not alter CI topology; they alone remove the trigger from all non-DOM files including the milestone files that failed. If Alex prefers a different scheduling remedy for the residual DOM-file exposure (e.g. dropping --parallel on ubuntu entirely, or accepting the residual risk), change 3 can be replaced independently.
+
+REVISED FIX (supersedes 'Fix (three coordinated changes)' above; changes 1-2 there were abandoned after container A/B testing): container experiments showed the per-file synchronous react-dom bootstrap broke web tests deterministically (react-dom/client must be initialized through the async preload path: E1 = serial DOM pass with async global preload -> fully green; E3 = per-file sync bootstrap -> 48 fail lines regardless of scheduling). Final shape, validated 4/4 green full-suite runs in an ubuntu (Bun 1.3.14) container with the exact CI command:
+1. src/test/test-preload.ts keeps the original async jsdom/react-dom preload but skips it when BACKLOG_TEST_SKIP_DOM_PRELOAD is set. Default behavior (local bun test, single-file runs) is unchanged.
+2. scripts/run-ci-tests.ts: the full profile now runs two passes: (a) all non-DOM test files with the forwarded --parallel flags and BACKLOG_TEST_SKIP_DOM_PRELOAD=1 (their realms never import jsdom, so the vulnerable process.stderr construction is gone from worker realms entirely); (b) the 15 DOM test files in a single-process 'bun test --isolate' pass with the preload active (the shape that has never exhibited the failure) writing test-results-dom.xml. The platform profile (mac/win) also sets the skip var: none of its files need the DOM preload, so those realms get faster too.
+3. .github/workflows/ci.yml: only the artifact upload path widened test-results.xml -> test-results*.xml. No job/matrix/step topology changes.
+Note: the two failures visible in container runs (backlog doctor incomplete-reference-scan, duplicate-task-repair unreadable-reference) are root-user chmod artifacts of the container, present identically in before/after runs, unrelated to this task.
+
+Evidence sample and validation status:
+- Local Linux-container reproduction of the EEXIST itself did NOT succeed: 6/6 full-suite runs of the pre-fix tree with the exact CI command (ubuntu container, Bun 1.3.14, --cpus=2) were clean, and an x86_64-emulation attempt crashed the local Docker VM. The failure needs the slower shared 4-vCPU GitHub runner load profile. Root-cause confidence therefore rests on: the CI stack traces, /proc fd+epoll probes inside real --parallel workers (worker fd 2 is an O_NONBLOCK socketpair; each realm's process.stderr construction registers a new epoll entry), Bun source (BunProcess.cpp swallows the construction error uncatchably; internal:fs/streams builds Bun.file(fd).writer() per realm), and the exact correlation with BACK-569 introducing --parallel (2026-08-03) after months of clean single-process --isolate runs with the same per-realm jsdom preload.
+- Post-fix evidence: 4/4 consecutive green full-suite container runs (exact CI command; only known root-user chmod noise), full local bun run test 1909 pass / 0 fail, bunx tsc --noEmit clean, bun run check clean. Runs are also ~15% faster than pre-fix in the same container because ~198 realms no longer import jsdom+react-dom.
+- CI-level confirmation (AC #1) still requires observation: pushes to a PR-less branch do not trigger this workflow. Validate on the next PRs to main: (1) job lint-and-unit-test (ubuntu-latest) must show two 'bun test' passes in the Run tests step and stay green; (2) grep the logs of the next ~6 ubuntu runs for 'epoll_ctl' and 'Cannot call describe' - both must be absent; (3) test-results-ubuntu-latest artifact now contains test-results.xml and test-results-dom.xml. Task left In Progress pending that observation.
+- Upstream: no existing Bun issue matches this signature; recommend filing one (uncatchable epoll_ctl EEXIST from process.stderr lazy construction in --parallel worker realms on Linux). Filing needs a maintainer decision since it is a public action; probe scripts and findings are preserved in this task's notes.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-585 - Diagnose-and-fix-the-ubuntu-latest-CI-test-runner-flake.md
+++ b/backlog/tasks/back-585 - Diagnose-and-fix-the-ubuntu-latest-CI-test-runner-flake.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-08-07 17:44'
-updated_date: '2026-08-07 21:36'
+updated_date: '2026-08-07 22:15'
 labels:
   - bug
   - ci
@@ -101,4 +101,6 @@ Evidence sample and validation status:
 - Post-fix evidence: 4/4 consecutive green full-suite container runs (exact CI command; only known root-user chmod noise), full local bun run test 1909 pass / 0 fail, bunx tsc --noEmit clean, bun run check clean. Runs are also ~15% faster than pre-fix in the same container because ~198 realms no longer import jsdom+react-dom.
 - CI-level confirmation (AC #1) still requires observation: pushes to a PR-less branch do not trigger this workflow. Validate on the next PRs to main: (1) job lint-and-unit-test (ubuntu-latest) must show two 'bun test' passes in the Run tests step and stay green; (2) grep the logs of the next ~6 ubuntu runs for 'epoll_ctl' and 'Cannot call describe' - both must be absent; (3) test-results-ubuntu-latest artifact now contains test-results.xml and test-results-dom.xml. Task left In Progress pending that observation.
 - Upstream: no existing Bun issue matches this signature; recommend filing one (uncatchable epoll_ctl EEXIST from process.stderr lazy construction in --parallel worker realms on Linux). Filing needs a maintainer decision since it is a public action; probe scripts and findings are preserved in this task's notes.
+
+Review outcome and maintainer decisions (2026-08-08): independent review approved the branch with no blocking findings; the two-pass full profile and the BACKLOG_TEST_SKIP_DOM_PRELOAD env gate were verified empirically, including the exact-union property (198 parallel + 15 DOM files, no overlap, no loss). Maintainer decisions recorded: (1) the two-pass CI shape is APPROVED (no longer a pending proposal); (2) NO upstream Bun issue will be filed while the Bun 1.4 test-runner rewrite is pending. One accepted simplification was applied: the hardcoded DOM_TEST_FILES list and its missing-file guard were replaced by content-derivation - the full profile scans the collected test files for a jsdom reference (/["']jsdom["']/) and adds react-dom-preload.test.ts explicitly (its jsdom load comes through react-dom-preload.ts). Re-verified after the change: full profile end-to-end with CI's exact args exits 0 and the JUnit file attributes reproduce the identical partition (198/15, disjoint, union = all 213 test files, DOM list byte-identical to the previous hardcoded 15); platform profile 389 pass / 0 fail; bunx tsc --noEmit clean; bun run check clean; full local bun run test 1909 pass / 0 fail. Task stays In Progress pending the CI-observation acceptance criterion (next PRs to main).
 <!-- SECTION:NOTES:END -->

--- a/scripts/run-ci-tests.ts
+++ b/scripts/run-ci-tests.ts
@@ -43,34 +43,6 @@ const PLATFORM_CONTRACT_FILES = [
 	"src/test/server-port.test.ts",
 ] as const;
 
-// Test files whose realms need the jsdom/react-dom preload. They must not run
-// inside `bun test --parallel` worker processes on Linux: the jsdom -> undici
-// -> node:assert import chain lazily constructs process.stderr per isolated
-// realm, and in a worker (whose stdio is a Bun socketpair) that construction
-// intermittently dies with an uncatchable "EEXIST: file already exists,
-// epoll_ctl", failing whole unrelated test files with "Cannot call describe()
-// after the test run has completed" (BACK-585). A plain single-process
-// `bun test --isolate` run has never shown the failure, so the full profile
-// runs these files in a separate non-parallel pass with the DOM preload, and
-// every other pass skips the preload via BACKLOG_TEST_SKIP_DOM_PRELOAD.
-const DOM_TEST_FILES = [
-	"src/test/mermaid-markdown.test.tsx",
-	"src/test/mermaid.test.ts",
-	"src/test/react-dom-preload.test.ts",
-	"src/test/web-board-filters.test.tsx",
-	"src/test/web-duplicate-id-repair.test.tsx",
-	"src/test/web-initialization-cursor.test.tsx",
-	"src/test/web-milestones-page-search.test.tsx",
-	"src/test/web-task-column-sort.test.tsx",
-	"src/test/web-task-detail-deeplink.test.tsx",
-	"src/test/web-task-details-modal-acceptance-criteria.test.tsx",
-	"src/test/web-task-details-modal-documentation.test.tsx",
-	"src/test/web-task-details-modal-final-summary.test.tsx",
-	"src/test/web-task-details-modal-keyboard-shortcuts.test.tsx",
-	"src/test/web-task-list-labels-menu.test.tsx",
-	"src/test/web-task-types.test.tsx",
-] as const;
-
 const profileArgument = process.argv.find((argument) => argument.startsWith("--profile="));
 const profile = profileArgument?.slice("--profile=".length) ?? "full";
 const forwardedArguments = process.argv.slice(2).filter((argument) => argument !== profileArgument);
@@ -101,13 +73,26 @@ if (profile === "platform") {
 const allTestFiles = [...new Bun.Glob("src/**/*.test.{ts,tsx}").scanSync()]
 	.map((file) => file.replaceAll("\\", "/"))
 	.sort();
-const domTestFiles = new Set<string>(DOM_TEST_FILES);
-const missingDomFiles = DOM_TEST_FILES.filter((file) => !allTestFiles.includes(file));
-if (missingDomFiles.length > 0) {
-	console.error(`DOM test files not found (update DOM_TEST_FILES): ${missingDomFiles.join(", ")}`);
-	process.exit(2);
+
+// Test files whose realms need the jsdom/react-dom preload must not run inside
+// `bun test --parallel` worker processes on Linux: the jsdom -> undici ->
+// node:assert import chain lazily constructs process.stderr per isolated
+// realm, and in a worker (whose stdio is a Bun socketpair) that construction
+// intermittently dies with an uncatchable "EEXIST: file already exists,
+// epoll_ctl", failing whole unrelated test files with "Cannot call describe()
+// after the test run has completed" (BACK-585). A plain single-process
+// `bun test --isolate` run has never shown the failure, so the full profile
+// runs these files in a separate non-parallel pass with the DOM preload, and
+// every other pass skips the preload via BACKLOG_TEST_SKIP_DOM_PRELOAD.
+// Files are detected by content: anything referencing jsdom, plus
+// react-dom-preload.test.ts, which loads jsdom through react-dom-preload.ts.
+const domTestFiles = new Set<string>(["src/test/react-dom-preload.test.ts"]);
+const jsdomReference = /["']jsdom["']/;
+for (const file of allTestFiles) {
+	if (jsdomReference.test(await Bun.file(file).text())) domTestFiles.add(file);
 }
 const parallelFiles = allTestFiles.filter((file) => !domTestFiles.has(file));
+const domFiles = allTestFiles.filter((file) => domTestFiles.has(file));
 
 // The DOM pass drops --parallel* (single process) and writes its own JUnit file.
 const domArguments = forwardedArguments
@@ -115,5 +100,5 @@ const domArguments = forwardedArguments
 	.map((argument) => (argument.startsWith("--reporter-outfile=") ? argument.replace(/\.xml$/, "-dom.xml") : argument));
 
 const parallelExit = await runBunTest(parallelFiles, forwardedArguments, { skipDomPreload: true });
-const domExit = await runBunTest(DOM_TEST_FILES, domArguments, { skipDomPreload: false });
+const domExit = await runBunTest(domFiles, domArguments, { skipDomPreload: false });
 process.exit(parallelExit !== 0 ? parallelExit : domExit);

--- a/scripts/run-ci-tests.ts
+++ b/scripts/run-ci-tests.ts
@@ -43,6 +43,34 @@ const PLATFORM_CONTRACT_FILES = [
 	"src/test/server-port.test.ts",
 ] as const;
 
+// Test files whose realms need the jsdom/react-dom preload. They must not run
+// inside `bun test --parallel` worker processes on Linux: the jsdom -> undici
+// -> node:assert import chain lazily constructs process.stderr per isolated
+// realm, and in a worker (whose stdio is a Bun socketpair) that construction
+// intermittently dies with an uncatchable "EEXIST: file already exists,
+// epoll_ctl", failing whole unrelated test files with "Cannot call describe()
+// after the test run has completed" (BACK-585). A plain single-process
+// `bun test --isolate` run has never shown the failure, so the full profile
+// runs these files in a separate non-parallel pass with the DOM preload, and
+// every other pass skips the preload via BACKLOG_TEST_SKIP_DOM_PRELOAD.
+const DOM_TEST_FILES = [
+	"src/test/mermaid-markdown.test.tsx",
+	"src/test/mermaid.test.ts",
+	"src/test/react-dom-preload.test.ts",
+	"src/test/web-board-filters.test.tsx",
+	"src/test/web-duplicate-id-repair.test.tsx",
+	"src/test/web-initialization-cursor.test.tsx",
+	"src/test/web-milestones-page-search.test.tsx",
+	"src/test/web-task-column-sort.test.tsx",
+	"src/test/web-task-detail-deeplink.test.tsx",
+	"src/test/web-task-details-modal-acceptance-criteria.test.tsx",
+	"src/test/web-task-details-modal-documentation.test.tsx",
+	"src/test/web-task-details-modal-final-summary.test.tsx",
+	"src/test/web-task-details-modal-keyboard-shortcuts.test.tsx",
+	"src/test/web-task-list-labels-menu.test.tsx",
+	"src/test/web-task-types.test.tsx",
+] as const;
+
 const profileArgument = process.argv.find((argument) => argument.startsWith("--profile="));
 const profile = profileArgument?.slice("--profile=".length) ?? "full";
 const forwardedArguments = process.argv.slice(2).filter((argument) => argument !== profileArgument);
@@ -52,12 +80,40 @@ if (profile !== "full" && profile !== "platform") {
 	process.exit(2);
 }
 
-const files = profile === "platform" ? PLATFORM_CONTRACT_FILES : [];
-const child = Bun.spawn([process.execPath, "test", ...files, ...forwardedArguments], {
-	stdin: "inherit",
-	stdout: "inherit",
-	stderr: "inherit",
-	env: process.env,
-});
+async function runBunTest(
+	files: readonly string[],
+	args: readonly string[],
+	options: { skipDomPreload: boolean },
+): Promise<number> {
+	const child = Bun.spawn([process.execPath, "test", ...files, ...args], {
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+		env: options.skipDomPreload ? { ...process.env, BACKLOG_TEST_SKIP_DOM_PRELOAD: "1" } : process.env,
+	});
+	return await child.exited;
+}
 
-process.exit(await child.exited);
+if (profile === "platform") {
+	process.exit(await runBunTest(PLATFORM_CONTRACT_FILES, forwardedArguments, { skipDomPreload: true }));
+}
+
+const allTestFiles = [...new Bun.Glob("src/**/*.test.{ts,tsx}").scanSync()]
+	.map((file) => file.replaceAll("\\", "/"))
+	.sort();
+const domTestFiles = new Set<string>(DOM_TEST_FILES);
+const missingDomFiles = DOM_TEST_FILES.filter((file) => !allTestFiles.includes(file));
+if (missingDomFiles.length > 0) {
+	console.error(`DOM test files not found (update DOM_TEST_FILES): ${missingDomFiles.join(", ")}`);
+	process.exit(2);
+}
+const parallelFiles = allTestFiles.filter((file) => !domTestFiles.has(file));
+
+// The DOM pass drops --parallel* (single process) and writes its own JUnit file.
+const domArguments = forwardedArguments
+	.filter((argument) => !argument.startsWith("--parallel"))
+	.map((argument) => (argument.startsWith("--reporter-outfile=") ? argument.replace(/\.xml$/, "-dom.xml") : argument));
+
+const parallelExit = await runBunTest(parallelFiles, forwardedArguments, { skipDomPreload: true });
+const domExit = await runBunTest(DOM_TEST_FILES, domArguments, { skipDomPreload: false });
+process.exit(parallelExit !== 0 ? parallelExit : domExit);

--- a/src/test/test-preload.ts
+++ b/src/test/test-preload.ts
@@ -5,4 +5,12 @@ process.env.GIT_AUTHOR_EMAIL = "test@example.com";
 process.env.GIT_COMMITTER_NAME = "Test User";
 process.env.GIT_COMMITTER_EMAIL = "test@example.com";
 
-await import("./react-dom-preload.ts");
+// The react-dom/jsdom preload is skipped for CI passes whose test files never
+// touch the DOM. Importing jsdom re-runs per isolated realm and its
+// jsdom -> undici -> node:assert chain constructs process.stderr, which inside
+// `bun test --parallel` workers on Linux can die with an uncatchable
+// "EEXIST: file already exists, epoll_ctl" that fails whole unrelated test
+// files (BACK-585). scripts/run-ci-tests.ts sets the variable for those passes.
+if (!process.env.BACKLOG_TEST_SKIP_DOM_PRELOAD) {
+	await import("./react-dom-preload.ts");
+}


### PR DESCRIPTION
Root cause of the intermittent ubuntu-only CI failures (nameless whole-file test aborts, ~4 of 6 recent runs): the test preload imports jsdom into every test realm; inside `--parallel` worker processes each realm's import chain lazily constructs `process.stderr`, registering with the process-wide epoll, and under runner load a stale registration collides — `epoll_ctl EEXIST`, which Bun reports as an uncatchable error that kills the file before its `describe()` calls run. Linux-only (kqueue/IOCP are idempotent) and started exactly when `--parallel=2` landed. Maintainer-approved fix shape (recorded in the task): a two-pass full profile in `scripts/run-ci-tests.ts` — non-DOM files keep `--parallel=2` with the jsdom preload env-gated off, and the jsdom-dependent files (auto-derived by content scan, no hardcoded list) run in one single-process isolated pass writing `test-results-dom.xml`. `ci.yml` changes only the artifact glob; job/matrix topology untouched; local `bun test` behavior unchanged. Bonus: ~15% faster since ~198 realms stop importing jsdom, and mac/win realms skip it too.

Evidence: 4/4 consecutive green full-suite container runs with the exact CI command on the fix (vs the mechanism probe-verified via /proc fdinfo in real workers); exact-union partition proof (198+15 files, no overlap, no loss, twice — once against the hardcoded list, once against the derived one); a new jsdom test file added without listing either runs genuinely in the parallel pass or fails loudly (verified empirically, never silently skipped or vacuous). Independently reviewed with no blocking findings. The task stays In Progress until ~6 consecutive ubuntu runs confirm the signature is gone, per its acceptance criteria. No upstream Bun issue filed per maintainer decision (Bun 1.4 rewrite pending).