### PR TITLE
BACK-597 - Add incremental reference flags to task edit

### DIFF
--- a/backlog/tasks/back-597 - Add-incremental-reference-flags-to-task-edit.md
+++ b/backlog/tasks/back-597 - Add-incremental-reference-flags-to-task-edit.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-597
 title: Add incremental reference flags to task edit
-status: To Do
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 21:36'
+updated_date: '2026-08-07 22:08'
 labels:
   - cli
 dependencies: []
@@ -31,19 +32,58 @@ Scope: references only. Documentation has the identical drift (MCP exposes addDo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 task edit --add-ref adds references while preserving existing references and does not create duplicates
-- [ ] #2 task edit --remove-ref removes references by value and leaves unrelated references unchanged
-- [ ] #3 Both flags accept repeated occurrences and comma-separated values like other multi-value task edit flags
-- [ ] #4 Blank --add-ref or --remove-ref values are rejected with a non-zero exit and the task is left unchanged
-- [ ] #5 --clear-refs cannot be combined with --add-ref or --remove-ref, and invalid input does not mutate the task
-- [ ] #6 The interactive-TTY edit wizard predicate includes the new flags so they apply directly instead of opening the wizard
-- [ ] #7 --ref still replaces the full reference list and CLI help documents --add-ref and --remove-ref
-- [ ] #8 Regression tests cover add and remove semantics, repeated and comma forms, blank rejection, the clear conflict, the interactive-TTY path, and unchanged MCP task_edit reference behavior
+- [x] #1 task edit --add-ref adds references while preserving existing references and does not create duplicates
+- [x] #2 task edit --remove-ref removes references by value and leaves unrelated references unchanged
+- [x] #3 Both flags accept repeated occurrences and comma-separated values like other multi-value task edit flags
+- [x] #4 Blank --add-ref or --remove-ref values are rejected with a non-zero exit and the task is left unchanged
+- [x] #5 --clear-refs cannot be combined with --add-ref or --remove-ref, and invalid input does not mutate the task
+- [x] #6 The interactive-TTY edit wizard predicate includes the new flags so they apply directly instead of opening the wizard
+- [x] #7 --ref still replaces the full reference list and CLI help documents --add-ref and --remove-ref
+- [x] #8 Regression tests cover add and remove semantics, repeated and comma forms, blank rejection, the clear conflict, the interactive-TTY path, and unchanged MCP task_edit reference behavior
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add --add-ref and --remove-ref to task edit: Commander options using createMultiValueAccumulator, parsed with parseDelimitedStringList so repeated and comma forms both work.
+2. Route through the shipped model ops: set editArgs.addReferences/removeReferences so buildTaskUpdateInput maps them to the same TaskUpdateInput fields MCP task_edit uses; no new merge logic.
+3. Join the BACK-586 conventions: add both flags to hasEditFieldFlags, and reuse validateClearableListInput per flag so blank occurrences are rejected and --clear-refs conflicts are caught, keeping the existing --ref error strings byte-identical.
+4. Reject --ref combined with --add-ref/--remove-ref, mirroring the --label vs --add-label/--remove-label rule, so replacement and incremental operations stay mutually exclusive across list fields.
+5. Add addHelpSchema entries for add-ref and remove-ref following the labels wording convention.
+6. Extend src/test/cli-refs-docs.test.ts: add preserves and dedups, remove matches values and leaves others, repeated and comma forms, blank rejection, clear conflict, --ref conflict, interactive-TTY path, and pin add+remove of the same value in one command to the shipped model order (add runs first, removal wins).
+7. Verify: bunx tsc --noEmit, bun run check ., cli-refs-docs / cli-dependency / mcp-refs-docs / references test files, then the full suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added task edit --add-ref and --remove-ref, routed through the shipped model operations MCP task_edit already uses: the CLI sets editArgs.addReferences/removeReferences, buildTaskUpdateInput maps them to TaskUpdateInput.addReferences/removeReferences, and Core.updateTask.resolveReferences applies them. No merge semantics were reimplemented.
+
+Conventions reused rather than duplicated:
+- Commander options use createMultiValueAccumulator and are parsed with parseDelimitedStringList, so repeated flags and comma-separated values both work (same shape as -a/--assignee and --label). --ref was switched to createMultiValueAccumulator too, replacing its inline copy of the same closure.
+- Both flags joined hasEditFieldFlags, so an interactive TTY applies them directly instead of opening the edit wizard.
+- Blank occurrences and --clear-refs conflicts reuse the shared validateClearableListInput helper introduced by BACK-586, called once per flag so the errors name the exact flag ("Cannot use an empty value with --add-ref. Use --clear-refs to remove all references."). The existing --ref/--doc/--clear-deps error strings are untouched.
+
+One decision beyond the issue text: --ref combined with --add-ref/--remove-ref is rejected, mirroring the existing --label vs --add-label/--remove-label rule, so replacement and incremental operations stay mutually exclusive across list fields (manifesto surface consistency). Without it the command would silently mean "replace, then add".
+
+Add + remove of the same value in one command: the shared model applies additions first and removals second, so the removal wins and the value ends up absent. That is pinned by a test rather than changed, so CLI and MCP agree.
+
+Public instruction surface: src/guidelines/agent-guidelines.md now lists Replace/Add/Remove references rows instead of a single "Add references" row that used the replace-all flag.
+
+Follow-up observation (scope guard, not implemented): documentation has the identical drift. MCP task_edit exposes addDocumentation/removeDocumentation and Core.updateTask implements them, but the CLI still has only --doc (replace) and --clear-docs. A follow-up would add --add-doc/--remove-doc through the same helpers.
+
+Validation: bunx tsc --noEmit clean; bun run check . clean (358 files); bun test src/test/cli-refs-docs.test.ts 31 pass; bun test src/test/mcp-refs-docs.test.ts src/test/cli-dependency.test.ts src/test/references.test.ts src/test/documentation.test.ts src/test/mcp-tasks.test.ts 62 pass (MCP reference behavior unchanged); bun test src/test/agent-instructions.test.ts green; full bun run test 1953 pass / 5 skip / 0 fail across 214 files (one unrelated flake appeared in an earlier full run and did not reproduce in two subsequent full runs). Live reproduction of issue #856 in a scratch project: seed:a,seed:b then --add-ref added:c preserves both seeds; --add-ref "seed:a,added:d" dedups seed:a; --remove-ref seed:a leaves the rest; blank, --clear-refs, and --ref conflicts exit 1 without mutating the task.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Exposed the existing incremental reference mutations through the canonical CLI as task edit --add-ref and --remove-ref, closing the surface drift reported in issue #856 where only MCP task_edit could add or remove a single reference. Both flags are repeatable and comma-parsed, route through the same shared model operations MCP uses (addReferences/removeReferences) instead of new merge logic, join the BACK-586 conventions (interactive-TTY predicate, per-flag blank rejection, mutual exclusion with --clear-refs), and are rejected alongside --ref so replacement and incremental edits stay exclusive like labels. --ref remains the replace-all operation. Verified with 9 new CLI regression tests, unchanged MCP reference tests, updated agent guidelines, a live reproduction of the issue, bunx tsc --noEmit, bun run check ., and the full suite (1953 pass, 5 skip, 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -467,6 +467,8 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.dep !== undefined ||
 			options.clearDeps ||
 			options.ref !== undefined ||
+			options.addRef !== undefined ||
+			options.removeRef !== undefined ||
 			options.clearRefs ||
 			options.doc !== undefined ||
 			options.clearDocs ||
@@ -2704,9 +2706,19 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			description: "Remove all task dependencies; cannot combine with dependency flags",
 		},
 		{
+			name: "add-ref",
+			type: "Comma-separated strings",
+			description: "Add references; repeat --add-ref or use ref1,ref2",
+		},
+		{
+			name: "remove-ref",
+			type: "Comma-separated strings",
+			description: "Remove references; repeat --remove-ref or use ref1,ref2",
+		},
+		{
 			name: "clear-refs",
 			type: "Boolean",
-			description: "Remove all references; cannot combine with --ref",
+			description: "Remove all references; cannot combine with --ref, --add-ref, or --remove-ref",
 		},
 		{
 			name: "clear-docs",
@@ -2840,11 +2852,22 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
 		return [...soFar, value];
 	})
-	.option("--ref <reference>", "set references (can be used multiple times)", (value, previous) => {
-		const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
-		return [...soFar, value];
-	})
-	.option("--clear-refs", "remove all references (cannot combine with --ref)")
+	.option(
+		"--ref <reference>",
+		"replace all references (comma-separated or repeatable; cannot combine with --add-ref/--remove-ref)",
+		createMultiValueAccumulator(),
+	)
+	.option(
+		"--add-ref <reference>",
+		"add references without replacing existing references (comma-separated or repeatable)",
+		createMultiValueAccumulator(),
+	)
+	.option(
+		"--remove-ref <reference>",
+		"remove references without replacing others (comma-separated or repeatable)",
+		createMultiValueAccumulator(),
+	)
+	.option("--clear-refs", "remove all references (cannot combine with --ref/--add-ref/--remove-ref)")
 	.option(
 		"--modified-file <path>",
 		"set modified file paths from project root (can be used multiple times)",
@@ -3064,6 +3087,8 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 
 		const combinedDependencies = [...toStringArray(options.dependsOn), ...toStringArray(options.dep)];
 		const rawReferences = toStringArray(options.ref);
+		const rawAddReferences = toStringArray(options.addRef);
+		const rawRemoveReferences = toStringArray(options.removeRef);
 		const rawDocumentation = toStringArray(options.doc);
 		const isBlankListValue = (value: string) => parseDelimitedStringList(value) === undefined;
 		const clearableListError =
@@ -3084,6 +3109,22 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 				subject: "references",
 			}) ??
 			validateClearableListInput({
+				rawValues: rawAddReferences,
+				cleared: Boolean(options.clearRefs),
+				isBlank: isBlankListValue,
+				setterFlags: "--add-ref",
+				clearFlag: "--clear-refs",
+				subject: "references",
+			}) ??
+			validateClearableListInput({
+				rawValues: rawRemoveReferences,
+				cleared: Boolean(options.clearRefs),
+				isBlank: isBlankListValue,
+				setterFlags: "--remove-ref",
+				clearFlag: "--clear-refs",
+				subject: "references",
+			}) ??
+			validateClearableListInput({
 				rawValues: rawDocumentation,
 				cleared: Boolean(options.clearDocs),
 				isBlank: isBlankListValue,
@@ -3096,9 +3137,19 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			process.exitCode = 1;
 			return;
 		}
+
+		if (options.ref !== undefined && (options.addRef !== undefined || options.removeRef !== undefined)) {
+			console.error(
+				"Cannot combine --ref with --add-ref or --remove-ref. Use --ref a,b for the final full reference set, or use add/remove flags without --ref.",
+			);
+			process.exitCode = 1;
+			return;
+		}
 		const dependencyValues = combinedDependencies.length > 0 ? normalizeDependencies(combinedDependencies) : undefined;
 
 		const normalizedReferences = parseDelimitedStringList(options.ref);
+		const addReferenceValues = parseDelimitedStringList(options.addRef) ?? [];
+		const removeReferenceValues = parseDelimitedStringList(options.removeRef) ?? [];
 		const normalizedDocumentation = parseDelimitedStringList(options.doc);
 		const normalizedModifiedFiles = parseDelimitedStringList(options.modifiedFile);
 
@@ -3153,6 +3204,12 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			editArgs.references = normalizedReferences;
 		} else if (options.clearRefs) {
 			editArgs.references = [];
+		}
+		if (addReferenceValues.length > 0) {
+			editArgs.addReferences = addReferenceValues;
+		}
+		if (removeReferenceValues.length > 0) {
+			editArgs.removeReferences = removeReferenceValues;
 		}
 		if (normalizedDocumentation) {
 			editArgs.documentation = normalizedDocumentation;

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -570,7 +570,7 @@ backlog search --modified-file src/server/api.ts --plain
 | Replace references | `backlog task edit 42 --ref src/api.ts --ref https://github.com/issue/123` |
 | Add references   | `backlog task edit 42 --add-ref src/api.ts --add-ref https://github.com/issue/123` |
 | Remove references | `backlog task edit 42 --remove-ref src/api.ts` |
-| Add documentation | `backlog task edit 42 --doc https://design-docs.example.com --doc docs/spec.md` |
+| Replace documentation | `backlog task edit 42 --doc https://design-docs.example.com --doc docs/spec.md` |
 | Set modified files | `backlog task edit 42 --modified-file src/api.ts --modified-file src/ui.ts` |
 
 ### Multi‑line Input (Description/Plan/Notes/Comments/Final Summary)

--- a/src/guidelines/agent-guidelines.md
+++ b/src/guidelines/agent-guidelines.md
@@ -567,7 +567,9 @@ backlog search --modified-file src/server/api.ts --plain
 | Append final summary | `backlog task edit 42 --append-final-summary "More details"` |
 | Clear final summary | `backlog task edit 42 --clear-final-summary` |
 | Add dependencies | `backlog task edit 42 --dep task-1 --dep task-2`         |
-| Add references   | `backlog task edit 42 --ref src/api.ts --ref https://github.com/issue/123` |
+| Replace references | `backlog task edit 42 --ref src/api.ts --ref https://github.com/issue/123` |
+| Add references   | `backlog task edit 42 --add-ref src/api.ts --add-ref https://github.com/issue/123` |
+| Remove references | `backlog task edit 42 --remove-ref src/api.ts` |
 | Add documentation | `backlog task edit 42 --doc https://design-docs.example.com --doc docs/spec.md` |
 | Set modified files | `backlog task edit 42 --modified-file src/api.ts --modified-file src/ui.ts` |
 

--- a/src/test/cli-refs-docs.test.ts
+++ b/src/test/cli-refs-docs.test.ts
@@ -288,6 +288,133 @@ await import(${JSON.stringify(pathToFileURL(cliPath).href)});
 		});
 	});
 
+	describe("task edit with --add-ref and --remove-ref", () => {
+		async function createTaskWithReferences() {
+			await $`bun ${cliPath} task create "Feature" --ref seed:a --ref seed:b --doc doc-a`.cwd(TEST_DIR).quiet();
+		}
+
+		async function loadReferences() {
+			return (await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.references;
+		}
+
+		it("adds references without replacing existing ones and skips duplicates", async () => {
+			await createTaskWithReferences();
+
+			const result = await $`bun ${cliPath} task edit 1 --add-ref added:c --add-ref seed:a --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toContain("References: seed:a, seed:b, added:c");
+			expect(await loadReferences()).toEqual(["seed:a", "seed:b", "added:c"]);
+		});
+
+		it("removes references by value and leaves unrelated references unchanged", async () => {
+			await createTaskWithReferences();
+
+			const result = await $`bun ${cliPath} task edit 1 --remove-ref seed:a --remove-ref missing:x --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			expect(result.exitCode).toBe(0);
+			expect(await loadReferences()).toEqual(["seed:b"]);
+			const task = await new Core(TEST_DIR).filesystem.loadTask("TASK-1");
+			expect(task?.documentation).toEqual(["doc-a"]);
+		});
+
+		it("accepts comma-separated values for both flags", async () => {
+			await createTaskWithReferences();
+
+			const added = await $`bun ${cliPath} task edit 1 --add-ref "added:c,added:d" --plain`.cwd(TEST_DIR).quiet();
+			expect(added.exitCode).toBe(0);
+			expect(await loadReferences()).toEqual(["seed:a", "seed:b", "added:c", "added:d"]);
+
+			const removed = await $`bun ${cliPath} task edit 1 --remove-ref "seed:a,added:d"`.cwd(TEST_DIR).quiet();
+			expect(removed.exitCode).toBe(0);
+			expect(await loadReferences()).toEqual(["seed:b", "added:c"]);
+		});
+
+		it("removes a reference that is added in the same command", async () => {
+			// Pins the shared model order used by MCP task_edit: additions apply first, then removals.
+			await createTaskWithReferences();
+
+			const result = await $`bun ${cliPath} task edit 1 --add-ref same:x --remove-ref same:x --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+
+			expect(result.exitCode).toBe(0);
+			expect(await loadReferences()).toEqual(["seed:a", "seed:b"]);
+		});
+
+		it("adds a reference in an interactive terminal", async () => {
+			await createTaskWithReferences();
+
+			const result = await runCliWithInteractiveTty(TEST_DIR, ["task", "edit", "1", "--add-ref", "added:c"]);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toContain("Updated task TASK-1");
+			expect(await loadReferences()).toEqual(["seed:a", "seed:b", "added:c"]);
+		});
+
+		it("rejects empty values and conflicting flags without changing references", async () => {
+			await createTaskWithReferences();
+
+			const emptyAdd = await $`bun ${cliPath} task edit 1 --add-ref ""`.cwd(TEST_DIR).quiet().nothrow();
+			expect(emptyAdd.exitCode).toBe(1);
+			expect(emptyAdd.stderr.toString()).toContain(
+				"Cannot use an empty value with --add-ref. Use --clear-refs to remove all references.",
+			);
+			expect(emptyAdd.stdout.toString()).not.toContain("Updated task");
+
+			const emptyRemove = await $`bun ${cliPath} task edit 1 --remove-ref seed:a --remove-ref ""`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(emptyRemove.exitCode).toBe(1);
+			expect(emptyRemove.stderr.toString()).toContain("Cannot use an empty value with --remove-ref");
+
+			const clearConflict = await $`bun ${cliPath} task edit 1 --clear-refs --add-ref added:c`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(clearConflict.exitCode).toBe(1);
+			expect(clearConflict.stderr.toString()).toContain("Cannot combine --clear-refs with --add-ref");
+
+			const clearRemoveConflict = await $`bun ${cliPath} task edit 1 --clear-refs --remove-ref seed:a`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(clearRemoveConflict.exitCode).toBe(1);
+			expect(clearRemoveConflict.stderr.toString()).toContain("Cannot combine --clear-refs with --remove-ref");
+
+			const replacementConflict = await $`bun ${cliPath} task edit 1 --ref only:c --add-ref added:c`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(replacementConflict.exitCode).toBe(1);
+			expect(replacementConflict.stderr.toString()).toContain("Cannot combine --ref with --add-ref or --remove-ref");
+
+			expect(await loadReferences()).toEqual(["seed:a", "seed:b"]);
+		});
+
+		it("keeps --ref as the replace-all operation", async () => {
+			await createTaskWithReferences();
+
+			const result = await $`bun ${cliPath} task edit 1 --ref only:c --plain`.cwd(TEST_DIR).quiet();
+
+			expect(result.exitCode).toBe(0);
+			expect(await loadReferences()).toEqual(["only:c"]);
+		});
+
+		it("documents --add-ref and --remove-ref in task edit help", async () => {
+			const result = await $`bun ${cliPath} task edit --help`.cwd(TEST_DIR).quiet();
+
+			const out = result.stdout.toString();
+			expect(out).toContain("--add-ref");
+			expect(out).toContain("--remove-ref");
+		});
+	});
+
 	describe("persistence in markdown files", () => {
 		it("persists references in task markdown file", async () => {
 			await $`bun ${cliPath} task create "Feature" --ref https://example.com --ref src/index.ts`.cwd(TEST_DIR).quiet();


### PR DESCRIPTION
Fixes #856.

`task edit --ref` replaces the whole references array, while the MCP schema already exposed `addReferences`/`removeReferences` from the shared model — CLI-vs-MCP surface drift that forced a client-side read-merge-replace workaround. `task edit` now supports `--add-ref` and `--remove-ref` (repeatable and comma-parsed per the multi-value convention), routed through the exact model operations MCP uses: additions preserve existing references and dedup; removals match values and leave everything else untouched; no core, builder, or MCP changes.

Conventions carried through: both flags join the interactive-TTY predicate, blank values are rejected per-occurrence via the shared validator, `--clear-refs` is mutually exclusive with both, and `--ref` combined with the incremental flags is rejected (mirroring the labels rule). Add+remove of the same value in one command resolves to removal, matching the model, pinned by a test. Also fixes two agent-guideline rows that documented the replace-all flags as "add".

Verification: the issue's exact sequence live, all invalid combinations exit non-zero with zero mutation (frontmatter inspected), MCP parity confirmed in-process for identical operations, non-vacuous TTY tests, full suite 1953 pass / 0 fail. Independently reviewed with no blocking findings.