### PR TITLE
BACK-582 - Add a decision list command

### DIFF
--- a/backlog/tasks/back-582 - Add-a-decision-list-command.md
+++ b/backlog/tasks/back-582 - Add-a-decision-list-command.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-582
 title: Add a decision list command
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 17:25'
+updated_date: '2026-08-07 22:51'
 labels:
   - enhancement
 dependencies: []
@@ -24,18 +26,57 @@ Maintainer direction to respect: bring docs and decisions operations toward task
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `backlog decision list` enumerates decisions
-- [ ] #2 `backlog decision list --plain` produces AI-friendly text output
-- [ ] #3 `backlog decision list --json` produces stable JSON output
-- [ ] #4 Listed output shows at least id, title, and status for each decision
-- [ ] #5 The new command is described in the CLI help schema
-- [ ] #6 Tests cover the new command
-- [ ] #7 Scope stays limited to list; a -d/--description option on `decision create` may ride along only if it is trivial
+- [x] #1 `backlog decision list` enumerates decisions
+- [x] #2 `backlog decision list --plain` produces AI-friendly text output
+- [x] #3 `backlog decision list --json` produces stable JSON output
+- [x] #4 Listed output shows at least id, title, and status for each decision
+- [x] #5 The new command is described in the CLI help schema
+- [x] #6 Tests cover the new command
+- [x] #7 Scope stays limited to list; a -d/--description option on `decision create` may ride along only if it is trivial
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add decisionListJson() to src/formatters/json-output.ts reusing the existing toDecisionSummaryJson helper, emitting { schemaVersion: 1, kind: "decision-list", decisions: [...] } to match taskListJson/searchJson envelopes.
+2. Add a 'decision list' subcommand in src/cli.ts next to 'decision create': addHelpSchema with reads/optional(plain,json)/output/examples, --plain and --json options, and getReadOutputMode() so --json and --plain conflict is rejected the same way task list rejects it.
+3. Output: JSON prints the versioned envelope (empty array when there are no decisions); text prints one row per decision as 'decision-1 - Title (status)' mirroring doc list rows plus task list's status suffix; empty text output prints 'No decisions found.' like doc list's 'No docs found.'. Statuses print as stored because decisions are free-form.
+4. Load via core.filesystem.listDecisions() only; no identity/duplicate changes (BACK-580 owns fail-closed identity for docs/decisions).
+5. Scope guards: no new MCP tools, no --status filter, no -d/--description on create (Decision has no description field; it would need a section mapping, so it is not trivial).
+6. Tests: CLI plain/empty/status coverage in src/test/cli-doc-decision-board.test.ts and a versioned JSON envelope + --json/--plain conflict test in src/test/cli-json-output.test.ts.
+7. Verify with bunx tsc --noEmit, bun run check ., scoped tests, then the full bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added `backlog decision list` in src/cli.ts next to `decision create`, plus `decisionListJson()` in src/formatters/json-output.ts.
+
+Design choices:
+- JSON reuses the existing `toDecisionSummaryJson` helper already used by `search --json`, so a decision has one public JSON shape (id, title, status, date) across commands. Envelope is { schemaVersion: 1, kind: "decision-list", decisions: [...] }, matching taskListJson/searchJson.
+- Output mode goes through the shared `getReadOutputMode()`/`resolveReadOutputMode()` path, so `--json --plain` is rejected with the same message and exit code as task list/view and search.
+- Text rows are 'decision-1 - Title (status)': doc list's 'id - title' row plus task list's '(status)' suffix. Statuses print exactly as stored because decisions accept free-form status values (parseDecision casts any string to the union type).
+- Empty log prints 'No decisions found.' in text mode (mirroring doc list's 'No docs found.') and an empty decisions array in JSON mode (mirroring the empty task-list/search envelopes).
+- No interactive picker: unlike doc list there is no `decision view` command to open, so an interactive select would be a dead end and would need its own decision-file lookup. Text output therefore covers both --plain and TTY runs; --plain is still accepted so agent guidance that always passes --plain works.
+
+Scope guards honored:
+- No new MCP tools.
+- No --status filter (not required; decisions are few and statuses are free-form, so a filter would add surface without a proven need).
+- No -d/--description on create: Decision has no description field, only Context/Decision/Consequences/Alternatives sections, so mapping a description would require picking a section - not trivial, so it was left out per AC #7.
+- No identity/duplicate-ID changes; listing uses core.filesystem.listDecisions() as-is, so duplicate decision IDs surface as separate rows rather than being silently collapsed. BACK-580 still owns fail-closed identity for docs/decisions.
+
+Left unchanged: `decision create --plain` still errors on the unknown option. That is outside this task's acceptance criteria (scope is list).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added `backlog decision list` so decisions are enumerable from the CLI, not just writable and searchable. Text mode prints 'decision-1 - Title (status)' rows (doc list row shape plus task list's status suffix, statuses shown exactly as stored since decisions are free-form) and 'No decisions found.' when empty; --json prints { schemaVersion: 1, kind: "decision-list", decisions: [...] } built from the same toDecisionSummaryJson helper that search --json already uses. Output mode resolution reuses getReadOutputMode, so --json --plain is rejected identically to task list/view and search, and the command is documented in the CLI help schema. Scope stayed on list: no MCP tools, no status filter, no create options, no identity changes (BACK-580 owns that). Verified with bunx tsc --noEmit, bun run check ., and bun run test (1971 pass / 5 skip / 0 fail), including new coverage in src/test/cli-doc-decision-board.test.ts (plain rows, non-TTY default, empty log in both modes) and src/test/cli-json-output.test.ts (versioned envelope, --json/--plain conflict, help documents --json).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-582 - Add-a-decision-list-command.md
+++ b/backlog/tasks/back-582 - Add-a-decision-list-command.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 17:25'
-updated_date: '2026-08-07 22:51'
+updated_date: '2026-08-07 23:00'
 labels:
   - enhancement
 dependencies: []
@@ -73,10 +73,24 @@ Scope guards honored:
 - No identity/duplicate-ID changes; listing uses core.filesystem.listDecisions() as-is, so duplicate decision IDs surface as separate rows rather than being silently collapsed. BACK-580 still owns fail-closed identity for docs/decisions.
 
 Left unchanged: `decision create --plain` still errors on the unknown option. That is outside this task's acceptance criteria (scope is list).
+
+Follow-up accepted by the coordinator as AC-adjacent in-scope work (issue #845 reported it as the sharp edge): `backlog decision create` now accepts `--plain` instead of failing with "error: unknown option '--plain'". Shipped agent guidance tells agents to always pass --plain, so the error was a guidance/CLI contradiction.
+
+- Mirrors the `task create --plain` shape: a plain output-mode flag on the create command, declared with `.option("--plain", ...)` and listed in the command's help schema.
+- Behavior is accept-and-proceed rather than a second output format. `decision create` already prints one plain line ('Created decision decision-1') with no color or interactive UI, and there is no `decision view`/`formatDecisionPlainText` to render a created record with, so inventing a decision detail format here would have added surface the task did not ask for. A code comment records why the flag is accepted.
+- `decision create` also gained the help schema and descriptions it never had (title, status, plain, writes, output, example); previously `backlog decision create --help` showed a bare undescribed `-s, --status`.
+
+Test added in src/test/cli-doc-decision-board.test.ts: create with --plain exits 0, writes no stderr, prints exactly 'Created decision decision-1' with no ANSI escapes, and the decision is persisted.
+
+Re-verified after this change: bunx tsc --noEmit clean, bun run check . clean, cli-doc-decision-board + cli-guidance + cli-json-output green (47 pass), full bun run test 1972 pass / 5 skip / 0 fail.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Added `backlog decision list` so decisions are enumerable from the CLI, not just writable and searchable. Text mode prints 'decision-1 - Title (status)' rows (doc list row shape plus task list's status suffix, statuses shown exactly as stored since decisions are free-form) and 'No decisions found.' when empty; --json prints { schemaVersion: 1, kind: "decision-list", decisions: [...] } built from the same toDecisionSummaryJson helper that search --json already uses. Output mode resolution reuses getReadOutputMode, so --json --plain is rejected identically to task list/view and search, and the command is documented in the CLI help schema. Scope stayed on list: no MCP tools, no status filter, no create options, no identity changes (BACK-580 owns that). Verified with bunx tsc --noEmit, bun run check ., and bun run test (1971 pass / 5 skip / 0 fail), including new coverage in src/test/cli-doc-decision-board.test.ts (plain rows, non-TTY default, empty log in both modes) and src/test/cli-json-output.test.ts (versioned envelope, --json/--plain conflict, help documents --json).
+Added `backlog decision list` so decisions are enumerable from the CLI, not just writable and searchable, and made `backlog decision create` accept `--plain` instead of erroring on it (issue #845's sharp edge, accepted by the coordinator as AC-adjacent).
+
+decision list: text mode prints 'decision-1 - Title (status)' rows (doc list row shape plus task list's status suffix, statuses shown exactly as stored since decisions are free-form) and 'No decisions found.' when empty; --json prints { schemaVersion: 1, kind: "decision-list", decisions: [...] } built from the same toDecisionSummaryJson helper that search --json already uses. Output mode resolution reuses getReadOutputMode, so --json --plain is rejected identically to task list/view and search. decision create: --plain is accepted as an output-mode flag mirroring task create; create output was already a single plain line, so the flag ends the guidance/CLI contradiction without inventing a decision detail format. Both commands are now described in the CLI help schema. Scope stayed on list plus that accepted create fix: no MCP tools, no status filter, no identity changes (BACK-580 owns that).
+
+Verified with bunx tsc --noEmit, bun run check ., and bun run test (1972 pass / 5 skip / 0 fail), including new coverage in src/test/cli-doc-decision-board.test.ts (create --plain, plain rows, non-TTY default, empty log in both modes) and src/test/cli-json-output.test.ts (versioned envelope, --json/--plain conflict, help documents --json).
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES } from "./constant
 import { type DuplicateRepairPlan, findLocalDuplicateTaskIds } from "./core/duplicate-task-repair.ts";
 import { initializeProject } from "./core/init.ts";
 import { buildMilestoneBuckets, collectArchivedMilestoneKeys, milestoneKey } from "./core/milestones.ts";
-import { printJson, searchJson, taskListJson, taskViewJson } from "./formatters/json-output.ts";
+import { decisionListJson, printJson, searchJson, taskListJson, taskViewJson } from "./formatters/json-output.ts";
 import { formatTaskPlainText } from "./formatters/task-plain-text.ts";
 import {
 	type AgentInstructionFile,
@@ -4310,6 +4310,44 @@ decisionCmd
 		};
 		await core.createDecision(decision);
 		console.log(`Created decision ${id}`);
+	});
+
+addHelpSchema(decisionCmd.command("list"), {
+	reads: "Decisions under the configured decisions directory",
+	writes: "None; this is a read-only command",
+	required: [],
+	optional: [
+		{ name: "plain", type: "Boolean", description: "Use plain text output, which is the default for this command" },
+		{ name: "json", type: "Boolean", description: "Use versioned machine-readable JSON output" },
+	],
+	output: "Decision list with IDs, titles, and statuses; versioned JSON with --json",
+	examples: ["backlog decision list --plain", "backlog decision list --json"],
+})
+	.description("list decisions")
+	.option("--plain", "use plain text output")
+	.option("--json", "print versioned machine-readable JSON output")
+	.action(async (options) => {
+		const outputMode = getReadOutputMode(options);
+		if (!outputMode) return;
+		const cwd = await requireProjectRoot();
+		const core = new Core(cwd);
+		const decisions = await core.filesystem.listDecisions();
+
+		if (outputMode === "json") {
+			printJson(decisionListJson(decisions));
+			return;
+		}
+
+		if (decisions.length === 0) {
+			console.log("No decisions found.");
+			return;
+		}
+
+		// Decisions have no interactive detail view, so text output covers plain and TTY runs.
+		for (const decision of decisions) {
+			const status = decision.status ? ` (${decision.status})` : "";
+			console.log(`${decision.id} - ${decision.title}${status}`);
+		}
 	});
 
 // Agents command group

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4291,9 +4291,20 @@ addHelpSchema(docCmd.command("view <docId>"), {
 
 const decisionCmd = program.command("decision");
 
-decisionCmd
-	.command("create <title>")
-	.option("-s, --status <status>")
+addHelpSchema(decisionCmd.command("create <title>"), {
+	required: [{ name: "title", type: "String", description: "Decision title" }],
+	optional: [
+		{ name: "status", type: "String", description: "Decision status; free-form, defaults to proposed" },
+		{ name: "plain", type: "Boolean", description: "Use plain text output" },
+	],
+	writes: "Creates a decision markdown file under the configured decisions directory",
+	output: "Created decision ID",
+	examples: ['backlog decision create "Adopt Bun test runner" -s accepted --plain'],
+})
+	.description("create a decision")
+	.option("-s, --status <status>", "set decision status (free-form, defaults to proposed)")
+	// Accepted so agent guidance that always passes --plain works; create output is already plain text.
+	.option("--plain", "use plain text output")
 	.action(async (title: string, options) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);

--- a/src/formatters/json-output.ts
+++ b/src/formatters/json-output.ts
@@ -179,6 +179,10 @@ export function taskViewJson(task: Task, projectRoot: string) {
 	return { schemaVersion: 1, kind: "task-view" as const, task: toTaskDetailsJson(task, projectRoot) };
 }
 
+export function decisionListJson(decisions: Decision[]) {
+	return { schemaVersion: 1, kind: "decision-list" as const, decisions: decisions.map(toDecisionSummaryJson) };
+}
+
 export function searchJson(results: SearchResult[], projectRoot: string, docsDir: string) {
 	const publicResults: SearchResultJson[] = [];
 	for (const result of results) {

--- a/src/test/cli-doc-decision-board.test.ts
+++ b/src/test/cli-doc-decision-board.test.ts
@@ -173,6 +173,41 @@ describe("CLI Integration", () => {
 			expect(decisions).toHaveLength(1);
 			expect(decisions[0]?.title).toBe("Choose Stack");
 		});
+
+		it("should list decisions with id, title, and status as plain text", async () => {
+			await $`bun ${CLI_PATH} decision create "Choose Stack" -s accepted`.cwd(TEST_DIR).quiet();
+			await $`bun ${CLI_PATH} decision create "Adopt Free Form Status" -s "Under Review"`.cwd(TEST_DIR).quiet();
+
+			const result = await $`bun ${CLI_PATH} decision list --plain`.cwd(TEST_DIR).quiet();
+			expect(result.exitCode).toBe(0);
+			const lines = result.stdout.toString().trim().split("\n");
+			expect(lines).toEqual([
+				"decision-1 - Choose Stack (accepted)",
+				"decision-2 - Adopt Free Form Status (Under Review)",
+			]);
+		});
+
+		it("should default to text output when stdout is not a TTY", async () => {
+			await $`bun ${CLI_PATH} decision create "Choose Stack"`.cwd(TEST_DIR).quiet();
+
+			const result = await $`bun ${CLI_PATH} decision list`.cwd(TEST_DIR).quiet();
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString().trim()).toBe("decision-1 - Choose Stack (proposed)");
+		});
+
+		it("should report an empty decision log in both output modes", async () => {
+			const plain = await $`bun ${CLI_PATH} decision list --plain`.cwd(TEST_DIR).quiet();
+			expect(plain.exitCode).toBe(0);
+			expect(plain.stdout.toString().trim()).toBe("No decisions found.");
+
+			const json = await $`bun ${CLI_PATH} decision list --json`.cwd(TEST_DIR).quiet();
+			expect(json.exitCode).toBe(0);
+			expect(JSON.parse(json.stdout.toString())).toEqual({
+				schemaVersion: 1,
+				kind: "decision-list",
+				decisions: [],
+			});
+		});
 	});
 
 	describe("board view command", () => {

--- a/src/test/cli-doc-decision-board.test.ts
+++ b/src/test/cli-doc-decision-board.test.ts
@@ -174,6 +174,21 @@ describe("CLI Integration", () => {
 			expect(decisions[0]?.title).toBe("Choose Stack");
 		});
 
+		it("should accept --plain when creating a decision", async () => {
+			const result = await $`bun ${CLI_PATH} decision create "Choose Stack" --plain`.cwd(TEST_DIR).quiet().nothrow();
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr.toString()).toBe("");
+
+			const stdout = result.stdout.toString();
+			expect(stdout.trim()).toBe("Created decision decision-1");
+			expect(stdout.includes("[")).toBe(false);
+
+			const core = new Core(TEST_DIR);
+			const decisions = await core.filesystem.listDecisions();
+			expect(decisions).toHaveLength(1);
+			expect(decisions[0]?.title).toBe("Choose Stack");
+		});
+
 		it("should list decisions with id, title, and status as plain text", async () => {
 			await $`bun ${CLI_PATH} decision create "Choose Stack" -s accepted`.cwd(TEST_DIR).quiet();
 			await $`bun ${CLI_PATH} decision create "Adopt Free Form Status" -s "Under Review"`.cwd(TEST_DIR).quiet();

--- a/src/test/cli-json-output.test.ts
+++ b/src/test/cli-json-output.test.ts
@@ -113,6 +113,28 @@ describe("CLI JSON output", () => {
 		expect(result.stdout.toString()).not.toContain("onStatusChange");
 	});
 
+	it("returns a compact versioned decision-list envelope", async () => {
+		const result = await runCli(["decision", "list", "--json"]);
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toBe("");
+		expect(result.stdout.toString().endsWith("\n")).toBe(true);
+
+		expect(JSON.parse(result.stdout.toString())).toEqual({
+			schemaVersion: 1,
+			kind: "decision-list",
+			decisions: [
+				{
+					id: "decision-1",
+					title: "Use stable JSON",
+					status: "accepted",
+					date: "2026-07-12",
+				},
+			],
+		});
+		expect(result.stdout.toString()).not.toContain("rawContent");
+		expect(result.stdout.toString()).not.toContain("Publish curated fields");
+	});
+
 	it("returns curated task details for view and shorthand", async () => {
 		for (const args of [
 			["task", "view", "1", "--json"],
@@ -234,6 +256,7 @@ describe("CLI JSON output", () => {
 			["task", "view", "1", "--json", "--plain"],
 			["task", "1", "--json", "--plain"],
 			["search", "JSON", "--json", "--plain"],
+			["decision", "list", "--json", "--plain"],
 		]) {
 			const result = await runCli(args);
 			expect(result.exitCode).toBe(1);
@@ -296,6 +319,7 @@ describe("CLI JSON output", () => {
 			["task", "view", "--help"],
 			["task", "--help"],
 			["search", "--help"],
+			["decision", "list", "--help"],
 		]) {
 			const result = await runCli(args);
 			expect(result.exitCode).toBe(0);


### PR DESCRIPTION
Fixes #845.

Decisions were writable and searchable but not enumerable: `backlog decision` exposed only `create`, and `decision create --plain` errored even though shipped agent guidance says to always pass `--plain`. `backlog decision list` now works with `--plain` and `--json` — rows show id, title, and status as stored (statuses are free-form on decisions), the JSON envelope follows the versioned shape `task list` uses and reuses the exact decision summary object `search --json` emits, and `--json --plain` conflicts identically to the other read commands via the shared output-mode resolver. `decision create` also now accepts `--plain` (accept-and-proceed; creation already prints one plain line and no decision detail format exists yet) and gained the help schema it never had.

Deliberately out of scope per the task: MCP tools, status filters, interactive picker (there is no `decision view` to open), and identity/duplicate handling (owned by BACK-580, verified non-overlapping).

Verification: all modes exercised empirically at 0/1/many decisions including free-form statuses and duplicate-ID files, JSON shape confirmed identical between surfaces, non-vacuous tests, full suite 1972 pass / 0 fail. Independently reviewed with no blocking findings.