### PR TITLE
BACK-608 - Remove gray-matter cache poisoning with a shared no-cache parse wrapper

### DIFF
--- a/backlog/tasks/back-608 - Remove-gray-matter-cache-poisoning-with-a-shared-no-cache-parse-wrapper.md
+++ b/backlog/tasks/back-608 - Remove-gray-matter-cache-poisoning-with-a-shared-no-cache-parse-wrapper.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-608
 title: Remove gray-matter cache poisoning with a shared no-cache parse wrapper
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-08 15:56'
+updated_date: '2026-08-08 16:22'
 labels: []
 dependencies: []
 ordinal: 247000
@@ -17,14 +19,54 @@ gray-matter caches parse results keyed by input string and hands back the same o
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A single shared frontmatter parse helper disables the gray-matter cache
-- [ ] #2 No direct gray-matter usage remains outside the shared helper
-- [ ] #3 A regression test demonstrates the former cache-poisoning scenario now parses correctly
+- [x] #1 A single shared frontmatter parse helper disables the gray-matter cache
+- [x] #2 No direct gray-matter usage remains outside the shared helper
+- [x] #3 A regression test demonstrates the former cache-poisoning scenario now parses correctly
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify the cache mechanism against installed gray-matter 4.0.3: matter(input) caches the file object by content and returns the same data object, so a mutating caller poisons later parses and a malformed file only throws on the first parse. Passing any options object skips both the cache read and the cache write (confirmed empirically: cache stays empty, second parse pristine, malformed input throws every time).
+2. Add src/markdown/frontmatter.ts as the only module that imports gray-matter: parseFrontmatter(content) calls matter(content, {}) and returns { data, content }; stringifyFrontmatter(content, data) calls matter.stringify(content, data, {}) so serialization output is byte-identical (verified) while no call path writes to the cache anymore.
+3. Migrate every gray-matter call site to the helper: src/markdown/parser.ts (parseMarkdown), src/file-system/operations.ts (parseConfigListValues, parseDefinitionOfDoneFromYaml), src/core/backlog.ts (updateDecisionFromContent dynamic import), src/markdown/serializer.ts (three matter.stringify calls). src/file-system/operations.ts parseAssigneeConfigValue keeps Bun.YAML.parse as-is.
+4. Add a regression test in src/test/markdown.test.ts: parse a string with the helper, mutate the returned data and content, parse the identical string again and assert the second result is pristine; plus the same at parseMarkdown/parseTask level so the app-facing path is covered. Verify the test fails when the helper call is reverted to a bare matter() call, then restore.
+5. Refresh the two stale test comments (src/test/content-identity.test.ts, src/test/cli-doctor.test.ts) that tell readers fixtures must have distinct bodies to dodge the parse cache.
+6. Verify: bunx tsc --noEmit, bun run check ., bun run test (full suite).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## What changed
+
+Added src/markdown/frontmatter.ts as the only module that imports gray-matter:
+- parseFrontmatter(content) calls matter(content, {}) and returns { data, content }.
+- stringifyFrontmatter(content, data) calls matter.stringify(content, data, {}).
+
+Migrated every gray-matter call site to it: src/markdown/parser.ts (parseMarkdown), src/markdown/serializer.ts (serializeTask/serializeDecision/serializeDocument), src/file-system/operations.ts (parseConfigListValues, parseDefinitionOfDoneFromYaml), src/core/backlog.ts (updateDecisionFromContent, which used a dynamic import of gray-matter). parseAssigneeConfigValue keeps Bun.YAML.parse, which was a deliberate choice unrelated to the cache. Also dropped two stale test comments that told readers fixtures need distinct bodies to dodge the parse cache.
+
+## Why
+
+gray-matter 4.0.3 only reads and writes its module-level cache when the options argument is falsy (node_modules/gray-matter/index.js: 'only cache if there are no options passed'). Verified empirically against the installed version: matter(input) twice returns a shared data object, so mutating the first result changed the second (title became the mutated value) and a malformed document threw only on its first parse; matter(input, {}) left matter.cache empty, returned a pristine second parse, and threw on every malformed parse. A shared options object behaves the same as a fresh one, so passing {} per call is enough. Two independent Aug 2026 review rounds hit this defect and worked around it locally (an options object in parser.ts, Bun.YAML.parse in operations.ts); routing all sites through one wrapper removes the whole class instead of patching individual sites, and stops the serializer from writing cache entries that can never be safely read.
+
+## Evidence
+
+- New regression tests in src/test/markdown.test.ts ('frontmatter parse cache'): one mutates parseFrontmatter's returned data (overwrite, extra key, array push) plus content and asserts the next parse of the identical string is pristine; one mutates a parseMarkdown result and asserts parseTask on the same string still sees the real id/title/labels.
+- Confirmed the tests catch the old behavior: temporarily changing the helper back to matter(content) failed both new tests (title 'mutated title', injected key, id '') plus the pre-existing malformed-frontmatter test, then restored the fix and they pass.
+- Serializer output is unchanged: matter.stringify(body, data) and matter.stringify(body, {...data}, {}) produce byte-identical strings, and the serializer test suites pass.
+- bunx tsc --noEmit clean; bun run check . clean (367 files); bun run test green (2062 pass, 6 skip, 0 fail, 2068 tests across 222 files).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+All frontmatter parsing now goes through one wrapper, src/markdown/frontmatter.ts, which passes an options object to gray-matter so its result cache is never read or written; no direct gray-matter usage remains outside that module. Verified with new regression tests in src/test/markdown.test.ts that mutate a parse result and assert the next parse of identical content is pristine (they fail against the old bare matter() call), plus bunx tsc --noEmit, bun run check ., and a full bun run test run (2062 pass, 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -3,6 +3,7 @@ import { basename, isAbsolute, join, relative } from "node:path";
 import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
 import { FileSystem, isCreateLockError } from "../file-system/operations.ts";
 import { type GitIndexEntry, GitOperations } from "../git/operations.ts";
+import { parseFrontmatter } from "../markdown/frontmatter.ts";
 import {
 	type AcceptanceCriterion,
 	type BacklogConfig,
@@ -2832,8 +2833,7 @@ export class Core {
 		}
 
 		// Parse the markdown content to extract the decision data
-		const matter = await import("gray-matter");
-		const { data } = matter.default(content);
+		const frontmatter = parseFrontmatter(content).data as Partial<Pick<Decision, "title" | "status" | "date">>;
 
 		const extractSection = (content: string, sectionName: string): string | undefined => {
 			const regex = new RegExp(`## ${sectionName}\\s*([\\s\\S]*?)(?=## |$)`, "i");
@@ -2843,9 +2843,9 @@ export class Core {
 
 		const updatedDecision = {
 			...existingDecision,
-			title: data.title || existingDecision.title,
-			status: data.status || existingDecision.status,
-			date: data.date || existingDecision.date,
+			title: frontmatter.title || existingDecision.title,
+			status: frontmatter.status || existingDecision.status,
+			date: frontmatter.date || existingDecision.date,
 			context: extractSection(content, "Context") || existingDecision.context,
 			decision: extractSection(content, "Decision") || existingDecision.decision,
 			consequences: extractSection(content, "Consequences") || existingDecision.consequences,

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1,8 +1,8 @@
 import { mkdir, rename, stat, unlink } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
-import matter from "gray-matter";
 import lockfile from "proper-lockfile";
 import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
+import { parseFrontmatter } from "../markdown/frontmatter.ts";
 import { parseDecision, parseDocument, parseMilestone, parseTask } from "../markdown/parser.ts";
 import { serializeDecision, serializeDocument, serializeTask } from "../markdown/serializer.ts";
 import type { BacklogConfig, Decision, Document, Milestone, Task, TaskListFilter } from "../types/index.ts";
@@ -1800,7 +1800,7 @@ ${description || `Milestone: ${title}`}`,
 	private parseConfigListValues(content: string): Partial<Record<ConfigListKey, string[]>> {
 		const result: Partial<Record<ConfigListKey, string[]>> = {};
 		try {
-			const data = matter(`---\n${content.trimEnd()}\n---\n`).data as Record<string, unknown>;
+			const { data } = parseFrontmatter(`---\n${content.trimEnd()}\n---\n`);
 			for (const key of CONFIG_LIST_KEYS) {
 				const value = data[key];
 				if (Array.isArray(value)) {
@@ -1836,7 +1836,7 @@ ${description || `Milestone: ${title}`}`,
 
 	private parseDefinitionOfDoneFromYaml(content: string): string[] | undefined {
 		try {
-			const data = matter(`---\n${content.trimEnd()}\n---\n`).data as Record<string, unknown>;
+			const { data } = parseFrontmatter(`---\n${content.trimEnd()}\n---\n`);
 			if (!Object.hasOwn(data, "definition_of_done")) {
 				return undefined;
 			}

--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -1,0 +1,20 @@
+import matter from "gray-matter";
+
+/**
+ * The only place in the codebase that talks to gray-matter.
+ *
+ * gray-matter keeps a module-level cache of parse results keyed by the input string and hands the
+ * same `data` object back to every later caller, so one caller mutating its result silently changes
+ * what the next parse of identical content returns, and a malformed file only throws on its first
+ * parse. Passing an options object skips the cache entirely (gray-matter 4.x only reads and writes
+ * the cache when `options` is falsy), so every call here passes one.
+ */
+export function parseFrontmatter(content: string): { data: Record<string, unknown>; content: string } {
+	const file = matter(content, {});
+	return { data: file.data, content: file.content };
+}
+
+/** Serialize `data` as frontmatter above `content`. */
+export function stringifyFrontmatter(content: string, data: Record<string, unknown>): string {
+	return matter.stringify(content, data, {});
+}

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -1,6 +1,6 @@
-import matter from "gray-matter";
 import type { AcceptanceCriterion, Decision, Document, Milestone, ParsedMarkdown, Task } from "../types/index.ts";
 import { normalizePriorityValue } from "../utils/priority-config.ts";
+import { parseFrontmatter } from "./frontmatter.ts";
 import {
 	AcceptanceCriteriaManager,
 	CommentsManager,
@@ -138,10 +138,7 @@ export function parseMarkdown(content: string): ParsedMarkdown {
 		toParse = content.replace(fmRegex, () => `---\n${processed}\n---`);
 	}
 
-	// Passing an options object bypasses gray-matter's cache. The cache stores the file object
-	// before parsing, so once a malformed file throws, later parses of the same content silently
-	// return empty frontmatter instead of failing again.
-	const parsed = matter(toParse, {});
+	const parsed = parseFrontmatter(toParse);
 	return {
 		frontmatter: parsed.data,
 		content: parsed.content.trim(),

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -1,6 +1,6 @@
-import matter from "gray-matter";
 import type { AcceptanceCriterion, Decision, Document, Task } from "../types/index.ts";
 import { normalizeAssignee } from "../utils/assignee.ts";
+import { stringifyFrontmatter } from "./frontmatter.ts";
 import {
 	AcceptanceCriteriaManager,
 	CommentsManager,
@@ -120,7 +120,7 @@ export function serializeTask(task: Task): string {
 		contentBody = updateTaskFinalSummary(contentBody, task.finalSummary);
 	}
 
-	const serialized = matter.stringify(contentBody, frontmatter);
+	const serialized = stringifyFrontmatter(contentBody, frontmatter);
 	// Ensure there's a blank line between frontmatter and content
 	return serialized.replace(/^(---\n(?:.*\n)*?---)\n(?!$)/, "$1\n\n");
 }
@@ -141,7 +141,7 @@ export function serializeDecision(decision: Decision): string {
 		content += `\n\n## Alternatives\n\n${decision.alternatives}`;
 	}
 
-	return matter.stringify(content, frontmatter);
+	return stringifyFrontmatter(content, frontmatter);
 }
 
 export function serializeDocument(document: Document): string {
@@ -154,7 +154,7 @@ export function serializeDocument(document: Document): string {
 		...(document.tags && document.tags.length > 0 && { tags: document.tags }),
 	};
 
-	return matter.stringify(document.rawContent, frontmatter);
+	return stringifyFrontmatter(document.rawContent, frontmatter);
 }
 
 export function updateTaskAcceptanceCriteria(content: string, criteria: string[]): string {

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -269,7 +269,7 @@ describe("document and decision identity", () => {
 
 	it("never reports healthy when a document or decision file cannot be parsed", async () => {
 		await writeDocument("doc-1 - Alpha.md", "doc-1", "Alpha");
-		// gray-matter rejects an unterminated flow collection; distinct bodies avoid its parse cache.
+		// gray-matter rejects an unterminated flow collection, so these files cannot be parsed at all.
 		await Bun.write(
 			join(core.filesystem.docsDir, "doc-2 - Broken.md"),
 			"---\nid: doc-2\ntitle: [unterminated\n---\n\ndoc body\n",

--- a/src/test/content-identity.test.ts
+++ b/src/test/content-identity.test.ts
@@ -51,7 +51,6 @@ async function writeDecision(filename: string, decision: Decision): Promise<stri
 }
 
 // gray-matter rejects an unterminated flow collection, so these files cannot be parsed at all.
-// Each fixture needs distinct content because gray-matter caches parse results by input string.
 function malformedFrontmatter(id: string): string {
 	return `---\nid: ${id}\ntitle: [unterminated\n---\n\n${id} body\n`;
 }

--- a/src/test/markdown.test.ts
+++ b/src/test/markdown.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { parseFrontmatter } from "../markdown/frontmatter.ts";
 import { parseDecision, parseDocument, parseMarkdown, parseTask } from "../markdown/parser.ts";
 import {
 	serializeDecision,
@@ -380,6 +381,37 @@ describe("malformed frontmatter", () => {
 		for (const parse of [parseDocument, parseDecision, parseTask, parseMarkdown]) {
 			expect(() => parse(malformed)).toThrow();
 		}
+	});
+});
+
+describe("frontmatter parse cache", () => {
+	// gray-matter hands the same data object to every caller that parses identical content, so a
+	// caller mutating its own result used to change what later parses of that content returned.
+	const content = "---\nid: task-608\ntitle: Cache probe\nlabels: [cache]\n---\n\nBody text\n";
+
+	it("gives each parseFrontmatter call an independent result", () => {
+		const first = parseFrontmatter(content);
+		first.data.title = "mutated title";
+		first.data.injected = true;
+		(first.data.labels as string[]).push("mutated label");
+		first.content = "mutated content";
+
+		const second = parseFrontmatter(content);
+		expect(second.data).toEqual({ id: "task-608", title: "Cache probe", labels: ["cache"] });
+		expect(second.content.trim()).toBe("Body text");
+	});
+
+	it("parses a task correctly after an earlier parse of the same content was mutated", () => {
+		const parsed = parseMarkdown(content);
+		parsed.frontmatter.title = "mutated title";
+		parsed.frontmatter.status = "Done";
+		delete parsed.frontmatter.id;
+
+		const task = parseTask(content);
+		expect(task.id).toBe("task-608");
+		expect(task.title).toBe("Cache probe");
+		expect(task.status).toBe("");
+		expect(task.labels).toEqual(["cache"]);
 	});
 });
 


### PR DESCRIPTION
## Problem

`gray-matter` keeps a module-level cache of parse results keyed by the input string and hands the **same** `data` object back to every later caller of identical content. Two consequences bit us twice independently during the Aug 2026 review rounds:

- any caller that mutates its parse result silently changes what the next parse of that content returns;
- a malformed document only throws on its **first** parse, so later parses of the same bytes look like a file with empty frontmatter.

Both incidents were patched locally rather than structurally: `parseMarkdown` passed an options object to dodge the cache, and `parseAssigneeConfigValue` switched to `Bun.YAML.parse`. Every other call site was still exposed.

## Fix

One shared wrapper, `src/markdown/frontmatter.ts`, is now the only module that imports `gray-matter`:

- `parseFrontmatter(content)` -> `matter(content, {})`, returning `{ data, content }`
- `stringifyFrontmatter(content, data)` -> `matter.stringify(content, data, {})`

`gray-matter` 4.0.3 only reads and writes its cache when the `options` argument is falsy (`node_modules/gray-matter/index.js`: *"only cache if there are no options passed"*), so passing an options object opts out of both. Every call site now routes through the wrapper:

- `src/markdown/parser.ts` — `parseMarkdown`
- `src/markdown/serializer.ts` — `serializeTask` / `serializeDecision` / `serializeDocument`
- `src/file-system/operations.ts` — `parseConfigListValues`, `parseDefinitionOfDoneFromYaml`
- `src/core/backlog.ts` — `updateDecisionFromContent` (was a dynamic `import("gray-matter")`)

`parseAssigneeConfigValue` deliberately uses `Bun.YAML.parse` for a single scalar/list value and stays as it is. No frontmatter format, engine, option, or serializer-output change: parsing semantics per site are unchanged, and the serializer keeps writing byte-identical output. Two stale test comments telling readers that fixtures need distinct bodies to dodge the parse cache were dropped.

## Evidence

- Mechanism verified against the installed version, not assumed: with no options, a second parse of the same string returned the mutated title and the malformed fixture threw only on the first attempt; with `{}`, `matter.cache` stayed empty, the second parse was pristine, and the malformed fixture threw every time. A shared options object behaves the same as a fresh one.
- New regression tests in `src/test/markdown.test.ts` (`frontmatter parse cache`): one mutates `parseFrontmatter`'s returned `data` (overwrite, extra key, array push) and `content`, then asserts the next parse of the identical string is pristine; one mutates a `parseMarkdown` result and asserts `parseTask` on the same string still sees the real `id`/`title`/`labels`.
- Those tests were confirmed to catch the old behavior: temporarily reverting the wrapper to a bare `matter(content)` failed both new tests (`title: "mutated title"`, injected key, `id: ""`) plus the pre-existing malformed-frontmatter test; restoring the fix turns them green.
- Serializer parity: `matter.stringify(body, data)` and `matter.stringify(body, {...data}, {})` produce byte-identical strings, and the serializer suites pass.
- `bunx tsc --noEmit` clean, `bun run check .` clean (367 files), `bun run test` green — 2062 pass, 6 skip, 0 fail across 222 files.

Task: BACK-608
