### PR TITLE
BACK-602 - Close doctor and web gaps from the identity review

### DIFF
--- a/backlog/tasks/back-602 - Close-doctor-and-web-gaps-from-the-identity-review.md
+++ b/backlog/tasks/back-602 - Close-doctor-and-web-gaps-from-the-identity-review.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-602
 title: Close doctor and web gaps from the identity review
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-08 07:46'
+updated_date: '2026-08-08 08:03'
 labels:
   - core
 dependencies: []
@@ -26,15 +28,49 @@ Two P2 findings from the final Codex review round on PR #872 (BACK-580) were mis
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 backlog doctor reports an unreadable document or decision directory as a finding and exits non-zero
-- [ ] #2 Entering the document create route after an ambiguity error renders the create editor instead of the stale notice
-- [ ] #3 The decision detail view is verified against the same stale-error pattern and fixed if affected
-- [ ] #4 Tests cover the unreadable-directory finding and the create-route recovery
+- [x] #1 backlog doctor reports an unreadable document or decision directory as a finding and exits non-zero
+- [x] #2 Entering the document create route after an ambiguity error renders the create editor instead of the stale notice
+- [x] #3 The decision detail view is verified against the same stale-error pattern and fixed if affected
+- [x] #4 Tests cover the unreadable-directory finding and the create-route recovery
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. src/file-system/operations.ts: add a shared recordUnreadableDirectory helper and call it from the outer catch of listDocuments and listDecisions, so a scan-level failure records the directory in the unreadable collector. Keep a missing directory silent (ENOENT) since a project that never created docs or decisions is healthy.
+2. src/core/backlog.ts: have diagnoseContentIdentity's path builder render the empty collected path as the content directory itself.
+3. src/cli.ts: widen the doctor section heading to 'Unreadable <label> files or directories'.
+4. src/web/components/DocumentationDetail.tsx and DecisionDetail.tsx: clear the error and detail state in the id === 'new' branch of the load effect so the create editor renders instead of a stale ambiguity notice.
+5. Tests: unreadable-directory findings at the Core and CLI level (guarded for Windows and for root, where chmod does not restrict), a regression test that a missing directory stays healthy, and DOM-harness tests that navigate from a 409 state to the create route for both components.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Finding 1: listDocuments and listDecisions caught scan-level failures in their outer try/catch and returned [] without touching the unreadable collector, so diagnoseContentIdentity saw zero entries and zero findings and doctor exited 0. Both catches now call a shared recordUnreadableDirectory helper.
+
+The important distinction is that a directory which does not exist is not the same as one that cannot be read. Verified empirically: Bun.Glob().scan() throws ENOENT for a missing directory and EACCES for a chmod-000 one. The helper stays silent on ENOENT, so a project that never created docs or decisions is still reported healthy, and anything else becomes a finding. A regression test covers that healthy case, because reporting it would make doctor cry wolf on most fresh projects.
+
+The collector holds directory-relative paths, so the directory itself is recorded as the empty string and Core renders it as backlog/docs or backlog/decisions. The doctor heading is now 'Unreadable <label> files or directories' to cover both.
+
+Finding 2: confirmed present in DocumentationDetail and, as suspected, identical in DecisionDetail. The id === 'new' branch of the load effect never cleared error, so after a 409 the notice kept rendering in place of the create editor. Both now clear error and the detail object when entering the create route.
+
+Both fixes were verified as non-vacuous by sabotaging each fix in turn and confirming the new tests fail: the doctor test drops its finding, and both create-route tests fail to find the title input.
+
+The DOM harness renders one route pattern with a sibling navigation button so a param change keeps the same component instance mounted, which is how the create route is actually reached in the app; remounting would not reproduce the defect. The harness also needed a ThemeProvider because the create editor renders MarkdownEditor, which calls useTheme.
+
+Verified: bunx tsc --noEmit, bun run check ., the doctor, server, filesystem, content-store, markdown, and web suites, and full bun run test at 2035 pass / 0 fail.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Closed the two P2 gaps left by the BACK-580 identity review. backlog doctor no longer reports healthy when it could not read a content directory: listDocuments and listDecisions record scan-level failures in the unreadable collector through a shared helper, Core renders that entry as the directory path, and doctor exits non-zero. A directory that simply does not exist stays silent, because Bun's glob throws ENOENT there and EACCES for an unreadable one, so fresh projects are still healthy. On the web, entering the document or decision create route after a 409 now clears the load error, so the create editor renders instead of a stale ambiguity notice; DecisionDetail had the same defect and was fixed alongside DocumentationDetail. Verified with bunx tsc --noEmit, bun run check ., new tests in src/test/content-identity.test.ts, src/test/cli-doctor.test.ts, and src/test/web-ambiguous-id.test.tsx (each confirmed to fail when its fix is reverted), and full bun run test at 2035 pass / 0 fail.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -401,7 +401,7 @@ function printContentIdentityReport(report: ContentIdentityReport): void {
 			console.log(`Add an id to each file; these ${label}s cannot be addressed until then.`);
 		}
 		if (issues.unreadable.length > 0) {
-			console.log(`\nUnreadable ${label} files (could not be read or parsed):`);
+			console.log(`\nUnreadable ${label} files or directories:`);
 			for (const path of issues.unreadable) console.log(`  - ${path}`);
 			console.log(`Repair the frontmatter or file permissions; identity could not be checked for these ${label}s.`);
 		}

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -292,7 +292,10 @@ export class Core {
 			this.fs.listDocuments(unreadableDocuments),
 			this.fs.listDecisions(unreadableDecisions),
 		]);
-		const locate = (directory: string, path: string) => `${this.fs.backlogDirName}/${directory}/${path}`;
+		// An empty collected path denotes the content directory itself, which the filesystem reports
+		// when it could not be scanned at all.
+		const locate = (directory: string, path: string) =>
+			path ? `${this.fs.backlogDirName}/${directory}/${path}` : `${this.fs.backlogDirName}/${directory}`;
 		const describe = (directory: string, item: { path?: string; title: string }) =>
 			item.path ? locate(directory, item.path) : item.title;
 		return {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -128,6 +128,17 @@ function taskLockError(message: string, cause?: unknown): Error {
 	return lockError(TASK_LOCK_ERROR_NAME, TASK_LOCK_ERROR_CODE, message, cause);
 }
 
+/**
+ * Records a directory-level listing failure so callers can report it instead of treating an
+ * unreadable directory as an empty one. A directory that does not exist yet is normal and is
+ * reported as empty; anything else means the contents could not be inspected. The empty string
+ * denotes the content directory itself.
+ */
+function recordUnreadableDirectory(error: unknown, unreadable?: string[]): void {
+	if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return;
+	unreadable?.push("");
+}
+
 export function isCreateLockError(error: unknown): error is Error {
 	return isLockError(error, CREATE_LOCK_ERROR_NAME, CREATE_LOCK_ERROR_CODE);
 }
@@ -1111,7 +1122,8 @@ export class FileSystem {
 				}
 			}
 			return sortByTaskId(decisions);
-		} catch {
+		} catch (error) {
+			recordUnreadableDirectory(error, unreadable);
 			return [];
 		}
 	}
@@ -1140,7 +1152,8 @@ export class FileSystem {
 
 			// Stable sort by title for UI/CLI listing
 			return docs.sort((a, b) => a.title.localeCompare(b.title));
-		} catch {
+		} catch (error) {
+			recordUnreadableDirectory(error, unreadable);
 			return [];
 		}
 	}

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -289,6 +289,33 @@ describe("document and decision identity", () => {
 		expect(output).toContain("backlog/decisions/decision-2 - Broken.md");
 	});
 
+	it.skipIf(process.platform === "win32")("reports a document directory it cannot scan", async () => {
+		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
+		// chmod is a no-op for root, so confirm the directory really became unreadable first.
+		await chmod(core.filesystem.docsDir, 0o000);
+		const reallyLocked = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: core.filesystem.docsDir }))
+			.then(() => false)
+			.catch(() => true);
+		if (!reallyLocked) {
+			await chmod(core.filesystem.docsDir, 0o755);
+			return;
+		}
+
+		const result = await (async () => {
+			try {
+				return await $`bun ${cliPath} doctor`.cwd(testDir).quiet().nothrow();
+			} finally {
+				await chmod(core.filesystem.docsDir, 0o755);
+			}
+		})();
+
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).not.toContain("No duplicate task, document, or decision IDs found.");
+		expect(output).toContain("Unreadable document files or directories");
+		expect(output).toContain("backlog/docs");
+	});
+
 	it("keeps valid documents readable when a sibling file cannot be parsed", async () => {
 		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
 		await Bun.write(

--- a/src/test/content-identity.test.ts
+++ b/src/test/content-identity.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdir } from "node:fs/promises";
+import { chmod, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { Core } from "../core/backlog.ts";
 import { serializeDecision, serializeDocument } from "../markdown/serializer.ts";
@@ -8,7 +8,7 @@ import { decisionIdKey } from "../utils/decision-id.ts";
 import { documentIdKey, documentIdsEqual } from "../utils/document-id.ts";
 import { hasContentIdentityIssues } from "../utils/duplicate-detection.ts";
 import { AmbiguousIdError } from "../utils/entity-id.ts";
-import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+import { createUniqueTestDir, initializeFilesystemTestProject, isWindows, safeCleanup } from "./test-utils.ts";
 
 let TEST_DIR: string;
 let core: Core;
@@ -216,5 +216,61 @@ describe("unreadable content files", () => {
 		expect(report.documents.duplicates).toEqual([]);
 		expect(report.documents.missingIds).toEqual([]);
 		expect(hasContentIdentityIssues(report)).toBe(true);
+	});
+});
+
+describe("unreadable content directories", () => {
+	// chmod has no effect for root, and Windows ignores these mode bits, so confirm the directory
+	// really became unreadable before asserting on the finding.
+	async function lockDirectory(directory: string): Promise<boolean> {
+		if (isWindows()) return false;
+		await chmod(directory, 0o000);
+		try {
+			await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: directory, followSymlinks: true }));
+			await chmod(directory, 0o755);
+			return false;
+		} catch {
+			return true;
+		}
+	}
+
+	it("reports a directory that cannot be scanned instead of calling identity healthy", async () => {
+		await writeDocument("doc-1 - Alpha.md", makeDocument("doc-1", "Alpha"));
+		const locked = await lockDirectory(core.filesystem.docsDir);
+		if (!locked) return;
+
+		try {
+			const unreadable: string[] = [];
+			expect(await core.filesystem.listDocuments(unreadable)).toEqual([]);
+			expect(unreadable).toEqual([""]);
+
+			const report = await core.diagnoseContentIdentity();
+			expect(report.documents.unreadable).toEqual(["backlog/docs"]);
+			expect(hasContentIdentityIssues(report)).toBe(true);
+		} finally {
+			await chmod(core.filesystem.docsDir, 0o755);
+		}
+	});
+
+	it("still treats a directory that does not exist as empty", async () => {
+		// A project that has never created docs or decisions is healthy, not broken.
+		const bareDir = createUniqueTestDir("content-identity-bare");
+		await mkdir(bareDir, { recursive: true });
+		const bare = new Core(bareDir);
+		await initializeFilesystemTestProject(bare, "Bare project");
+		await safeCleanup(bare.filesystem.docsDir);
+		await safeCleanup(bare.filesystem.decisionsDir);
+
+		try {
+			const unreadable: string[] = [];
+			expect(await bare.filesystem.listDocuments(unreadable)).toEqual([]);
+			expect(await bare.filesystem.listDecisions(unreadable)).toEqual([]);
+			expect(unreadable).toEqual([]);
+			expect(hasContentIdentityIssues(await bare.diagnoseContentIdentity())).toBe(false);
+		} finally {
+			bare.disposeSearchService();
+			bare.disposeContentStore();
+			await safeCleanup(bareDir);
+		}
 	});
 });

--- a/src/test/web-ambiguous-id.test.tsx
+++ b/src/test/web-ambiguous-id.test.tsx
@@ -2,10 +2,11 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { JSDOM } from "jsdom";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import type { Decision as BacklogDecision, Document as BacklogDocument } from "../types/index.ts";
 import DecisionDetail from "../web/components/DecisionDetail.tsx";
 import DocumentationDetail from "../web/components/DocumentationDetail.tsx";
+import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
 
 let activeRoot: Root | null = null;
 const originalFetch = globalThis.fetch;
@@ -50,15 +51,63 @@ async function renderRoute(path: string, pattern: string, element: React.ReactEl
 	activeRoot = createRoot(container);
 	await act(async () => {
 		activeRoot?.render(
-			<MemoryRouter initialEntries={[path]}>
-				<Routes>
-					<Route path={pattern} element={element} />
-				</Routes>
-			</MemoryRouter>,
+			<ThemeProvider>
+				<MemoryRouter initialEntries={[path]}>
+					<Routes>
+						<Route path={pattern} element={element} />
+					</Routes>
+				</MemoryRouter>
+			</ThemeProvider>,
 		);
 		await Promise.resolve();
 	});
 	return container;
+}
+
+function NavigateButton({ to }: { to: string }): React.ReactElement {
+	const navigate = useNavigate();
+	return (
+		<button type="button" data-testid="navigate" onClick={() => navigate(to)}>
+			navigate
+		</button>
+	);
+}
+
+/**
+ * Renders one route pattern with a sibling navigation button so a param change keeps the same
+ * component instance mounted, which is how the create route is reached in the real app.
+ */
+async function renderReusableRoute(
+	path: string,
+	pattern: string,
+	createPath: string,
+	element: React.ReactElement,
+): Promise<HTMLElement> {
+	const container = setupDom();
+	activeRoot = createRoot(container);
+	await act(async () => {
+		activeRoot?.render(
+			<ThemeProvider>
+				<MemoryRouter initialEntries={[path]}>
+					<NavigateButton to={createPath} />
+					<Routes>
+						<Route path={pattern} element={element} />
+					</Routes>
+				</MemoryRouter>
+			</ThemeProvider>,
+		);
+		await Promise.resolve();
+	});
+	return container;
+}
+
+async function clickNavigate(container: HTMLElement): Promise<void> {
+	const button = container.querySelector('[data-testid="navigate"]') as HTMLButtonElement;
+	expect(button).toBeTruthy();
+	await act(async () => {
+		button.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+		await Promise.resolve();
+	});
 }
 
 afterEach(() => {
@@ -118,5 +167,59 @@ describe("web ambiguous ID handling", () => {
 		expect(container.textContent).toContain("backlog doctor");
 		expect(container.textContent).not.toContain("Cached body that must not be shown");
 		expect(container.textContent).not.toContain("Cached Alpha");
+	});
+});
+
+describe("create route after an ambiguity error", () => {
+	it("renders the document create editor instead of the stale notice", async () => {
+		respondWithConflict(AMBIGUOUS_DOCUMENT_MESSAGE);
+		const cached: BacklogDocument = {
+			id: "doc-1",
+			title: "Cached Alpha",
+			type: "other",
+			createdDate: "2026-01-01 00:00",
+			rawContent: "Cached body",
+			path: "doc-1 - Alpha.md",
+		};
+
+		const container = await renderReusableRoute(
+			"/documentation/1",
+			"/documentation/:id",
+			"/documentation/new",
+			<DocumentationDetail docs={[cached]} onRefreshData={async () => {}} />,
+		);
+		expect(container.textContent).toContain("This ID matches more than one file");
+
+		await clickNavigate(container);
+
+		expect(container.textContent).not.toContain("This ID matches more than one file");
+		expect(container.querySelector('input[placeholder="Document title"]')).toBeTruthy();
+	});
+
+	it("renders the decision create editor instead of the stale notice", async () => {
+		respondWithConflict(AMBIGUOUS_DECISION_MESSAGE);
+		const cached: BacklogDecision = {
+			id: "decision-1",
+			title: "Cached Alpha",
+			date: "2026-01-01 00:00",
+			status: "proposed",
+			context: "",
+			decision: "",
+			consequences: "",
+			rawContent: "Cached body",
+		};
+
+		const container = await renderReusableRoute(
+			"/decisions/1",
+			"/decisions/:id",
+			"/decisions/new",
+			<DecisionDetail decisions={[cached]} onRefreshData={async () => {}} />,
+		);
+		expect(container.textContent).toContain("This ID matches more than one file");
+
+		await clickNavigate(container);
+
+		expect(container.textContent).not.toContain("This ID matches more than one file");
+		expect(container.querySelector('input[placeholder="Decision title"]')).toBeTruthy();
 	});
 });

--- a/src/web/components/DecisionDetail.tsx
+++ b/src/web/components/DecisionDetail.tsx
@@ -95,6 +95,10 @@ export default function DecisionDetail({ decisions, onRefreshData, dateFormat }:
 			setIsNewDecision(true);
 			setIsEditing(true);
 			setIsLoading(false);
+			// Creating is unrelated to whatever failed to load before, so clear any load error.
+			// Otherwise a previous ambiguity notice keeps rendering instead of the create editor.
+			setError(null);
+			setDecision(null);
 			setDecisionTitle('');
 			setOriginalDecisionTitle('');
 			setContent('');

--- a/src/web/components/DocumentationDetail.tsx
+++ b/src/web/components/DocumentationDetail.tsx
@@ -99,6 +99,10 @@ export default function DocumentationDetail({docs, onRefreshData, dateFormat}: D
             setIsNewDocument(true);
             setIsEditing(true);
             setIsLoading(false);
+            // Creating is unrelated to whatever failed to load before, so clear any load error.
+            // Otherwise a previous ambiguity notice keeps rendering instead of the create editor.
+            setError(null);
+            setDocument(null);
             setDocTitle('');
             setOriginalDocTitle('');
             setDocPath('');


### PR DESCRIPTION
Fix-forward for two review findings from #872 (BACK-580) that were missed before its merge.

1. Doctor reported healthy when an entire content directory was unreadable: the scan-level catch returned an empty list without recording anything. Directory-level failures now surface as doctor findings (exit 1), with the important distinction that a missing directory (ENOENT) stays silent — fresh projects without docs/decisions are healthy — while an unreadable one (EACCES) is reported.

2. After a 409 ambiguity error, navigating to the create route reused the component without clearing the error state, so the stale ambiguity notice rendered instead of the create editor — in both DocumentationDetail and DecisionDetail.

Both fixes verified non-vacuous (sabotage each → its test fails); chmod tests skip on Windows and self-check the directory actually became unreadable. Full suite 2035 pass / 0 fail.