### PR TITLE
BACK-580 - Fail closed on ambiguous document and decision identity

### DIFF
--- a/backlog/tasks/back-580 - Fail-closed-on-ambiguous-document-and-decision-identity.md
+++ b/backlog/tasks/back-580 - Fail-closed-on-ambiguous-document-and-decision-identity.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-580
 title: Fail closed on ambiguous document and decision identity
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-07 17:25'
+updated_date: '2026-08-07 23:29'
 labels:
   - bug
 dependencies: []
@@ -29,17 +31,53 @@ Maintainer context: docs and decisions operations lag well behind tasks, and equ
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `backlog doctor` detects duplicate document IDs
-- [ ] #2 `backlog doctor` detects duplicate decision IDs
-- [ ] #3 Looking up an ambiguous document or decision ID fails with a clear error instead of silently picking a winner
-- [ ] #4 The empty-string ID no longer resolves to any document
-- [ ] #5 Documents missing an `id:` in frontmatter are surfaced as malformed rather than silently half-usable
-- [ ] #6 Tests cover duplicate detection, ambiguous lookup failure, the empty-string ID, and documents missing an id
+- [x] #1 `backlog doctor` detects duplicate document IDs
+- [x] #2 `backlog doctor` detects duplicate decision IDs
+- [x] #3 Looking up an ambiguous document or decision ID fails with a clear error instead of silently picking a winner
+- [x] #4 The empty-string ID no longer resolves to any document
+- [x] #5 Documents missing an `id:` in frontmatter are surfaced as malformed rather than silently half-usable
+- [x] #6 Tests cover duplicate detection, ambiguous lookup failure, the empty-string ID, and documents missing an id
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add src/utils/entity-id.ts: one shared prefixed-ID identity helper (canonical key, equality that treats a blank ID body as unaddressable, AmbiguousIdError, findUniqueById). Make AmbiguousTaskIdError extend AmbiguousIdError so there is one ambiguity error shape.
+2. Reduce src/utils/document-id.ts to thin wrappers over it and add src/utils/decision-id.ts mirroring it (findDocumentById / findDecisionById throw on more than one match).
+3. src/file-system/operations.ts: listDecisions records each decision's backlog-relative path (new optional Decision.path); loadDocument and loadDecision resolve through the shared resolver and fail closed on ambiguity; decisions resolve by frontmatter ID like documents.
+4. src/core/backlog.ts: getDocument uses the shared resolver; add diagnoseContentIdentity() returning duplicate and missing-ID findings for documents and decisions.
+5. src/utils/duplicate-detection.ts: add detectContentIdentityIssues() next to detectDuplicateTaskIds (group by canonical key, collect entries with no ID).
+6. src/cli.ts: doctor reports duplicate and malformed document/decision IDs alongside task findings and exits 1; update the doctor help schema/description; doc view surfaces the ambiguity error instead of reporting not found.
+7. src/server/index.ts document and decision GET endpoints return 409 on ambiguity; src/mcp/errors maps AmbiguousIdError to a clear code.
+8. Tests: extend src/test/cli-doctor.test.ts, src/test/filesystem.test.ts, src/test/documentation.test.ts (or a focused new file) covering duplicate detection, ambiguous lookup failure, the empty-string ID, and documents missing an id.
+9. Verify: bunx tsc --noEmit, bun run check ., scoped tests, then full bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Identity is now enforced by one shared helper, src/utils/entity-id.ts: a canonical key per prefixed ID, equality that returns false whenever either side has no addressable body, AmbiguousIdError, and findUniqueEntityById. AmbiguousTaskIdError now extends AmbiguousIdError so tasks, documents, and decisions raise the same error shape (existing task message text unchanged). src/utils/document-id.ts became thin wrappers over it and src/utils/decision-id.ts mirrors it.
+
+Fail-closed lookups: FileSystem.loadDocument, FileSystem.loadDecision, and Core.getDocument now resolve through findDocumentById/findDecisionById and throw instead of taking the first title-sorted match. loadDecision previously matched on filename prefix and now matches frontmatter IDs like documents do, so a single authoritative identity applies across surfaces. The empty-string ID resolves to nothing anywhere because documentIdsEqual("", "") is false.
+
+Doctor: Core.diagnoseContentIdentity() reuses the tasks-side pattern (detectContentIdentityIssues sits next to detectDuplicateTaskIds in src/utils/duplicate-detection.ts) and reports duplicate document/decision IDs plus files with no id in frontmatter. Findings are diagnostic-only, like cross-branch findings; no automatic doc/decision repair was added. Doctor exits 1 when findings exist and its help schema and description now name documents and decisions.
+
+Other surfaces kept consistent: doc view prints the ambiguity error instead of "not found"; the server document and decision GET endpoints answer 409; MCP maps AmbiguousIdError to AMBIGUOUS_ID.
+
+Two supporting changes: Decision gained an optional path (set by listDecisions and by the decision watcher) so diagnostics can name files, and the existing MCP test that asserted an update silently collapsing duplicate doc-1/doc-01 files now asserts the fail-closed behavior instead, because that silent collapse is what this task removes.
+
+Documents and decisions missing an id are still listed by doc list and search rather than hidden; hiding them would trade one silent failure for another. They are surfaced by doctor as malformed and are unaddressable by ID.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Document and decision identity now fails closed instead of resolving by title sort order. A single shared helper (src/utils/entity-id.ts) defines the canonical key, blank-ID rejection, and AmbiguousIdError that tasks, documents, and decisions all use; FileSystem.loadDocument, FileSystem.loadDecision, and Core.getDocument raise that error rather than picking a winner, and the empty-string ID no longer matches anything. backlog doctor now reports duplicate document and decision IDs plus files with no id in frontmatter as diagnostic-only findings and exits 1, reusing the existing tasks-side detection module. doc view, the server document and decision endpoints (409), and MCP surface the ambiguity error clearly. Verified with bunx tsc --noEmit, bun run check ., new src/test/content-identity.test.ts (9 tests), new backlog doctor cases in src/test/cli-doctor.test.ts, a server 409 case in src/test/server-documents-endpoint.test.ts, and full bun run test (1982 pass, 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-580 - Fail-closed-on-ambiguous-document-and-decision-identity.md
+++ b/backlog/tasks/back-580 - Fail-closed-on-ambiguous-document-and-decision-identity.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 17:25'
-updated_date: '2026-08-07 23:29'
+updated_date: '2026-08-07 23:59'
 labels:
   - bug
 dependencies: []
@@ -74,10 +74,20 @@ Other surfaces kept consistent: doc view prints the ambiguity error instead of "
 Two supporting changes: Decision gained an optional path (set by listDecisions and by the decision watcher) so diagnostics can name files, and the existing MCP test that asserted an update silently collapsing duplicate doc-1/doc-01 files now asserts the fail-closed behavior instead, because that silent collapse is what this task removes.
 
 Documents and decisions missing an id are still listed by doc list and search rather than hidden; hiding them would trade one silent failure for another. They are surfaced by doctor as malformed and are unaddressable by ID.
+
+Review outcome: approved with no blocking findings.
+
+Accepted ride-along (A2): the server document and decision PUT endpoints previously fell through to generic 500s on ambiguity while the GETs already answered 409 with the full message. Both catches now branch on isAmbiguousIdError first, so mutation callers get the same legible 409. Covered by a new case in src/test/server-documents-endpoint.test.ts asserting 409 on PUT for both endpoints and that every candidate file is byte-identical afterward.
+
+Recorded as observations, not fixed here:
+
+A1 (split out as BACK-600): reads now key on frontmatter identity but save-side duplicate cleanup still keys on the filename prefix. Pre-existing on main and unchanged by this task, a file such as nested/doc-2 - Shadow.md carrying frontmatter id: doc-99 is silently deleted by doc update doc-2 because the removal loop matches by filename prefix. Newly reachable but fail-safe, updating a decision whose filename prefix disagrees with its frontmatter ID writes a new file, leaves the old one, and manufactures a duplicate that doctor then reports. Fix direction recorded in BACK-600: locate source files by frontmatter identity using Document.path/Decision.path, and have doctor flag filename-prefix-vs-frontmatter-ID mismatches.
+
+A3-A5 advisories: doc list and search still show documents and decisions with no id (deliberate, they stay visible and are reported by doctor rather than hidden); the web surfaces turn the 409 into a generic fetch failure message rather than showing the ambiguity detail; and doctor reports doc/decision findings as diagnostic-only with no automatic repair, matching how cross-branch task findings are handled.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Document and decision identity now fails closed instead of resolving by title sort order. A single shared helper (src/utils/entity-id.ts) defines the canonical key, blank-ID rejection, and AmbiguousIdError that tasks, documents, and decisions all use; FileSystem.loadDocument, FileSystem.loadDecision, and Core.getDocument raise that error rather than picking a winner, and the empty-string ID no longer matches anything. backlog doctor now reports duplicate document and decision IDs plus files with no id in frontmatter as diagnostic-only findings and exits 1, reusing the existing tasks-side detection module. doc view, the server document and decision endpoints (409), and MCP surface the ambiguity error clearly. Verified with bunx tsc --noEmit, bun run check ., new src/test/content-identity.test.ts (9 tests), new backlog doctor cases in src/test/cli-doctor.test.ts, a server 409 case in src/test/server-documents-endpoint.test.ts, and full bun run test (1982 pass, 0 fail).
+Document and decision identity now fails closed instead of resolving by title sort order. A single shared helper (src/utils/entity-id.ts) defines the canonical key, blank-ID rejection, and AmbiguousIdError that tasks, documents, and decisions all use; FileSystem.loadDocument, FileSystem.loadDecision, and Core.getDocument raise that error rather than picking a winner, and the empty-string ID no longer matches anything. backlog doctor now reports duplicate document and decision IDs plus files with no id in frontmatter as diagnostic-only findings and exits 1, reusing the existing tasks-side detection module. doc view, the server document and decision GET and PUT endpoints (409), and MCP surface the ambiguity error clearly. Verified with bunx tsc --noEmit, bun run check ., new src/test/content-identity.test.ts (9 tests), new backlog doctor cases in src/test/cli-doctor.test.ts, GET and PUT 409 cases in src/test/server-documents-endpoint.test.ts, the server test suite (46 pass), and full bun run test (2005 pass, 0 fail). Reviewed and approved with no blocking findings; the save-side identity gap found during review is tracked as BACK-600.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-580 - Fail-closed-on-ambiguous-document-and-decision-identity.md
+++ b/backlog/tasks/back-580 - Fail-closed-on-ambiguous-document-and-decision-identity.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-07 17:25'
-updated_date: '2026-08-07 23:59'
+updated_date: '2026-08-08 05:12'
 labels:
   - bug
 dependencies: []
@@ -84,10 +84,26 @@ Recorded as observations, not fixed here:
 A1 (split out as BACK-600): reads now key on frontmatter identity but save-side duplicate cleanup still keys on the filename prefix. Pre-existing on main and unchanged by this task, a file such as nested/doc-2 - Shadow.md carrying frontmatter id: doc-99 is silently deleted by doc update doc-2 because the removal loop matches by filename prefix. Newly reachable but fail-safe, updating a decision whose filename prefix disagrees with its frontmatter ID writes a new file, leaves the old one, and manufactures a duplicate that doctor then reports. Fix direction recorded in BACK-600: locate source files by frontmatter identity using Document.path/Decision.path, and have doctor flag filename-prefix-vs-frontmatter-ID mismatches.
 
 A3-A5 advisories: doc list and search still show documents and decisions with no id (deliberate, they stay visible and are reported by doctor rather than hidden); the web surfaces turn the 409 into a generic fetch failure message rather than showing the ambiguity detail; and doctor reports doc/decision findings as diagnostic-only with no automatic repair, matching how cross-branch task findings are handled.
+
+Codex round 2 on #872: four findings accepted, one deferred.
+
+P1 store-backed resolution: ContentStore.replaceDecisions keys its map on the raw frontmatter ID, so two files carrying the identical raw id collapsed to one entry before the ambiguity resolver ran and the server answered 200 with a silently chosen winner. handleGetDecision now resolves from disk via filesystem.loadDecision, matching how handleGetDoc already resolves through core.getDocument. Documents were already disk-backed on this path (patchFilesystem only wraps the save methods), so no document change was needed. Verified the new test reproduces the bug: with the old store-based resolver it returns 200 instead of 409.
+
+P2 collection-wide catch: listDocuments and listDecisions wrapped the whole scan in one try/catch, so a single malformed file returned an empty array and hid every valid document or decision from lookup. Both now catch per file, skip the unreadable one, and collect its path in an optional out-param.
+
+P2 doctor blind spot: ContentIdentityIssues gained an unreadable list, diagnoseContentIdentity passes the collectors, and doctor prints an 'Unreadable ... files' section and exits 1. Doctor can no longer report healthy on a repo it could not fully read.
+
+Root cause found while testing the above: gray-matter stores the file object in its cache BEFORE parsing, so once a malformed file threw, every later parse of the same content returned empty frontmatter instead of failing. An unparseable file therefore silently became a document with no id, and its doctor classification depended on parse order. parseMarkdown now passes an options object, which bypasses that cache. Regression test in markdown.test.ts asserts malformed frontmatter fails on every parse. Tradeoff: Backlog no longer benefits from gray-matter's memoization of identical content; deterministic identity reporting is worth more than that micro-optimization, and the full suite runtime is unchanged.
+
+P1 web display: the API client discarded the 409 body and both detail components fell back to the cached list entry, rendering one ambiguous candidate as if resolution had succeeded. api.ts now builds an ApiError that keeps the server message and status for the document and decision fetch/update calls, and exports isAmbiguousIdConflict. DocumentationDetail and DecisionDetail never fall back to the cached entry on a 409 and render one shared AmbiguousIdNotice with the server's candidate list. DocumentationDetail's error state was previously declared but discarded; it is now read rather than duplicated.
+
+Deferred: the filename-vs-frontmatter decision update that leaves the old file behind is BACK-600 case (b), already filed with this evidence. Coordinator handles the reply.
+
+Verified: bunx tsc --noEmit, bun run check ., new tests for each accepted finding (server identical-raw-ID 409, per-file parse isolation, doctor unreadable findings, parser cache regression, web ambiguity rendering for both components), and full bun run test at 2014 pass / 0 fail.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Document and decision identity now fails closed instead of resolving by title sort order. A single shared helper (src/utils/entity-id.ts) defines the canonical key, blank-ID rejection, and AmbiguousIdError that tasks, documents, and decisions all use; FileSystem.loadDocument, FileSystem.loadDecision, and Core.getDocument raise that error rather than picking a winner, and the empty-string ID no longer matches anything. backlog doctor now reports duplicate document and decision IDs plus files with no id in frontmatter as diagnostic-only findings and exits 1, reusing the existing tasks-side detection module. doc view, the server document and decision GET and PUT endpoints (409), and MCP surface the ambiguity error clearly. Verified with bunx tsc --noEmit, bun run check ., new src/test/content-identity.test.ts (9 tests), new backlog doctor cases in src/test/cli-doctor.test.ts, GET and PUT 409 cases in src/test/server-documents-endpoint.test.ts, the server test suite (46 pass), and full bun run test (2005 pass, 0 fail). Reviewed and approved with no blocking findings; the save-side identity gap found during review is tracked as BACK-600.
+Document and decision identity now fails closed instead of resolving by title sort order. A single shared helper (src/utils/entity-id.ts) defines the canonical key, blank-ID rejection, and AmbiguousIdError that tasks, documents, and decisions all use; FileSystem.loadDocument, FileSystem.loadDecision, and Core.getDocument raise that error rather than picking a winner, and the empty-string ID no longer matches anything. Lookups resolve from disk on every surface, so two files sharing an identical raw frontmatter ID cannot be collapsed by the content store's by-ID map before the check runs. backlog doctor reports duplicate document and decision IDs, files with no id, and files it could not parse, and exits 1, reusing the existing tasks-side detection module. Per-file parse isolation means one malformed file no longer hides every other document or decision, and parseMarkdown bypasses gray-matter's cache so a malformed file fails on every parse instead of silently becoming a document with no id. doc view, the server document and decision GET and PUT endpoints (409), MCP, and the two web detail components all surface the ambiguity instead of a chosen candidate. Verified with bunx tsc --noEmit, bun run check ., new tests in src/test/content-identity.test.ts, src/test/cli-doctor.test.ts, src/test/server-documents-endpoint.test.ts, src/test/markdown.test.ts, and src/test/web-ambiguous-id.test.tsx, plus full bun run test at 2014 pass / 0 fail. Reviewed twice with no blocking findings; the save-side identity gap is tracked as BACK-600.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -400,6 +400,11 @@ function printContentIdentityReport(report: ContentIdentityReport): void {
 			for (const path of issues.missingIds) console.log(`  - ${path}`);
 			console.log(`Add an id to each file; these ${label}s cannot be addressed until then.`);
 		}
+		if (issues.unreadable.length > 0) {
+			console.log(`\nUnreadable ${label} files (could not be read or parsed):`);
+			for (const path of issues.unreadable) console.log(`  - ${path}`);
+			console.log(`Repair the frontmatter or file permissions; identity could not be checked for these ${label}s.`);
+		}
 	}
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,12 @@ import { scrollableViewer } from "./ui/tui.ts";
 import { type AgentSelectionValue, processAgentSelection } from "./utils/agent-selection.ts";
 import { normalizeProjectBacklogDirectory } from "./utils/backlog-directory.ts";
 import { launchBrowser } from "./utils/browser-launch.ts";
-import { formatDuplicateTaskIdWarning } from "./utils/duplicate-detection.ts";
+import {
+	type ContentIdentityReport,
+	formatDuplicateTaskIdWarning,
+	hasContentIdentityIssues,
+} from "./utils/duplicate-detection.ts";
+import { isAmbiguousIdError } from "./utils/entity-id.ts";
 import { findBacklogRoot } from "./utils/find-backlog-root.ts";
 import { labelsToLower } from "./utils/label-filter.ts";
 import {
@@ -373,6 +378,28 @@ function printDuplicateRepairPlan(plan: DuplicateRepairPlan): void {
 	if (plan.blockedReasons.length > 0) {
 		console.log("\nRepair is blocked:");
 		for (const reason of plan.blockedReasons) console.log(`  - ${reason}`);
+	}
+}
+
+function printContentIdentityReport(report: ContentIdentityReport): void {
+	const sections = [
+		["document", report.documents],
+		["decision", report.decisions],
+	] as const;
+	for (const [label, issues] of sections) {
+		if (issues.duplicates.length > 0) {
+			console.log(`\nDuplicate ${label} IDs (diagnostic only):`);
+			for (const group of issues.duplicates) {
+				console.log(`  ${group.id}:`);
+				for (const path of group.paths) console.log(`    - ${path}`);
+			}
+			console.log(`Give each file a unique id; ${label} lookups for these IDs stay blocked until then.`);
+		}
+		if (issues.missingIds.length > 0) {
+			console.log(`\nMalformed ${label} files without an id in frontmatter:`);
+			for (const path of issues.missingIds) console.log(`  - ${path}`);
+			console.log(`Add an id to each file; these ${label}s cannot be addressed until then.`);
+		}
 	}
 }
 
@@ -4287,7 +4314,12 @@ addHelpSchema(docCmd.command("view <docId>"), {
 				return;
 			}
 			await scrollableViewer(content);
-		} catch {
+		} catch (error) {
+			if (isAmbiguousIdError(error)) {
+				console.error(error.message);
+				process.exitCode = 1;
+				return;
+			}
 			console.error(`Document ${docId} not found.`);
 		}
 	});
@@ -4921,7 +4953,7 @@ addHelpSchema(configCmd.command("list"), {
 		}
 	});
 addHelpSchema(program.command("doctor"), {
-	reads: "Active and completed task files plus Backlog Markdown references",
+	reads: "Active and completed task files, document and decision files, plus Backlog Markdown references",
 	required: [],
 	optional: [
 		{ name: "fix", type: "Boolean", description: "Apply the displayed duplicate-ID repair" },
@@ -4929,10 +4961,11 @@ addHelpSchema(program.command("doctor"), {
 	],
 	writes:
 		"With --fix, atomically renames duplicate task files and updates only their frontmatter IDs; ambiguous references are reported for human review",
-	output: "Duplicate-ID diagnosis, deterministic repair preview, and reference-review report",
+	output:
+		"Duplicate-ID diagnosis for tasks, documents, and decisions, a deterministic task repair preview, and a reference-review report",
 	examples: ["backlog doctor", "backlog doctor --fix", "backlog doctor --fix --yes"],
 })
-	.description("diagnose and safely repair duplicate task IDs")
+	.description("diagnose duplicate task, document, and decision IDs and safely repair duplicate task IDs")
 	.option("--fix", "apply the displayed duplicate task ID repair")
 	.option("--yes", "confirm --fix without prompting")
 	.action(async (options: { fix?: boolean; yes?: boolean }) => {
@@ -4946,12 +4979,15 @@ addHelpSchema(program.command("doctor"), {
 		const core = new Core(cwd);
 		try {
 			const plan = await core.previewDuplicateTaskIdRepair({ includeBranches: true });
-			if (plan.groups.length === 0 && plan.crossBranchFindings.length === 0) {
-				console.log("No duplicate task IDs found in active or completed tasks.");
+			const contentIdentity = await core.diagnoseContentIdentity();
+			const contentIdentityBroken = hasContentIdentityIssues(contentIdentity);
+			if (plan.groups.length === 0 && plan.crossBranchFindings.length === 0 && !contentIdentityBroken) {
+				console.log("No duplicate task, document, or decision IDs found.");
 				return;
 			}
 
 			printDuplicateRepairPlan(plan);
+			printContentIdentityReport(contentIdentity);
 			if (!options.fix) {
 				if (plan.groups.length > 0 && plan.repairable) {
 					console.log("\nRun 'backlog doctor --fix' to apply this repair after reviewing the preview.");
@@ -4962,7 +4998,7 @@ addHelpSchema(program.command("doctor"), {
 				return;
 			}
 			if (plan.groups.length === 0) {
-				console.error("Cross-branch findings cannot be repaired from the current branch.");
+				console.error("The reported findings cannot be repaired automatically; resolve them by hand.");
 				process.exitCode = 1;
 				return;
 			}
@@ -5004,6 +5040,10 @@ addHelpSchema(program.command("doctor"), {
 			console.log("Verification passed: no duplicate active/completed task IDs remain.");
 			if (plan.crossBranchFindings.length > 0) {
 				console.log("Cross-branch findings remain diagnostic-only and still require branch-by-branch review.");
+				process.exitCode = 1;
+			}
+			if (contentIdentityBroken) {
+				console.log("Document and decision findings remain diagnostic-only and still require manual review.");
 				process.exitCode = 1;
 			}
 		} catch (error) {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -286,17 +286,25 @@ export class Core {
 
 	/** Reports document and decision files whose IDs collide or are missing, so lookups can fail closed. */
 	async diagnoseContentIdentity(): Promise<ContentIdentityReport> {
-		const [documents, decisions] = await Promise.all([this.fs.listDocuments(), this.fs.listDecisions()]);
-		const locate = (directory: string, item: { path?: string; title: string }) =>
-			item.path ? `${this.fs.backlogDirName}/${directory}/${item.path}` : item.title;
+		const unreadableDocuments: string[] = [];
+		const unreadableDecisions: string[] = [];
+		const [documents, decisions] = await Promise.all([
+			this.fs.listDocuments(unreadableDocuments),
+			this.fs.listDecisions(unreadableDecisions),
+		]);
+		const locate = (directory: string, path: string) => `${this.fs.backlogDirName}/${directory}/${path}`;
+		const describe = (directory: string, item: { path?: string; title: string }) =>
+			item.path ? locate(directory, item.path) : item.title;
 		return {
 			documents: detectContentIdentityIssues(
-				documents.map((document) => ({ id: document.id, path: locate(DEFAULT_DIRECTORIES.DOCS, document) })),
+				documents.map((document) => ({ id: document.id, path: describe(DEFAULT_DIRECTORIES.DOCS, document) })),
 				documentIdKey,
+				unreadableDocuments.map((path) => locate(DEFAULT_DIRECTORIES.DOCS, path)),
 			),
 			decisions: detectContentIdentityIssues(
-				decisions.map((decision) => ({ id: decision.id, path: locate(DEFAULT_DIRECTORIES.DECISIONS, decision) })),
+				decisions.map((decision) => ({ id: decision.id, path: describe(DEFAULT_DIRECTORIES.DECISIONS, decision) })),
 				decisionIdKey,
+				unreadableDecisions.map((path) => locate(DEFAULT_DIRECTORIES.DECISIONS, path)),
 			),
 		};
 	}

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -23,12 +23,14 @@ import {
 	type TaskUpdateInput,
 } from "../types/index.ts";
 import { normalizeAssignee } from "../utils/assignee.ts";
-import { documentIdsEqual, normalizeDocumentId } from "../utils/document-id.ts";
+import { decisionIdKey } from "../utils/decision-id.ts";
+import { documentIdKey, findDocumentById, normalizeDocumentId } from "../utils/document-id.ts";
 import {
 	getDocumentSubPathFromRelativePath,
 	normalizeDocumentRelativePath,
 	normalizeDocumentSubPath,
 } from "../utils/document-path.ts";
+import { type ContentIdentityReport, detectContentIdentityIssues } from "../utils/duplicate-detection.ts";
 import { openInEditor } from "../utils/editor.ts";
 import { generateNextDocId } from "../utils/id-generators.ts";
 import {
@@ -280,6 +282,23 @@ export class Core {
 			await this.contentStore.refreshTasks();
 		}
 		return result;
+	}
+
+	/** Reports document and decision files whose IDs collide or are missing, so lookups can fail closed. */
+	async diagnoseContentIdentity(): Promise<ContentIdentityReport> {
+		const [documents, decisions] = await Promise.all([this.fs.listDocuments(), this.fs.listDecisions()]);
+		const locate = (directory: string, item: { path?: string; title: string }) =>
+			item.path ? `${this.fs.backlogDirName}/${directory}/${item.path}` : item.title;
+		return {
+			documents: detectContentIdentityIssues(
+				documents.map((document) => ({ id: document.id, path: locate(DEFAULT_DIRECTORIES.DOCS, document) })),
+				documentIdKey,
+			),
+			decisions: detectContentIdentityIssues(
+				decisions.map((decision) => ({ id: decision.id, path: locate(DEFAULT_DIRECTORIES.DECISIONS, decision) })),
+				decisionIdKey,
+			),
+		};
 	}
 
 	private async resolveCreateOrdinal(inputOrdinal: number | undefined, isDraft: boolean): Promise<number | undefined> {
@@ -688,9 +707,7 @@ export class Core {
 	}
 
 	async getDocument(documentId: string): Promise<Document | null> {
-		const documents = await this.fs.listDocuments();
-		const match = documents.find((doc) => documentIdsEqual(documentId, doc.id));
-		return match ?? null;
+		return findDocumentById(await this.fs.listDocuments(), documentId);
 	}
 
 	async getDocumentContent(documentId: string): Promise<string | null> {

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -1020,7 +1020,7 @@ export class ContentStore {
 						epoch,
 						readEventPath: async () => {
 							if (!(await Bun.file(fullPath).exists())) return null;
-							const decision = parseDecision(await Bun.file(fullPath).text());
+							const decision = { ...parseDecision(await Bun.file(fullPath).text()), path: file };
 							if (decision.id !== id) throw new Error("Decision identity mismatch");
 							return decision;
 						},
@@ -1029,8 +1029,11 @@ export class ContentStore {
 								decisionsDir,
 								"decision-*.md",
 								(path) => basename(path).split(" - ")[0] === id,
-								async (candidatePath) => {
-									const decision = parseDecision(await Bun.file(candidatePath).text());
+								async (candidatePath, candidateRelativePath) => {
+									const decision = {
+										...parseDecision(await Bun.file(candidatePath).text()),
+										path: candidateRelativePath,
+									};
 									if (decision.id !== id) throw new Error("Decision identity mismatch");
 									return decision;
 								},
@@ -1049,7 +1052,7 @@ export class ContentStore {
 						return false;
 					}
 					try {
-						const decision = parseDecision(await Bun.file(fullPath).text());
+						const decision = { ...parseDecision(await Bun.file(fullPath).text()), path: file };
 						if (decision.id !== id) return true;
 						const previous = this.decisions.get(id);
 						if (previous && !this.hasDecisionChanged(previous, decision)) return true;

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1088,7 +1088,8 @@ export class FileSystem {
 		return { relativePath, removedFilepaths };
 	}
 
-	async listDecisions(): Promise<Decision[]> {
+	/** Lists decisions, skipping files that cannot be read or parsed and collecting their paths in `unreadable`. */
+	async listDecisions(unreadable?: string[]): Promise<Decision[]> {
 		try {
 			const decisionsDir = await this.getDecisionsDir();
 			const decisionFiles = await Array.fromAsync(
@@ -1101,8 +1102,13 @@ export class FileSystem {
 					continue;
 				}
 				const filepath = join(decisionsDir, file);
-				const content = await Bun.file(filepath).text();
-				decisions.push({ ...parseDecision(content), path: file });
+				try {
+					const content = await Bun.file(filepath).text();
+					decisions.push({ ...parseDecision(content), path: file });
+				} catch {
+					// One malformed file must not hide every other decision from lookups.
+					unreadable?.push(file);
+				}
 			}
 			return sortByTaskId(decisions);
 		} catch {
@@ -1110,7 +1116,8 @@ export class FileSystem {
 		}
 	}
 
-	async listDocuments(): Promise<Document[]> {
+	/** Lists documents, skipping files that cannot be read or parsed and collecting their paths in `unreadable`. */
+	async listDocuments(unreadable?: string[]): Promise<Document[]> {
 		try {
 			const docsDir = await this.getDocsDir();
 			// Recursively include all markdown files under docs, excluding README.md variants
@@ -1122,12 +1129,13 @@ export class FileSystem {
 				const base = relativePath.split("/").pop() || relativePath;
 				if (base.toLowerCase() === "readme.md") continue;
 				const filepath = join(docsDir, ...relativePath.split("/"));
-				const content = await Bun.file(filepath).text();
-				const parsed = parseDocument(content);
-				docs.push({
-					...parsed,
-					path: relativePath,
-				});
+				try {
+					const content = await Bun.file(filepath).text();
+					docs.push({ ...parseDocument(content), path: relativePath });
+				} catch {
+					// One malformed file must not hide every other document from lookups.
+					unreadable?.push(relativePath);
+				}
 			}
 
 			// Stable sort by title for UI/CLI listing

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -12,7 +12,8 @@ import {
 	resolveBacklogDirectory,
 	resolveBacklogDirectoryFromRootConfig,
 } from "../utils/backlog-directory.ts";
-import { documentIdsEqual, normalizeDocumentId } from "../utils/document-id.ts";
+import { findDecisionById } from "../utils/decision-id.ts";
+import { documentIdsEqual, findDocumentById, normalizeDocumentId } from "../utils/document-id.ts";
 import { normalizeDocumentRelativePath, normalizeDocumentSubPath } from "../utils/document-path.ts";
 import {
 	buildGlobPattern,
@@ -1021,24 +1022,7 @@ export class FileSystem {
 	}
 
 	async loadDecision(decisionId: string): Promise<Decision | null> {
-		try {
-			const decisionsDir = await this.getDecisionsDir();
-			const files = await Array.fromAsync(
-				new Bun.Glob("decision-*.md").scan({ cwd: decisionsDir, followSymlinks: true }),
-			);
-
-			// Normalize ID - remove "decision-" prefix if present
-			const normalizedId = decisionId.replace(/^decision-/, "");
-			const decisionFile = files.find((file) => file.startsWith(`decision-${normalizedId} -`));
-
-			if (!decisionFile) return null;
-
-			const filepath = join(decisionsDir, decisionFile);
-			const content = await Bun.file(filepath).text();
-			return parseDecision(content);
-		} catch (_error) {
-			return null;
-		}
+		return findDecisionById(await this.listDecisions(), decisionId);
 	}
 
 	// Document operations
@@ -1118,7 +1102,7 @@ export class FileSystem {
 				}
 				const filepath = join(decisionsDir, file);
 				const content = await Bun.file(filepath).text();
-				decisions.push(parseDecision(content));
+				decisions.push({ ...parseDecision(content), path: file });
 			}
 			return sortByTaskId(decisions);
 		} catch {
@@ -1154,8 +1138,7 @@ export class FileSystem {
 	}
 
 	async loadDocument(id: string): Promise<Document> {
-		const documents = await this.listDocuments();
-		const document = documents.find((doc) => documentIdsEqual(id, doc.id));
+		const document = findDocumentById(await this.listDocuments(), id);
 		if (!document) {
 			throw new Error(`Document not found: ${id}`);
 		}

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -138,7 +138,10 @@ export function parseMarkdown(content: string): ParsedMarkdown {
 		toParse = content.replace(fmRegex, () => `---\n${processed}\n---`);
 	}
 
-	const parsed = matter(toParse);
+	// Passing an options object bypasses gray-matter's cache. The cache stores the file object
+	// before parsing, so once a malformed file throws, later parses of the same content silently
+	// return empty frontmatter instead of failing again.
+	const parsed = matter(toParse, {});
 	return {
 		frontmatter: parsed.data,
 		content: parsed.content.trim(),

--- a/src/mcp/errors/mcp-errors.ts
+++ b/src/mcp/errors/mcp-errors.ts
@@ -1,3 +1,4 @@
+import { isAmbiguousIdError } from "../../utils/entity-id.ts";
 import { isAmbiguousTaskIdError } from "../../utils/task-path.ts";
 import type { CallToolResult } from "../types.ts";
 
@@ -75,6 +76,9 @@ export function handleBacklogToolError(error: unknown): CallToolResult {
 	}
 	if (isAmbiguousTaskIdError(error)) {
 		return buildErrorResult("AMBIGUOUS_TASK_ID", error.message, { candidates: error.candidates });
+	}
+	if (isAmbiguousIdError(error)) {
+		return buildErrorResult("AMBIGUOUS_ID", error.message, { candidates: error.candidates });
 	}
 
 	console.error("Unexpected MCP error:", error);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,6 +19,8 @@ import {
 } from "../types/index.ts";
 import { launchBrowser } from "../utils/browser-launch.ts";
 import type { BrowserLoadingState } from "../utils/browser-loading-state.ts";
+import { findDecisionById } from "../utils/decision-id.ts";
+import { isAmbiguousIdError } from "../utils/entity-id.ts";
 import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
 import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import { formatValidStatuses, getCanonicalStatuses, getValidStatuses } from "../utils/status.ts";
@@ -1124,6 +1126,9 @@ export class BacklogServer {
 			}
 			return Response.json(doc);
 		} catch (error) {
+			if (isAmbiguousIdError(error)) {
+				return Response.json({ error: error.message }, { status: 409 });
+			}
 			console.error("Error loading document:", error);
 			return Response.json({ error: "Document not found" }, { status: 404 });
 		}
@@ -1234,8 +1239,7 @@ export class BacklogServer {
 	private async handleGetDecision(decisionId: string): Promise<Response> {
 		try {
 			const store = await this.getContentStoreInstance();
-			const normalizedId = decisionId.startsWith("decision-") ? decisionId : `decision-${decisionId}`;
-			const decision = store.getDecisions().find((item) => item.id === normalizedId || item.id === decisionId);
+			const decision = findDecisionById(store.getDecisions(), decisionId);
 
 			if (!decision) {
 				return Response.json({ error: "Decision not found" }, { status: 404 });
@@ -1243,6 +1247,9 @@ export class BacklogServer {
 
 			return Response.json(decision);
 		} catch (error) {
+			if (isAmbiguousIdError(error)) {
+				return Response.json({ error: error.message }, { status: 409 });
+			}
 			console.error("Error loading decision:", error);
 			return Response.json({ error: "Decision not found" }, { status: 404 });
 		}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,7 +19,6 @@ import {
 } from "../types/index.ts";
 import { launchBrowser } from "../utils/browser-launch.ts";
 import type { BrowserLoadingState } from "../utils/browser-loading-state.ts";
-import { findDecisionById } from "../utils/decision-id.ts";
 import { isAmbiguousIdError } from "../utils/entity-id.ts";
 import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
 import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
@@ -1241,8 +1240,9 @@ export class BacklogServer {
 
 	private async handleGetDecision(decisionId: string): Promise<Response> {
 		try {
-			const store = await this.getContentStoreInstance();
-			const decision = findDecisionById(store.getDecisions(), decisionId);
+			// Resolve from disk, not the content store: the store keys decisions by raw ID and would
+			// silently drop one of two files that share an ID before the ambiguity check could run.
+			const decision = await this.core.filesystem.loadDecision(decisionId);
 
 			if (!decision) {
 				return Response.json({ error: "Decision not found" }, { status: 404 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1201,6 +1201,9 @@ export class BacklogServer {
 			if (error instanceof SyntaxError) {
 				return Response.json({ error: "Invalid request payload" }, { status: 400 });
 			}
+			if (isAmbiguousIdError(error)) {
+				return Response.json({ error: error.message }, { status: 409 });
+			}
 			if (error instanceof Error) {
 				if (error.message.startsWith("Document not found")) {
 					return Response.json({ error: error.message }, { status: 404 });
@@ -1274,6 +1277,9 @@ export class BacklogServer {
 			await this.core.updateDecisionFromContent(decisionId, content);
 			return Response.json({ success: true });
 		} catch (error) {
+			if (isAmbiguousIdError(error)) {
+				return Response.json({ error: error.message }, { status: 409 });
+			}
 			if (error instanceof Error && error.message.includes("not found")) {
 				return Response.json({ error: "Decision not found" }, { status: 404 });
 			}

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -267,6 +267,42 @@ describe("document and decision identity", () => {
 		expect(output).toContain("backlog/decisions/decision-orphan.md");
 	});
 
+	it("never reports healthy when a document or decision file cannot be parsed", async () => {
+		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
+		// gray-matter rejects an unterminated flow collection; distinct bodies avoid its parse cache.
+		await Bun.write(
+			join(core.filesystem.docsDir, "doc-2 - Broken.md"),
+			"---\nid: doc-2\ntitle: [unterminated\n---\n\ndoc body\n",
+		);
+		await Bun.write(
+			join(core.filesystem.decisionsDir, "decision-2 - Broken.md"),
+			"---\nid: decision-2\ntitle: [unterminated\n---\n\ndecision body\n",
+		);
+
+		const result = await $`bun ${cliPath} doctor`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).not.toContain("No duplicate task, document, or decision IDs found.");
+		expect(output).toContain("Unreadable document files");
+		expect(output).toContain("backlog/docs/doc-2 - Broken.md");
+		expect(output).toContain("Unreadable decision files");
+		expect(output).toContain("backlog/decisions/decision-2 - Broken.md");
+	});
+
+	it("keeps valid documents readable when a sibling file cannot be parsed", async () => {
+		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
+		await Bun.write(
+			join(core.filesystem.docsDir, "doc-2 - Broken.md"),
+			"---\nid: doc-2\ntitle: [unterminated\n---\n\ndoc body\n",
+		);
+
+		const result = await $`bun ${cliPath} doc view doc-1 --plain`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(0);
+		expect(output).toContain("Alpha");
+		expect(output).not.toContain("not found");
+	});
+
 	it("refuses to repair document findings with --fix", async () => {
 		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
 		await writeDocument("nested/doc-01 - Beta.md", "doc-01", "Beta");

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -3,7 +3,7 @@ import { chmod, mkdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
-import { serializeTask } from "../markdown/serializer.ts";
+import { serializeDecision, serializeDocument, serializeTask } from "../markdown/serializer.ts";
 import type { Task } from "../types/index.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
@@ -23,6 +23,37 @@ function makeTask(id: string, title: string): Task {
 		dependencies: [],
 		rawContent: `## Description\n\n${title} content with TASK-1 reference.`,
 	};
+}
+
+async function removeDuplicateTasks(): Promise<void> {
+	await unlink(join(core.filesystem.tasksDir, "task-01 - Beta.md"));
+	await unlink(join(core.filesystem.completedDir, "task-001 - Gamma.md"));
+}
+
+async function writeDocument(relativePath: string, id: string, title: string): Promise<void> {
+	const filePath = join(core.filesystem.docsDir, ...relativePath.split("/"));
+	await mkdir(join(filePath, ".."), { recursive: true });
+	await Bun.write(
+		filePath,
+		serializeDocument({ id, title, type: "other", createdDate: "2026-01-01 00:00", rawContent: title }),
+	);
+}
+
+async function writeDecision(filename: string, id: string, title: string): Promise<void> {
+	await mkdir(core.filesystem.decisionsDir, { recursive: true });
+	await Bun.write(
+		join(core.filesystem.decisionsDir, filename),
+		serializeDecision({
+			id,
+			title,
+			date: "2026-01-01 00:00",
+			status: "proposed",
+			context: "",
+			decision: "",
+			consequences: "",
+			rawContent: "",
+		}),
+	);
 }
 
 async function writeDuplicateTasks(): Promise<void> {
@@ -188,5 +219,83 @@ describe("CLI collision safety", () => {
 		expect(output).toContain("backlog/tasks/task-1 - Alpha.md");
 		expect(output).toContain("backlog/completed/task-001 - Gamma.md");
 		expect(await Bun.file(outputPath).text()).toBe("sentinel board content");
+	});
+});
+
+describe("document and decision identity", () => {
+	beforeEach(async () => {
+		await removeDuplicateTasks();
+	});
+
+	it("reports a project with no colliding IDs as healthy", async () => {
+		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
+		await writeDecision("decision-1 - Alpha.md", "decision-1", "Alpha");
+
+		const result = await $`bun ${cliPath} doctor`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(0);
+		expect(output).toContain("No duplicate task, document, or decision IDs found.");
+	});
+
+	it("detects duplicate document and decision IDs", async () => {
+		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
+		await writeDocument("nested/doc-01 - Beta.md", "doc-01", "Beta");
+		await writeDecision("decision-2 - Gamma.md", "decision-2", "Gamma");
+		await writeDecision("decision-002 - Delta.md", "decision-002", "Delta");
+
+		const result = await $`bun ${cliPath} doctor`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).toContain("Duplicate document IDs (diagnostic only)");
+		expect(output).toContain("backlog/docs/doc-1 - Alpha.md");
+		expect(output).toContain("backlog/docs/nested/doc-01 - Beta.md");
+		expect(output).toContain("Duplicate decision IDs (diagnostic only)");
+		expect(output).toContain("backlog/decisions/decision-2 - Gamma.md");
+		expect(output).toContain("backlog/decisions/decision-002 - Delta.md");
+	});
+
+	it("surfaces documents and decisions without an id as malformed", async () => {
+		await writeDocument("orphan.md", "", "Orphan doc");
+		await writeDecision("decision-orphan.md", "", "Orphan decision");
+
+		const result = await $`bun ${cliPath} doctor`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).toContain("Malformed document files without an id in frontmatter");
+		expect(output).toContain("backlog/docs/orphan.md");
+		expect(output).toContain("Malformed decision files without an id in frontmatter");
+		expect(output).toContain("backlog/decisions/decision-orphan.md");
+	});
+
+	it("refuses to repair document findings with --fix", async () => {
+		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
+		await writeDocument("nested/doc-01 - Beta.md", "doc-01", "Beta");
+
+		const result = await $`bun ${cliPath} doctor --fix --yes`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).toContain("cannot be repaired automatically");
+		expect(await Bun.file(join(core.filesystem.docsDir, "doc-1 - Alpha.md")).exists()).toBe(true);
+		expect(await Bun.file(join(core.filesystem.docsDir, "nested", "doc-01 - Beta.md")).exists()).toBe(true);
+	});
+
+	it("blocks ambiguous document reads and mutations instead of picking a winner", async () => {
+		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
+		await writeDocument("nested/doc-01 - Beta.md", "doc-01", "Beta");
+		const alphaPath = join(core.filesystem.docsDir, "doc-1 - Alpha.md");
+		const alphaBefore = await Bun.file(alphaPath).text();
+
+		const view = await $`bun ${cliPath} doc view doc-1 --plain`.cwd(testDir).quiet().nothrow();
+		const update = await $`bun ${cliPath} doc update doc-1 --title Changed`.cwd(testDir).quiet().nothrow();
+
+		for (const result of [view, update]) {
+			const output = `${result.stdout}${result.stderr}`;
+			expect(result.exitCode).toBe(1);
+			expect(output).toContain("Document ID doc-1 is ambiguous");
+			expect(output).toContain("doc-1 - Alpha.md");
+			expect(output).toContain("nested/doc-01 - Beta.md");
+			expect(output).toContain("backlog doctor");
+		}
+		expect(await Bun.file(alphaPath).text()).toBe(alphaBefore);
 	});
 });

--- a/src/test/content-identity.test.ts
+++ b/src/test/content-identity.test.ts
@@ -6,6 +6,7 @@ import { serializeDecision, serializeDocument } from "../markdown/serializer.ts"
 import type { Decision, Document } from "../types/index.ts";
 import { decisionIdKey } from "../utils/decision-id.ts";
 import { documentIdKey, documentIdsEqual } from "../utils/document-id.ts";
+import { hasContentIdentityIssues } from "../utils/duplicate-detection.ts";
 import { AmbiguousIdError } from "../utils/entity-id.ts";
 import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
 
@@ -47,6 +48,18 @@ async function writeDecision(filename: string, decision: Decision): Promise<stri
 	await mkdir(core.filesystem.decisionsDir, { recursive: true });
 	await Bun.write(filePath, serializeDecision(decision));
 	return filePath;
+}
+
+// gray-matter rejects an unterminated flow collection, so these files cannot be parsed at all.
+// Each fixture needs distinct content because gray-matter caches parse results by input string.
+function malformedFrontmatter(id: string): string {
+	return `---\nid: ${id}\ntitle: [unterminated\n---\n\n${id} body\n`;
+}
+
+async function writeRaw(directory: string, relativePath: string, content: string): Promise<void> {
+	const filePath = join(directory, ...relativePath.split("/"));
+	await mkdir(join(filePath, ".."), { recursive: true });
+	await Bun.write(filePath, content);
 }
 
 beforeEach(async () => {
@@ -137,8 +150,8 @@ describe("diagnoseContentIdentity", () => {
 		await writeDecision("decision-1 - Alpha.md", makeDecision("decision-1", "Alpha"));
 
 		expect(await core.diagnoseContentIdentity()).toEqual({
-			documents: { duplicates: [], missingIds: [] },
-			decisions: { duplicates: [], missingIds: [] },
+			documents: { duplicates: [], missingIds: [], unreadable: [] },
+			decisions: { duplicates: [], missingIds: [], unreadable: [] },
 		});
 	});
 
@@ -169,5 +182,39 @@ describe("diagnoseContentIdentity", () => {
 		expect(report.decisions.missingIds).toEqual(["backlog/decisions/decision-blank.md"]);
 		expect(report.documents.duplicates).toEqual([]);
 		expect(report.decisions.duplicates).toEqual([]);
+	});
+});
+
+describe("unreadable content files", () => {
+	it("keeps every other document and decision resolvable", async () => {
+		await writeDocument("doc-1 - Alpha.md", makeDocument("doc-1", "Alpha"));
+		await writeRaw(core.filesystem.docsDir, "doc-2 - Broken.md", malformedFrontmatter("doc-2"));
+		await writeDecision("decision-1 - Alpha.md", makeDecision("decision-1", "Alpha"));
+		await writeRaw(core.filesystem.decisionsDir, "decision-2 - Broken.md", malformedFrontmatter("decision-2"));
+
+		const unreadableDocuments: string[] = [];
+		const documents = await core.filesystem.listDocuments(unreadableDocuments);
+		expect(documents.map((document) => document.id)).toEqual(["doc-1"]);
+		expect(unreadableDocuments).toEqual(["doc-2 - Broken.md"]);
+
+		const unreadableDecisions: string[] = [];
+		const decisions = await core.filesystem.listDecisions(unreadableDecisions);
+		expect(decisions.map((decision) => decision.id)).toEqual(["decision-1"]);
+		expect(unreadableDecisions).toEqual(["decision-2 - Broken.md"]);
+
+		expect((await core.getDocument("doc-1"))?.title).toBe("Alpha");
+		expect((await core.filesystem.loadDecision("decision-1"))?.title).toBe("Alpha");
+	});
+
+	it("are reported as findings so identity is never called healthy on an unread file", async () => {
+		await writeRaw(core.filesystem.docsDir, "nested/doc-2 - Broken.md", malformedFrontmatter("doc-9"));
+		await writeRaw(core.filesystem.decisionsDir, "decision-2 - Broken.md", malformedFrontmatter("decision-9"));
+
+		const report = await core.diagnoseContentIdentity();
+		expect(report.documents.unreadable).toEqual(["backlog/docs/nested/doc-2 - Broken.md"]);
+		expect(report.decisions.unreadable).toEqual(["backlog/decisions/decision-2 - Broken.md"]);
+		expect(report.documents.duplicates).toEqual([]);
+		expect(report.documents.missingIds).toEqual([]);
+		expect(hasContentIdentityIssues(report)).toBe(true);
 	});
 });

--- a/src/test/content-identity.test.ts
+++ b/src/test/content-identity.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { Core } from "../core/backlog.ts";
+import { serializeDecision, serializeDocument } from "../markdown/serializer.ts";
+import type { Decision, Document } from "../types/index.ts";
+import { decisionIdKey } from "../utils/decision-id.ts";
+import { documentIdKey, documentIdsEqual } from "../utils/document-id.ts";
+import { AmbiguousIdError } from "../utils/entity-id.ts";
+import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let core: Core;
+
+function makeDocument(id: string, title: string): Document {
+	return {
+		id,
+		title,
+		type: "other",
+		createdDate: "2026-08-01 00:00",
+		rawContent: `${title} body`,
+	};
+}
+
+function makeDecision(id: string, title: string): Decision {
+	return {
+		id,
+		title,
+		date: "2026-08-01 00:00",
+		status: "proposed",
+		context: "",
+		decision: "",
+		consequences: "",
+		rawContent: "",
+	};
+}
+
+async function writeDocument(relativePath: string, document: Document): Promise<string> {
+	const filePath = join(core.filesystem.docsDir, ...relativePath.split("/"));
+	await mkdir(join(filePath, ".."), { recursive: true });
+	await Bun.write(filePath, serializeDocument(document));
+	return filePath;
+}
+
+async function writeDecision(filename: string, decision: Decision): Promise<string> {
+	const filePath = join(core.filesystem.decisionsDir, filename);
+	await mkdir(core.filesystem.decisionsDir, { recursive: true });
+	await Bun.write(filePath, serializeDecision(decision));
+	return filePath;
+}
+
+beforeEach(async () => {
+	TEST_DIR = createUniqueTestDir("content-identity");
+	await mkdir(TEST_DIR, { recursive: true });
+	core = new Core(TEST_DIR);
+	await initializeFilesystemTestProject(core, "Content identity");
+});
+
+afterEach(async () => {
+	core.disposeSearchService();
+	core.disposeContentStore();
+	await safeCleanup(TEST_DIR);
+});
+
+describe("blank entity IDs", () => {
+	it("never match another ID, including another blank one", () => {
+		expect(documentIdsEqual("", "")).toBe(false);
+		expect(documentIdsEqual("doc-", "doc-")).toBe(false);
+		expect(documentIdsEqual("   ", "doc-1")).toBe(false);
+		expect(documentIdsEqual("doc-1", "doc-001")).toBe(true);
+	});
+
+	it("have no canonical lookup key", () => {
+		expect(documentIdKey("")).toBeNull();
+		expect(documentIdKey("doc-")).toBeNull();
+		expect(decisionIdKey("")).toBeNull();
+		expect(documentIdKey("doc-01")).toBe("doc-1");
+		expect(decisionIdKey("2")).toBe("decision-2");
+	});
+
+	it("keep documents and decisions without an id in frontmatter unaddressable", async () => {
+		await writeDocument("no-id.md", { ...makeDocument("", "Unidentified doc"), id: "" });
+		await writeDecision("decision-blank.md", { ...makeDecision("", "Unidentified decision"), id: "" });
+
+		expect((await core.filesystem.listDocuments()).map((document) => document.title)).toContain("Unidentified doc");
+		expect((await core.filesystem.listDecisions()).map((decision) => decision.title)).toContain(
+			"Unidentified decision",
+		);
+
+		expect(await core.getDocument("")).toBeNull();
+		expect(await core.getDocumentContent("")).toBeNull();
+		expect(core.filesystem.loadDocument("")).rejects.toThrow("Document not found");
+		expect(await core.filesystem.loadDecision("")).toBeNull();
+		expect(await core.filesystem.loadDecision("decision-")).toBeNull();
+	});
+});
+
+describe("ambiguous content identity", () => {
+	it("fails closed when a document ID matches several files", async () => {
+		await writeDocument("doc-1 - Alpha.md", makeDocument("doc-1", "Alpha"));
+		await writeDocument("nested/doc-01 - Beta.md", makeDocument("doc-01", "Beta"));
+
+		expect(core.getDocument("doc-1")).rejects.toBeInstanceOf(AmbiguousIdError);
+		expect(core.filesystem.loadDocument("DOC-001")).rejects.toBeInstanceOf(AmbiguousIdError);
+
+		const error = await core.getDocument("doc-1").catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(AmbiguousIdError);
+		expect((error as AmbiguousIdError).message).toContain("Document ID doc-1 is ambiguous; 2 files match:");
+		expect((error as AmbiguousIdError).candidates).toEqual(["doc-1 - Alpha.md", "nested/doc-01 - Beta.md"]);
+		expect((error as AmbiguousIdError).message).toContain("backlog doctor");
+	});
+
+	it("fails closed when a decision ID matches several files", async () => {
+		await writeDecision("decision-1 - Alpha.md", makeDecision("decision-1", "Alpha"));
+		await writeDecision("decision-01 - Beta.md", makeDecision("decision-01", "Beta"));
+
+		const error = await core.filesystem.loadDecision("decision-1").catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(AmbiguousIdError);
+		expect((error as AmbiguousIdError).message).toContain("Decision ID decision-1 is ambiguous; 2 files match:");
+		expect((error as AmbiguousIdError).candidates).toEqual(["decision-01 - Beta.md", "decision-1 - Alpha.md"]);
+	});
+
+	it("still resolves unambiguous IDs", async () => {
+		await writeDocument("doc-1 - Alpha.md", makeDocument("doc-1", "Alpha"));
+		await writeDecision("decision-2 - Beta.md", makeDecision("decision-2", "Beta"));
+
+		expect((await core.getDocument("1"))?.title).toBe("Alpha");
+		expect((await core.filesystem.loadDecision("2"))?.title).toBe("Beta");
+		expect(await core.getDocument("doc-9")).toBeNull();
+		expect(await core.filesystem.loadDecision("decision-9")).toBeNull();
+	});
+});
+
+describe("diagnoseContentIdentity", () => {
+	it("reports nothing for a healthy project", async () => {
+		await writeDocument("doc-1 - Alpha.md", makeDocument("doc-1", "Alpha"));
+		await writeDecision("decision-1 - Alpha.md", makeDecision("decision-1", "Alpha"));
+
+		expect(await core.diagnoseContentIdentity()).toEqual({
+			documents: { duplicates: [], missingIds: [] },
+			decisions: { duplicates: [], missingIds: [] },
+		});
+	});
+
+	it("groups duplicate document and decision IDs by canonical ID", async () => {
+		await writeDocument("doc-1 - Alpha.md", makeDocument("doc-1", "Alpha"));
+		await writeDocument("nested/doc-01 - Beta.md", makeDocument("doc-01", "Beta"));
+		await writeDecision("decision-3 - Gamma.md", makeDecision("decision-3", "Gamma"));
+		await writeDecision("decision-003 - Delta.md", makeDecision("decision-003", "Delta"));
+
+		const report = await core.diagnoseContentIdentity();
+		expect(report.documents.duplicates).toEqual([
+			{ id: "doc-1", paths: ["backlog/docs/doc-1 - Alpha.md", "backlog/docs/nested/doc-01 - Beta.md"] },
+		]);
+		expect(report.decisions.duplicates).toEqual([
+			{
+				id: "decision-3",
+				paths: ["backlog/decisions/decision-003 - Delta.md", "backlog/decisions/decision-3 - Gamma.md"],
+			},
+		]);
+	});
+
+	it("reports documents and decisions with no id as malformed", async () => {
+		await writeDocument("no-id.md", { ...makeDocument("", "Unidentified doc"), id: "" });
+		await writeDecision("decision-blank.md", { ...makeDecision("", "Unidentified decision"), id: "" });
+
+		const report = await core.diagnoseContentIdentity();
+		expect(report.documents.missingIds).toEqual(["backlog/docs/no-id.md"]);
+		expect(report.decisions.missingIds).toEqual(["backlog/decisions/decision-blank.md"]);
+		expect(report.documents.duplicates).toEqual([]);
+		expect(report.decisions.duplicates).toEqual([]);
+	});
+});

--- a/src/test/markdown.test.ts
+++ b/src/test/markdown.test.ts
@@ -371,6 +371,18 @@ Document body.`;
 	});
 });
 
+describe("malformed frontmatter", () => {
+	// gray-matter caches the file object before parsing, so an uncached second parse used to
+	// return empty frontmatter and make an unparseable file look like one with no id.
+	it("fails on every parse, not just the first", () => {
+		const malformed = "---\nid: doc-2\ntitle: [unterminated\n---\n\nBody\n";
+
+		for (const parse of [parseDocument, parseDecision, parseTask, parseMarkdown]) {
+			expect(() => parse(malformed)).toThrow();
+		}
+	});
+});
+
 describe("Markdown Serializer", () => {
 	describe("serializeTask", () => {
 		it("should serialize a task correctly", () => {

--- a/src/test/mcp-documents.test.ts
+++ b/src/test/mcp-documents.test.ts
@@ -387,7 +387,7 @@ describe("MCP document tools", () => {
 		expect(status).toContain("?? backlog/plans/");
 	});
 
-	it("commits every duplicate document path removed by an update", async () => {
+	it("refuses to update a document whose ID matches more than one file", async () => {
 		await enableGitTestProject();
 		await mcpServer.testInterface.callTool({
 			params: {
@@ -416,6 +416,10 @@ describe("MCP document tools", () => {
 		await mcpServer.filesystem.saveConfig(config);
 		await mcpServer.ensureConfigLoaded();
 
+		const primaryPath = join(mcpServer.filesystem.docsDir, "doc-1 - Primary-document.md");
+		const primaryBefore = await Bun.file(primaryPath).text();
+		const duplicateBefore = await Bun.file(duplicatePath).text();
+
 		const updateResult = await mcpServer.testInterface.callTool({
 			params: {
 				name: "document_update",
@@ -427,12 +431,15 @@ describe("MCP document tools", () => {
 				},
 			},
 		});
-		expect(getText(updateResult.content)).toContain("Document updated successfully.");
+		const message = getText(updateResult.content);
+		expect(updateResult.isError).toBe(true);
+		expect(message).toContain("Document ID doc-1 is ambiguous");
+		expect(message).toContain("doc-1 - Primary-document.md");
+		expect(message).toContain("duplicates/doc-01 - ZZZ-Duplicate.md");
+		expect(message).toContain("backlog doctor");
 
-		const committed = await $`git show --no-renames --name-only --pretty=format:`.cwd(TEST_DIR).text();
-		expect(committed).toContain("backlog/docs/doc-1 - Primary-document.md");
-		expect(committed).toContain("backlog/docs/duplicates/doc-01 - ZZZ-Duplicate.md");
-		expect(committed).toContain("backlog/docs/runbooks/doc-1 - Renamed-document.md");
+		expect(await Bun.file(primaryPath).text()).toBe(primaryBefore);
+		expect(await Bun.file(duplicatePath).text()).toBe(duplicateBefore);
 		expect(await $`git status --short`.cwd(TEST_DIR).text()).not.toContain("backlog/docs/");
 	});
 });

--- a/src/test/server-documents-endpoint.test.ts
+++ b/src/test/server-documents-endpoint.test.ts
@@ -222,56 +222,64 @@ describe("BacklogServer document endpoints", () => {
 	});
 });
 
+// The second file's raw frontmatter ID is a parameter: `doc-01` differs from `doc-1` as a raw
+// map key, while an identical `doc-1` also collides inside the ContentStore's by-ID maps.
+async function startServerWithColliding(secondDocumentId: string, secondDecisionId: string): Promise<void> {
+	TEST_DIR = createUniqueTestDir("server-content-identity");
+	const filesystem = new FileSystem(TEST_DIR);
+	await filesystem.ensureBacklogStructure();
+	await filesystem.saveConfig({
+		projectName: "Server Content Identity",
+		statuses: ["To Do", "In Progress", "Done"],
+		labels: [],
+		milestones: [],
+		dateFormat: "YYYY-MM-DD",
+		remoteOperations: false,
+	});
+
+	const document = (id: string, title: string): string =>
+		serializeDocument({ id, title, type: "other", createdDate: "2026-01-01 00:00", rawContent: title });
+	const decision = (id: string, title: string): string =>
+		serializeDecision({
+			id,
+			title,
+			date: "2026-01-01 00:00",
+			status: "proposed",
+			context: "",
+			decision: "",
+			consequences: "",
+			rawContent: "",
+		});
+	await Bun.write(join(filesystem.docsDir, "doc-1 - Alpha.md"), document("doc-1", "Alpha"));
+	await Bun.write(join(filesystem.docsDir, "nested", "doc-01 - Beta.md"), document(secondDocumentId, "Beta"));
+	await Bun.write(join(filesystem.decisionsDir, "decision-1 - Alpha.md"), decision("decision-1", "Alpha"));
+	await Bun.write(join(filesystem.decisionsDir, "decision-01 - Beta.md"), decision(secondDecisionId, "Beta"));
+
+	server = new BacklogServer(TEST_DIR);
+	await server.start(0, false);
+	const port = server.getPort();
+	expect(port).not.toBeNull();
+	serverPort = port ?? 0;
+
+	await retry(async () => {
+		await fetchJson<Document[]>("/api/docs");
+	});
+}
+
+async function stopServer(): Promise<void> {
+	if (server) {
+		await server.stop();
+		server = null;
+	}
+	await safeCleanup(TEST_DIR);
+}
+
 describe("BacklogServer ambiguous content identity", () => {
 	beforeEach(async () => {
-		TEST_DIR = createUniqueTestDir("server-content-identity");
-		const filesystem = new FileSystem(TEST_DIR);
-		await filesystem.ensureBacklogStructure();
-		await filesystem.saveConfig({
-			projectName: "Server Content Identity",
-			statuses: ["To Do", "In Progress", "Done"],
-			labels: [],
-			milestones: [],
-			dateFormat: "YYYY-MM-DD",
-			remoteOperations: false,
-		});
-
-		const document = (id: string, title: string): string =>
-			serializeDocument({ id, title, type: "other", createdDate: "2026-01-01 00:00", rawContent: title });
-		const decision = (id: string, title: string): string =>
-			serializeDecision({
-				id,
-				title,
-				date: "2026-01-01 00:00",
-				status: "proposed",
-				context: "",
-				decision: "",
-				consequences: "",
-				rawContent: "",
-			});
-		await Bun.write(join(filesystem.docsDir, "doc-1 - Alpha.md"), document("doc-1", "Alpha"));
-		await Bun.write(join(filesystem.docsDir, "nested", "doc-01 - Beta.md"), document("doc-01", "Beta"));
-		await Bun.write(join(filesystem.decisionsDir, "decision-1 - Alpha.md"), decision("decision-1", "Alpha"));
-		await Bun.write(join(filesystem.decisionsDir, "decision-01 - Beta.md"), decision("decision-01", "Beta"));
-
-		server = new BacklogServer(TEST_DIR);
-		await server.start(0, false);
-		const port = server.getPort();
-		expect(port).not.toBeNull();
-		serverPort = port ?? 0;
-
-		await retry(async () => {
-			await fetchJson<Document[]>("/api/docs");
-		});
+		await startServerWithColliding("doc-01", "decision-01");
 	});
 
-	afterEach(async () => {
-		if (server) {
-			await server.stop();
-			server = null;
-		}
-		await safeCleanup(TEST_DIR);
-	});
+	afterEach(stopServer);
 
 	it("answers 409 instead of picking a winner", async () => {
 		const documentResponse = await fetch(`http://127.0.0.1:${serverPort}/api/docs/doc-1`);
@@ -312,5 +320,29 @@ describe("BacklogServer ambiguous content identity", () => {
 
 		expect(await Bun.file(documentPath).text()).toBe(documentBefore);
 		expect(await Bun.file(decisionPath).text()).toBe(decisionBefore);
+	});
+});
+
+describe("BacklogServer identical raw content IDs", () => {
+	beforeEach(async () => {
+		await startServerWithColliding("doc-1", "decision-1");
+	});
+
+	afterEach(stopServer);
+
+	it("still answers 409 when both files carry the exact same frontmatter ID", async () => {
+		const documentResponse = await fetch(`http://127.0.0.1:${serverPort}/api/docs/doc-1`);
+		expect(documentResponse.status).toBe(409);
+		const documentBody = await documentResponse.text();
+		expect(documentBody).toContain("Document ID doc-1 is ambiguous; 2 files match:");
+		expect(documentBody).toContain("doc-1 - Alpha.md");
+		expect(documentBody).toContain("nested/doc-01 - Beta.md");
+
+		const decisionResponse = await fetch(`http://127.0.0.1:${serverPort}/api/decisions/decision-1`);
+		expect(decisionResponse.status).toBe(409);
+		const decisionBody = await decisionResponse.text();
+		expect(decisionBody).toContain("Decision ID decision-1 is ambiguous; 2 files match:");
+		expect(decisionBody).toContain("decision-1 - Alpha.md");
+		expect(decisionBody).toContain("decision-01 - Beta.md");
 	});
 });

--- a/src/test/server-documents-endpoint.test.ts
+++ b/src/test/server-documents-endpoint.test.ts
@@ -286,4 +286,31 @@ describe("BacklogServer ambiguous content identity", () => {
 		expect(decisionBody).toContain("Decision ID decision-1 is ambiguous");
 		expect(decisionBody).toContain("decision-01 - Beta.md");
 	});
+
+	it("answers 409 on writes and leaves every candidate file untouched", async () => {
+		const filesystem = new FileSystem(TEST_DIR);
+		const documentPath = join(filesystem.docsDir, "doc-1 - Alpha.md");
+		const decisionPath = join(filesystem.decisionsDir, "decision-1 - Alpha.md");
+		const documentBefore = await Bun.file(documentPath).text();
+		const decisionBefore = await Bun.file(decisionPath).text();
+
+		const documentResponse = await fetch(`http://127.0.0.1:${serverPort}/api/docs/doc-1`, {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Changed", content: "Changed body" }),
+		});
+		expect(documentResponse.status).toBe(409);
+		expect(await documentResponse.text()).toContain("Document ID doc-1 is ambiguous");
+
+		const decisionResponse = await fetch(`http://127.0.0.1:${serverPort}/api/decisions/decision-1`, {
+			method: "PUT",
+			headers: { "Content-Type": "text/plain" },
+			body: "## Context\n\nChanged\n",
+		});
+		expect(decisionResponse.status).toBe(409);
+		expect(await decisionResponse.text()).toContain("Decision ID decision-1 is ambiguous");
+
+		expect(await Bun.file(documentPath).text()).toBe(documentBefore);
+		expect(await Bun.file(decisionPath).text()).toBe(decisionBefore);
+	});
 });

--- a/src/test/server-documents-endpoint.test.ts
+++ b/src/test/server-documents-endpoint.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { join } from "node:path";
 import { FileSystem } from "../file-system/operations.ts";
+import { serializeDecision, serializeDocument } from "../markdown/serializer.ts";
 import { BacklogServer } from "../server/index.ts";
 import type { Document } from "../types/index.ts";
 import { createUniqueTestDir, retry, safeCleanup } from "./test-utils.ts";
@@ -217,5 +219,71 @@ describe("BacklogServer document endpoints", () => {
 		});
 		expect(updateResponse.status).toBe(500);
 		expect(await updateResponse.text()).toContain("Failed to update document");
+	});
+});
+
+describe("BacklogServer ambiguous content identity", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("server-content-identity");
+		const filesystem = new FileSystem(TEST_DIR);
+		await filesystem.ensureBacklogStructure();
+		await filesystem.saveConfig({
+			projectName: "Server Content Identity",
+			statuses: ["To Do", "In Progress", "Done"],
+			labels: [],
+			milestones: [],
+			dateFormat: "YYYY-MM-DD",
+			remoteOperations: false,
+		});
+
+		const document = (id: string, title: string): string =>
+			serializeDocument({ id, title, type: "other", createdDate: "2026-01-01 00:00", rawContent: title });
+		const decision = (id: string, title: string): string =>
+			serializeDecision({
+				id,
+				title,
+				date: "2026-01-01 00:00",
+				status: "proposed",
+				context: "",
+				decision: "",
+				consequences: "",
+				rawContent: "",
+			});
+		await Bun.write(join(filesystem.docsDir, "doc-1 - Alpha.md"), document("doc-1", "Alpha"));
+		await Bun.write(join(filesystem.docsDir, "nested", "doc-01 - Beta.md"), document("doc-01", "Beta"));
+		await Bun.write(join(filesystem.decisionsDir, "decision-1 - Alpha.md"), decision("decision-1", "Alpha"));
+		await Bun.write(join(filesystem.decisionsDir, "decision-01 - Beta.md"), decision("decision-01", "Beta"));
+
+		server = new BacklogServer(TEST_DIR);
+		await server.start(0, false);
+		const port = server.getPort();
+		expect(port).not.toBeNull();
+		serverPort = port ?? 0;
+
+		await retry(async () => {
+			await fetchJson<Document[]>("/api/docs");
+		});
+	});
+
+	afterEach(async () => {
+		if (server) {
+			await server.stop();
+			server = null;
+		}
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("answers 409 instead of picking a winner", async () => {
+		const documentResponse = await fetch(`http://127.0.0.1:${serverPort}/api/docs/doc-1`);
+		expect(documentResponse.status).toBe(409);
+		const documentBody = await documentResponse.text();
+		expect(documentBody).toContain("Document ID doc-1 is ambiguous");
+		expect(documentBody).toContain("nested/doc-01 - Beta.md");
+
+		const decisionResponse = await fetch(`http://127.0.0.1:${serverPort}/api/decisions/decision-1`);
+		expect(decisionResponse.status).toBe(409);
+		const decisionBody = await decisionResponse.text();
+		expect(decisionBody).toContain("Decision ID decision-1 is ambiguous");
+		expect(decisionBody).toContain("decision-01 - Beta.md");
 	});
 });

--- a/src/test/web-ambiguous-id.test.tsx
+++ b/src/test/web-ambiguous-id.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import type { Decision as BacklogDecision, Document as BacklogDocument } from "../types/index.ts";
+import DecisionDetail from "../web/components/DecisionDetail.tsx";
+import DocumentationDetail from "../web/components/DocumentationDetail.tsx";
+
+let activeRoot: Root | null = null;
+const originalFetch = globalThis.fetch;
+
+const AMBIGUOUS_DOCUMENT_MESSAGE = [
+	"Document ID doc-1 is ambiguous; 2 files match:",
+	"  - doc-1 - Alpha.md",
+	"  - nested/doc-01 - Beta.md",
+	"Run 'backlog doctor' to review the conflicting files.",
+].join("\n");
+
+const AMBIGUOUS_DECISION_MESSAGE = [
+	"Decision ID decision-1 is ambiguous; 2 files match:",
+	"  - decision-01 - Beta.md",
+	"  - decision-1 - Alpha.md",
+	"Run 'backlog doctor' to review the conflicting files.",
+].join("\n");
+
+function setupDom(): HTMLElement {
+	const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { url: "http://localhost" });
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = dom.window as unknown as Window & typeof globalThis;
+	globalThis.document = dom.window.document as unknown as typeof globalThis.document;
+	globalThis.navigator = dom.window.navigator as unknown as Navigator;
+	globalThis.localStorage = dom.window.localStorage;
+	if (!window.matchMedia) {
+		window.matchMedia = (() => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} })) as never;
+	}
+	return dom.window.document.getElementById("root") as unknown as HTMLElement;
+}
+
+function respondWithConflict(message: string): void {
+	globalThis.fetch = (async () =>
+		new Response(JSON.stringify({ error: message }), {
+			status: 409,
+			headers: { "Content-Type": "application/json" },
+		})) as unknown as typeof globalThis.fetch;
+}
+
+async function renderRoute(path: string, pattern: string, element: React.ReactElement): Promise<HTMLElement> {
+	const container = setupDom();
+	activeRoot = createRoot(container);
+	await act(async () => {
+		activeRoot?.render(
+			<MemoryRouter initialEntries={[path]}>
+				<Routes>
+					<Route path={pattern} element={element} />
+				</Routes>
+			</MemoryRouter>,
+		);
+		await Promise.resolve();
+	});
+	return container;
+}
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => activeRoot?.unmount());
+		activeRoot = null;
+	}
+	globalThis.fetch = originalFetch;
+});
+
+describe("web ambiguous ID handling", () => {
+	it("shows the ambiguity instead of the cached document entry", async () => {
+		respondWithConflict(AMBIGUOUS_DOCUMENT_MESSAGE);
+		const cached: BacklogDocument = {
+			id: "doc-1",
+			title: "Cached Alpha",
+			type: "other",
+			createdDate: "2026-01-01 00:00",
+			rawContent: "Cached body that must not be shown",
+			path: "doc-1 - Alpha.md",
+		};
+
+		const container = await renderRoute(
+			"/documentation/1/cached-alpha",
+			"/documentation/:id/:title",
+			<DocumentationDetail docs={[cached]} onRefreshData={async () => {}} />,
+		);
+
+		expect(container.textContent).toContain("This ID matches more than one file");
+		expect(container.textContent).toContain("nested/doc-01 - Beta.md");
+		expect(container.textContent).toContain("backlog doctor");
+		expect(container.textContent).not.toContain("Cached body that must not be shown");
+		expect(container.textContent).not.toContain("Cached Alpha");
+	});
+
+	it("shows the ambiguity instead of the cached decision entry", async () => {
+		respondWithConflict(AMBIGUOUS_DECISION_MESSAGE);
+		const cached: BacklogDecision = {
+			id: "decision-1",
+			title: "Cached Alpha",
+			date: "2026-01-01 00:00",
+			status: "proposed",
+			context: "",
+			decision: "",
+			consequences: "",
+			rawContent: "Cached body that must not be shown",
+		};
+
+		const container = await renderRoute(
+			"/decisions/1/cached-alpha",
+			"/decisions/:id/:title",
+			<DecisionDetail decisions={[cached]} onRefreshData={async () => {}} />,
+		);
+
+		expect(container.textContent).toContain("This ID matches more than one file");
+		expect(container.textContent).toContain("decision-01 - Beta.md");
+		expect(container.textContent).toContain("backlog doctor");
+		expect(container.textContent).not.toContain("Cached body that must not be shown");
+		expect(container.textContent).not.toContain("Cached Alpha");
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -192,6 +192,7 @@ export interface Decision {
 	consequences: string;
 	alternatives?: string;
 	readonly rawContent: string; // Raw markdown content without frontmatter
+	path?: string; // Decisions-relative file path, set when listed from disk
 }
 
 export interface Milestone {

--- a/src/utils/decision-id.ts
+++ b/src/utils/decision-id.ts
@@ -1,0 +1,20 @@
+import { entityIdKey, findUniqueEntityById } from "./entity-id.ts";
+
+const DECISION_PREFIX = "decision";
+
+type DecisionIdentity = { id: string; title: string; path?: string };
+
+/** Canonical lookup key, or null when the decision has no addressable ID. */
+export function decisionIdKey(id: string): string | null {
+	return entityIdKey(DECISION_PREFIX, id);
+}
+
+export function findDecisionById<T extends DecisionIdentity>(decisions: readonly T[], id: string): T | null {
+	return findUniqueEntityById(
+		"Decision",
+		DECISION_PREFIX,
+		id,
+		decisions,
+		(decision) => decision.path ?? decision.title,
+	);
+}

--- a/src/utils/document-id.ts
+++ b/src/utils/document-id.ts
@@ -1,25 +1,28 @@
-function ensureDocumentPrefix(value: string): string {
-	const trimmed = value.trim();
-	const match = trimmed.match(/^doc-(.+)$/i);
-	const body = match ? match[1] : trimmed;
-	return `doc-${body}`;
-}
+import { entityIdKey, entityIdsEqual, findUniqueEntityById, normalizeEntityId } from "./entity-id.ts";
 
-function extractDocumentNumber(value: string): string | null {
-	const trimmed = value.trim();
-	const match = trimmed.match(/^(?:doc-)?0*([0-9]+)$/i);
-	return match?.[1] ?? null;
-}
+const DOCUMENT_PREFIX = "doc";
+
+type DocumentIdentity = { id: string; title: string; path?: string };
 
 export function normalizeDocumentId(id: string): string {
-	return ensureDocumentPrefix(id);
+	return normalizeEntityId(DOCUMENT_PREFIX, id);
+}
+
+/** Canonical lookup key, or null when the document has no addressable ID. */
+export function documentIdKey(id: string): string | null {
+	return entityIdKey(DOCUMENT_PREFIX, id);
 }
 
 export function documentIdsEqual(left: string, right: string): boolean {
-	const leftNumber = extractDocumentNumber(left);
-	const rightNumber = extractDocumentNumber(right);
-	if (leftNumber !== null && rightNumber !== null) {
-		return leftNumber === rightNumber;
-	}
-	return normalizeDocumentId(left).toLowerCase() === normalizeDocumentId(right).toLowerCase();
+	return entityIdsEqual(DOCUMENT_PREFIX, left, right);
+}
+
+export function findDocumentById<T extends DocumentIdentity>(documents: readonly T[], id: string): T | null {
+	return findUniqueEntityById(
+		"Document",
+		DOCUMENT_PREFIX,
+		id,
+		documents,
+		(document) => document.path ?? document.title,
+	);
 }

--- a/src/utils/duplicate-detection.ts
+++ b/src/utils/duplicate-detection.ts
@@ -6,15 +6,17 @@ export type DuplicateGroup = {
 	tasks: Task[];
 };
 
-/** Duplicate and missing-ID findings for a content collection such as documents or decisions. */
+/** Duplicate, missing-ID, and unreadable-file findings for documents or decisions. */
 export type ContentIdentityIssues = {
 	duplicates: Array<{ id: string; paths: string[] }>;
 	missingIds: string[];
+	unreadable: string[];
 };
 
 export function detectContentIdentityIssues(
 	entries: ReadonlyArray<{ id: string; path: string }>,
 	toKey: (id: string) => string | null,
+	unreadable: readonly string[] = [],
 ): ContentIdentityIssues {
 	const byKey = new Map<string, string[]>();
 	const missingIds: string[] = [];
@@ -32,7 +34,11 @@ export function detectContentIdentityIssues(
 		.filter(([, paths]) => paths.length > 1)
 		.map(([id, paths]) => ({ id, paths: [...paths].sort((left, right) => left.localeCompare(right)) }))
 		.sort((left, right) => left.id.localeCompare(right.id, undefined, { numeric: true }));
-	return { duplicates, missingIds: missingIds.sort((left, right) => left.localeCompare(right)) };
+	return {
+		duplicates,
+		missingIds: missingIds.sort((left, right) => left.localeCompare(right)),
+		unreadable: [...unreadable].sort((left, right) => left.localeCompare(right)),
+	};
 }
 
 export type ContentIdentityReport = {
@@ -42,7 +48,7 @@ export type ContentIdentityReport = {
 
 export function hasContentIdentityIssues(report: ContentIdentityReport): boolean {
 	return [report.documents, report.decisions].some(
-		(issues) => issues.duplicates.length > 0 || issues.missingIds.length > 0,
+		(issues) => issues.duplicates.length > 0 || issues.missingIds.length > 0 || issues.unreadable.length > 0,
 	);
 }
 

--- a/src/utils/duplicate-detection.ts
+++ b/src/utils/duplicate-detection.ts
@@ -6,6 +6,46 @@ export type DuplicateGroup = {
 	tasks: Task[];
 };
 
+/** Duplicate and missing-ID findings for a content collection such as documents or decisions. */
+export type ContentIdentityIssues = {
+	duplicates: Array<{ id: string; paths: string[] }>;
+	missingIds: string[];
+};
+
+export function detectContentIdentityIssues(
+	entries: ReadonlyArray<{ id: string; path: string }>,
+	toKey: (id: string) => string | null,
+): ContentIdentityIssues {
+	const byKey = new Map<string, string[]>();
+	const missingIds: string[] = [];
+	for (const entry of entries) {
+		const key = toKey(entry.id);
+		if (key === null) {
+			missingIds.push(entry.path);
+			continue;
+		}
+		const paths = byKey.get(key) ?? [];
+		paths.push(entry.path);
+		byKey.set(key, paths);
+	}
+	const duplicates = Array.from(byKey.entries())
+		.filter(([, paths]) => paths.length > 1)
+		.map(([id, paths]) => ({ id, paths: [...paths].sort((left, right) => left.localeCompare(right)) }))
+		.sort((left, right) => left.id.localeCompare(right.id, undefined, { numeric: true }));
+	return { duplicates, missingIds: missingIds.sort((left, right) => left.localeCompare(right)) };
+}
+
+export type ContentIdentityReport = {
+	documents: ContentIdentityIssues;
+	decisions: ContentIdentityIssues;
+};
+
+export function hasContentIdentityIssues(report: ContentIdentityReport): boolean {
+	return [report.documents, report.decisions].some(
+		(issues) => issues.duplicates.length > 0 || issues.missingIds.length > 0,
+	);
+}
+
 export function detectDuplicateTaskIds(tasks: Task[]): DuplicateGroup[] {
 	const byId = new Map<string, Task[]>();
 	for (const task of tasks) {

--- a/src/utils/entity-id.ts
+++ b/src/utils/entity-id.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared identity rules for prefixed entity IDs (tasks, documents, decisions).
+ *
+ * Identity must fail closed: an ID with no addressable body never matches, and an ID that
+ * matches more than one file raises {@link AmbiguousIdError} instead of picking a winner.
+ */
+
+export class AmbiguousIdError extends Error {
+	readonly id: string;
+	readonly candidates: string[];
+
+	constructor(entityLabel: string, id: string, candidates: string[], guidance: string) {
+		const sortedCandidates = [...candidates].sort((left, right) => left.localeCompare(right));
+		super(
+			[
+				`${entityLabel} ID ${id} is ambiguous; ${sortedCandidates.length} files match:`,
+				...sortedCandidates.map((candidate) => `  - ${candidate}`),
+				guidance,
+			].join("\n"),
+		);
+		this.name = "AmbiguousIdError";
+		this.id = id;
+		this.candidates = sortedCandidates;
+	}
+}
+
+export function isAmbiguousIdError(error: unknown): error is AmbiguousIdError {
+	return error instanceof AmbiguousIdError;
+}
+
+function entityIdBody(prefix: string, value: string): string {
+	const trimmed = value.trim();
+	const match = trimmed.match(new RegExp(`^${prefix}-(.*)$`, "i"));
+	return match?.[1] ?? trimmed;
+}
+
+/** Canonical comparison key, or null when the ID carries no addressable value. */
+export function entityIdKey(prefix: string, id: string): string | null {
+	const body = entityIdBody(prefix, id).trim();
+	if (body === "") return null;
+	const numeric = body.match(/^0*([0-9]+)$/)?.[1];
+	return `${prefix}-${numeric ?? body.toLowerCase()}`;
+}
+
+export function normalizeEntityId(prefix: string, id: string): string {
+	return `${prefix}-${entityIdBody(prefix, id)}`;
+}
+
+export function entityIdsEqual(prefix: string, left: string, right: string): boolean {
+	const leftKey = entityIdKey(prefix, left);
+	return leftKey !== null && leftKey === entityIdKey(prefix, right);
+}
+
+/** Resolves one entity by ID, throwing {@link AmbiguousIdError} when several files claim it. */
+export function findUniqueEntityById<T extends { id: string }>(
+	entityLabel: string,
+	prefix: string,
+	id: string,
+	items: readonly T[],
+	describe: (item: T) => string,
+): T | null {
+	const matches = items.filter((item) => entityIdsEqual(prefix, id, item.id));
+	if (matches.length > 1) {
+		throw new AmbiguousIdError(
+			entityLabel,
+			normalizeEntityId(prefix, id),
+			matches.map(describe),
+			"Run 'backlog doctor' to review the conflicting files.",
+		);
+	}
+	return matches[0] ?? null;
+}

--- a/src/utils/task-path.ts
+++ b/src/utils/task-path.ts
@@ -1,6 +1,7 @@
 import { basename, join } from "node:path";
 import { Core } from "../core/backlog.ts";
 import type { Task } from "../types/index.ts";
+import { AmbiguousIdError } from "./entity-id.ts";
 import {
 	buildFilenameIdRegex,
 	buildGlobPattern,
@@ -38,22 +39,13 @@ export function normalizeTaskIdentity(task: Task): Task {
 	};
 }
 
-export class AmbiguousTaskIdError extends Error {
+export class AmbiguousTaskIdError extends AmbiguousIdError {
 	readonly taskId: string;
-	readonly candidates: string[];
 
 	constructor(taskId: string, candidates: string[]) {
-		const sortedCandidates = [...candidates].sort((left, right) => left.localeCompare(right));
-		super(
-			[
-				`Task ID ${canonicalTaskId(taskId)} is ambiguous; ${sortedCandidates.length} files match:`,
-				...sortedCandidates.map((candidate) => `  - ${candidate}`),
-				"Run 'backlog doctor' to preview a safe repair.",
-			].join("\n"),
-		);
+		super("Task", canonicalTaskId(taskId), candidates, "Run 'backlog doctor' to preview a safe repair.");
 		this.name = "AmbiguousTaskIdError";
 		this.taskId = taskId;
-		this.candidates = sortedCandidates;
 	}
 }
 

--- a/src/web/components/AmbiguousIdNotice.tsx
+++ b/src/web/components/AmbiguousIdNotice.tsx
@@ -1,0 +1,21 @@
+import { memo } from 'react';
+
+const AmbiguousIdNotice = memo(function AmbiguousIdNotice({ message }: { message: string }) {
+    return (
+        <div className="flex-1 flex items-center justify-center p-8">
+            <div
+                role="alert"
+                className="w-full max-w-xl rounded-lg border border-amber-300 bg-amber-50 p-6 dark:border-amber-700 dark:bg-amber-950 transition-colors duration-200"
+            >
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100">
+                    This ID matches more than one file
+                </h2>
+                <pre className="mt-3 whitespace-pre-wrap break-words font-mono text-sm text-amber-900 dark:text-amber-100">
+                    {message}
+                </pre>
+            </div>
+        </div>
+    );
+});
+
+export default AmbiguousIdNotice;

--- a/src/web/components/DecisionDetail.tsx
+++ b/src/web/components/DecisionDetail.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, memo } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { apiClient } from '../lib/api';
+import { apiClient, isAmbiguousIdConflict } from '../lib/api';
 import MDEditor from '@uiw/react-md-editor';
 import MermaidMarkdown from './MermaidMarkdown';
 import { type Decision } from '../../types';
+import AmbiguousIdNotice from './AmbiguousIdNotice';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { SuccessToast } from './SuccessToast';
 import { useTheme } from '../contexts/ThemeContext';
@@ -84,8 +85,7 @@ export default function DecisionDetail({ decisions, onRefreshData, dateFormat }:
 	const [isLoading, setIsLoading] = useState(true);
 	const [isSaving, setIsSaving] = useState(false);
 	const [isEditing, setIsEditing] = useState(false);
-	
-	
+	const [error, setError] = useState<Error | null>(null);
 	const [isNewDecision, setIsNewDecision] = useState(false);
 	const [showSaveSuccess, setShowSaveSuccess] = useState(false);
 
@@ -123,6 +123,7 @@ export default function DecisionDetail({ decisions, onRefreshData, dateFormat }:
 		
 		try {
 			setIsLoading(true);
+			setError(null);
 			// Find decision from props
 			const prefixedId = addDecisionPrefix(id);
 			const decision = decisions.find(d => d.id === prefixedId);
@@ -138,8 +139,14 @@ export default function DecisionDetail({ decisions, onRefreshData, dateFormat }:
 				// Update decision state with full data
 				setDecision(fullDecision);
 			} catch (fetchError) {
-				// If fetch fails and we don't have the decision in props, show error
-				if (!decision) {
+				// Never fall back to the cached list entry when the ID is ambiguous: that entry is
+				// one of the candidates, and showing it would silently pick a winner.
+				if (isAmbiguousIdConflict(fetchError)) {
+					setDecision(null);
+					setError(fetchError);
+					console.error('Failed to load decision:', fetchError);
+				} else if (!decision) {
+					// If fetch fails and we don't have the decision in props, show error
 					console.error('Failed to load decision:', fetchError);
 				} else {
 					// We have basic info from props even if fetch failed
@@ -245,6 +252,10 @@ export default function DecisionDetail({ decisions, onRefreshData, dateFormat }:
 				<div className="text-gray-500">Loading...</div>
 			</div>
 		);
+	}
+
+	if (isAmbiguousIdConflict(error)) {
+		return <AmbiguousIdNotice message={error.message} />;
 	}
 
 	return (

--- a/src/web/components/DocumentationDetail.tsx
+++ b/src/web/components/DocumentationDetail.tsx
@@ -1,9 +1,10 @@
 import {useState, useEffect, memo, useCallback} from 'react';
 import {useParams, useNavigate, useSearchParams} from 'react-router-dom';
-import {apiClient} from '../lib/api';
+import {apiClient, isAmbiguousIdConflict} from '../lib/api';
 import MDEditor from '@uiw/react-md-editor';
 import MermaidMarkdown from './MermaidMarkdown';
 import {type Document} from '../../types';
+import AmbiguousIdNotice from './AmbiguousIdNotice';
 import ErrorBoundary from '../components/ErrorBoundary';
 import {SuccessToast} from './SuccessToast';
 import { useTheme } from '../contexts/ThemeContext';
@@ -87,7 +88,7 @@ export default function DocumentationDetail({docs, onRefreshData, dateFormat}: D
     const [isLoading, setIsLoading] = useState(true);
     const [isSaving, setIsSaving] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
-    const [, setError] = useState<Error | null>(null);
+    const [error, setError] = useState<Error | null>(null);
     const [saveError, setSaveError] = useState<Error | null>(null);
     const [isNewDocument, setIsNewDocument] = useState(false);
     const [showSaveSuccess, setShowSaveSuccess] = useState(false);
@@ -146,8 +147,14 @@ export default function DocumentationDetail({docs, onRefreshData, dateFormat}: D
                 // Update document state with full data
                 setDocument(fullDoc);
             } catch (fetchError) {
-                // If fetch fails and we don't have the doc in props, show error
-                if (!doc) {
+                // Never fall back to the cached list entry when the ID is ambiguous: that entry is
+                // one of the candidates, and showing it would silently pick a winner.
+                if (isAmbiguousIdConflict(fetchError)) {
+                    setDocument(null);
+                    setError(fetchError);
+                    console.error('Failed to load document:', fetchError);
+                } else if (!doc) {
+                    // If fetch fails and we don't have the doc in props, show error
                     setError(new Error(`Document with ID "${prefixedId}" not found`));
                     console.error('Failed to load document:', fetchError);
                 } else {
@@ -285,6 +292,10 @@ export default function DocumentationDetail({docs, onRefreshData, dateFormat}: D
                 <div className="text-gray-500">Loading...</div>
             </div>
         );
+    }
+
+    if (isAmbiguousIdConflict(error)) {
+        return <AmbiguousIdNotice message={error.message} />;
     }
 
     return (

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -66,6 +66,20 @@ export class NetworkError extends Error {
 	}
 }
 
+/** Builds an ApiError that keeps the server's message when the response body carries one. */
+async function toApiError(response: Response, fallbackMessage: string): Promise<ApiError> {
+	const data = await response.json().catch(() => undefined);
+	const serverMessage = typeof data === "object" && data !== null ? (data as { error?: unknown }).error : undefined;
+	const message =
+		typeof serverMessage === "string" && serverMessage.trim().length > 0 ? serverMessage : fallbackMessage;
+	return new ApiError(message, response.status, response.statusText, data);
+}
+
+/** The document and decision endpoints answer 409 only when an ID matches more than one file. */
+export function isAmbiguousIdConflict(error: unknown): error is ApiError {
+	return error instanceof ApiError && error.status === 409;
+}
+
 // Request configuration interface
 interface RequestConfig {
 	retries?: number;
@@ -373,7 +387,7 @@ export class ApiClient {
 	async fetchDoc(filename: string): Promise<Document> {
 		const response = await fetch(`${API_BASE}/docs/${encodeURIComponent(filename)}`);
 		if (!response.ok) {
-			throw new Error("Failed to fetch document");
+			throw await toApiError(response, "Failed to fetch document");
 		}
 		return response.json();
 	}
@@ -381,7 +395,7 @@ export class ApiClient {
 	async fetchDocument(id: string): Promise<Document> {
 		const response = await fetch(`${API_BASE}/doc/${encodeURIComponent(id)}`);
 		if (!response.ok) {
-			throw new Error("Failed to fetch document");
+			throw await toApiError(response, "Failed to fetch document");
 		}
 		return response.json();
 	}
@@ -403,7 +417,7 @@ export class ApiClient {
 			body: JSON.stringify(payload),
 		});
 		if (!response.ok) {
-			throw new Error("Failed to update document");
+			throw await toApiError(response, "Failed to update document");
 		}
 		return response.json();
 	}
@@ -433,7 +447,7 @@ export class ApiClient {
 	async fetchDecision(id: string): Promise<Decision> {
 		const response = await fetch(`${API_BASE}/decisions/${encodeURIComponent(id)}`);
 		if (!response.ok) {
-			throw new Error("Failed to fetch decision");
+			throw await toApiError(response, "Failed to fetch decision");
 		}
 		return response.json();
 	}
@@ -441,7 +455,7 @@ export class ApiClient {
 	async fetchDecisionData(id: string): Promise<Decision> {
 		const response = await fetch(`${API_BASE}/decision/${encodeURIComponent(id)}`);
 		if (!response.ok) {
-			throw new Error("Failed to fetch decision");
+			throw await toApiError(response, "Failed to fetch decision");
 		}
 		return response.json();
 	}
@@ -455,7 +469,7 @@ export class ApiClient {
 			body: content,
 		});
 		if (!response.ok) {
-			throw new Error("Failed to update decision");
+			throw await toApiError(response, "Failed to update decision");
 		}
 	}
 


### PR DESCRIPTION
Fixes #846. Fixes #847.

Duplicate document and decision IDs were silently resolved by title sort order — retitling a file silently re-pointed what an ID resolved to — `doctor` scanned only tasks, and a document missing `id:` frontmatter was listed and searchable yet unaddressable except via the empty string. One existing MCP test even asserted the silent duplicate collapse #846 reports; it now asserts fail-closed with both files byte-identical.

The change introduces one shared identity module (canonical key, ambiguity error, unique resolver — `AmbiguousTaskIdError` now extends it with task behavior byte-for-byte preserved), makes document and decision lookups fail closed with a legible error naming both files, stops the empty-string ID resolving anywhere, fixes decisions resolving by filename prefix while every other surface used frontmatter, and teaches `doctor` to report duplicate doc/decision IDs and missing-id files as diagnostic findings (exit 1, no invented auto-repair). Server GETs and PUTs answer 409 with the full ambiguity message; MCP maps to AMBIGUOUS_ID.

Write-side cleanup still keying on filenames (including a pre-existing silent-deletion path on main) is split out as BACK-600 rather than smuggled in.

Verification: every fail-closed claim tested adversarially against hand-corrupted fixtures across CLI, server (409s with bytes-untouched proof), and real-stdio MCP; task identity suites pass unmodified; full suite 2005 pass / 0 fail. Independently reviewed with no blocking findings.