### PR TITLE
BACK-546 - Add dependency readiness guidance to TUI and browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           RUN_INTERACTIVE_TUI_TESTS=1 \
           TUI_TEST_CLI_RUNTIME= \
           TUI_TEST_CLI_PATH="$PWD/backlog-test" \
-          bun test src/test/tui-interactive-editor-handoff.test.ts --timeout=30000
+          bun test src/test/tui-interactive-editor-handoff.test.ts src/test/tui-ready-filter-pty.test.ts --timeout=30000
       - name: Upload compiled-binary interactive transcripts on failure
         if: failure() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v7

--- a/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
+++ b/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-08-07 23:46'
+updated_date: '2026-08-08 05:42'
 labels:
   - tui
   - web
@@ -89,6 +89,24 @@ Final verification on the built binary (dist/backlog) against a disposable proje
 - Browser: the Dependencies card shows the matching amber and green badges in light and dark themes with no console errors.
 
 Merged origin/main (BACK-593 web task-ID linking) into the branch. The merge was clean, but the full suite then failed one rendered assertion: main made the task-details modal router-dependent, so the readiness modal test now wraps it in MemoryRouter and TaskIdIndexProvider like the other modal tests. Re-verified on the merged tree: bun run test 2008 pass, 0 fail across 219 files; tsc, biome and build clean; TUI detail pane, browser modal (ready and blocked, no console errors), and task list --ready all re-checked on the rebuilt binary.
+
+Review round 2 (Codex on PR #873, ten P2s: seven accepted and fixed here, three deferred to BACK-601).
+
+1. Interactive --ready combined with --assignee, --unassigned or --parent resolved readiness against the prefiltered display list, so a dependency owned by someone else read as an unknown dependency and a blocked task could pass the filter. The interactive loader now returns the unfiltered corpus as readinessTasks, unified-view threads it to the viewer, and the viewer resolves readiness against it while still displaying only the filtered list. The one-shot plain and json paths were already correct because they used loadReadinessGraph.
+2. Duplicate canonical identities in the graph were resolved first-wins, so the verdict depended on insertion order. An identity claimed by more than one record now resolves as unresolved and fails closed, per the manifesto's rule on ambiguous identity.
+3. statuses: [] in config left no terminal status, so every dependency looked unfinished and everything was blocked. The CLI and server paths defaulted to DEFAULT_STATUSES but the interactive loader passed the empty array straight through. The default now resolves once inside createReadinessGraph, which covers every surface.
+4. A record in backlog/completed whose status is not the currently configured terminal one (renamed statuses, or history from Core.completeTask) classified as unfinished and blocked its dependents permanently. Location in the completed corpus is now the completion evidence: completed records are passed separately and satisfy a dependency whatever their status string says.
+5. The browser modal derived readiness from the persisted task.status and ignored the optimistic inline status state, so a task set to a terminal status inline still showed its blocked or ready badge until a refresh. It now depends on the edited status.
+6. Completing a task with the TUI C shortcut removed it from the display list but left the startup completed snapshot stale, so dependents immediately flipped to 'Unknown dependency'. The shortcut now moves the record from the active side of the readiness graph to the completed side.
+7. The id-to-task index was rebuilt for every evaluated candidate, which is quadratic on large ready-filters. It is built once per filter pass and passed through as a ReadinessGraph value. applyTaskFilters now takes ready?: ReadinessGraph instead of ready/statuses/readinessTasks, so readiness filtering cannot be requested without the graph it needs.
+
+Deferred to BACK-601 (created off main, low priority, labels tui+web): draft-on-draft dependencies unresolvable in the browser, the readiness filter silently dropping when tabbing to the board, and cross-branch terminal dependencies missing from the graph under checkActiveBranches.
+
+New coverage: duplicate-identity fail-closed in both insertion orders, renamed-terminal completed record, a task whose own record is completed, statuses: [] falling back to the default, readiness verdicts independent of the filters that narrowed the display list, a 2000-task scale guard that the quadratic version failed, CLI --ready with --assignee and --unassigned where the dependencies are hidden by the filter, and unified-view plumbing of the unfiltered corpus.
+
+Rendered re-verification on the rebuilt binary: task list --ready --assignee @me returns only the task whose dependency is completed; the detail pane of the assignee-filtered list reports 'Blocked by TASK-2' for a dependency that is not in the list; completing that dependency with C leaves the dependent reading '✓ Ready to start' with the record confirmed in backlog/completed; and the browser badge switches off and back on immediately when the status is changed inline, with no console errors.
+
+Verification after the review fixes: bun run test -> 2015 pass, 0 fail across 219 files, exit 0; bunx tsc --noEmit and bun run check . clean; bun run build clean. Follow-up task BACK-601 created on a branch off main so it lands independently of this PR.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
+++ b/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-08-08 05:42'
+updated_date: '2026-08-08 05:54'
 labels:
   - tui
   - web
@@ -107,6 +107,8 @@ New coverage: duplicate-identity fail-closed in both insertion orders, renamed-t
 Rendered re-verification on the rebuilt binary: task list --ready --assignee @me returns only the task whose dependency is completed; the detail pane of the assignee-filtered list reports 'Blocked by TASK-2' for a dependency that is not in the list; completing that dependency with C leaves the dependent reading '✓ Ready to start' with the record confirmed in backlog/completed; and the browser badge switches off and back on immediately when the status is changed inline, with no console errors.
 
 Verification after the review fixes: bun run test -> 2015 pass, 0 fail across 219 files, exit 0; bunx tsc --noEmit and bun run check . clean; bun run build clean. Follow-up task BACK-601 created on a branch off main so it lands independently of this PR.
+
+Integrated a merge commit that had been pushed to the remote branch (a merge of main into the pre-fix branch state) instead of force-pushing over it. The result is content-identical to the review fixes: readiness.ts, task-search.ts, task-viewer-with-search.ts, unified-view.ts and TaskDetailsModal.tsx are byte-identical to the fix commit, and cli.ts differs only by main's decision-list and defaultAssignee changes. Re-verified: bun run test 2031 pass, 0 fail across 219 files; tsc, biome and build clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
+++ b/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-08-08 05:54'
+updated_date: '2026-08-08 07:55'
 labels:
   - tui
   - web
@@ -109,6 +109,16 @@ Rendered re-verification on the rebuilt binary: task list --ready --assignee @me
 Verification after the review fixes: bun run test -> 2015 pass, 0 fail across 219 files, exit 0; bunx tsc --noEmit and bun run check . clean; bun run build clean. Follow-up task BACK-601 created on a branch off main so it lands independently of this PR.
 
 Integrated a merge commit that had been pushed to the remote branch (a merge of main into the pre-fix branch state) instead of force-pushing over it. The result is content-identical to the review fixes: readiness.ts, task-search.ts, task-viewer-with-search.ts, unified-view.ts and TaskDetailsModal.tsx are byte-identical to the fix commit, and cli.ts differs only by main's decision-list and defaultAssignee changes. Re-verified: bun run test 2031 pass, 0 fail across 219 files; tsc, biome and build clean.
+
+Review round 3 (Codex on PR #873): three accepted, one deferred. All three are fixed, but two of the accepted findings do not reproduce as described, and that is worth recording.
+
+1. filtersActive omitted options.readyFilter, so the first render was not routed through applyFilters(). Fixed by listing readyFilter with the other narrowing filters. However the claimed symptom, that interactive 'task list --ready' never filters, is NOT reproducible: unified-view's subscribeUpdates calls emitTaskListUpdate() synchronously on subscription, and that callback ends in applyFilters(), so the list is always filtered before anything is painted. Verified directly by reverting the one-line fix and rendering in a PTY: 'task list --ready' still showed Tasks (2) with the blocked task excluded and no unfiltered flash. Today unified-view is the only caller that passes readyFilter, so the defect was latent. The fix is still right: a narrowing filter should gate the initial render on its own rather than depend on an incidental initial emit from the caller.
+2. The A archive shortcut left the archived task in readinessSnapshot. Fixed by dropping the record from the snapshot for both lifecycle actions and re-adding only a completed one as completion evidence, so an archived dependency reads as unresolvable rather than as still-blocking. The claimed stale verdict also does not reproduce through the shortcut: archiving rewrites dependents' frontmatter to drop the reference, so in a rendered check the dependent simply lost its Dependencies and Readiness lines. The fix matters when the in-memory record has not caught up.
+3. Genuine user-visible bug, reproduced and now covered by a test. A completed task opened by direct link, whose historical status is no longer the configured terminal status, was absent from the completed side of the graph, so the modal offered it as '✓ Ready to start'. The open task's own completed-corpus membership is now treated as completion evidence, the same location-is-evidence rule already used for dependencies. Reverting the fix makes the new assertion fail with the badge present in the rendered HTML.
+
+Testing: added src/test/tui-ready-filter-pty.test.ts, an expect-driven PTY test asserting the interactive --ready render never lists the blocked task, following the project's existing RUN_INTERACTIVE_TUI_TESTS convention, and wired it into the CI step that runs interactive TUI tests against the compiled binary. Note that it passes with and without fix 1 for the reason above, so it guards the end-to-end behavior rather than proving that one line. The routed-completed-task case is covered by an assertion in readiness.test.tsx that does fail without its fix.
+
+Deferred item 4 appended to BACK-601: getTaskStatistics counts blockers with exact-ID matching and a hard-coded 'Done'.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
+++ b/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-08-08 07:55'
+updated_date: '2026-08-08 08:13'
 labels:
   - tui
   - web
@@ -119,6 +119,8 @@ Review round 3 (Codex on PR #873): three accepted, one deferred. All three are f
 Testing: added src/test/tui-ready-filter-pty.test.ts, an expect-driven PTY test asserting the interactive --ready render never lists the blocked task, following the project's existing RUN_INTERACTIVE_TUI_TESTS convention, and wired it into the CI step that runs interactive TUI tests against the compiled binary. Note that it passes with and without fix 1 for the reason above, so it guards the end-to-end behavior rather than proving that one line. The routed-completed-task case is covered by an assertion in readiness.test.tsx that does fail without its fix.
 
 Deferred item 4 appended to BACK-601: getTaskStatistics counts blockers with exact-ID matching and a hard-coded 'Done'.
+
+Merged origin/main again (BACK-580 and BACK-602 identity work) with no conflicts; the round-3 fixes are intact. Final verification on the merged tree: bun run test 2055 pass, 0 fail across 222 files, exit 0; scripts/run-tui-interactive-tests.sh 5 pass, 0 fail including the new readiness PTY test; bunx tsc --noEmit, bun run check ., and bun run build clean.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
+++ b/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-546
 title: Add dependency readiness guidance to TUI and browser
-status: To Do
+status: In Progress
 assignee:
   - '@alex-agent'
 created_date: '2026-07-13 16:06'
+updated_date: '2026-08-07 23:20'
 labels:
   - tui
   - web
@@ -38,3 +39,43 @@ Address the reported need to see what can be worked next without silently restor
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Takeover of contributor PR #814 (cottrell, draft). Maintainer decision: the readiness code is needed and should merge; original work by David Cottrell (@cottrell) is ported with authorship preserved on the first commit, adaptations recorded here.
+
+1. Port his branch (base was 63 commits behind main) onto current main and resolve conflicts in src/cli.ts and src/web/components/TaskDetailsModal.tsx.
+2. Keep the shared helper getTaskReadiness(task, allTasks, statuses) in src/utils/readiness.ts, resolved per task from dependencies at read time. No ordering or state semantics; the removed sequences model is not restored.
+3. Fix dependency identity resolution: match dependency IDs with the project canonicalTaskId identity instead of raw lowercase string equality, so zero padded and prefixed variants resolve like the rest of the product.
+4. Represent partial graphs honestly: report resolved-but-unfinished dependencies (blocked by) separately from dependency IDs that cannot be resolved (unknown), and fail closed (not ready) for both.
+5. Replace the contributor's full-graph loading strategy. Measured on this repo: core.loadTasks({includeCompleted:true}) costs 6.6s versus 1.7s for the active load and 112ms for filesystem.listCompletedTasks(). His patch called the 6.6s load unconditionally in viewTaskEnhanced and in the unified-view loader, which would add seconds to every TUI launch. Build the readiness graph instead from the corpus each surface already has plus listCompletedTasks(), loaded in parallel with existing startup work.
+6. Revert the fullGraphTasks plumbing through unified-view.ts; keep only the ready filter flowing from the CLI flag into the interactive viewer.
+7. Drop TaskListFilter.ready: Core.applyTaskFilters ignores it, so it was a silently dead filter field. Readiness filtering stays where the full graph is available.
+8. Surfaces: backlog task list --ready (plain, json, interactive), TUI detail pane readiness line, browser task-details modal badge, and MCP task_list ready parity through the existing tool (no new MCP tools).
+9. Adapt his tests (readiness, cli-task-list, mcp-tasks, unified-view-filters) and verify with tsc, biome, bun test, a rendered TUI check in tmux against a disposable project, and the web modal in the running server.
+
+Deliberate scope boundary: the browser resolves readiness against the corpus the web app already loads, which excludes backlog/completed. Sending 455 completed tasks to the client was judged not worth the payload for this change; unresolved dependencies render honestly as unknown. Out of scope per the maintainer's split of PR #814: the Web 'Ready only' toggle and the TUI R shortcut.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Takeover of contributor PR #814 (cottrell). Original implementation by David Cottrell (@cottrell) is preserved as the first commit on this branch with his git authorship; the adaptation commits are the maintainer's.
+
+Survived from his branch mostly intact: the shared getTaskReadiness helper and its semantics, the --ready flag on task list (help schema, option, plain/json/interactive paths), the MCP task_list ready argument and JSON schema (no new MCP tools), the readiness line in the TUI detail pane, the readiness badge in the browser task-details modal, and the CLI/MCP/unified-view test cases.
+
+Adapted during the takeover:
+- Performance. His branch called core.loadTasks({includeCompleted:true}) unconditionally in viewTaskEnhanced and in the unified-view task loader. Measured on this repo (121 active, 455 completed tasks): that call takes 6.6s versus 1.7s for the normal active load, so every TUI launch and every task view would have paid several extra seconds. Replaced with filesystem.listCompletedTasks() (112ms, issued in parallel with the milestone metadata the viewer already loads) and, for CLI/MCP, a shared loadReadinessGraph() that reuses the warm ContentStore via queryTasks plus the completed tasks.
+- Reverted the fullGraphTasks plumbing through unified-view.ts entirely; only the ready filter still flows from the CLI flag into the interactive viewer.
+- Removed TaskListFilter.ready. Core.applyTaskFilters never handled it, so it was a filter field that silently did nothing.
+- Dependency identity. His lookup used raw lowercase string equality, which misses the zero-padded and prefixed variants the rest of the product treats as the same task. Now keyed on canonicalTaskId.
+- Partial graphs. His helper folded unresolvable dependency IDs into blockingDependencies, so the UI claimed a task was blocked by unfinished work when the ID simply could not be resolved. blockingDependencies now means resolved-but-unfinished, missingDependencies means unresolvable, both fail closed, and a shared formatReadinessBlockers renders them distinctly on every surface.
+- Copy and placement. Readiness only renders when a task actually has dependencies, instead of adding a line to every task that restates its status; his 'Terminal status (Done)' row is gone for the same reason. In the browser the standalone banner moved into the Dependencies card, next to the dependencies it explains.
+- TUI rendering bug found in rendered QA: the hourglass glyph is East Asian Wide, blessed miscounts its width, and the detail pane left stale cells behind when re-rendering a shorter line. Replaced with the single-width bullet the TUI already uses for blocked status.
+- Browser/CLI divergence found in rendered QA: the web task corpus excludes backlog/completed, so a dependency that had been completed and filed showed 'Unknown dependency TASK-1' in the browser while the CLI and TUI said 'Ready to start'. The modal now resolves only its unresolved dependency IDs through the existing GET /api/tasks/:id endpoint, which already reads completed tasks, so all four surfaces agree without shipping the completed corpus to the client.
+
+Verification: bunx tsc --noEmit, bun run check ., bun run build, and the readiness/cli-task-list/mcp-tasks/unified-view-filters suites all pass. Rendered QA on a disposable project with met, unmet, and completed-and-filed dependencies: TUI detail pane shows 'Readiness: ● Blocked by TASK-2', 'Readiness: ✓ Ready to start', and nothing at all for a task without dependencies; task list --ready returns the same three ready tasks in plain, json and interactive modes; the browser modal shows the matching amber and green badges in the Dependencies card in both light and dark themes.
+
+Known follow-up, deliberately out of scope per the split of PR #814: the interactive view gives no on-screen indication that --ready is active, the same as the existing --limit flag. That belongs with the deferred Web 'Ready only' toggle and TUI shortcut work.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
+++ b/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-08-07 23:33'
+updated_date: '2026-08-07 23:46'
 labels:
   - tui
   - web
@@ -87,6 +87,8 @@ Final verification on the built binary (dist/backlog) against a disposable proje
 - MCP: driven over stdio against the shipped binary, task_list with ready true returns the same three tasks and without it returns all four. No new MCP tools; the existing tool and schema carry the filter.
 - TUI: detail pane shows 'Readiness: ● Blocked by TASK-2' and 'Readiness: ✓ Ready to start', nothing for a task without dependencies, and no stale render cells when navigating between them.
 - Browser: the Dependencies card shows the matching amber and green badges in light and dark themes with no console errors.
+
+Merged origin/main (BACK-593 web task-ID linking) into the branch. The merge was clean, but the full suite then failed one rendered assertion: main made the task-details modal router-dependent, so the readiness modal test now wraps it in MemoryRouter and TaskIdIndexProvider like the other modal tests. Re-verified on the merged tree: bun run test 2008 pass, 0 fail across 219 files; tsc, biome and build clean; TUI detail pane, browser modal (ready and blocked, no console errors), and task list --ready all re-checked on the rebuilt binary.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
+++ b/backlog/tasks/back-546 - Add-dependency-readiness-guidance-to-TUI-and-browser.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-546
 title: Add dependency readiness guidance to TUI and browser
-status: In Progress
+status: Done
 assignee:
   - '@alex-agent'
 created_date: '2026-07-13 16:06'
-updated_date: '2026-08-07 23:20'
+updated_date: '2026-08-07 23:33'
 labels:
   - tui
   - web
@@ -25,19 +25,19 @@ Address the reported need to see what can be worked next without silently restor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Plan review defines ready and blocked semantics for partial graphs, cycles, missing dependencies, and dependencies in other statuses
-- [ ] #2 The TUI and browser present consistent, non-mutating readiness and blocked guidance
-- [ ] #3 Existing ordinal order remains authoritative unless Alex explicitly approves an ordering change
-- [ ] #4 Cycles and ambiguous dependency data are represented honestly and fail safely
-- [ ] #5 Users can identify which dependencies block a task
-- [ ] #6 Automated tests and rendered QA cover ready, blocked, cross-status, missing, and cyclic examples
+- [x] #1 Plan review defines ready and blocked semantics for partial graphs, cycles, missing dependencies, and dependencies in other statuses
+- [x] #2 The TUI and browser present consistent, non-mutating readiness and blocked guidance
+- [x] #3 Existing ordinal order remains authoritative unless Alex explicitly approves an ordering change
+- [x] #4 Cycles and ambiguous dependency data are represented honestly and fail safely
+- [x] #5 Users can identify which dependencies block a task
+- [x] #6 Automated tests and rendered QA cover ready, blocked, cross-status, missing, and cyclic examples
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -78,4 +78,23 @@ Adapted during the takeover:
 Verification: bunx tsc --noEmit, bun run check ., bun run build, and the readiness/cli-task-list/mcp-tasks/unified-view-filters suites all pass. Rendered QA on a disposable project with met, unmet, and completed-and-filed dependencies: TUI detail pane shows 'Readiness: ● Blocked by TASK-2', 'Readiness: ✓ Ready to start', and nothing at all for a task without dependencies; task list --ready returns the same three ready tasks in plain, json and interactive modes; the browser modal shows the matching amber and green badges in the Dependencies card in both light and dark themes.
 
 Known follow-up, deliberately out of scope per the split of PR #814: the interactive view gives no on-screen indication that --ready is active, the same as the existing --limit flag. That belongs with the deferred Web 'Ready only' toggle and TUI shortcut work.
+
+Final verification on the built binary (dist/backlog) against a disposable project with a met dependency, an unmet dependency, and a dependency completed into backlog/completed:
+- Full suite: bun run test -> 1985 pass, 0 fail, 1990 tests across 217 files, exit 0. bunx tsc --noEmit, bun run check ., and bun run build all clean.
+- The full suite caught two regressions that the scoped tests missed, both now fixed and re-verified: an infinite React render loop in the task-details modal (the readiness effect depended on arrays recreated every render and reset state with a fresh empty array), and the shipped MCP workflow overview, which mcp-server.test.ts requires to document every task_list schema filter.
+- Also fixed during review: the board quick-look popup calls generateDetailContent without a task graph and would have reported every dependency as unknown. Readiness inputs are now an explicit optional context, so that popup makes no readiness claim at all. Verified by rendered board QA.
+- CLI: task list --ready returns TASK-2, TASK-4, TASK-6 and excludes blocked TASK-3, in plain, json and interactive modes, including with --status 'To Do'. TASK-4 depends on a task living in backlog/completed and is still correctly reported ready.
+- MCP: driven over stdio against the shipped binary, task_list with ready true returns the same three tasks and without it returns all four. No new MCP tools; the existing tool and schema carry the filter.
+- TUI: detail pane shows 'Readiness: ● Blocked by TASK-2' and 'Readiness: ✓ Ready to start', nothing for a task without dependencies, and no stale render cells when navigating between them.
+- Browser: the Dependencies card shows the matching amber and green badges in light and dark themes with no console errors.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Took over contributor PR #814 (cottrell) and landed dependency readiness guidance across the CLI, TUI, browser, and MCP. A shared getTaskReadiness(task, allTasks, statuses) helper derives readiness per task from its dependencies at read time, with no ordering or state semantics and no revival of the removed sequences model: resolved-but-unfinished dependencies are reported as blocking, dependency IDs that cannot be resolved are reported as unknown, and both fail closed. Surfaced through backlog task list --ready, the TUI detail pane, the browser task-details modal, and the existing MCP task_list tool.
+
+David Cottrell's implementation is preserved as the first commit with his authorship. The adaptation replaced his full-graph loading strategy, which called core.loadTasks({includeCompleted:true}) unconditionally in the TUI (measured at 6.6s per call on this repo versus 1.7s for the normal load), fixed dependency resolution to use canonical task identity instead of raw string equality, separated unknown dependencies from blocked ones, removed a dead TaskListFilter.ready field, and reverted the fullGraphTasks plumbing through unified-view.
+
+Verified with bunx tsc --noEmit, bun run check ., bun run build, and the full bun run test suite (1985 pass, 0 fail). Rendered QA on the built binary against a disposable project covering met, unmet, and completed-and-filed dependencies: TUI detail pane in tmux, task list --ready in plain, json and interactive modes, the browser modal in light and dark themes, and an MCP task_list stdio round-trip. Rendered QA also caught three defects the unit tests missed: a blessed wide-glyph rendering artifact in the TUI, a browser/CLI disagreement about completed dependencies, and an infinite render loop in the modal.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/scripts/run-tui-interactive-tests.sh
+++ b/scripts/run-tui-interactive-tests.sh
@@ -6,5 +6,8 @@ if ! command -v expect >/dev/null 2>&1; then
 	exit 0
 fi
 
-echo "Running interactive TUI editor handoff tests with expect..."
-RUN_INTERACTIVE_TUI_TESTS=1 bun test src/test/tui-interactive-editor-handoff.test.ts --timeout=30000
+echo "Running interactive TUI tests with expect..."
+RUN_INTERACTIVE_TUI_TESTS=1 bun test \
+	src/test/tui-interactive-editor-handoff.test.ts \
+	src/test/tui-ready-filter-pty.test.ts \
+	--timeout=30000

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,7 @@ import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
 import { hasAnyPrefix } from "./utils/prefix-config.ts";
 import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
 import { type ReadOutputMode, resolveReadOutputMode } from "./utils/read-output-mode.ts";
+import { getTaskReadiness } from "./utils/readiness.ts";
 import { resolveRuntimeCwd } from "./utils/runtime-cwd.ts";
 import { formatValidStatuses, getCanonicalStatus, getCanonicalStatuses, getValidStatuses } from "./utils/status.ts";
 import {
@@ -2308,6 +2309,7 @@ addHelpSchema(taskCmd.command("list"), {
 			description: "Require every listed label; repeat --labels or use label1,label2",
 		},
 		{ name: "search", type: "String", description: "Search task title, description, notes, comments, and metadata" },
+		{ name: "ready", type: "Boolean", description: "Only show unblocked tasks with all dependencies completed" },
 		{ name: "limit", type: "Positive integer", description: "Maximum tasks to display after sorting" },
 		{ name: "sort", type: choiceType(TASK_SORT_FIELDS), description: "Task ordering before applying limit" },
 		{ name: "plain", type: "Boolean", description: "Use text output instead of interactive UI" },
@@ -2316,6 +2318,7 @@ addHelpSchema(taskCmd.command("list"), {
 	output: "Interactive task list, plain text with --plain, or versioned JSON with --json",
 	examples: [
 		'backlog task list --status "<todo status>" --plain',
+		"backlog task list --ready --plain",
 		'backlog task list --status "<todo status>" --json',
 		"backlog task list --parent {{TASK_ID:1}}",
 		`backlog task list --type ${TASK_TYPE_EXAMPLE} --plain`,
@@ -2345,6 +2348,7 @@ addHelpSchema(taskCmd.command("list"), {
 		createMultiValueAccumulator(),
 	)
 	.option("--search <query>", "search task title, description, notes, comments, and metadata")
+	.option("--ready", "only show unblocked tasks with all dependencies completed")
 	.option("--limit <number>", "limit tasks displayed after sorting")
 	.option("--sort <field>", `sort tasks by field (${TASK_SORT_FIELD_LIST})`)
 	.option("--plain", "use plain text output instead of interactive UI")
@@ -2387,6 +2391,9 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 		if (options.unassigned) {
 			baseFilters.unassigned = true;
+		}
+		if (options.ready) {
+			baseFilters.ready = true;
 		}
 		if (options.milestone) {
 			baseFilters.milestone = options.milestone;
@@ -2439,12 +2446,18 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 
 		if (outputMode !== "interactive") {
-			const tasks = await core.queryTasks({
+			let tasks = await core.queryTasks({
 				query: searchQuery || undefined,
 				filters: Object.keys(baseFilters).length > 0 ? baseFilters : undefined,
 				includeCrossBranch: false,
 			});
 			const config = await core.filesystem.loadConfig();
+			const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
+
+			if (options.ready) {
+				const fullTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
+				tasks = tasks.filter((task) => getTaskReadiness(task, fullTasks, statuses).isReady);
+			}
 
 			if (parentId) {
 				const parentExists = (await core.queryTasks({ includeCrossBranch: false })).some((task) =>
@@ -2509,7 +2522,6 @@ addHelpSchema(taskCmd.command("list"), {
 			}
 
 			const canonicalByLower = new Map<string, string>();
-			const statuses = config?.statuses || [];
 			for (const status of statuses) {
 				canonicalByLower.set(status.toLowerCase(), status);
 			}
@@ -2567,6 +2579,8 @@ addHelpSchema(taskCmd.command("list"), {
 		if (taskLimit !== undefined) activeFilters.push(`Limit: ${taskLimit}`);
 		if (options.sort) activeFilters.push(`Sort: ${options.sort}`);
 
+		if (options.ready) activeFilters.push("Ready");
+
 		if (activeFilters.length > 0) {
 			filterDescription = activeFilters.join(", ");
 			title = `Tasks (${activeFilters.join(" • ")})`;
@@ -2586,6 +2600,7 @@ addHelpSchema(taskCmd.command("list"), {
 			filterDescription?: string;
 			parentTaskId?: string;
 			limit?: number;
+			ready?: boolean;
 		} = {
 			status: options.status,
 			excludeStatus: Array.isArray(baseFilters.excludeStatus) ? baseFilters.excludeStatus : undefined,
@@ -2600,6 +2615,7 @@ addHelpSchema(taskCmd.command("list"), {
 			filterDescription,
 			parentTaskId: parentId,
 			limit: taskLimit,
+			ready: options.ready,
 		};
 		if (searchQuery) {
 			initialUnifiedFilter.searchQuery = searchQuery;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,7 @@ import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
 import { hasAnyPrefix } from "./utils/prefix-config.ts";
 import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
 import { type ReadOutputMode, resolveReadOutputMode } from "./utils/read-output-mode.ts";
-import { getTaskReadiness } from "./utils/readiness.ts";
+import { getTaskReadiness, loadReadinessGraph } from "./utils/readiness.ts";
 import { resolveRuntimeCwd } from "./utils/runtime-cwd.ts";
 import { formatValidStatuses, getCanonicalStatus, getCanonicalStatuses, getValidStatuses } from "./utils/status.ts";
 import {
@@ -2392,9 +2392,6 @@ addHelpSchema(taskCmd.command("list"), {
 		if (options.unassigned) {
 			baseFilters.unassigned = true;
 		}
-		if (options.ready) {
-			baseFilters.ready = true;
-		}
 		if (options.milestone) {
 			baseFilters.milestone = options.milestone;
 		}
@@ -2452,11 +2449,11 @@ addHelpSchema(taskCmd.command("list"), {
 				includeCrossBranch: false,
 			});
 			const config = await core.filesystem.loadConfig();
-			const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
 
 			if (options.ready) {
-				const fullTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
-				tasks = tasks.filter((task) => getTaskReadiness(task, fullTasks, statuses).isReady);
+				const readinessTasks = await loadReadinessGraph(core);
+				const readinessStatuses = config?.statuses?.length ? config.statuses : [...DEFAULT_STATUSES];
+				tasks = tasks.filter((task) => getTaskReadiness(task, readinessTasks, readinessStatuses).isReady);
 			}
 
 			if (parentId) {
@@ -2522,6 +2519,7 @@ addHelpSchema(taskCmd.command("list"), {
 			}
 
 			const canonicalByLower = new Map<string, string>();
+			const statuses = config?.statuses || [];
 			for (const status of statuses) {
 				canonicalByLower.set(status.toLowerCase(), status);
 			}
@@ -2565,6 +2563,7 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 		if (options.assignee) activeFilters.push(`Assignee: ${options.assignee}`);
 		if (options.unassigned) activeFilters.push("Unassigned");
+		if (options.ready) activeFilters.push("Ready");
 		if (options.parent) {
 			activeFilters.push(`Parent: ${normalizeTaskId(String(options.parent))}`);
 		}
@@ -2578,8 +2577,6 @@ addHelpSchema(taskCmd.command("list"), {
 		if (searchQuery) activeFilters.push(`Search: ${searchQuery}`);
 		if (taskLimit !== undefined) activeFilters.push(`Limit: ${taskLimit}`);
 		if (options.sort) activeFilters.push(`Sort: ${options.sort}`);
-
-		if (options.ready) activeFilters.push("Ready");
 
 		if (activeFilters.length > 0) {
 			filterDescription = activeFilters.join(", ");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2451,9 +2451,8 @@ addHelpSchema(taskCmd.command("list"), {
 			const config = await core.filesystem.loadConfig();
 
 			if (options.ready) {
-				const readinessTasks = await loadReadinessGraph(core);
-				const readinessStatuses = config?.statuses?.length ? config.statuses : [...DEFAULT_STATUSES];
-				tasks = tasks.filter((task) => getTaskReadiness(task, readinessTasks, readinessStatuses).isReady);
+				const readinessGraph = await loadReadinessGraph(core);
+				tasks = tasks.filter((task) => getTaskReadiness(task, readinessGraph).isReady);
 			}
 
 			if (parentId) {
@@ -2629,6 +2628,7 @@ addHelpSchema(taskCmd.command("list"), {
 		if (parentId) {
 			interactiveLoaderFilters.parentTaskId = parentId;
 		}
+		const prefiltersDisplayList = Object.keys(interactiveLoaderFilters).length > 0;
 		await runUnifiedView({
 			core,
 			initialView: "task-list",
@@ -2678,6 +2678,9 @@ addHelpSchema(taskCmd.command("list"), {
 				return {
 					tasks: filtered,
 					statuses: config?.statuses || [],
+					// The filters above narrow what is displayed. Dependency readiness must still see
+					// every task, or a dependency assigned to someone else reads as unknown.
+					readinessTasks: prefiltersDisplayList ? await core.queryTasks({ includeCrossBranch: false }) : undefined,
 				};
 			},
 			filter: initialUnifiedFilter,

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -52,7 +52,7 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 
 **Note:** "Done" tasks stay in the Done column until periodic cleanup moves them to the completed folder. Don't use `task_complete` immediately after finishing—it's for batch cleanup, not per-task workflow.
 
-- `task_list` — list tasks with optional filtering by status, configured task type, assignee (or `unassigned: true`), milestone, labels, search, or limit
+- `task_list` — list tasks with optional filtering by status, configured task type, assignee (or `unassigned: true`), milestone, labels, search, `ready: true` for unblocked tasks, or limit
 - `task_search` — search tasks by title and description, or filter by configured task type and project-root-relative `modifiedFiles` path substrings
 - `task_view` — read full task context (description, plan, notes, comments, final summary, acceptance criteria, Definition of Done)
 - `definition_of_done_defaults_get` — read project-level Definition of Done defaults from config

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -12,7 +12,7 @@ import type { TaskEditArgs, TaskEditRequest } from "../../../types/task-edit-arg
 import { formatDuplicateTaskIdWarning } from "../../../utils/duplicate-detection.ts";
 import { createMilestoneFilterMatcher, createMilestoneFilterValueResolver } from "../../../utils/milestone-filter.ts";
 import { resolveMilestoneInputForStorage } from "../../../utils/milestone-storage.ts";
-import { getTaskReadiness } from "../../../utils/readiness.ts";
+import { getTaskReadiness, loadReadinessGraph } from "../../../utils/readiness.ts";
 import { buildTaskUpdateInput } from "../../../utils/task-edit-builder.ts";
 import { createTaskSearchIndex } from "../../../utils/task-search.ts";
 import { sortByOrdinalAndPriority } from "../../../utils/task-sorting.ts";
@@ -155,6 +155,7 @@ export class TaskHandlers {
 		}
 		const config = await this.core.filesystem.loadConfig();
 		const priorities = config?.priorities;
+		const readinessStatuses = config?.statuses?.length ? config.statuses : [...DEFAULT_STATUSES];
 		if (this.isDraftStatus(args.status)) {
 			let drafts = await this.core.filesystem.listDrafts();
 			const milestoneCandidates = drafts;
@@ -196,9 +197,8 @@ export class TaskHandlers {
 			}
 
 			if (args.ready) {
-				const allTasksForDrafts = await this.core.loadTasks(undefined, undefined, { includeCompleted: true });
-				const statusesForDrafts: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
-				drafts = drafts.filter((draft) => getTaskReadiness(draft, allTasksForDrafts, statusesForDrafts).isReady);
+				const readinessTasks = await loadReadinessGraph(this.core);
+				drafts = drafts.filter((draft) => getTaskReadiness(draft, readinessTasks, readinessStatuses).isReady);
 			}
 
 			if (drafts.length === 0) {
@@ -247,20 +247,16 @@ export class TaskHandlers {
 		if (args.milestone) {
 			filters.milestone = args.milestone;
 		}
-		if (args.ready) {
-			filters.ready = true;
-		}
 
 		let tasks = await this.core.queryTasks({
 			query: args.search,
 			filters: Object.keys(filters).length > 0 ? filters : undefined,
 			includeCrossBranch: false,
 		});
-		const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
 
 		if (args.ready) {
-			const fullTasks = await this.core.loadTasks(undefined, undefined, { includeCompleted: true });
-			tasks = tasks.filter((task) => getTaskReadiness(task, fullTasks, statuses).isReady);
+			const readinessTasks = await loadReadinessGraph(this.core);
+			tasks = tasks.filter((task) => getTaskReadiness(task, readinessTasks, readinessStatuses).isReady);
 		}
 
 		let filteredByLabels = tasks.filter((task) => isLocalEditableTask(task));
@@ -282,6 +278,8 @@ export class TaskHandlers {
 				],
 			};
 		}
+
+		const statuses = config?.statuses ?? [];
 
 		const canonicalByLower = new Map<string, string>();
 		for (const status of statuses) {

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -155,7 +155,6 @@ export class TaskHandlers {
 		}
 		const config = await this.core.filesystem.loadConfig();
 		const priorities = config?.priorities;
-		const readinessStatuses = config?.statuses?.length ? config.statuses : [...DEFAULT_STATUSES];
 		if (this.isDraftStatus(args.status)) {
 			let drafts = await this.core.filesystem.listDrafts();
 			const milestoneCandidates = drafts;
@@ -197,8 +196,8 @@ export class TaskHandlers {
 			}
 
 			if (args.ready) {
-				const readinessTasks = await loadReadinessGraph(this.core);
-				drafts = drafts.filter((draft) => getTaskReadiness(draft, readinessTasks, readinessStatuses).isReady);
+				const readinessGraph = await loadReadinessGraph(this.core);
+				drafts = drafts.filter((draft) => getTaskReadiness(draft, readinessGraph).isReady);
 			}
 
 			if (drafts.length === 0) {
@@ -255,8 +254,8 @@ export class TaskHandlers {
 		});
 
 		if (args.ready) {
-			const readinessTasks = await loadReadinessGraph(this.core);
-			tasks = tasks.filter((task) => getTaskReadiness(task, readinessTasks, readinessStatuses).isReady);
+			const readinessGraph = await loadReadinessGraph(this.core);
+			tasks = tasks.filter((task) => getTaskReadiness(task, readinessGraph).isReady);
 		}
 
 		let filteredByLabels = tasks.filter((task) => isLocalEditableTask(task));

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -12,6 +12,7 @@ import type { TaskEditArgs, TaskEditRequest } from "../../../types/task-edit-arg
 import { formatDuplicateTaskIdWarning } from "../../../utils/duplicate-detection.ts";
 import { createMilestoneFilterMatcher, createMilestoneFilterValueResolver } from "../../../utils/milestone-filter.ts";
 import { resolveMilestoneInputForStorage } from "../../../utils/milestone-storage.ts";
+import { getTaskReadiness } from "../../../utils/readiness.ts";
 import { buildTaskUpdateInput } from "../../../utils/task-edit-builder.ts";
 import { createTaskSearchIndex } from "../../../utils/task-search.ts";
 import { sortByOrdinalAndPriority } from "../../../utils/task-sorting.ts";
@@ -50,6 +51,7 @@ export type TaskListArgs = {
 	milestone?: string;
 	labels?: string[];
 	search?: string;
+	ready?: boolean;
 	limit?: number;
 };
 
@@ -193,6 +195,12 @@ export class TaskHandlers {
 				});
 			}
 
+			if (args.ready) {
+				const allTasksForDrafts = await this.core.loadTasks(undefined, undefined, { includeCompleted: true });
+				const statusesForDrafts: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
+				drafts = drafts.filter((draft) => getTaskReadiness(draft, allTasksForDrafts, statusesForDrafts).isReady);
+			}
+
 			if (drafts.length === 0) {
 				return {
 					content: [
@@ -239,12 +247,21 @@ export class TaskHandlers {
 		if (args.milestone) {
 			filters.milestone = args.milestone;
 		}
+		if (args.ready) {
+			filters.ready = true;
+		}
 
-		const tasks = await this.core.queryTasks({
+		let tasks = await this.core.queryTasks({
 			query: args.search,
 			filters: Object.keys(filters).length > 0 ? filters : undefined,
 			includeCrossBranch: false,
 		});
+		const statuses: string[] = config?.statuses ?? [...DEFAULT_STATUSES];
+
+		if (args.ready) {
+			const fullTasks = await this.core.loadTasks(undefined, undefined, { includeCompleted: true });
+			tasks = tasks.filter((task) => getTaskReadiness(task, fullTasks, statuses).isReady);
+		}
 
 		let filteredByLabels = tasks.filter((task) => isLocalEditableTask(task));
 		const labelFilters = args.labels ?? [];
@@ -265,8 +282,6 @@ export class TaskHandlers {
 				],
 			};
 		}
-
-		const statuses = config?.statuses ?? [];
 
 		const canonicalByLower = new Map<string, string>();
 		for (const status of statuses) {

--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -90,6 +90,10 @@ export function generateTaskListSchema(config: Pick<BacklogConfig, "types">): Js
 				type: "string",
 				maxLength: 200,
 			},
+			ready: {
+				type: "boolean",
+				description: "When true, filter tasks that are ready for work (all dependencies satisfied/completed).",
+			},
 			limit: {
 				type: "number",
 				minimum: 1,

--- a/src/test/cli-task-list.test.ts
+++ b/src/test/cli-task-list.test.ts
@@ -505,6 +505,77 @@ describe("CLI Integration", () => {
 			expect(out).not.toContain("TASK-2 - OAuth Callback Other Parent");
 		});
 
+		it("should filter tasks by readiness using --ready and --ready --json", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-1",
+					title: "Done Dep",
+					status: "Done",
+					assignee: [],
+					labels: [],
+					dependencies: [],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-2",
+					title: "In Progress Dep",
+					status: "In Progress",
+					assignee: [],
+					labels: [],
+					dependencies: [],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-3",
+					title: "Blocked Task",
+					status: "To Do",
+					assignee: [],
+					labels: [],
+					dependencies: ["task-2"],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-4",
+					title: "Ready Task",
+					status: "To Do",
+					assignee: [],
+					labels: [],
+					dependencies: ["task-1"],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+
+			const plainResult = await $`bun ${CLI_PATH} task list --plain --ready`.cwd(TEST_DIR).quiet();
+			const plainOut = plainResult.stdout.toString();
+			expect(plainOut).toContain("TASK-4 - Ready Task");
+			expect(plainOut).toContain("TASK-2 - In Progress Dep");
+			expect(plainOut).not.toContain("TASK-3 - Blocked Task");
+
+			const jsonResult = await $`bun ${CLI_PATH} task list --json --ready`.cwd(TEST_DIR).quiet();
+			const json = JSON.parse(jsonResult.stdout.toString());
+			const readyIds = json.tasks.map((t: { id: string }) => t.id);
+			expect(readyIds).toContain("TASK-4");
+			expect(readyIds).toContain("TASK-2");
+			expect(readyIds).not.toContain("TASK-3");
+			expect(readyIds).not.toContain("TASK-1");
+		});
+
 		it("should reject invalid task list limit", async () => {
 			const result = await $`bun ${CLI_PATH} task list --plain --limit 0`.cwd(TEST_DIR).nothrow().quiet();
 			const out = result.stdout.toString() + result.stderr.toString();

--- a/src/test/cli-task-list.test.ts
+++ b/src/test/cli-task-list.test.ts
@@ -574,6 +574,63 @@ describe("CLI Integration", () => {
 			expect(readyIds).toContain("TASK-2");
 			expect(readyIds).not.toContain("TASK-3");
 			expect(readyIds).not.toContain("TASK-1");
+
+			// Readiness must resolve against the whole graph, not the tasks left after --status.
+			const scopedResult = await $`bun ${CLI_PATH} task list --plain --ready --status "To Do"`.cwd(TEST_DIR).quiet();
+			const scopedOut = scopedResult.stdout.toString();
+			expect(scopedOut).toContain("TASK-4 - Ready Task");
+			expect(scopedOut).not.toContain("TASK-3 - Blocked Task");
+		});
+
+		it("should resolve --ready dependencies that were completed and moved out of the active corpus", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-1",
+					title: "Completed Dep",
+					status: "Done",
+					assignee: [],
+					labels: [],
+					dependencies: [],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-2",
+					title: "Depends On Completed",
+					status: "To Do",
+					assignee: [],
+					labels: [],
+					dependencies: ["task-1"],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-3",
+					title: "Depends On Nothing Known",
+					status: "To Do",
+					assignee: [],
+					labels: [],
+					dependencies: ["task-404"],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			expect(await core.completeTask("task-1", false)).toBe(true);
+
+			const result = await $`bun ${CLI_PATH} task list --plain --ready`.cwd(TEST_DIR).quiet();
+			const out = result.stdout.toString();
+			expect(out).toContain("TASK-2 - Depends On Completed");
+			// An unresolvable dependency fails closed instead of being treated as satisfied.
+			expect(out).not.toContain("TASK-3 - Depends On Nothing Known");
 		});
 
 		it("should reject invalid task list limit", async () => {

--- a/src/test/cli-task-list.test.ts
+++ b/src/test/cli-task-list.test.ts
@@ -633,6 +633,74 @@ describe("CLI Integration", () => {
 			expect(out).not.toContain("TASK-3 - Depends On Nothing Known");
 		});
 
+		it("should keep --ready verdicts correct when display filters hide the dependencies", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-1",
+					title: "Someone Elses Blocker",
+					status: "In Progress",
+					assignee: ["@other"],
+					labels: [],
+					dependencies: [],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-2",
+					title: "Someone Elses Finished Work",
+					status: "Done",
+					assignee: ["@other"],
+					labels: [],
+					dependencies: [],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-3",
+					title: "Mine Blocked",
+					status: "To Do",
+					assignee: ["@me"],
+					labels: [],
+					dependencies: ["task-1"],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-4",
+					title: "Mine Ready",
+					status: "To Do",
+					assignee: ["@me"],
+					labels: [],
+					dependencies: ["task-2"],
+					createdDate: "2026-07-24",
+					rawContent: "",
+				},
+				false,
+			);
+
+			// Both dependencies belong to @other, so --assignee @me removes them from the listing.
+			// Readiness must still resolve them instead of calling them unknown.
+			const assigneeResult = await $`bun ${CLI_PATH} task list --plain --ready --assignee @me`.cwd(TEST_DIR).quiet();
+			const assigneeOut = assigneeResult.stdout.toString();
+			expect(assigneeOut).toContain("TASK-4 - Mine Ready");
+			expect(assigneeOut).not.toContain("TASK-3 - Mine Blocked");
+			expect(assigneeOut).not.toContain("TASK-1 - Someone Elses Blocker");
+
+			const unassignedResult = await $`bun ${CLI_PATH} task list --plain --ready --unassigned`.cwd(TEST_DIR).quiet();
+			expect(unassignedResult.stdout.toString()).toContain("No tasks found.");
+		});
+
 		it("should reject invalid task list limit", async () => {
 			const result = await $`bun ${CLI_PATH} task list --plain --limit 0`.cwd(TEST_DIR).nothrow().quiet();
 			const out = result.stdout.toString() + result.stderr.toString();

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -499,6 +499,28 @@ describe("MCP task tools (MVP)", () => {
 		expect(getText(conflictResult.content)).toContain("unassigned cannot be combined with assignee");
 	});
 
+	it("filters task_list by ready argument in MCP tool", async () => {
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Completed Dep", status: "Done" } },
+		});
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "InProgress Dep", status: "In Progress" } },
+		});
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Blocked Task", status: "To Do", dependencies: ["TASK-2"] } },
+		});
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Ready Task", status: "To Do", dependencies: ["TASK-1"] } },
+		});
+
+		const readyResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_list", arguments: { ready: true } },
+		});
+		const text = getText(readyResult.content);
+		expect(text).toContain("TASK-4 - Ready Task");
+		expect(text).not.toContain("TASK-3 - Blocked Task");
+	});
+
 	it("applies unassigned filtering in task_list draft status path", async () => {
 		await mcpServer.testInterface.callTool({
 			params: {

--- a/src/test/readiness.test.tsx
+++ b/src/test/readiness.test.tsx
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { renderToString } from "react-dom/server";
+import type { Task } from "../types/index.ts";
+import { generateDetailContent } from "../ui/task-viewer-with-search.ts";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
+import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
+import { getTaskReadiness } from "../utils/readiness.ts";
+import { applyTaskFilters } from "../utils/task-search.ts";
+
+const statuses = ["To Do", "In Progress", "Done"];
+
+function makeTask(id: string, status: string, dependencies: string[] = []): Task {
+	return {
+		id,
+		title: `Task ${id}`,
+		status,
+		dependencies,
+		assignee: [],
+		labels: [],
+		createdDate: "2026-07-24",
+		rawContent: "",
+	};
+}
+
+describe("getTaskReadiness", () => {
+	it("returns ready for a task with no dependencies", () => {
+		const task = makeTask("BACK-1", "To Do");
+		const readiness = getTaskReadiness(task, [task], statuses);
+
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.isBlocked).toBe(false);
+		expect(readiness.blockingDependencies).toEqual([]);
+	});
+
+	it("returns ready when all dependencies are in terminal status", () => {
+		const dep = makeTask("BACK-1", "Done");
+		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
+		const readiness = getTaskReadiness(task, [dep, task], statuses);
+
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.isBlocked).toBe(false);
+	});
+
+	it("returns blocked when a dependency is in non-terminal status", () => {
+		const dep = makeTask("BACK-1", "In Progress");
+		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
+		const readiness = getTaskReadiness(task, [dep, task], statuses);
+
+		expect(readiness.isReady).toBe(false);
+		expect(readiness.isBlocked).toBe(true);
+		expect(readiness.blockingDependencies).toEqual(["BACK-1"]);
+	});
+
+	it("returns blocked when a dependency is missing", () => {
+		const task = makeTask("BACK-2", "To Do", ["BACK-99"]);
+		const readiness = getTaskReadiness(task, [task], statuses);
+
+		expect(readiness.isReady).toBe(false);
+		expect(readiness.isBlocked).toBe(true);
+		expect(readiness.missingDependencies).toEqual(["BACK-99"]);
+	});
+
+	it("returns not ready and not blocked for tasks already in terminal status", () => {
+		const task = makeTask("BACK-1", "Done");
+		const readiness = getTaskReadiness(task, [task], statuses);
+
+		expect(readiness.isReady).toBe(false);
+		expect(readiness.isBlocked).toBe(false);
+	});
+
+	it("handles dependency cycles safely without infinite recursion", () => {
+		const task1 = makeTask("BACK-1", "To Do", ["BACK-2"]);
+		const task2 = makeTask("BACK-2", "To Do", ["BACK-1"]);
+		const readiness1 = getTaskReadiness(task1, [task1, task2], statuses);
+		const readiness2 = getTaskReadiness(task2, [task1, task2], statuses);
+
+		expect(readiness1.isReady).toBe(false);
+		expect(readiness1.isBlocked).toBe(true);
+		expect(readiness1.blockingDependencies).toEqual(["BACK-2"]);
+
+		expect(readiness2.isReady).toBe(false);
+		expect(readiness2.isBlocked).toBe(true);
+		expect(readiness2.blockingDependencies).toEqual(["BACK-1"]);
+	});
+
+	it("respects custom configured terminal statuses (e.g. Closed)", () => {
+		const customStatuses = ["Open", "In Review", "Closed"];
+		const dep = makeTask("BACK-1", "Closed");
+		const task = makeTask("BACK-2", "Open", ["BACK-1"]);
+
+		const readiness = getTaskReadiness(task, [dep, task], customStatuses);
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.isBlocked).toBe(false);
+	});
+});
+
+describe("applyTaskFilters with readiness filter integration", () => {
+	it("filters candidates correctly when ready: true is requested", () => {
+		const doneDep = makeTask("BACK-1", "Done");
+		const blockedTask = makeTask("BACK-2", "To Do", ["BACK-3"]);
+		const inProgDep = makeTask("BACK-3", "In Progress");
+		const readyTask = makeTask("BACK-4", "To Do", ["BACK-1"]);
+
+		const allTasks = [doneDep, blockedTask, inProgDep, readyTask];
+
+		// Filter for ready tasks: BACK-3 (In Progress, no deps) and BACK-4 (To Do, BACK-1 dep is Done) are unblocked/ready
+		const readyFiltered = applyTaskFilters(allTasks, { ready: true, statuses });
+		expect(readyFiltered.map((t) => t.id)).toEqual(["BACK-3", "BACK-4"]);
+
+		// Combine ready filter with status filter
+		const readyToDoFiltered = applyTaskFilters(allTasks, { ready: true, status: "To Do", statuses });
+		expect(readyToDoFiltered.map((t) => t.id)).toEqual(["BACK-4"]);
+	});
+
+	it("evaluates readiness against fullGraphTasks when display candidates omit completed tasks", () => {
+		const archivedDoneDep = makeTask("BACK-1", "Done");
+		const activeTask = makeTask("BACK-2", "To Do", ["BACK-1"]);
+
+		const displayCandidates = [activeTask]; // BACK-1 excluded from active candidates
+		const fullGraph = [archivedDoneDep, activeTask];
+
+		// Filtering display candidates with fullGraphTasks supplied
+		const result = applyTaskFilters(displayCandidates, { ready: true, statuses, fullGraphTasks: fullGraph });
+		expect(result.map((t) => t.id)).toEqual(["BACK-2"]);
+	});
+});
+
+describe("Rendered TUI and Web UI readiness guidance assertions", () => {
+	it("renders TUI detail readiness guidance for ready, blocked, and terminal tasks", () => {
+		const doneDep = makeTask("BACK-1", "Done");
+		const inProgDep = makeTask("BACK-2", "In Progress");
+		const readyTask = makeTask("BACK-3", "To Do", ["BACK-1"]);
+		const blockedTask = makeTask("BACK-4", "To Do", ["BACK-2"]);
+		const fullGraph = [doneDep, inProgDep, readyTask, blockedTask];
+
+		const readyDetail = generateDetailContent(readyTask, undefined, undefined, fullGraph, statuses);
+		const readyText = readyDetail.bodyContent.join("\n");
+		expect(readyText).toContain("Readiness:");
+		expect(readyText).toContain("✓ Ready to start");
+
+		const blockedDetail = generateDetailContent(blockedTask, undefined, undefined, fullGraph, statuses);
+		const blockedText = blockedDetail.bodyContent.join("\n");
+		expect(blockedText).toContain("Readiness:");
+		expect(blockedText).toContain("⏳ Blocked by: BACK-2");
+
+		const terminalDetail = generateDetailContent(doneDep, undefined, undefined, fullGraph, statuses);
+		const terminalText = terminalDetail.bodyContent.join("\n");
+		expect(terminalText).toContain("Readiness:");
+		expect(terminalText).toContain("Terminal status (Done)");
+	});
+
+	it("renders Web TaskDetailsModal readiness badge accurately for ready, blocked, and terminal tasks", () => {
+		const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost" });
+		globalThis.window = dom.window as unknown as Window & typeof globalThis;
+		globalThis.document = dom.window.document as Document;
+		globalThis.navigator = dom.window.navigator as Navigator;
+		globalThis.localStorage = dom.window.localStorage;
+
+		if (!window.matchMedia) {
+			window.matchMedia = () =>
+				({
+					matches: false,
+					media: "",
+					onchange: null,
+					addListener: () => {},
+					removeListener: () => {},
+					addEventListener: () => {},
+					removeEventListener: () => {},
+					dispatchEvent: () => false,
+				}) as MediaQueryList;
+		}
+
+		const doneDep = makeTask("BACK-1", "Done");
+		const inProgDep = makeTask("BACK-2", "In Progress");
+		const readyTask = makeTask("BACK-3", "To Do", ["BACK-1"]);
+		const blockedTask = makeTask("BACK-4", "To Do", ["BACK-2"]);
+		const availableTasks = [doneDep, inProgDep, readyTask, blockedTask];
+
+		const readyHtml = renderToString(
+			<ThemeProvider>
+				<TaskDetailsModal task={readyTask} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
+			</ThemeProvider>,
+		);
+		expect(readyHtml).toContain("Readiness:");
+		expect(readyHtml).toContain("✓ Ready to start");
+
+		const blockedHtml = renderToString(
+			<ThemeProvider>
+				<TaskDetailsModal task={blockedTask} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
+			</ThemeProvider>,
+		);
+		expect(blockedHtml).toContain("Readiness:");
+		expect(blockedHtml).toContain("BACK-2");
+
+		const terminalHtml = renderToString(
+			<ThemeProvider>
+				<TaskDetailsModal task={doneDep} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
+			</ThemeProvider>,
+		);
+		expect(terminalHtml).toContain("Readiness:");
+		expect(terminalHtml).toContain("Done");
+	});
+});

--- a/src/test/readiness.test.tsx
+++ b/src/test/readiness.test.tsx
@@ -4,7 +4,7 @@ import { renderToString } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import type { Task } from "../types/index.ts";
 import { generateDetailContent } from "../ui/task-viewer-with-search.ts";
-import { formatReadinessBlockers, getTaskReadiness } from "../utils/readiness.ts";
+import { createReadinessGraph, formatReadinessBlockers, getTaskReadiness } from "../utils/readiness.ts";
 import { applyTaskFilters } from "../utils/task-search.ts";
 import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
 import { TaskIdIndexProvider } from "../web/contexts/TaskIdIndexContext.tsx";
@@ -25,10 +25,19 @@ function makeTask(id: string, status: string, dependencies: string[] = []): Task
 	};
 }
 
+/** Readiness against an active-only corpus with the default statuses. */
+function graphOf(tasks: Task[], graphStatuses: readonly string[] = statuses) {
+	return createReadinessGraph({ tasks, statuses: graphStatuses });
+}
+
+function readinessOf(task: Task, tasks: Task[], graphStatuses: readonly string[] = statuses) {
+	return getTaskReadiness(task, graphOf(tasks, graphStatuses));
+}
+
 describe("getTaskReadiness", () => {
 	it("returns ready for a task with no dependencies", () => {
 		const task = makeTask("BACK-1", "To Do");
-		const readiness = getTaskReadiness(task, [task], statuses);
+		const readiness = readinessOf(task, [task]);
 
 		expect(readiness.isReady).toBe(true);
 		expect(readiness.isBlocked).toBe(false);
@@ -39,7 +48,7 @@ describe("getTaskReadiness", () => {
 	it("returns ready when all dependencies are in terminal status", () => {
 		const dep = makeTask("BACK-1", "Done");
 		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
-		const readiness = getTaskReadiness(task, [dep, task], statuses);
+		const readiness = readinessOf(task, [dep, task]);
 
 		expect(readiness.isReady).toBe(true);
 		expect(readiness.isBlocked).toBe(false);
@@ -48,7 +57,7 @@ describe("getTaskReadiness", () => {
 	it("returns blocked when a dependency is in non-terminal status", () => {
 		const dep = makeTask("BACK-1", "In Progress");
 		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
-		const readiness = getTaskReadiness(task, [dep, task], statuses);
+		const readiness = readinessOf(task, [dep, task]);
 
 		expect(readiness.isReady).toBe(false);
 		expect(readiness.isBlocked).toBe(true);
@@ -59,7 +68,7 @@ describe("getTaskReadiness", () => {
 	it("reports an unresolvable dependency separately from an unfinished one and fails closed", () => {
 		const unfinished = makeTask("BACK-1", "In Progress");
 		const task = makeTask("BACK-2", "To Do", ["BACK-1", "BACK-99"]);
-		const readiness = getTaskReadiness(task, [unfinished, task], statuses);
+		const readiness = readinessOf(task, [unfinished, task]);
 
 		expect(readiness.isReady).toBe(false);
 		expect(readiness.isBlocked).toBe(true);
@@ -71,7 +80,7 @@ describe("getTaskReadiness", () => {
 	it("resolves dependencies through canonical task identity, not raw string equality", () => {
 		const dep = makeTask("BACK-007", "Done");
 		const task = makeTask("BACK-2", "To Do", ["back-7"]);
-		const readiness = getTaskReadiness(task, [dep, task], statuses);
+		const readiness = readinessOf(task, [dep, task]);
 
 		expect(readiness.isReady).toBe(true);
 		expect(readiness.missingDependencies).toEqual([]);
@@ -80,23 +89,67 @@ describe("getTaskReadiness", () => {
 	it("does not confuse task IDs that only differ by prefix", () => {
 		const otherPrefix = makeTask("BACK-355.01", "Done");
 		const task = makeTask("BACK-2", "To Do", ["task-355.01"]);
-		const readiness = getTaskReadiness(task, [otherPrefix, task], statuses);
+		const readiness = readinessOf(task, [otherPrefix, task]);
 
 		expect(readiness.isReady).toBe(false);
 		expect(readiness.missingDependencies).toEqual(["task-355.01"]);
 	});
 
-	it("prefers the first entry when the graph carries a duplicate identity", () => {
-		const live = makeTask("BACK-1", "In Progress");
-		const completedCopy = makeTask("BACK-1", "Done");
+	it("fails closed when more than one record claims the dependency identity", () => {
+		const unfinished = makeTask("BACK-1", "In Progress");
+		const doneCopy = makeTask("BACK-01", "Done");
 		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
 
-		expect(getTaskReadiness(task, [live, completedCopy, task], statuses).isReady).toBe(false);
+		// Order must not decide the verdict: an ambiguous identity is never satisfied by luck.
+		for (const corpus of [
+			[unfinished, doneCopy, task],
+			[doneCopy, unfinished, task],
+		]) {
+			const readiness = readinessOf(task, corpus);
+			expect(readiness.isReady).toBe(false);
+			expect(readiness.isBlocked).toBe(true);
+			expect(readiness.missingDependencies).toEqual(["BACK-1"]);
+			expect(readiness.blockingDependencies).toEqual([]);
+		}
+	});
+
+	it("treats a record in the completed corpus as completed whatever its status string says", () => {
+		// The terminal status was renamed to Shipped, so the archived record's "Done" is not terminal.
+		const renamedStatuses = ["To Do", "In Progress", "Shipped"];
+		const completedDep = makeTask("BACK-1", "Done");
+		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
+
+		const graph = createReadinessGraph({ tasks: [task], completedTasks: [completedDep], statuses: renamedStatuses });
+		const readiness = getTaskReadiness(task, graph);
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.isBlocked).toBe(false);
+
+		// The same record left in the active corpus is genuinely unfinished under that configuration.
+		expect(readinessOf(task, [completedDep, task], renamedStatuses).blockingDependencies).toEqual(["BACK-1"]);
+	});
+
+	it("treats a task whose own record is in the completed corpus as not actionable", () => {
+		const completedTask = makeTask("BACK-1", "To Do", ["BACK-2"]);
+		const graph = createReadinessGraph({ tasks: [], completedTasks: [completedTask], statuses });
+
+		const readiness = getTaskReadiness(completedTask, graph);
+		expect(readiness.isReady).toBe(false);
+		expect(readiness.isBlocked).toBe(false);
+	});
+
+	it("falls back to the default statuses when the configured list is empty", () => {
+		const dep = makeTask("BACK-1", "Done");
+		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
+
+		// An empty statuses array leaves no terminal status, which would block everything forever.
+		const readiness = readinessOf(task, [dep, task], []);
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.isBlocked).toBe(false);
 	});
 
 	it("returns not ready and not blocked for tasks already in terminal status", () => {
 		const task = makeTask("BACK-1", "Done");
-		const readiness = getTaskReadiness(task, [task], statuses);
+		const readiness = readinessOf(task, [task]);
 
 		expect(readiness.isReady).toBe(false);
 		expect(readiness.isBlocked).toBe(false);
@@ -105,8 +158,8 @@ describe("getTaskReadiness", () => {
 	it("handles dependency cycles safely without infinite recursion", () => {
 		const task1 = makeTask("BACK-1", "To Do", ["BACK-2"]);
 		const task2 = makeTask("BACK-2", "To Do", ["BACK-1"]);
-		const readiness1 = getTaskReadiness(task1, [task1, task2], statuses);
-		const readiness2 = getTaskReadiness(task2, [task1, task2], statuses);
+		const readiness1 = readinessOf(task1, [task1, task2]);
+		const readiness2 = readinessOf(task2, [task1, task2]);
 
 		expect(readiness1.isReady).toBe(false);
 		expect(readiness1.isBlocked).toBe(true);
@@ -122,7 +175,7 @@ describe("getTaskReadiness", () => {
 		const dep = makeTask("BACK-1", "Closed");
 		const task = makeTask("BACK-2", "Open", ["BACK-1"]);
 
-		const readiness = getTaskReadiness(task, [dep, task], customStatuses);
+		const readiness = readinessOf(task, [dep, task], customStatuses);
 		expect(readiness.isReady).toBe(true);
 		expect(readiness.isBlocked).toBe(false);
 	});
@@ -136,29 +189,47 @@ describe("applyTaskFilters with readiness filter integration", () => {
 		const readyTask = makeTask("BACK-4", "To Do", ["BACK-1"]);
 
 		const allTasks = [doneDep, blockedTask, inProgDep, readyTask];
+		const graph = graphOf(allTasks);
 
 		// BACK-3 (In Progress, no deps) and BACK-4 (To Do, dependency BACK-1 is Done) can be worked on
-		const readyFiltered = applyTaskFilters(allTasks, { ready: true, statuses });
+		const readyFiltered = applyTaskFilters(allTasks, { ready: graph });
 		expect(readyFiltered.map((t) => t.id)).toEqual(["BACK-3", "BACK-4"]);
 
 		// Combine ready filter with status filter
-		const readyToDoFiltered = applyTaskFilters(allTasks, { ready: true, status: "To Do", statuses });
+		const readyToDoFiltered = applyTaskFilters(allTasks, { ready: graph, status: "To Do" });
 		expect(readyToDoFiltered.map((t) => t.id)).toEqual(["BACK-4"]);
 	});
 
-	it("evaluates readiness against readinessTasks when display candidates omit completed tasks", () => {
+	it("keeps readiness verdicts independent of the filters that narrowed the display list", () => {
+		// The display list was prefiltered by assignee, so the blocking and completed dependencies
+		// are both absent from it. Readiness must still resolve them.
 		const completedDep = makeTask("BACK-1", "Done");
-		const activeTask = makeTask("BACK-2", "To Do", ["BACK-1"]);
+		const unfinishedDep = makeTask("BACK-2", "In Progress");
+		const readyTask = makeTask("BACK-3", "To Do", ["BACK-1"]);
+		const blockedTask = makeTask("BACK-4", "To Do", ["BACK-2"]);
 
-		const displayCandidates = [activeTask]; // BACK-1 excluded from active candidates
-		const readinessTasks = [activeTask, completedDep];
+		const displayCandidates = [readyTask, blockedTask];
+		const fullCorpus = [completedDep, unfinishedDep, readyTask, blockedTask];
 
-		expect(applyTaskFilters(displayCandidates, { ready: true, statuses, readinessTasks }).map((t) => t.id)).toEqual([
-			"BACK-2",
-		]);
+		expect(applyTaskFilters(displayCandidates, { ready: graphOf(fullCorpus) }).map((t) => t.id)).toEqual(["BACK-3"]);
 
-		// Without the wider graph the same dependency is unresolvable, so the task fails closed.
-		expect(applyTaskFilters(displayCandidates, { ready: true, statuses })).toEqual([]);
+		// Resolving against the narrowed list instead loses both verdicts and fails closed.
+		expect(applyTaskFilters(displayCandidates, { ready: graphOf(displayCandidates) })).toEqual([]);
+	});
+
+	it("stays linear when filtering a large dependent corpus", () => {
+		// The graph index is built once per filter pass. Rebuilding it per candidate made this
+		// quadratic and took seconds at this size.
+		const dependency = makeTask("BACK-0", "Done");
+		const dependents = Array.from({ length: 2000 }, (_, index) => makeTask(`BACK-${index + 1}`, "To Do", ["BACK-0"]));
+		const corpus = [dependency, ...dependents];
+
+		const startedAt = performance.now();
+		const ready = applyTaskFilters(corpus, { ready: graphOf(corpus) });
+		const elapsedMs = performance.now() - startedAt;
+
+		expect(ready).toHaveLength(dependents.length);
+		expect(elapsedMs).toBeLessThan(2000);
 	});
 });
 
@@ -173,7 +244,7 @@ describe("rendered readiness guidance", () => {
 		const graph = [doneDep, inProgDep, readyTask, blockedTask, unknownDepTask, noDepsTask];
 
 		const detailBody = (task: Task) =>
-			generateDetailContent(task, undefined, undefined, { tasks: graph, statuses }).bodyContent.join("\n");
+			generateDetailContent(task, undefined, undefined, graphOf(graph)).bodyContent.join("\n");
 
 		expect(detailBody(readyTask)).toContain("Readiness:");
 		expect(detailBody(readyTask)).toContain("✓ Ready to start");

--- a/src/test/readiness.test.tsx
+++ b/src/test/readiness.test.tsx
@@ -3,10 +3,10 @@ import { JSDOM } from "jsdom";
 import { renderToString } from "react-dom/server";
 import type { Task } from "../types/index.ts";
 import { generateDetailContent } from "../ui/task-viewer-with-search.ts";
+import { formatReadinessBlockers, getTaskReadiness } from "../utils/readiness.ts";
+import { applyTaskFilters } from "../utils/task-search.ts";
 import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
 import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
-import { getTaskReadiness } from "../utils/readiness.ts";
-import { applyTaskFilters } from "../utils/task-search.ts";
 
 const statuses = ["To Do", "In Progress", "Done"];
 
@@ -31,6 +31,7 @@ describe("getTaskReadiness", () => {
 		expect(readiness.isReady).toBe(true);
 		expect(readiness.isBlocked).toBe(false);
 		expect(readiness.blockingDependencies).toEqual([]);
+		expect(readiness.missingDependencies).toEqual([]);
 	});
 
 	it("returns ready when all dependencies are in terminal status", () => {
@@ -50,15 +51,45 @@ describe("getTaskReadiness", () => {
 		expect(readiness.isReady).toBe(false);
 		expect(readiness.isBlocked).toBe(true);
 		expect(readiness.blockingDependencies).toEqual(["BACK-1"]);
+		expect(readiness.missingDependencies).toEqual([]);
 	});
 
-	it("returns blocked when a dependency is missing", () => {
-		const task = makeTask("BACK-2", "To Do", ["BACK-99"]);
-		const readiness = getTaskReadiness(task, [task], statuses);
+	it("reports an unresolvable dependency separately from an unfinished one and fails closed", () => {
+		const unfinished = makeTask("BACK-1", "In Progress");
+		const task = makeTask("BACK-2", "To Do", ["BACK-1", "BACK-99"]);
+		const readiness = getTaskReadiness(task, [unfinished, task], statuses);
 
 		expect(readiness.isReady).toBe(false);
 		expect(readiness.isBlocked).toBe(true);
+		expect(readiness.blockingDependencies).toEqual(["BACK-1"]);
 		expect(readiness.missingDependencies).toEqual(["BACK-99"]);
+		expect(formatReadinessBlockers(readiness)).toBe("Blocked by BACK-1; Unknown dependency BACK-99");
+	});
+
+	it("resolves dependencies through canonical task identity, not raw string equality", () => {
+		const dep = makeTask("BACK-007", "Done");
+		const task = makeTask("BACK-2", "To Do", ["back-7"]);
+		const readiness = getTaskReadiness(task, [dep, task], statuses);
+
+		expect(readiness.isReady).toBe(true);
+		expect(readiness.missingDependencies).toEqual([]);
+	});
+
+	it("does not confuse task IDs that only differ by prefix", () => {
+		const otherPrefix = makeTask("BACK-355.01", "Done");
+		const task = makeTask("BACK-2", "To Do", ["task-355.01"]);
+		const readiness = getTaskReadiness(task, [otherPrefix, task], statuses);
+
+		expect(readiness.isReady).toBe(false);
+		expect(readiness.missingDependencies).toEqual(["task-355.01"]);
+	});
+
+	it("prefers the first entry when the graph carries a duplicate identity", () => {
+		const live = makeTask("BACK-1", "In Progress");
+		const completedCopy = makeTask("BACK-1", "Done");
+		const task = makeTask("BACK-2", "To Do", ["BACK-1"]);
+
+		expect(getTaskReadiness(task, [live, completedCopy, task], statuses).isReady).toBe(false);
 	});
 
 	it("returns not ready and not blocked for tasks already in terminal status", () => {
@@ -104,7 +135,7 @@ describe("applyTaskFilters with readiness filter integration", () => {
 
 		const allTasks = [doneDep, blockedTask, inProgDep, readyTask];
 
-		// Filter for ready tasks: BACK-3 (In Progress, no deps) and BACK-4 (To Do, BACK-1 dep is Done) are unblocked/ready
+		// BACK-3 (In Progress, no deps) and BACK-4 (To Do, dependency BACK-1 is Done) can be worked on
 		const readyFiltered = applyTaskFilters(allTasks, { ready: true, statuses });
 		expect(readyFiltered.map((t) => t.id)).toEqual(["BACK-3", "BACK-4"]);
 
@@ -113,44 +144,48 @@ describe("applyTaskFilters with readiness filter integration", () => {
 		expect(readyToDoFiltered.map((t) => t.id)).toEqual(["BACK-4"]);
 	});
 
-	it("evaluates readiness against fullGraphTasks when display candidates omit completed tasks", () => {
-		const archivedDoneDep = makeTask("BACK-1", "Done");
+	it("evaluates readiness against readinessTasks when display candidates omit completed tasks", () => {
+		const completedDep = makeTask("BACK-1", "Done");
 		const activeTask = makeTask("BACK-2", "To Do", ["BACK-1"]);
 
 		const displayCandidates = [activeTask]; // BACK-1 excluded from active candidates
-		const fullGraph = [archivedDoneDep, activeTask];
+		const readinessTasks = [activeTask, completedDep];
 
-		// Filtering display candidates with fullGraphTasks supplied
-		const result = applyTaskFilters(displayCandidates, { ready: true, statuses, fullGraphTasks: fullGraph });
-		expect(result.map((t) => t.id)).toEqual(["BACK-2"]);
+		expect(applyTaskFilters(displayCandidates, { ready: true, statuses, readinessTasks }).map((t) => t.id)).toEqual([
+			"BACK-2",
+		]);
+
+		// Without the wider graph the same dependency is unresolvable, so the task fails closed.
+		expect(applyTaskFilters(displayCandidates, { ready: true, statuses })).toEqual([]);
 	});
 });
 
-describe("Rendered TUI and Web UI readiness guidance assertions", () => {
-	it("renders TUI detail readiness guidance for ready, blocked, and terminal tasks", () => {
+describe("rendered readiness guidance", () => {
+	it("renders TUI detail readiness guidance for ready, blocked, and unresolved dependencies", () => {
 		const doneDep = makeTask("BACK-1", "Done");
 		const inProgDep = makeTask("BACK-2", "In Progress");
 		const readyTask = makeTask("BACK-3", "To Do", ["BACK-1"]);
 		const blockedTask = makeTask("BACK-4", "To Do", ["BACK-2"]);
-		const fullGraph = [doneDep, inProgDep, readyTask, blockedTask];
+		const unknownDepTask = makeTask("BACK-5", "To Do", ["BACK-404"]);
+		const noDepsTask = makeTask("BACK-6", "To Do");
+		const graph = [doneDep, inProgDep, readyTask, blockedTask, unknownDepTask, noDepsTask];
 
-		const readyDetail = generateDetailContent(readyTask, undefined, undefined, fullGraph, statuses);
-		const readyText = readyDetail.bodyContent.join("\n");
-		expect(readyText).toContain("Readiness:");
-		expect(readyText).toContain("✓ Ready to start");
+		const detailBody = (task: Task) =>
+			generateDetailContent(task, undefined, undefined, graph, statuses).bodyContent.join("\n");
 
-		const blockedDetail = generateDetailContent(blockedTask, undefined, undefined, fullGraph, statuses);
-		const blockedText = blockedDetail.bodyContent.join("\n");
-		expect(blockedText).toContain("Readiness:");
-		expect(blockedText).toContain("⏳ Blocked by: BACK-2");
+		expect(detailBody(readyTask)).toContain("Readiness:");
+		expect(detailBody(readyTask)).toContain("✓ Ready to start");
 
-		const terminalDetail = generateDetailContent(doneDep, undefined, undefined, fullGraph, statuses);
-		const terminalText = terminalDetail.bodyContent.join("\n");
-		expect(terminalText).toContain("Readiness:");
-		expect(terminalText).toContain("Terminal status (Done)");
+		expect(detailBody(blockedTask)).toContain("● Blocked by BACK-2");
+
+		expect(detailBody(unknownDepTask)).toContain("● Unknown dependency BACK-404");
+
+		// Readiness stays out of the way when it would only restate the status.
+		expect(detailBody(noDepsTask)).not.toContain("Readiness:");
+		expect(detailBody(doneDep)).not.toContain("Readiness:");
 	});
 
-	it("renders Web TaskDetailsModal readiness badge accurately for ready, blocked, and terminal tasks", () => {
+	it("renders the web task details modal readiness badge for ready, blocked, and unresolved dependencies", () => {
 		const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost" });
 		globalThis.window = dom.window as unknown as Window & typeof globalThis;
 		globalThis.document = dom.window.document as Document;
@@ -175,30 +210,29 @@ describe("Rendered TUI and Web UI readiness guidance assertions", () => {
 		const inProgDep = makeTask("BACK-2", "In Progress");
 		const readyTask = makeTask("BACK-3", "To Do", ["BACK-1"]);
 		const blockedTask = makeTask("BACK-4", "To Do", ["BACK-2"]);
-		const availableTasks = [doneDep, inProgDep, readyTask, blockedTask];
+		const unknownDepTask = makeTask("BACK-5", "To Do", ["BACK-404"]);
+		const noDepsTask = makeTask("BACK-6", "To Do");
+		const availableTasks = [doneDep, inProgDep, readyTask, blockedTask, unknownDepTask, noDepsTask];
 
-		const readyHtml = renderToString(
-			<ThemeProvider>
-				<TaskDetailsModal task={readyTask} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
-			</ThemeProvider>,
-		);
-		expect(readyHtml).toContain("Readiness:");
-		expect(readyHtml).toContain("✓ Ready to start");
+		const renderModal = (task: Task) =>
+			renderToString(
+				<ThemeProvider>
+					<TaskDetailsModal
+						task={task}
+						availableTasks={availableTasks}
+						availableStatuses={statuses}
+						isOpen={true}
+						onClose={() => {}}
+					/>
+				</ThemeProvider>,
+			);
 
-		const blockedHtml = renderToString(
-			<ThemeProvider>
-				<TaskDetailsModal task={blockedTask} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
-			</ThemeProvider>,
-		);
-		expect(blockedHtml).toContain("Readiness:");
-		expect(blockedHtml).toContain("BACK-2");
+		expect(renderModal(readyTask)).toContain("Ready to start");
+		expect(renderModal(blockedTask)).toContain("Blocked by BACK-2");
+		expect(renderModal(unknownDepTask)).toContain("Unknown dependency BACK-404");
 
-		const terminalHtml = renderToString(
-			<ThemeProvider>
-				<TaskDetailsModal task={doneDep} availableTasks={availableTasks} isOpen={true} onClose={() => {}} />
-			</ThemeProvider>,
-		);
-		expect(terminalHtml).toContain("Readiness:");
-		expect(terminalHtml).toContain("Done");
+		// Same rule as the TUI: no readiness copy without dependencies, or once the task is done.
+		expect(renderModal(noDepsTask)).not.toContain("Ready to start");
+		expect(renderModal(doneDep)).not.toContain("Ready to start");
 	});
 });

--- a/src/test/readiness.test.tsx
+++ b/src/test/readiness.test.tsx
@@ -315,5 +315,14 @@ describe("rendered readiness guidance", () => {
 		// Same rule as the TUI: no readiness copy without dependencies, or once the task is done.
 		expect(renderModal(noDepsTask)).not.toContain("Ready to start");
 		expect(renderModal(doneDep)).not.toContain("Ready to start");
+
+		// A direct link can open a completed task whose historical status is no longer the configured
+		// terminal one. Its location in the completed corpus still means the work is finished, so the
+		// modal must not offer it as ready to start.
+		const routedCompletedTask: Task = {
+			...makeTask("BACK-7", "Shipped", ["BACK-1"]),
+			source: "completed",
+		};
+		expect(renderModal(routedCompletedTask)).not.toContain("Ready to start");
 	});
 });

--- a/src/test/readiness.test.tsx
+++ b/src/test/readiness.test.tsx
@@ -171,7 +171,7 @@ describe("rendered readiness guidance", () => {
 		const graph = [doneDep, inProgDep, readyTask, blockedTask, unknownDepTask, noDepsTask];
 
 		const detailBody = (task: Task) =>
-			generateDetailContent(task, undefined, undefined, graph, statuses).bodyContent.join("\n");
+			generateDetailContent(task, undefined, undefined, { tasks: graph, statuses }).bodyContent.join("\n");
 
 		expect(detailBody(readyTask)).toContain("Readiness:");
 		expect(detailBody(readyTask)).toContain("✓ Ready to start");
@@ -183,6 +183,10 @@ describe("rendered readiness guidance", () => {
 		// Readiness stays out of the way when it would only restate the status.
 		expect(detailBody(noDepsTask)).not.toContain("Readiness:");
 		expect(detailBody(doneDep)).not.toContain("Readiness:");
+
+		// Callers without a task graph (the board quick-look popup) get no readiness claim at all
+		// rather than one derived from an empty graph.
+		expect(generateDetailContent(blockedTask).bodyContent.join("\n")).not.toContain("Readiness:");
 	});
 
 	it("renders the web task details modal readiness badge for ready, blocked, and unresolved dependencies", () => {

--- a/src/test/readiness.test.tsx
+++ b/src/test/readiness.test.tsx
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { JSDOM } from "jsdom";
 import { renderToString } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
 import type { Task } from "../types/index.ts";
 import { generateDetailContent } from "../ui/task-viewer-with-search.ts";
 import { formatReadinessBlockers, getTaskReadiness } from "../utils/readiness.ts";
 import { applyTaskFilters } from "../utils/task-search.ts";
 import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
+import { TaskIdIndexProvider } from "../web/contexts/TaskIdIndexContext.tsx";
 import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
 
 const statuses = ["To Do", "In Progress", "Done"];
@@ -220,15 +222,19 @@ describe("rendered readiness guidance", () => {
 
 		const renderModal = (task: Task) =>
 			renderToString(
-				<ThemeProvider>
-					<TaskDetailsModal
-						task={task}
-						availableTasks={availableTasks}
-						availableStatuses={statuses}
-						isOpen={true}
-						onClose={() => {}}
-					/>
-				</ThemeProvider>,
+				<MemoryRouter initialEntries={[`/tasks/${task.id}`]}>
+					<ThemeProvider>
+						<TaskIdIndexProvider tasks={availableTasks}>
+							<TaskDetailsModal
+								task={task}
+								availableTasks={availableTasks}
+								availableStatuses={statuses}
+								isOpen={true}
+								onClose={() => {}}
+							/>
+						</TaskIdIndexProvider>
+					</ThemeProvider>
+				</MemoryRouter>,
 			);
 
 		expect(renderModal(readyTask)).toContain("Ready to start");

--- a/src/test/tui-ready-filter-pty.test.ts
+++ b/src/test/tui-ready-filter-pty.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import type { BacklogConfig } from "../types/index.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+const CLI_PATH = process.env.TUI_TEST_CLI_PATH?.trim() || getTestCliPath();
+const CLI_RUNTIME = process.env.TUI_TEST_CLI_RUNTIME?.trim() ?? "bun";
+const TRANSCRIPT_DIR = join(process.cwd(), "tmp", "tui-interactive-transcripts");
+const EXPECT_PATH = Bun.which("expect");
+const RUN_INTERACTIVE_TUI_TESTS = process.env.RUN_INTERACTIVE_TUI_TESTS === "1";
+
+function getSkipReason(): string | null {
+	if (process.platform === "win32") {
+		return "interactive PTY tests require a Unix-like environment";
+	}
+	if (!RUN_INTERACTIVE_TUI_TESTS) {
+		return "set RUN_INTERACTIVE_TUI_TESTS=1 to enable interactive PTY tests";
+	}
+	if (!EXPECT_PATH) {
+		return "expect is not installed";
+	}
+	return null;
+}
+
+const skipReason = getSkipReason();
+if (skipReason) {
+	console.warn(`[tui-ready-filter] Skipping interactive --ready render test: ${skipReason}`);
+}
+const itInteractive = skipReason ? it.skip : it;
+
+function buildSpawnCommand(cliArgs: string[]): string {
+	const argsSegment = cliArgs.map((arg) => `"${arg}"`).join(" ");
+	if (CLI_RUNTIME.length === 0) {
+		return `spawn {${CLI_PATH}} ${argsSegment}`;
+	}
+	return `spawn {${CLI_RUNTIME}} {${CLI_PATH}} ${argsSegment}`;
+}
+
+describe("interactive task list --ready", () => {
+	itInteractive(
+		"filters blocked tasks out of the very first render",
+		async () => {
+			const testDir = createUniqueTestDir("tui-ready-filter");
+			await mkdir(testDir, { recursive: true });
+			await mkdir(TRANSCRIPT_DIR, { recursive: true });
+			const transcriptPath = join(TRANSCRIPT_DIR, `ready-filter-${Date.now()}.log`);
+			const expectScriptPath = join(testDir, "ready-filter.expect");
+
+			try {
+				await $`git init -b main`.cwd(testDir).quiet();
+				const core = new Core(testDir);
+				await initializeTestProject(core, "Ready Filter");
+
+				const config = await core.filesystem.loadConfig();
+				if (!config) throw new Error("Failed to load config");
+				const updatedConfig: BacklogConfig = { ...config, remoteOperations: false, checkActiveBranches: false };
+				await core.filesystem.saveConfig(updatedConfig);
+
+				const baseTask = {
+					assignee: [],
+					labels: [],
+					createdDate: "2026-08-08",
+					rawContent: "",
+					dependencies: [] as string[],
+				};
+				// The blocker carries High priority so the unfiltered list would sort it first: if the
+				// initial render skips the readiness filter, this title reaches the terminal before any
+				// ready task does.
+				await core.createTask({ ...baseTask, id: "task-1", title: "Zulu Blocker", status: "In Progress" }, false);
+				await core.createTask(
+					{
+						...baseTask,
+						id: "task-2",
+						title: "Zulu Blocked",
+						status: "To Do",
+						priority: "high",
+						dependencies: ["task-1"],
+					},
+					false,
+				);
+				await core.createTask(
+					{ ...baseTask, id: "task-3", title: "Alpha Ready", status: "To Do", priority: "low", dependencies: [] },
+					false,
+				);
+
+				await writeFile(
+					expectScriptPath,
+					`#!/usr/bin/expect -f
+set timeout 30
+log_user 0
+log_file -a {${transcriptPath}}
+set env(NO_COLOR) {1}
+set env(TERM) {xterm-256color}
+${buildSpawnCommand(["task", "list", "--ready"])}
+expect {
+	-re {Zulu Blocked} { exit 92 }
+	-re {Alpha Ready} {}
+	timeout { exit 91 }
+}
+send "q"
+expect eof
+exit 0
+`,
+				);
+
+				const child = Bun.spawn([EXPECT_PATH as string, "-f", expectScriptPath], {
+					cwd: testDir,
+					stdout: "pipe",
+					stderr: "pipe",
+					env: { ...process.env, NO_COLOR: "1" },
+				});
+				const stdout = child.stdout ? await new Response(child.stdout).text() : "";
+				const stderr = child.stderr ? await new Response(child.stderr).text() : "";
+				const exitCode = await child.exited;
+
+				if (exitCode === 92) {
+					throw new Error(
+						`The first interactive render listed the blocked task, so --ready was not applied.\nTranscript: ${transcriptPath}`,
+					);
+				}
+				if (exitCode !== 0) {
+					throw new Error(
+						`Interactive --ready render failed with ${exitCode}.\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`,
+					);
+				}
+				expect(exitCode).toBe(0);
+			} finally {
+				await safeCleanup(testDir);
+			}
+		},
+		60_000,
+	);
+});

--- a/src/test/unified-view-filters.test.ts
+++ b/src/test/unified-view-filters.test.ts
@@ -502,4 +502,36 @@ describe("unified view filter state", () => {
 		expect(listResults).toEqual(["task-1", "task-2"]);
 		expect(literalMilestoneResults).toEqual(["task-4"]);
 	});
+
+	it("evaluates interactive TUI --ready filter against fullGraphTasks when active candidates omit completed tasks", () => {
+		const archivedDoneDep: Task = {
+			id: "task-1",
+			title: "Archived Completed Dep",
+			status: "Done",
+			assignee: [],
+			createdDate: "2026-07-01",
+			labels: [],
+			dependencies: [],
+		};
+		const activeTask: Task = {
+			id: "task-2",
+			title: "Active Dependent Task",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-07-24",
+			labels: [],
+			dependencies: ["task-1"],
+		};
+
+		const displayCandidates = [activeTask];
+		const fullGraph = [archivedDoneDep, activeTask];
+
+		const readyFiltered = applyTaskFilters(displayCandidates, {
+			ready: true,
+			statuses: ["To Do", "In Progress", "Done"],
+			fullGraphTasks: fullGraph,
+		});
+
+		expect(readyFiltered.map((task) => task.id)).toEqual(["task-2"]);
+	});
 });

--- a/src/test/unified-view-filters.test.ts
+++ b/src/test/unified-view-filters.test.ts
@@ -503,7 +503,7 @@ describe("unified view filter state", () => {
 		expect(literalMilestoneResults).toEqual(["task-4"]);
 	});
 
-	it("evaluates interactive TUI --ready filter against fullGraphTasks when active candidates omit completed tasks", () => {
+	it("evaluates interactive TUI --ready filter against readinessTasks when active candidates omit completed tasks", () => {
 		const archivedDoneDep: Task = {
 			id: "task-1",
 			title: "Archived Completed Dep",
@@ -529,7 +529,7 @@ describe("unified view filter state", () => {
 		const readyFiltered = applyTaskFilters(displayCandidates, {
 			ready: true,
 			statuses: ["To Do", "In Progress", "Done"],
-			fullGraphTasks: fullGraph,
+			readinessTasks: fullGraph,
 		});
 
 		expect(readyFiltered.map((task) => task.id)).toEqual(["task-2"]);

--- a/src/test/unified-view-filters.test.ts
+++ b/src/test/unified-view-filters.test.ts
@@ -8,6 +8,7 @@ import {
 	type UnifiedViewFilters,
 } from "../ui/unified-view.ts";
 import { NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
+import { createReadinessGraph } from "../utils/readiness.ts";
 import { applyTaskFilters } from "../utils/task-search.ts";
 
 describe("unified view filter state", () => {
@@ -503,10 +504,10 @@ describe("unified view filter state", () => {
 		expect(literalMilestoneResults).toEqual(["task-4"]);
 	});
 
-	it("evaluates interactive TUI --ready filter against readinessTasks when active candidates omit completed tasks", () => {
-		const archivedDoneDep: Task = {
+	it("evaluates the interactive --ready filter against the full corpus, not the display candidates", () => {
+		const completedDep: Task = {
 			id: "task-1",
-			title: "Archived Completed Dep",
+			title: "Completed Dep",
 			status: "Done",
 			assignee: [],
 			createdDate: "2026-07-01",
@@ -524,12 +525,8 @@ describe("unified view filter state", () => {
 		};
 
 		const displayCandidates = [activeTask];
-		const fullGraph = [archivedDoneDep, activeTask];
-
 		const readyFiltered = applyTaskFilters(displayCandidates, {
-			ready: true,
-			statuses: ["To Do", "In Progress", "Done"],
-			readinessTasks: fullGraph,
+			ready: createReadinessGraph({ tasks: [activeTask], completedTasks: [completedDep] }),
 		});
 
 		expect(readyFiltered.map((task) => task.id)).toEqual(["task-2"]);

--- a/src/test/unified-view-loading.test.ts
+++ b/src/test/unified-view-loading.test.ts
@@ -50,6 +50,33 @@ describe("loadTasksForUnifiedView", () => {
 		expect(result.statuses).toEqual(["To Do", "In Progress"]);
 	});
 
+	it("passes the loader's unfiltered readiness corpus through to the viewer", async () => {
+		const displayed = { id: "TASK-2", title: "Displayed", status: "To Do" } as never;
+		const hiddenDependency = { id: "TASK-1", title: "Hidden dependency", status: "Done" } as never;
+
+		const result = await loadTasksForUnifiedView(core, {
+			tasksLoader: async () => ({
+				tasks: [displayed],
+				statuses: ["To Do", "Done"],
+				readinessTasks: [hiddenDependency, displayed],
+			}),
+			loadingScreenFactory: async () => null,
+		});
+
+		expect(result.tasks).toEqual([displayed]);
+		// Without this the viewer would resolve readiness against the narrowed display list only.
+		expect(result.readinessTasks).toEqual([hiddenDependency, displayed]);
+	});
+
+	it("leaves the readiness corpus unset when the loader did not narrow the task list", async () => {
+		const result = await loadTasksForUnifiedView(core, {
+			tasksLoader: async () => ({ tasks: [], statuses: ["To Do"] }),
+			loadingScreenFactory: async () => null,
+		});
+
+		expect(result.readinessTasks).toBeUndefined();
+	});
+
 	it("opens an unfiltered empty kanban but preserves other empty-result messages", () => {
 		expect(getEmptyUnifiedViewMessage("kanban")).toBeNull();
 		expect(getEmptyUnifiedViewMessage("task-list")).toBe("No tasks found.");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,6 +180,7 @@ export interface TaskListFilter {
 	milestone?: string;
 	parentTaskId?: string;
 	labels?: string[];
+	ready?: boolean;
 }
 
 export interface Decision {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -180,7 +180,6 @@ export interface TaskListFilter {
 	milestone?: string;
 	parentTaskId?: string;
 	labels?: string[];
-	ready?: boolean;
 }
 
 export interface Decision {

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -1081,13 +1081,10 @@ export async function viewTaskEnhanced(
 
 		screen.title = formatTuiTitle(`Task ${currentSelectedTask.id} - ${currentSelectedTask.title}`, projectName);
 
-		const detailContent = generateDetailContent(
-			currentSelectedTask,
-			resolveMilestoneLabel,
-			dateFormat,
-			readinessTasks(),
+		const detailContent = generateDetailContent(currentSelectedTask, resolveMilestoneLabel, dateFormat, {
+			tasks: readinessTasks(),
 			statuses,
-		);
+		});
 
 		// Calculate header height based on content and available width
 		const detailPaneWidth = typeof detailPane.width === "number" ? detailPane.width : 60;
@@ -1498,8 +1495,10 @@ export function generateDetailContent(
 	task: Task,
 	resolveMilestoneLabel?: (milestone: string) => string,
 	dateFormat?: string,
-	allTasks: Task[] = [],
-	statuses: readonly string[] = ["To Do", "In Progress", "Done"],
+	// Readiness is rendered only when the caller can supply the task graph to resolve dependencies
+	// against. Callers without one (the board quick-look popup) get no readiness line rather than a
+	// wrong one derived from an empty graph.
+	readinessContext?: { tasks: Task[]; statuses: readonly string[] },
 ): { headerContent: string[]; bodyContent: string[] } {
 	const headerContent = [
 		` ${wrapStatusColor(formatStatusWithIcon(task.status), getStatusColor(task.status))} {bold}{blue-fg}${task.id}{/blue-fg}{/bold} - ${task.title}`,
@@ -1555,13 +1554,15 @@ export function generateDetailContent(
 	if (task.dependencies?.length) {
 		metadata.push(`{bold}Dependencies:{/bold} ${task.dependencies.join(", ")}`);
 		// Readiness only earns a line when dependencies exist; otherwise the status already says it.
-		const readiness = getTaskReadiness(task, allTasks, statuses);
-		if (readiness.isReady) {
-			metadata.push("{bold}Readiness:{/bold} {green-fg}✓ Ready to start{/}");
-		} else if (readiness.isBlocked) {
-			// Single-width glyphs only: blessed miscounts East Asian Wide characters and leaves
-			// stale cells behind when the detail pane re-renders a shorter line.
-			metadata.push(`{bold}Readiness:{/bold} {yellow-fg}● ${formatReadinessBlockers(readiness)}{/}`);
+		if (readinessContext) {
+			const readiness = getTaskReadiness(task, readinessContext.tasks, readinessContext.statuses);
+			if (readiness.isReady) {
+				metadata.push("{bold}Readiness:{/bold} {green-fg}✓ Ready to start{/}");
+			} else if (readiness.isBlocked) {
+				// Single-width glyphs only: blessed miscounts East Asian Wide characters and leaves
+				// stale cells behind when the detail pane re-renders a shorter line.
+				metadata.push(`{bold}Readiness:{/bold} {yellow-fg}● ${formatReadinessBlockers(readiness)}{/}`);
+			}
 		}
 	}
 	if (task.modifiedFiles?.length) {

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -330,6 +330,9 @@ export async function viewTaskEnhanced(
 		labelFilter = options.labelFilter.filter((label) => availableSet.has(label.toLowerCase()));
 	}
 
+	// Decides whether the first render goes through applyFilters(). Every filter that narrows the
+	// list has to be listed here, or the flag that set it silently does nothing until something
+	// else triggers a refilter.
 	const filtersActive = Boolean(
 		searchQuery ||
 			statusFilter ||
@@ -338,6 +341,7 @@ export async function viewTaskEnhanced(
 			priorityFilter ||
 			labelFilter.length > 0 ||
 			milestoneFilter ||
+			options.readyFilter ||
 			taskLimit !== undefined,
 	);
 	let requireInitialFilterSelection = filtersActive;
@@ -1302,10 +1306,11 @@ export async function viewTaskEnhanced(
 						};
 
 			if (result.success) {
+				// The record just left the active corpus, so drop it from the readiness graph. A
+				// completed one is re-added as completion evidence; an archived one is simply gone, and
+				// its dependents honestly report it as an unresolvable dependency from now on.
+				readinessSnapshot = readinessSnapshot?.filter((candidate) => !taskIdsEqual(candidate.id, task.id)) ?? null;
 				if (action === "complete") {
-					// The record just moved into the completed corpus. Move it in the readiness graph too,
-					// or dependents would immediately report it as an unknown dependency.
-					readinessSnapshot = readinessSnapshot?.filter((candidate) => !taskIdsEqual(candidate.id, task.id)) ?? null;
 					readinessCompletedTasks.push(task);
 				}
 				removeTaskFromCurrentView(task.id);

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -21,7 +21,13 @@ import {
 } from "../utils/milestone-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
 import { formatPriorityLabel, getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
-import { formatReadinessBlockers, getTaskReadiness } from "../utils/readiness.ts";
+import {
+	createReadinessGraph,
+	formatReadinessBlockers,
+	getTaskReadiness,
+	type ReadinessGraph,
+} from "../utils/readiness.ts";
+import { canonicalTaskId, taskIdsEqual } from "../utils/task-id.ts";
 import { applyTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
@@ -185,6 +191,8 @@ export async function viewTaskEnhanced(
 		labelFilter?: string[];
 		labelMatch?: LabelMatchMode;
 		readyFilter?: boolean;
+		/** Unfiltered corpus for dependency readiness; defaults to the tasks being displayed. */
+		readinessTasks?: Task[];
 		limit?: number;
 		startWithDetailFocus?: boolean;
 		startWithSearchFocus?: boolean;
@@ -281,9 +289,21 @@ export async function viewTaskEnhanced(
 	// Collect available labels from config, tasks, and CLI-provided filters.
 	availableLabels = collectAvailableLabels(allTasks, [...labels, ...(options.labelFilter ?? [])]);
 
-	// Dependency readiness resolves against the loaded tasks plus completed ones. Live tasks come
-	// first so they win over a stale completed copy of the same ID.
-	const readinessTasks = () => (completedTasks.length > 0 ? [...allTasks, ...completedTasks] : allTasks);
+	// Dependency readiness must resolve against the whole corpus, not the filtered display list, so
+	// it uses the unfiltered snapshot when the caller narrowed what is shown. Both sides stay
+	// mutable because completing a task from this view moves it between them.
+	let readinessSnapshot = options.readinessTasks ? [...options.readinessTasks] : null;
+	const readinessCompletedTasks = [...completedTasks];
+	const buildReadinessGraph = () => {
+		let tasks = allTasks;
+		if (readinessSnapshot) {
+			// Live display copies win over the snapshot so status edits in this session count.
+			const byId = new Map(readinessSnapshot.map((task) => [canonicalTaskId(task.id), task]));
+			for (const task of allTasks) byId.set(canonicalTaskId(task.id), task);
+			tasks = [...byId.values()];
+		}
+		return createReadinessGraph({ tasks, completedTasks: readinessCompletedTasks, statuses });
+	};
 
 	// State for filtering - normalize filters to match configured values
 	let searchQuery = options.searchQuery || "";
@@ -697,9 +717,7 @@ export async function viewTaskEnhanced(
 					labelMatch,
 					milestone: milestoneFilter || undefined,
 					resolveMilestoneLabel,
-					ready: options.readyFilter,
-					statuses,
-					readinessTasks: readinessTasks(),
+					ready: options.readyFilter ? buildReadinessGraph() : undefined,
 				},
 				taskSearchIndex,
 			);
@@ -734,8 +752,8 @@ export async function viewTaskEnhanced(
 				});
 			}
 			if (options.readyFilter) {
-				const graph = readinessTasks();
-				nextFilteredTasks = nextFilteredTasks.filter((task) => getTaskReadiness(task, graph, statuses).isReady);
+				const graph = buildReadinessGraph();
+				nextFilteredTasks = nextFilteredTasks.filter((task) => getTaskReadiness(task, graph).isReady);
 			}
 		} else {
 			nextFilteredTasks = [...allTasks];
@@ -1081,10 +1099,12 @@ export async function viewTaskEnhanced(
 
 		screen.title = formatTuiTitle(`Task ${currentSelectedTask.id} - ${currentSelectedTask.title}`, projectName);
 
-		const detailContent = generateDetailContent(currentSelectedTask, resolveMilestoneLabel, dateFormat, {
-			tasks: readinessTasks(),
-			statuses,
-		});
+		const detailContent = generateDetailContent(
+			currentSelectedTask,
+			resolveMilestoneLabel,
+			dateFormat,
+			buildReadinessGraph(),
+		);
 
 		// Calculate header height based on content and available width
 		const detailPaneWidth = typeof detailPane.width === "number" ? detailPane.width : 60;
@@ -1282,6 +1302,12 @@ export async function viewTaskEnhanced(
 						};
 
 			if (result.success) {
+				if (action === "complete") {
+					// The record just moved into the completed corpus. Move it in the readiness graph too,
+					// or dependents would immediately report it as an unknown dependency.
+					readinessSnapshot = readinessSnapshot?.filter((candidate) => !taskIdsEqual(candidate.id, task.id)) ?? null;
+					readinessCompletedTasks.push(task);
+				}
 				removeTaskFromCurrentView(task.id);
 				const label = action === "complete" ? "Completed" : "Archived";
 				showTransientHelp(` {green-fg}${label} ${task.id}{/}`);
@@ -1498,7 +1524,7 @@ export function generateDetailContent(
 	// Readiness is rendered only when the caller can supply the task graph to resolve dependencies
 	// against. Callers without one (the board quick-look popup) get no readiness line rather than a
 	// wrong one derived from an empty graph.
-	readinessContext?: { tasks: Task[]; statuses: readonly string[] },
+	readinessGraph?: ReadinessGraph,
 ): { headerContent: string[]; bodyContent: string[] } {
 	const headerContent = [
 		` ${wrapStatusColor(formatStatusWithIcon(task.status), getStatusColor(task.status))} {bold}{blue-fg}${task.id}{/blue-fg}{/bold} - ${task.title}`,
@@ -1554,8 +1580,8 @@ export function generateDetailContent(
 	if (task.dependencies?.length) {
 		metadata.push(`{bold}Dependencies:{/bold} ${task.dependencies.join(", ")}`);
 		// Readiness only earns a line when dependencies exist; otherwise the status already says it.
-		if (readinessContext) {
-			const readiness = getTaskReadiness(task, readinessContext.tasks, readinessContext.statuses);
+		if (readinessGraph) {
+			const readiness = getTaskReadiness(task, readinessGraph);
 			if (readiness.isReady) {
 				metadata.push("{bold}Readiness:{/bold} {green-fg}✓ Ready to start{/}");
 			} else if (readiness.isBlocked) {

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -21,6 +21,7 @@ import {
 } from "../utils/milestone-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
 import { formatPriorityLabel, getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
+import { getTaskReadiness } from "../utils/readiness.ts";
 import { applyTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
@@ -172,6 +173,7 @@ export async function viewTaskEnhanced(
 	task: Task,
 	options: {
 		tasks?: Task[];
+		fullGraphTasks?: Task[];
 		core?: Core;
 		title?: string;
 		filterDescription?: string;
@@ -183,6 +185,7 @@ export async function viewTaskEnhanced(
 		milestoneFilter?: string;
 		labelFilter?: string[];
 		labelMatch?: LabelMatchMode;
+		readyFilter?: boolean;
 		limit?: number;
 		startWithDetailFocus?: boolean;
 		startWithSearchFocus?: boolean;
@@ -236,6 +239,10 @@ export async function viewTaskEnhanced(
 
 	let dateFormat: string | undefined;
 	let projectName: string | undefined;
+
+	// Load complete task graph for dependency readiness resolution across all surfaces
+	const fullGraphTasks =
+		options.fullGraphTasks ?? (await core.loadTasks(undefined, undefined, { includeCompleted: true }));
 
 	if (options.tasks) {
 		// Tasks already provided - use in-memory search (no ContentStore loading)
@@ -669,7 +676,8 @@ export async function viewTaskEnhanced(
 				taskTypeFilter.length > 0 ||
 				priorityFilter ||
 				labelFilter.length > 0 ||
-				milestoneFilter,
+				milestoneFilter ||
+				options.readyFilter,
 		);
 		let nextFilteredTasks: Task[];
 		if (!hasActiveFilters) {
@@ -687,6 +695,9 @@ export async function viewTaskEnhanced(
 					labelMatch,
 					milestone: milestoneFilter || undefined,
 					resolveMilestoneLabel,
+					ready: options.readyFilter,
+					statuses,
+					fullGraphTasks,
 				},
 				taskSearchIndex,
 			);
@@ -719,6 +730,11 @@ export async function viewTaskEnhanced(
 					const taskLabels = new Set(labelsToLower(task.labels ?? []));
 					return requiredLabels.every((label) => taskLabels.has(label));
 				});
+			}
+			if (options.readyFilter) {
+				nextFilteredTasks = nextFilteredTasks.filter(
+					(task) => getTaskReadiness(task, fullGraphTasks, statuses).isReady,
+				);
 			}
 		} else {
 			nextFilteredTasks = [...allTasks];
@@ -1064,7 +1080,13 @@ export async function viewTaskEnhanced(
 
 		screen.title = formatTuiTitle(`Task ${currentSelectedTask.id} - ${currentSelectedTask.title}`, projectName);
 
-		const detailContent = generateDetailContent(currentSelectedTask, resolveMilestoneLabel, dateFormat);
+		const detailContent = generateDetailContent(
+			currentSelectedTask,
+			resolveMilestoneLabel,
+			dateFormat,
+			fullGraphTasks,
+			statuses,
+		);
 
 		// Calculate header height based on content and available width
 		const detailPaneWidth = typeof detailPane.width === "number" ? detailPane.width : 60;
@@ -1471,10 +1493,12 @@ export async function viewTaskEnhanced(
 	});
 }
 
-function generateDetailContent(
+export function generateDetailContent(
 	task: Task,
 	resolveMilestoneLabel?: (milestone: string) => string,
 	dateFormat?: string,
+	allTasks: Task[] = [],
+	statuses: readonly string[] = ["To Do", "In Progress", "Done"],
 ): { headerContent: string[]; bodyContent: string[] } {
 	const headerContent = [
 		` ${wrapStatusColor(formatStatusWithIcon(task.status), getStatusColor(task.status))} {bold}{blue-fg}${task.id}{/blue-fg}{/bold} - ${task.title}`,
@@ -1529,6 +1553,14 @@ function generateDetailContent(
 	}
 	if (task.dependencies?.length) {
 		metadata.push(`{bold}Dependencies:{/bold} ${task.dependencies.join(", ")}`);
+	}
+	const readiness = getTaskReadiness(task, allTasks, statuses);
+	if (readiness.isReady) {
+		metadata.push("{bold}Readiness:{/bold} {green-fg}✓ Ready to start{/}");
+	} else if (readiness.isBlocked) {
+		metadata.push(`{bold}Readiness:{/bold} {yellow-fg}⏳ Blocked by: ${readiness.blockingDependencies.join(", ")}{/}`);
+	} else {
+		metadata.push(`{bold}Readiness:{/bold} {gray-fg}Terminal status (${task.status}){/}`);
 	}
 	if (task.modifiedFiles?.length) {
 		metadata.push(`{bold}Modified files:{/bold} ${task.modifiedFiles.join(", ")}`);

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -21,7 +21,7 @@ import {
 } from "../utils/milestone-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
 import { formatPriorityLabel, getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
-import { getTaskReadiness } from "../utils/readiness.ts";
+import { formatReadinessBlockers, getTaskReadiness } from "../utils/readiness.ts";
 import { applyTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
@@ -173,7 +173,6 @@ export async function viewTaskEnhanced(
 	task: Task,
 	options: {
 		tasks?: Task[];
-		fullGraphTasks?: Task[];
 		core?: Core;
 		title?: string;
 		filterDescription?: string;
@@ -228,9 +227,12 @@ export async function viewTaskEnhanced(
 	let taskSearchIndex: ReturnType<typeof createTaskSearchIndex> | null = null;
 	let searchService: Awaited<ReturnType<typeof core.getSearchService>> | null = null;
 	let contentStore: Awaited<ReturnType<typeof core.getContentStore>> | null = null;
-	const [milestoneEntities, archivedMilestones] = await Promise.all([
+	// Completed tasks are loaded alongside the milestone metadata so dependency readiness can
+	// resolve dependencies that already left the active corpus, without a second full task load.
+	const [milestoneEntities, archivedMilestones, completedTasks] = await Promise.all([
 		core.filesystem.listMilestones(),
 		core.filesystem.listArchivedMilestones(),
+		core.filesystem.listCompletedTasks(),
 	]);
 	const { availableMilestoneTitles, resolveMilestoneLabel } = buildTaskViewerMilestoneFilterModel(
 		milestoneEntities,
@@ -239,10 +241,6 @@ export async function viewTaskEnhanced(
 
 	let dateFormat: string | undefined;
 	let projectName: string | undefined;
-
-	// Load complete task graph for dependency readiness resolution across all surfaces
-	const fullGraphTasks =
-		options.fullGraphTasks ?? (await core.loadTasks(undefined, undefined, { includeCompleted: true }));
 
 	if (options.tasks) {
 		// Tasks already provided - use in-memory search (no ContentStore loading)
@@ -282,6 +280,10 @@ export async function viewTaskEnhanced(
 
 	// Collect available labels from config, tasks, and CLI-provided filters.
 	availableLabels = collectAvailableLabels(allTasks, [...labels, ...(options.labelFilter ?? [])]);
+
+	// Dependency readiness resolves against the loaded tasks plus completed ones. Live tasks come
+	// first so they win over a stale completed copy of the same ID.
+	const readinessTasks = () => (completedTasks.length > 0 ? [...allTasks, ...completedTasks] : allTasks);
 
 	// State for filtering - normalize filters to match configured values
 	let searchQuery = options.searchQuery || "";
@@ -697,7 +699,7 @@ export async function viewTaskEnhanced(
 					resolveMilestoneLabel,
 					ready: options.readyFilter,
 					statuses,
-					fullGraphTasks,
+					readinessTasks: readinessTasks(),
 				},
 				taskSearchIndex,
 			);
@@ -732,9 +734,8 @@ export async function viewTaskEnhanced(
 				});
 			}
 			if (options.readyFilter) {
-				nextFilteredTasks = nextFilteredTasks.filter(
-					(task) => getTaskReadiness(task, fullGraphTasks, statuses).isReady,
-				);
+				const graph = readinessTasks();
+				nextFilteredTasks = nextFilteredTasks.filter((task) => getTaskReadiness(task, graph, statuses).isReady);
 			}
 		} else {
 			nextFilteredTasks = [...allTasks];
@@ -1084,7 +1085,7 @@ export async function viewTaskEnhanced(
 			currentSelectedTask,
 			resolveMilestoneLabel,
 			dateFormat,
-			fullGraphTasks,
+			readinessTasks(),
 			statuses,
 		);
 
@@ -1553,14 +1554,15 @@ export function generateDetailContent(
 	}
 	if (task.dependencies?.length) {
 		metadata.push(`{bold}Dependencies:{/bold} ${task.dependencies.join(", ")}`);
-	}
-	const readiness = getTaskReadiness(task, allTasks, statuses);
-	if (readiness.isReady) {
-		metadata.push("{bold}Readiness:{/bold} {green-fg}✓ Ready to start{/}");
-	} else if (readiness.isBlocked) {
-		metadata.push(`{bold}Readiness:{/bold} {yellow-fg}⏳ Blocked by: ${readiness.blockingDependencies.join(", ")}{/}`);
-	} else {
-		metadata.push(`{bold}Readiness:{/bold} {gray-fg}Terminal status (${task.status}){/}`);
+		// Readiness only earns a line when dependencies exist; otherwise the status already says it.
+		const readiness = getTaskReadiness(task, allTasks, statuses);
+		if (readiness.isReady) {
+			metadata.push("{bold}Readiness:{/bold} {green-fg}✓ Ready to start{/}");
+		} else if (readiness.isBlocked) {
+			// Single-width glyphs only: blessed miscounts East Asian Wide characters and leaves
+			// stale cells behind when the detail pane re-renders a shorter line.
+			metadata.push(`{bold}Readiness:{/bold} {yellow-fg}● ${formatReadinessBlockers(readiness)}{/}`);
+		}
 	}
 	if (task.modifiedFiles?.length) {
 		metadata.push(`{bold}Modified files:{/bold} ${task.modifiedFiles.join(", ")}`);

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -21,7 +21,10 @@ export interface UnifiedViewOptions {
 	initialView: ViewType;
 	selectedTask?: Task;
 	tasks?: Task[];
-	tasksLoader?: (updateProgress: (message: string) => void) => Promise<{ tasks: Task[]; statuses: string[] }>;
+	fullGraphTasks?: Task[];
+	tasksLoader?: (
+		updateProgress: (message: string) => void,
+	) => Promise<{ tasks: Task[]; statuses: string[]; fullGraphTasks?: Task[] }>;
 	loadingScreenFactory?: (initialMessage: string) => Promise<LoadingScreen | null>;
 	title?: string;
 	filter?: {
@@ -39,6 +42,7 @@ export interface UnifiedViewOptions {
 		excludeStatus?: string[];
 		parentTaskId?: string;
 		limit?: number;
+		ready?: boolean;
 	};
 	preloadedKanbanData?: {
 		tasks: Task[];
@@ -56,6 +60,7 @@ type LoadingScreen = {
 export interface UnifiedViewLoadResult {
 	tasks: Task[];
 	statuses: string[];
+	fullGraphTasks?: Task[];
 }
 
 export type UnifiedTaskUpdate = { type: "upsert"; task: Task } | { type: "remove"; taskId: string };
@@ -206,24 +211,29 @@ export function mergeUnifiedViewFilters(
 
 export async function loadTasksForUnifiedView(
 	core: Core,
-	options: Pick<UnifiedViewOptions, "tasks" | "tasksLoader" | "loadingScreenFactory">,
+	options: Pick<UnifiedViewOptions, "tasks" | "fullGraphTasks" | "tasksLoader" | "loadingScreenFactory">,
 ): Promise<UnifiedViewLoadResult> {
 	if (options.tasks && options.tasks.length > 0) {
 		const config = await core.filesystem.loadConfig();
 		return {
 			tasks: options.tasks,
 			statuses: config?.statuses || ["To Do", "In Progress", "Done"],
+			fullGraphTasks: options.fullGraphTasks,
 		};
 	}
 
 	const loader =
 		options.tasksLoader ||
-		(async (updateProgress: (message: string) => void): Promise<{ tasks: Task[]; statuses: string[] }> => {
+		(async (
+			updateProgress: (message: string) => void,
+		): Promise<{ tasks: Task[]; statuses: string[]; fullGraphTasks?: Task[] }> => {
 			const tasks = await core.loadTasks(updateProgress);
+			const fullGraphTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
 			const config = await core.filesystem.loadConfig();
 			return {
 				tasks,
 				statuses: config?.statuses || ["To Do", "In Progress", "Done"],
+				fullGraphTasks,
 			};
 		});
 
@@ -238,6 +248,7 @@ export async function loadTasksForUnifiedView(
 		return {
 			tasks: result.tasks,
 			statuses: result.statuses,
+			fullGraphTasks: result.fullGraphTasks,
 		};
 	} finally {
 		await loadingScreen?.close();
@@ -272,8 +283,13 @@ export async function createTaskFromBoard(
  */
 export async function runUnifiedView(options: UnifiedViewOptions): Promise<void> {
 	try {
-		const { tasks: loadedTasks, statuses: loadedStatuses } = await loadTasksForUnifiedView(options.core, {
+		const {
+			tasks: loadedTasks,
+			statuses: loadedStatuses,
+			fullGraphTasks: loadedFullGraphTasks,
+		} = await loadTasksForUnifiedView(options.core, {
 			tasks: options.tasks,
+			fullGraphTasks: options.fullGraphTasks,
 			tasksLoader: options.tasksLoader,
 			loadingScreenFactory: options.loadingScreenFactory,
 		});
@@ -408,6 +424,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 
 				viewTaskEnhanced(taskToView, {
 					tasks: availableTasks,
+					fullGraphTasks: loadedFullGraphTasks,
 					core: options.core,
 					title: options.filter?.title,
 					filterDescription: options.filter?.filterDescription,
@@ -419,6 +436,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					labelFilter: currentFilters.labelFilter,
 					labelMatch: currentFilters.labelMatch,
 					milestoneFilter: currentFilters.milestoneFilter,
+					readyFilter: options.filter?.ready,
 					limit: currentFilters.limit,
 					startWithDetailFocus: currentView === "task-detail",
 					startWithSearchFocus: shouldFocusSearch,

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -21,7 +21,9 @@ export interface UnifiedViewOptions {
 	initialView: ViewType;
 	selectedTask?: Task;
 	tasks?: Task[];
-	tasksLoader?: (updateProgress: (message: string) => void) => Promise<{ tasks: Task[]; statuses: string[] }>;
+	tasksLoader?: (
+		updateProgress: (message: string) => void,
+	) => Promise<{ tasks: Task[]; statuses: string[]; readinessTasks?: Task[] }>;
 	loadingScreenFactory?: (initialMessage: string) => Promise<LoadingScreen | null>;
 	title?: string;
 	filter?: {
@@ -57,6 +59,11 @@ type LoadingScreen = {
 export interface UnifiedViewLoadResult {
 	tasks: Task[];
 	statuses: string[];
+	/**
+	 * Unfiltered task corpus for dependency readiness. Only needed when `tasks` was narrowed by
+	 * loader-side filters; otherwise `tasks` is already the whole corpus.
+	 */
+	readinessTasks?: Task[];
 }
 
 export type UnifiedTaskUpdate = { type: "upsert"; task: Task } | { type: "remove"; taskId: string };
@@ -219,7 +226,9 @@ export async function loadTasksForUnifiedView(
 
 	const loader =
 		options.tasksLoader ||
-		(async (updateProgress: (message: string) => void): Promise<{ tasks: Task[]; statuses: string[] }> => {
+		(async (
+			updateProgress: (message: string) => void,
+		): Promise<{ tasks: Task[]; statuses: string[]; readinessTasks?: Task[] }> => {
 			const tasks = await core.loadTasks(updateProgress);
 			const config = await core.filesystem.loadConfig();
 			return {
@@ -239,6 +248,7 @@ export async function loadTasksForUnifiedView(
 		return {
 			tasks: result.tasks,
 			statuses: result.statuses,
+			readinessTasks: result.readinessTasks,
 		};
 	} finally {
 		await loadingScreen?.close();
@@ -273,7 +283,11 @@ export async function createTaskFromBoard(
  */
 export async function runUnifiedView(options: UnifiedViewOptions): Promise<void> {
 	try {
-		const { tasks: loadedTasks, statuses: loadedStatuses } = await loadTasksForUnifiedView(options.core, {
+		const {
+			tasks: loadedTasks,
+			statuses: loadedStatuses,
+			readinessTasks: loadedReadinessTasks,
+		} = await loadTasksForUnifiedView(options.core, {
 			tasks: options.tasks,
 			tasksLoader: options.tasksLoader,
 			loadingScreenFactory: options.loadingScreenFactory,
@@ -421,6 +435,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					labelMatch: currentFilters.labelMatch,
 					milestoneFilter: currentFilters.milestoneFilter,
 					readyFilter: options.filter?.ready,
+					readinessTasks: loadedReadinessTasks,
 					limit: currentFilters.limit,
 					startWithDetailFocus: currentView === "task-detail",
 					startWithSearchFocus: shouldFocusSearch,

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -21,10 +21,7 @@ export interface UnifiedViewOptions {
 	initialView: ViewType;
 	selectedTask?: Task;
 	tasks?: Task[];
-	fullGraphTasks?: Task[];
-	tasksLoader?: (
-		updateProgress: (message: string) => void,
-	) => Promise<{ tasks: Task[]; statuses: string[]; fullGraphTasks?: Task[] }>;
+	tasksLoader?: (updateProgress: (message: string) => void) => Promise<{ tasks: Task[]; statuses: string[] }>;
 	loadingScreenFactory?: (initialMessage: string) => Promise<LoadingScreen | null>;
 	title?: string;
 	filter?: {
@@ -60,7 +57,6 @@ type LoadingScreen = {
 export interface UnifiedViewLoadResult {
 	tasks: Task[];
 	statuses: string[];
-	fullGraphTasks?: Task[];
 }
 
 export type UnifiedTaskUpdate = { type: "upsert"; task: Task } | { type: "remove"; taskId: string };
@@ -211,29 +207,24 @@ export function mergeUnifiedViewFilters(
 
 export async function loadTasksForUnifiedView(
 	core: Core,
-	options: Pick<UnifiedViewOptions, "tasks" | "fullGraphTasks" | "tasksLoader" | "loadingScreenFactory">,
+	options: Pick<UnifiedViewOptions, "tasks" | "tasksLoader" | "loadingScreenFactory">,
 ): Promise<UnifiedViewLoadResult> {
 	if (options.tasks && options.tasks.length > 0) {
 		const config = await core.filesystem.loadConfig();
 		return {
 			tasks: options.tasks,
 			statuses: config?.statuses || ["To Do", "In Progress", "Done"],
-			fullGraphTasks: options.fullGraphTasks,
 		};
 	}
 
 	const loader =
 		options.tasksLoader ||
-		(async (
-			updateProgress: (message: string) => void,
-		): Promise<{ tasks: Task[]; statuses: string[]; fullGraphTasks?: Task[] }> => {
+		(async (updateProgress: (message: string) => void): Promise<{ tasks: Task[]; statuses: string[] }> => {
 			const tasks = await core.loadTasks(updateProgress);
-			const fullGraphTasks = await core.loadTasks(undefined, undefined, { includeCompleted: true });
 			const config = await core.filesystem.loadConfig();
 			return {
 				tasks,
 				statuses: config?.statuses || ["To Do", "In Progress", "Done"],
-				fullGraphTasks,
 			};
 		});
 
@@ -248,7 +239,6 @@ export async function loadTasksForUnifiedView(
 		return {
 			tasks: result.tasks,
 			statuses: result.statuses,
-			fullGraphTasks: result.fullGraphTasks,
 		};
 	} finally {
 		await loadingScreen?.close();
@@ -283,13 +273,8 @@ export async function createTaskFromBoard(
  */
 export async function runUnifiedView(options: UnifiedViewOptions): Promise<void> {
 	try {
-		const {
-			tasks: loadedTasks,
-			statuses: loadedStatuses,
-			fullGraphTasks: loadedFullGraphTasks,
-		} = await loadTasksForUnifiedView(options.core, {
+		const { tasks: loadedTasks, statuses: loadedStatuses } = await loadTasksForUnifiedView(options.core, {
 			tasks: options.tasks,
-			fullGraphTasks: options.fullGraphTasks,
 			tasksLoader: options.tasksLoader,
 			loadingScreenFactory: options.loadingScreenFactory,
 		});
@@ -424,7 +409,6 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 
 				viewTaskEnhanced(taskToView, {
 					tasks: availableTasks,
-					fullGraphTasks: loadedFullGraphTasks,
 					core: options.core,
 					title: options.filter?.title,
 					filterDescription: options.filter?.filterDescription,

--- a/src/utils/readiness.ts
+++ b/src/utils/readiness.ts
@@ -1,0 +1,57 @@
+import type { Task } from "../types/index.ts";
+import { isTerminalStatus } from "./terminal-status.ts";
+
+export interface TaskReadiness {
+	isReady: boolean;
+	isBlocked: boolean;
+	blockingDependencies: string[];
+	missingDependencies: string[];
+}
+
+export function getTaskReadiness(task: Task, allTasks: Task[], statuses: readonly string[]): TaskReadiness {
+	// If task itself is already terminal/done, it is not "ready for work"
+	if (isTerminalStatus(task.status, statuses)) {
+		return {
+			isReady: false,
+			isBlocked: false,
+			blockingDependencies: [],
+			missingDependencies: [],
+		};
+	}
+
+	const dependencies = task.dependencies ?? [];
+	if (dependencies.length === 0) {
+		return {
+			isReady: true,
+			isBlocked: false,
+			blockingDependencies: [],
+			missingDependencies: [],
+		};
+	}
+
+	const taskMap = new Map<string, Task>();
+	for (const t of allTasks) {
+		taskMap.set(t.id.toLowerCase(), t);
+	}
+
+	const blockingDependencies: string[] = [];
+	const missingDependencies: string[] = [];
+
+	for (const depId of dependencies) {
+		const targetTask = taskMap.get(depId.toLowerCase());
+		if (!targetTask) {
+			missingDependencies.push(depId);
+			blockingDependencies.push(depId);
+		} else if (!isTerminalStatus(targetTask.status, statuses)) {
+			blockingDependencies.push(targetTask.id);
+		}
+	}
+
+	const isBlocked = blockingDependencies.length > 0;
+	return {
+		isReady: !isBlocked,
+		isBlocked,
+		blockingDependencies,
+		missingDependencies,
+	};
+}

--- a/src/utils/readiness.ts
+++ b/src/utils/readiness.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_STATUSES } from "../constants/index.ts";
 import type { Core } from "../core/backlog.ts";
 import type { Task } from "../types/index.ts";
 import { canonicalTaskId } from "./task-id.ts";
@@ -8,27 +9,92 @@ export interface TaskReadiness {
 	isReady: boolean;
 	/** Work cannot start: at least one dependency is unfinished or unresolved. */
 	isBlocked: boolean;
-	/** Dependencies that resolved to a task that has not reached the terminal status. */
+	/** Dependencies that resolved to a task that has not been completed. */
 	blockingDependencies: string[];
-	/** Dependency IDs that could not be resolved in the provided task graph. */
+	/** Dependency IDs that could not be resolved to exactly one task in the graph. */
 	missingDependencies: string[];
+}
+
+type DependencyResolution =
+	| { state: "completed" }
+	| { state: "unfinished"; id: string }
+	/** Not in the graph, or more than one record claims the identity. Never treated as satisfied. */
+	| { state: "unresolved" };
+
+/**
+ * An index over the task graph readiness resolves dependencies against.
+ *
+ * Built once per evaluation so filtering a large list stays linear, and it is what makes the
+ * two completion signals explicit: a record's location in the completed corpus, and its status.
+ */
+export interface ReadinessGraph {
+	resolveDependency(dependencyId: string): DependencyResolution;
+	/** True when this task's own record lives in the completed corpus. */
+	isCompletedRecord(taskId: string): boolean;
+	/** Configured statuses with the project default applied, so an empty config still resolves. */
+	readonly statuses: readonly string[];
+}
+
+/**
+ * Build the readiness index.
+ *
+ * `completedTasks` are records that live in the completed corpus (`backlog/completed`). Their
+ * location is the completion evidence, so they satisfy a dependency whatever their status string
+ * says: the terminal status may have been renamed since, or the record may predate the current
+ * configuration. Passing them separately is what keeps that distinction available.
+ *
+ * Identity is canonical, and an identity claimed by more than one record resolves as unresolved
+ * rather than picking a winner by insertion order.
+ */
+export function createReadinessGraph(options: {
+	tasks: Task[];
+	completedTasks?: Task[];
+	statuses?: readonly string[];
+}): ReadinessGraph {
+	const statuses = options.statuses?.length ? options.statuses : DEFAULT_STATUSES;
+	const records = new Map<string, { task: Task; completed: boolean } | "ambiguous">();
+
+	const add = (task: Task, completed: boolean) => {
+		const key = canonicalTaskId(task.id);
+		records.set(key, records.has(key) ? "ambiguous" : { task, completed });
+	};
+	for (const task of options.tasks) add(task, false);
+	for (const task of options.completedTasks ?? []) add(task, true);
+
+	return {
+		statuses,
+		isCompletedRecord(taskId) {
+			const record = records.get(canonicalTaskId(taskId));
+			return record !== undefined && record !== "ambiguous" && record.completed;
+		},
+		resolveDependency(dependencyId) {
+			const record = records.get(canonicalTaskId(dependencyId));
+			if (record === undefined || record === "ambiguous") return { state: "unresolved" };
+			if (record.completed || isTerminalStatus(record.task.status, statuses)) return { state: "completed" };
+			return { state: "unfinished", id: record.task.id };
+		},
+	};
 }
 
 /**
  * Derive readiness for a single task from its dependencies at read time.
  *
- * Readiness never reorders or mutates anything: it answers "can this task be started now?"
- * by resolving each dependency against the task graph the caller supplies. Dependency IDs
- * that cannot be resolved are reported separately from unfinished ones and fail closed, so a
- * partial graph is never mistaken for satisfied work.
- *
- * When `allTasks` holds more than one entry for the same task identity, the first one wins, so
- * callers can append a fallback corpus (for example completed tasks) after the live one.
+ * Readiness never reorders or mutates anything: it answers "can this task be started now?".
+ * Dependencies that resolved to unfinished work and dependency IDs that could not be resolved are
+ * reported separately, and both fail closed, so a partial or ambiguous graph is never mistaken for
+ * satisfied work.
  */
-export function getTaskReadiness(task: Task, allTasks: Task[], statuses: readonly string[]): TaskReadiness {
-	// A task that already reached the terminal status is neither ready to start nor blocked.
-	if (isTerminalStatus(task.status, statuses)) {
-		return { isReady: false, isBlocked: false, blockingDependencies: [], missingDependencies: [] };
+export function getTaskReadiness(task: Task, graph: ReadinessGraph): TaskReadiness {
+	const notActionable: TaskReadiness = {
+		isReady: false,
+		isBlocked: false,
+		blockingDependencies: [],
+		missingDependencies: [],
+	};
+
+	// A task that is already completed is neither ready to start nor blocked.
+	if (graph.isCompletedRecord(task.id) || isTerminalStatus(task.status, graph.statuses)) {
+		return notActionable;
 	}
 
 	const dependencies = task.dependencies ?? [];
@@ -36,23 +102,14 @@ export function getTaskReadiness(task: Task, allTasks: Task[], statuses: readonl
 		return { isReady: true, isBlocked: false, blockingDependencies: [], missingDependencies: [] };
 	}
 
-	// Key by the project's canonical task identity so zero-padded and prefixed variants
-	// resolve the same way they do everywhere else in the product.
-	const tasksById = new Map<string, Task>();
-	for (const candidate of allTasks) {
-		const key = canonicalTaskId(candidate.id);
-		if (!tasksById.has(key)) tasksById.set(key, candidate);
-	}
-
 	const blockingDependencies: string[] = [];
 	const missingDependencies: string[] = [];
-
 	for (const dependencyId of dependencies) {
-		const dependency = tasksById.get(canonicalTaskId(dependencyId));
-		if (!dependency) {
+		const resolution = graph.resolveDependency(dependencyId);
+		if (resolution.state === "unresolved") {
 			missingDependencies.push(dependencyId);
-		} else if (!isTerminalStatus(dependency.status, statuses)) {
-			blockingDependencies.push(dependency.id);
+		} else if (resolution.state === "unfinished") {
+			blockingDependencies.push(resolution.id);
 		}
 	}
 
@@ -77,16 +134,16 @@ export function formatReadinessBlockers(readiness: TaskReadiness): string {
 }
 
 /**
- * Load the task graph readiness resolves against: the unfiltered task corpus plus completed
- * tasks, so a dependency that was completed and moved out of the active corpus still resolves.
- *
- * Readiness must never be evaluated against a filtered list: `--status "To Do" --ready` would
- * otherwise see none of the completed dependencies it needs to answer the question.
+ * Build the readiness graph for a one-shot command: the whole local task corpus plus the completed
+ * one, never the list being displayed. `--status "To Do" --ready` must still see the completed
+ * dependencies it needs to answer the question, and `--assignee` must not hide someone else's
+ * blocking task.
  */
-export async function loadReadinessGraph(core: Core): Promise<Task[]> {
-	const [tasks, completedTasks] = await Promise.all([
+export async function loadReadinessGraph(core: Core): Promise<ReadinessGraph> {
+	const [tasks, completedTasks, config] = await Promise.all([
 		core.queryTasks({ includeCrossBranch: false }),
 		core.filesystem.listCompletedTasks(),
+		core.filesystem.loadConfig(),
 	]);
-	return [...tasks, ...completedTasks];
+	return createReadinessGraph({ tasks, completedTasks, statuses: config?.statuses });
 }

--- a/src/utils/readiness.ts
+++ b/src/utils/readiness.ts
@@ -1,57 +1,92 @@
+import type { Core } from "../core/backlog.ts";
 import type { Task } from "../types/index.ts";
+import { canonicalTaskId } from "./task-id.ts";
 import { isTerminalStatus } from "./terminal-status.ts";
 
 export interface TaskReadiness {
+	/** Work can start now: the task is unfinished and every dependency is resolved and completed. */
 	isReady: boolean;
+	/** Work cannot start: at least one dependency is unfinished or unresolved. */
 	isBlocked: boolean;
+	/** Dependencies that resolved to a task that has not reached the terminal status. */
 	blockingDependencies: string[];
+	/** Dependency IDs that could not be resolved in the provided task graph. */
 	missingDependencies: string[];
 }
 
+/**
+ * Derive readiness for a single task from its dependencies at read time.
+ *
+ * Readiness never reorders or mutates anything: it answers "can this task be started now?"
+ * by resolving each dependency against the task graph the caller supplies. Dependency IDs
+ * that cannot be resolved are reported separately from unfinished ones and fail closed, so a
+ * partial graph is never mistaken for satisfied work.
+ *
+ * When `allTasks` holds more than one entry for the same task identity, the first one wins, so
+ * callers can append a fallback corpus (for example completed tasks) after the live one.
+ */
 export function getTaskReadiness(task: Task, allTasks: Task[], statuses: readonly string[]): TaskReadiness {
-	// If task itself is already terminal/done, it is not "ready for work"
+	// A task that already reached the terminal status is neither ready to start nor blocked.
 	if (isTerminalStatus(task.status, statuses)) {
-		return {
-			isReady: false,
-			isBlocked: false,
-			blockingDependencies: [],
-			missingDependencies: [],
-		};
+		return { isReady: false, isBlocked: false, blockingDependencies: [], missingDependencies: [] };
 	}
 
 	const dependencies = task.dependencies ?? [];
 	if (dependencies.length === 0) {
-		return {
-			isReady: true,
-			isBlocked: false,
-			blockingDependencies: [],
-			missingDependencies: [],
-		};
+		return { isReady: true, isBlocked: false, blockingDependencies: [], missingDependencies: [] };
 	}
 
-	const taskMap = new Map<string, Task>();
-	for (const t of allTasks) {
-		taskMap.set(t.id.toLowerCase(), t);
+	// Key by the project's canonical task identity so zero-padded and prefixed variants
+	// resolve the same way they do everywhere else in the product.
+	const tasksById = new Map<string, Task>();
+	for (const candidate of allTasks) {
+		const key = canonicalTaskId(candidate.id);
+		if (!tasksById.has(key)) tasksById.set(key, candidate);
 	}
 
 	const blockingDependencies: string[] = [];
 	const missingDependencies: string[] = [];
 
-	for (const depId of dependencies) {
-		const targetTask = taskMap.get(depId.toLowerCase());
-		if (!targetTask) {
-			missingDependencies.push(depId);
-			blockingDependencies.push(depId);
-		} else if (!isTerminalStatus(targetTask.status, statuses)) {
-			blockingDependencies.push(targetTask.id);
+	for (const dependencyId of dependencies) {
+		const dependency = tasksById.get(canonicalTaskId(dependencyId));
+		if (!dependency) {
+			missingDependencies.push(dependencyId);
+		} else if (!isTerminalStatus(dependency.status, statuses)) {
+			blockingDependencies.push(dependency.id);
 		}
 	}
 
-	const isBlocked = blockingDependencies.length > 0;
-	return {
-		isReady: !isBlocked,
-		isBlocked,
-		blockingDependencies,
-		missingDependencies,
-	};
+	const isBlocked = blockingDependencies.length > 0 || missingDependencies.length > 0;
+	return { isReady: !isBlocked, isBlocked, blockingDependencies, missingDependencies };
+}
+
+/**
+ * Explain why a task is not ready, in one line shared by every surface. Unfinished dependencies
+ * and dependency IDs that could not be resolved are named separately so they are not confused.
+ */
+export function formatReadinessBlockers(readiness: TaskReadiness): string {
+	const reasons: string[] = [];
+	if (readiness.blockingDependencies.length > 0) {
+		reasons.push(`Blocked by ${readiness.blockingDependencies.join(", ")}`);
+	}
+	if (readiness.missingDependencies.length > 0) {
+		const noun = readiness.missingDependencies.length === 1 ? "dependency" : "dependencies";
+		reasons.push(`Unknown ${noun} ${readiness.missingDependencies.join(", ")}`);
+	}
+	return reasons.join("; ");
+}
+
+/**
+ * Load the task graph readiness resolves against: the unfiltered task corpus plus completed
+ * tasks, so a dependency that was completed and moved out of the active corpus still resolves.
+ *
+ * Readiness must never be evaluated against a filtered list: `--status "To Do" --ready` would
+ * otherwise see none of the completed dependencies it needs to answer the question.
+ */
+export async function loadReadinessGraph(core: Core): Promise<Task[]> {
+	const [tasks, completedTasks] = await Promise.all([
+		core.queryTasks({ includeCrossBranch: false }),
+		core.filesystem.listCompletedTasks(),
+	]);
+	return [...tasks, ...completedTasks];
 }

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -4,6 +4,7 @@
  */
 
 import Fuse from "fuse.js";
+import { DEFAULT_STATUSES } from "../constants/index.ts";
 import type { Task } from "../types/index.ts";
 import { labelsToLower } from "./label-filter.ts";
 import {
@@ -13,6 +14,7 @@ import {
 } from "./milestone-filter.ts";
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "./modified-files.ts";
 import { normalizePriorityValue } from "./priority-config.ts";
+import { getTaskReadiness } from "./readiness.ts";
 import { matchesTaskTypeFilter } from "./task-type-config.ts";
 
 export type LabelMatchMode = "any" | "all";
@@ -28,9 +30,6 @@ export interface TaskSearchOptions {
 	modifiedFiles?: string[];
 }
 
-import { DEFAULT_STATUSES } from "../constants/index.ts";
-import { getTaskReadiness } from "./readiness.ts";
-
 export interface SharedTaskFilterOptions {
 	query?: string;
 	excludeStatus?: string | string[];
@@ -41,14 +40,16 @@ export interface SharedTaskFilterOptions {
 	modifiedFiles?: string[];
 	milestone?: string;
 	resolveMilestoneLabel?: (milestone: string) => string;
-	ready?: boolean;
-	statuses?: readonly string[];
-	fullGraphTasks?: Task[];
 }
 
 export interface TaskFilterOptions extends SharedTaskFilterOptions {
 	status?: string;
 	excludeStatus?: string | string[];
+	ready?: boolean;
+	/** Configured statuses, used to decide which status counts as completed. */
+	statuses?: readonly string[];
+	/** Task graph readiness resolves against; defaults to the tasks being filtered. */
+	readinessTasks?: Task[];
 }
 
 export interface TaskSearchIndex {
@@ -300,7 +301,7 @@ export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, inde
 
 	if (options.ready) {
 		const statuses = options.statuses ?? DEFAULT_STATUSES;
-		const graph = options.fullGraphTasks ?? tasks;
+		const graph = options.readinessTasks ?? tasks;
 		results = results.filter((task) => getTaskReadiness(task, graph, statuses).isReady);
 	}
 
@@ -324,9 +325,6 @@ export function applySharedTaskFilters(
 			modifiedFiles: options.modifiedFiles,
 			milestone: options.milestone,
 			resolveMilestoneLabel: options.resolveMilestoneLabel,
-			ready: options.ready,
-			statuses: options.statuses,
-			fullGraphTasks: options.fullGraphTasks,
 		},
 		index,
 	);

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -28,6 +28,9 @@ export interface TaskSearchOptions {
 	modifiedFiles?: string[];
 }
 
+import { DEFAULT_STATUSES } from "../constants/index.ts";
+import { getTaskReadiness } from "./readiness.ts";
+
 export interface SharedTaskFilterOptions {
 	query?: string;
 	excludeStatus?: string | string[];
@@ -38,6 +41,9 @@ export interface SharedTaskFilterOptions {
 	modifiedFiles?: string[];
 	milestone?: string;
 	resolveMilestoneLabel?: (milestone: string) => string;
+	ready?: boolean;
+	statuses?: readonly string[];
+	fullGraphTasks?: Task[];
 }
 
 export interface TaskFilterOptions extends SharedTaskFilterOptions {
@@ -292,6 +298,12 @@ export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, inde
 		results = applyMilestoneFilter(results, options.milestone, options.resolveMilestoneLabel, tasks);
 	}
 
+	if (options.ready) {
+		const statuses = options.statuses ?? DEFAULT_STATUSES;
+		const graph = options.fullGraphTasks ?? tasks;
+		results = results.filter((task) => getTaskReadiness(task, graph, statuses).isReady);
+	}
+
 	return results;
 }
 
@@ -312,6 +324,9 @@ export function applySharedTaskFilters(
 			modifiedFiles: options.modifiedFiles,
 			milestone: options.milestone,
 			resolveMilestoneLabel: options.resolveMilestoneLabel,
+			ready: options.ready,
+			statuses: options.statuses,
+			fullGraphTasks: options.fullGraphTasks,
 		},
 		index,
 	);

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -4,7 +4,6 @@
  */
 
 import Fuse from "fuse.js";
-import { DEFAULT_STATUSES } from "../constants/index.ts";
 import type { Task } from "../types/index.ts";
 import { labelsToLower } from "./label-filter.ts";
 import {
@@ -14,7 +13,7 @@ import {
 } from "./milestone-filter.ts";
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "./modified-files.ts";
 import { normalizePriorityValue } from "./priority-config.ts";
-import { getTaskReadiness } from "./readiness.ts";
+import { getTaskReadiness, type ReadinessGraph } from "./readiness.ts";
 import { matchesTaskTypeFilter } from "./task-type-config.ts";
 
 export type LabelMatchMode = "any" | "all";
@@ -45,11 +44,11 @@ export interface SharedTaskFilterOptions {
 export interface TaskFilterOptions extends SharedTaskFilterOptions {
 	status?: string;
 	excludeStatus?: string | string[];
-	ready?: boolean;
-	/** Configured statuses, used to decide which status counts as completed. */
-	statuses?: readonly string[];
-	/** Task graph readiness resolves against; defaults to the tasks being filtered. */
-	readinessTasks?: Task[];
+	/**
+	 * When set, keep only tasks that are ready according to this graph. The graph carries the full
+	 * task corpus, so readiness never depends on which tasks survived the other filters.
+	 */
+	ready?: ReadinessGraph;
 }
 
 export interface TaskSearchIndex {
@@ -300,9 +299,8 @@ export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, inde
 	}
 
 	if (options.ready) {
-		const statuses = options.statuses ?? DEFAULT_STATUSES;
-		const graph = options.readinessTasks ?? tasks;
-		results = results.filter((task) => getTaskReadiness(task, graph, statuses).isReady);
+		const graph = options.ready;
+		results = results.filter((task) => getTaskReadiness(task, graph).isReady);
 	}
 
 	return results;

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -330,22 +330,29 @@ export const TaskDetailsModal: React.FC<Props> = ({
 
   // Dependencies that already left the board corpus (completed tasks) are fetched by ID so the
   // browser resolves the same task graph the CLI does instead of calling them unknown.
+  // Keyed on a string because availableTasks and dependencies are new arrays on every render.
+  const unresolvedDependencyKey = useMemo(() => {
+    const known = new Set(availableTasks.map((candidate) => canonicalTaskId(candidate.id)));
+    return dependencies
+      .filter((id) => !known.has(canonicalTaskId(id)))
+      .join(",");
+  }, [availableTasks, dependencies]);
   const [offBoardDependencies, setOffBoardDependencies] = useState<Task[]>([]);
   useEffect(() => {
-    const known = new Set(availableTasks.map((candidate) => canonicalTaskId(candidate.id)));
-    const unresolved = dependencies.filter((id) => !known.has(canonicalTaskId(id)));
-    if (!isOpen || unresolved.length === 0) {
-      setOffBoardDependencies([]);
+    if (!isOpen || unresolvedDependencyKey === "") {
+      setOffBoardDependencies((current) => (current.length === 0 ? current : []));
       return;
     }
     let cancelled = false;
-    Promise.all(unresolved.map((id) => apiClient.fetchTask(id).catch(() => null))).then((results) => {
-      if (!cancelled) setOffBoardDependencies(results.filter((result): result is Task => Boolean(result)));
-    });
+    Promise.all(unresolvedDependencyKey.split(",").map((id) => apiClient.fetchTask(id).catch(() => null))).then(
+      (results) => {
+        if (!cancelled) setOffBoardDependencies(results.filter((result): result is Task => Boolean(result)));
+      },
+    );
     return () => {
       cancelled = true;
     };
-  }, [isOpen, dependencies, availableTasks]);
+  }, [isOpen, unresolvedDependencyKey]);
 
   // Dependency readiness, derived at render time from the dependencies currently shown.
   // Only meaningful while dependencies exist and the task has not reached the terminal status.

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -358,11 +358,14 @@ export const TaskDetailsModal: React.FC<Props> = ({
   // Only meaningful while dependencies exist and the task has not been completed.
   const readiness = useMemo(() => {
     if (!task || dependencies.length === 0) return null;
-    // A dependency resolved outside the board corpus came from backlog/completed, where the
-    // record's location is the completion evidence rather than its status string.
+    // Records resolved outside the board corpus come from backlog/completed, where the record's
+    // location is the completion evidence rather than its status string. That applies to the open
+    // task itself as well: a direct link can open a completed task whose historical status is no
+    // longer the configured terminal one.
+    const offBoard = [...offBoardDependencies, ...(task.source === "completed" ? [task] : [])];
     const graph = createReadinessGraph({
-      tasks: [...availableTasks, ...offBoardDependencies.filter((dep) => dep.source !== "completed")],
-      completedTasks: offBoardDependencies.filter((dep) => dep.source === "completed"),
+      tasks: [...availableTasks, ...offBoard.filter((entry) => entry.source !== "completed")],
+      completedTasks: offBoard.filter((entry) => entry.source === "completed"),
       statuses: availableStatuses,
     });
     const result = getTaskReadiness({ ...task, dependencies, status }, graph);

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -11,7 +11,9 @@ import DependencyInput from "./DependencyInput";
 import { formatStoredUtcDateForDisplay } from "../utils/date-display";
 import { getPriorityOptions } from "../../utils/priority-config";
 import { getTaskTypeValues, resolveTaskTypeValue } from "../../utils/task-type-config";
-import { getTaskReadiness } from "../../utils/readiness";
+import { DEFAULT_STATUSES } from "../../constants/index.ts";
+import { formatReadinessBlockers, getTaskReadiness } from "../../utils/readiness";
+import { canonicalTaskId } from "../../utils/task-id.ts";
 
 interface Props {
   task?: Task; // Optional for create mode
@@ -325,6 +327,34 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const typeSelectionValue = canonicalTypeSelection ?? taskType;
   const milestoneSelectionValue = resolveMilestoneToId(milestone);
   const hasMilestoneSelection = (milestoneEntities ?? []).some((milestoneEntity) => milestoneEntity.id === milestoneSelectionValue);
+
+  // Dependencies that already left the board corpus (completed tasks) are fetched by ID so the
+  // browser resolves the same task graph the CLI does instead of calling them unknown.
+  const [offBoardDependencies, setOffBoardDependencies] = useState<Task[]>([]);
+  useEffect(() => {
+    const known = new Set(availableTasks.map((candidate) => canonicalTaskId(candidate.id)));
+    const unresolved = dependencies.filter((id) => !known.has(canonicalTaskId(id)));
+    if (!isOpen || unresolved.length === 0) {
+      setOffBoardDependencies([]);
+      return;
+    }
+    let cancelled = false;
+    Promise.all(unresolved.map((id) => apiClient.fetchTask(id).catch(() => null))).then((results) => {
+      if (!cancelled) setOffBoardDependencies(results.filter((result): result is Task => Boolean(result)));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, dependencies, availableTasks]);
+
+  // Dependency readiness, derived at render time from the dependencies currently shown.
+  // Only meaningful while dependencies exist and the task has not reached the terminal status.
+  const readiness = useMemo(() => {
+    if (!task || dependencies.length === 0) return null;
+    const graph = [...availableTasks, ...offBoardDependencies];
+    const result = getTaskReadiness({ ...task, dependencies }, graph, availableStatuses ?? DEFAULT_STATUSES);
+    return result.isReady || result.isBlocked ? result : null;
+  }, [task, dependencies, availableTasks, offBoardDependencies, availableStatuses]);
 
   // Keep a baseline for dirty-check
   const baseline = useMemo(() => ({
@@ -919,41 +949,6 @@ export const TaskDetailsModal: React.FC<Props> = ({
         </div>
       )}
 
-      {/* Task Readiness Guidance */}
-      {task && (() => {
-        const readiness = getTaskReadiness(
-          { ...task, dependencies },
-          availableTasks,
-          availableStatuses ?? ["To Do", "In Progress", "Done"],
-        );
-
-        if (!readiness.isReady && !readiness.isBlocked) {
-          return (
-            <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
-              <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
-              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
-                Task in terminal status ({task.status})
-              </span>
-            </div>
-          );
-        }
-
-        return (
-          <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
-            <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
-            {readiness.isReady ? (
-              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">
-                ✓ Ready to start ({dependencies.length === 0 ? "no dependencies" : "all dependencies satisfied"})
-              </span>
-            ) : (
-              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300">
-                ⏳ Blocked by: {readiness.blockingDependencies.join(", ")}
-              </span>
-            )}
-          </div>
-        );
-      })()}
-
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Main content */}
         <div className="md:col-span-2 space-y-6">
@@ -1447,6 +1442,18 @@ export const TaskDetailsModal: React.FC<Props> = ({
               label=""
               disabled={isFromOtherBranch}
             />
+            {readiness && (
+              <div
+                className={`mt-2 flex items-start gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium ${
+                  readiness.isReady
+                    ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-300'
+                    : 'bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300'
+                }`}
+              >
+                <span aria-hidden="true">{readiness.isReady ? '✓' : '⏳'}</span>
+                <span>{readiness.isReady ? 'Ready to start' : formatReadinessBlockers(readiness)}</span>
+              </div>
+            )}
           </div>
 
           {/* Archive button at bottom of sidebar */}

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -11,8 +11,7 @@ import DependencyInput from "./DependencyInput";
 import { formatStoredUtcDateForDisplay } from "../utils/date-display";
 import { getPriorityOptions } from "../../utils/priority-config";
 import { getTaskTypeValues, resolveTaskTypeValue } from "../../utils/task-type-config";
-import { DEFAULT_STATUSES } from "../../constants/index.ts";
-import { formatReadinessBlockers, getTaskReadiness } from "../../utils/readiness";
+import { createReadinessGraph, formatReadinessBlockers, getTaskReadiness } from "../../utils/readiness";
 import { canonicalTaskId } from "../../utils/task-id.ts";
 
 interface Props {
@@ -354,14 +353,21 @@ export const TaskDetailsModal: React.FC<Props> = ({
     };
   }, [isOpen, unresolvedDependencyKey]);
 
-  // Dependency readiness, derived at render time from the dependencies currently shown.
-  // Only meaningful while dependencies exist and the task has not reached the terminal status.
+  // Dependency readiness, derived at render time from the dependencies and status currently shown,
+  // so an inline edit is reflected immediately instead of waiting for a refresh.
+  // Only meaningful while dependencies exist and the task has not been completed.
   const readiness = useMemo(() => {
     if (!task || dependencies.length === 0) return null;
-    const graph = [...availableTasks, ...offBoardDependencies];
-    const result = getTaskReadiness({ ...task, dependencies }, graph, availableStatuses ?? DEFAULT_STATUSES);
+    // A dependency resolved outside the board corpus came from backlog/completed, where the
+    // record's location is the completion evidence rather than its status string.
+    const graph = createReadinessGraph({
+      tasks: [...availableTasks, ...offBoardDependencies.filter((dep) => dep.source !== "completed")],
+      completedTasks: offBoardDependencies.filter((dep) => dep.source === "completed"),
+      statuses: availableStatuses,
+    });
+    const result = getTaskReadiness({ ...task, dependencies, status }, graph);
     return result.isReady || result.isBlocked ? result : null;
-  }, [task, dependencies, availableTasks, offBoardDependencies, availableStatuses]);
+  }, [task, dependencies, status, availableTasks, offBoardDependencies, availableStatuses]);
 
   // Keep a baseline for dirty-check
   const baseline = useMemo(() => ({

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -11,6 +11,7 @@ import DependencyInput from "./DependencyInput";
 import { formatStoredUtcDateForDisplay } from "../utils/date-display";
 import { getPriorityOptions } from "../../utils/priority-config";
 import { getTaskTypeValues, resolveTaskTypeValue } from "../../utils/task-type-config";
+import { getTaskReadiness } from "../../utils/readiness";
 
 interface Props {
   task?: Task; // Optional for create mode
@@ -917,6 +918,41 @@ export const TaskDetailsModal: React.FC<Props> = ({
           </div>
         </div>
       )}
+
+      {/* Task Readiness Guidance */}
+      {task && (() => {
+        const readiness = getTaskReadiness(
+          { ...task, dependencies },
+          availableTasks,
+          availableStatuses ?? ["To Do", "In Progress", "Done"],
+        );
+
+        if (!readiness.isReady && !readiness.isBlocked) {
+          return (
+            <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
+              <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                Task in terminal status ({task.status})
+              </span>
+            </div>
+          );
+        }
+
+        return (
+          <div className="mb-4 flex items-center gap-2 px-4 py-2.5 bg-gray-50 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg text-sm">
+            <span className="font-semibold text-gray-700 dark:text-gray-300">Readiness:</span>
+            {readiness.isReady ? (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-300">
+                ✓ Ready to start ({dependencies.length === 0 ? "no dependencies" : "all dependencies satisfied"})
+              </span>
+            ) : (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300">
+                ⏳ Blocked by: {readiness.blockingDependencies.join(", ")}
+              </span>
+            )}
+          </div>
+        );
+      })()}
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Main content */}


### PR DESCRIPTION
Takeover of #814 by @cottrell — his core commit lands verbatim with authorship preserved; adaptation commits bring it across ~150 commits of drift. Closes #785 (the narrowed --ready ask from that thread).

Tasks now expose derived dependency readiness — ready, blocked-by, or unknown-dependency, computed per task at read time from dependencies only (no ordering semantics; the removed sequences model stays dead) — surfaced as `task list --ready`, an MCP `task_list` ready argument (no new tools), a readiness line in the TUI detail pane, and a badge in the browser task modal.

The adaptations matter: the original loaded the full completed corpus on every TUI launch and task view (~6.6s measured on this repo); the takeover loads completed-task metadata in ~112ms in parallel with existing startup work (measured net TUI cost ~56ms). Dependency lookups resolve canonically (case/zero-padding), unresolvable IDs are separated from blocking ones and both fail closed, and rendered QA caught three defects code inspection missed (a wide-glyph artifact in blessed, a web-vs-CLI verdict divergence for filed tasks, and a board-popup context gap), plus a React render loop the full suite caught.

Verification: live fixture with met/unmet/filed/dangling/cyclic dependencies agreeing across all five surfaces, measured timings, mutation-tested suites (readiness lies break 6 tests across 4 layers), full suite 2008 pass / 0 fail. Independently reviewed with no blocking findings — the review's summary line: every failure direction is toward blocked, never a false ready.