### PR TITLE
BACK-605 - Route all TUI operations through shared core with runtime cwd

### DIFF
--- a/backlog/tasks/back-605 - Route-all-TUI-operations-through-shared-core-with-runtime-cwd.md
+++ b/backlog/tasks/back-605 - Route-all-TUI-operations-through-shared-core-with-runtime-cwd.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-605
 title: Route all TUI operations through shared core with runtime cwd
-status: In Progress
+status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 16:04'
+updated_date: '2026-08-08 16:23'
 labels: []
 dependencies: []
 ordinal: 244000
@@ -19,17 +19,17 @@ TUI board handlers construct Core(process.cwd()) directly at multiple sites in s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No TUI code constructs Core from process.cwd() directly; all handlers reuse the shared core instance or the shared runtime cwd resolver
-- [ ] #2 TUI operations honor BACKLOG_CWD end to end
-- [ ] #3 A repo-wide audit confirms no other interface constructs Core from process.cwd() outside the shared resolver, or aligns the stragglers
-- [ ] #4 Tests or recorded verification evidence cover the BACKLOG_CWD path in the TUI
+- [x] #1 No TUI code constructs Core from process.cwd() directly; all handlers reuse the shared core instance or the shared runtime cwd resolver
+- [x] #2 TUI operations honor BACKLOG_CWD end to end
+- [x] #3 A repo-wide audit confirms no other interface constructs Core from process.cwd() outside the shared resolver, or aligns the stragglers
+- [x] #4 Tests or recorded verification evidence cover the BACKLOG_CWD path in the TUI
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -42,3 +42,49 @@ TUI board handlers construct Core(process.cwd()) directly at multiple sites in s
 5. Tests: unit-test createRuntimeCore honouring BACKLOG_CWD and falling back to process.cwd(); TUI test that presses 'n' with a stub composer that calls the default `persist`, once with BACKLOG_CWD pointing at a fixture (task lands in the fixture while process.cwd() is elsewhere) and once with an explicit core for a second fixture (task lands there, proving the passed instance is reused).
 6. Verify: grep -rn "Core(process.cwd" src/ is empty, bunx tsc --noEmit, bun run check ., bun run test.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+## Implementation
+
+Added one shared resolution path and threaded the existing Core through the TUI.
+
+- `createRuntimeCore(options?)` (src/core/backlog.ts, exported next to `Core`) builds a Core from `resolveRuntimeCwd()`, so `--cwd`/`BACKLOG_CWD` (else `process.cwd()`) is honoured in exactly one place. It fails closed when the override points at a missing directory, matching the CLI entry points.
+- src/ui/board.ts: `renderBoardTui` takes `core?: Core` and all seven handlers (create, edit, complete x2, archive x2, reorder) now call a single `getCore()` closure that returns the caller's instance, memoising a `createRuntimeCore({ enableWatchers: true })` fallback only when no instance was supplied (tests call renderBoardTui directly). Previously each handler built `new Core(process.cwd(), { enableWatchers: true })`.
+- src/ui/unified-view.ts, src/ui/simple-unified-view.ts and src/ui/enhanced-views.ts pass the Core they already hold; enhanced-views no longer builds its own from `process.cwd()`.
+- src/ui/task-viewer-with-search.ts fallback uses `createRuntimeCore` instead of `new Core(process.cwd(), ...)`.
+
+Notable side effect of threading the instance: the board previously bound mutations to `process.cwd()` while rendering from the project root resolved by `requireProjectRoot()`. That diverged not only under BACKLOG_CWD but also whenever the TUI was launched from a subdirectory. Board mutations now share the Core the task viewer already used, so all TUI surfaces read one project root and the board stops creating throwaway watcher-enabled Cores per keypress.
+
+## Interface audit (repo-wide)
+
+Aligned on the shared resolver:
+- src/utils/task-path.ts `getTaskPath` optional-core fallback.
+- src/utils/status.ts `getValidStatuses` optional-core fallback.
+- src/completions/data-providers.ts shell-completion data provider (dropped its local `createCore`).
+
+Already resolver-based, unchanged:
+- Web server: `new BacklogServer(cwd)` at src/cli.ts:5230 with `cwd` from `requireProjectRoot()` -> `requireRuntimeCwd()` -> `resolveRuntimeCwd()`.
+- MCP: `createMcpServer(runtimeCwd.cwd)` from src/commands/mcp.ts, which calls `resolveRuntimeCwd({ cwd: options.cwd })`.
+- Every `new Core(cwd)` in src/cli.ts takes `cwd` from `requireProjectRoot()`/`requireRuntimeCwd()`.
+
+Remaining `process.cwd()` uses that are not project resolution and were left alone:
+- src/server/index.ts:483 saves/restores the process cwd around the bundled-asset `chdir`; it never builds a Core.
+- src/readme.ts writes README.md and a temp board file relative to `process.cwd()` (output path, a separate concern from project resolution).
+- src/commands/help-schema.ts:183 resolves an output directory override for schema generation.
+
+## Verification
+
+- `grep -rn "Core(process.cwd" src/` -> no matches (exit 1).
+- `bunx tsc --noEmit` clean; `bun run check .` clean (367 files); `bun run test` -> 2065 pass, 6 skip, 0 fail across 223 files.
+- New src/test/tui-runtime-cwd.test.ts drives the board's `n` handler through its own `persist` with process.cwd() pointed at an unrelated directory: one case asserts the task lands in BACKLOG_CWD, the other asserts a supplied Core instance wins over BACKLOG_CWD. Both fail against the pre-change board.ts (`Expected length: 1 / Received length: 0`) and pass after.
+- src/test/runtime-cwd.test.ts covers `createRuntimeCore` for the process.cwd() default, the BACKLOG_CWD override, and the invalid-override rejection.
+- PTY verification of a real mutation: cwd = this repo worktree (a different Backlog project), BACKLOG_CWD = a /tmp fixture project holding one task. `expect` spawned `bun src/cli.ts board`, the window title rendered as "Fixture Project - Board" with the fixture's TASK-1, then `a` + Enter produced the "Archived TASK-1" footer and moved `backlog/tasks/task-1 - Second-fixture-task.md` into the fixture's `backlog/archive/tasks/`. The same script against the pre-change board.ts timed out waiting for the footer and left the file in `backlog/tasks/`.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Routed every TUI mutation through the Core instance its caller already holds, with a single `createRuntimeCore()` factory (resolveRuntimeCwd, so --cwd/BACKLOG_CWD then process.cwd()) as the only remaining construction path. All seven board.ts handlers, enhanced-views and the task-viewer fallback no longer build `new Core(process.cwd())`; the same factory now covers the getTaskPath/getValidStatuses fallbacks and the shell-completion provider. Web server and MCP were already resolver-based and unchanged. Verified with `grep -rn 'Core(process.cwd' src/` (no matches), new src/test/tui-runtime-cwd.test.ts plus createRuntimeCore cases in src/test/runtime-cwd.test.ts (both new suites fail against the pre-change board.ts), a PTY run where BACKLOG_CWD archived a fixture task while cwd sat in a different Backlog project, and clean bunx tsc --noEmit, bun run check ., bun run test (2065 pass / 6 skip / 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-605 - Route-all-TUI-operations-through-shared-core-with-runtime-cwd.md
+++ b/backlog/tasks/back-605 - Route-all-TUI-operations-through-shared-core-with-runtime-cwd.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-605
 title: Route all TUI operations through shared core with runtime cwd
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@Claude'
 created_date: '2026-08-08 15:56'
+updated_date: '2026-08-08 16:04'
 labels: []
 dependencies: []
 ordinal: 244000
@@ -29,3 +31,14 @@ TUI board handlers construct Core(process.cwd()) directly at multiple sites in s
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add one shared runtime-core factory next to Core: `createRuntimeCore(options?)` in src/core/backlog.ts, which builds a Core from `resolveRuntimeCwd()` (honours --cwd/BACKLOG_CWD, else process.cwd()). Single resolution path for every surface.
+2. Thread the already-constructed Core into the board TUI: add `core?: Core` to renderBoardTui options; unified-view.ts, simple-unified-view.ts and enhanced-views.ts pass their existing `options.core`. Inside board.ts replace all 7 `new Core(process.cwd(), { enableWatchers: true })` sites (create, edit, complete x2, archive x2, reorder) with one closure that returns the passed instance, falling back to a memoised createRuntimeCore() only when no instance was supplied (tests call renderBoardTui directly).
+3. Remove the remaining TUI cwd construction: src/ui/enhanced-views.ts uses the threaded core instead of `new Core(process.cwd())`; src/ui/task-viewer-with-search.ts fallback uses createRuntimeCore instead of `new Core(process.cwd(), ...)`.
+4. Align non-TUI stragglers on the same factory: src/utils/task-path.ts (getTaskPath fallback), src/utils/status.ts (getValidStatuses fallback), src/completions/data-providers.ts (shell completion data). Audit and record the rest: web server (Core built from requireProjectRoot in cli.ts) and MCP (resolveRuntimeCwd in commands/mcp.ts) are already resolver-based; src/server/index.ts process.cwd() is asset-dir chdir bookkeeping, src/readme.ts writes README relative to process.cwd() (output path, not project resolution).
+5. Tests: unit-test createRuntimeCore honouring BACKLOG_CWD and falling back to process.cwd(); TUI test that presses 'n' with a stub composer that calls the default `persist`, once with BACKLOG_CWD pointing at a fixture (task lands in the fixture while process.cwd() is elsewhere) and once with an explicit core for a second fixture (task lands there, proving the passed instance is reused).
+6. Verify: grep -rn "Core(process.cwd" src/ is empty, bunx tsc --noEmit, bun run check ., bun run test.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/back-605 - Route-all-TUI-operations-through-shared-core-with-runtime-cwd.md
+++ b/backlog/tasks/back-605 - Route-all-TUI-operations-through-shared-core-with-runtime-cwd.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 16:23'
+updated_date: '2026-08-08 16:41'
 labels: []
 dependencies: []
 ordinal: 244000
@@ -81,10 +81,26 @@ Remaining `process.cwd()` uses that are not project resolution and were left alo
 - New src/test/tui-runtime-cwd.test.ts drives the board's `n` handler through its own `persist` with process.cwd() pointed at an unrelated directory: one case asserts the task lands in BACKLOG_CWD, the other asserts a supplied Core instance wins over BACKLOG_CWD. Both fail against the pre-change board.ts (`Expected length: 1 / Received length: 0`) and pass after.
 - src/test/runtime-cwd.test.ts covers `createRuntimeCore` for the process.cwd() default, the BACKLOG_CWD override, and the invalid-override rejection.
 - PTY verification of a real mutation: cwd = this repo worktree (a different Backlog project), BACKLOG_CWD = a /tmp fixture project holding one task. `expect` spawned `bun src/cli.ts board`, the window title rendered as "Fixture Project - Board" with the fixture's TASK-1, then `a` + Enter produced the "Archived TASK-1" footer and moved `backlog/tasks/task-1 - Second-fixture-task.md` into the fixture's `backlog/archive/tasks/`. The same script against the pre-change board.ts timed out waiting for the footer and left the file in `backlog/tasks/`.
+
+## Review follow-up (Codex P2 on PR #876, thread src/core/backlog.ts:3306)
+
+`createRuntimeCore` used `resolveRuntimeCwd()` verbatim, but the CLI goes `requireProjectRoot()` -> `findBacklogRoot()`, which ascends from the resolved directory to the actual project root. So when BACKLOG_CWD (or the shell cwd, for fallback callers) pointed at a *subdirectory* of a valid project, the factory targeted `<subdir>/backlog`, which does not exist: shell completions silently returned empty task/label/assignee lists while CLI commands on the same environment worked. That is the same cross-interface divergence this task exists to remove, so it was fixed here rather than deferred.
+
+Fix: `createRuntimeCore` now resolves the runtime cwd and then walks up with the existing `findBacklogRoot`, mirroring `requireProjectRoot`.
+
+Not-found semantics: when `findBacklogRoot` returns null the factory keeps the resolved directory as the project root (`(await findBacklogRoot(cwd)) ?? cwd`) instead of exiting the way `requireProjectRoot` does. That preserves the exact pre-change behaviour of every caller — these are optional-core fallbacks in library code, not CLI entry points, so completions must degrade to their static fallbacks and never crash the shell. An invalid BACKLOG_CWD still rejects from `resolveRuntimeCwd` (fail closed), which `withCore` swallows into the static fallback. No semantics fork: exiting the process was never an option for these call sites.
+
+Coverage added to src/test/runtime-cwd.test.ts: BACKLOG_CWD at a nested subdirectory resolves to the parent project root; the same via process.cwd(); no-project stays on the resolved directory; and completion providers (`getTaskIds`/`getLabels`/`getAssignees`) read the parent project from a subdirectory plus two graceful-degradation cases. The three subdirectory assertions fail without the ascent, reproducing Codex's empty-`getTaskIds()` finding.
+
+CLI-level confirmation with BACKLOG_CWD pointing at `<fixture>/packages/cli` inside an initialized fixture project:
+- after: `bun src/cli.ts completion __complete "backlog task view " 18` -> `TASK-1`, `--plain`, `--json`
+- before: same command -> `--plain`, `--json` only (task ID missing)
+
+Re-verified: `bunx tsc --noEmit` clean, `bun run check .` clean (367 files), `bun run test` -> 2071 pass, 6 skip, 0 fail (2077 tests, 223 files).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Routed every TUI mutation through the Core instance its caller already holds, with a single `createRuntimeCore()` factory (resolveRuntimeCwd, so --cwd/BACKLOG_CWD then process.cwd()) as the only remaining construction path. All seven board.ts handlers, enhanced-views and the task-viewer fallback no longer build `new Core(process.cwd())`; the same factory now covers the getTaskPath/getValidStatuses fallbacks and the shell-completion provider. Web server and MCP were already resolver-based and unchanged. Verified with `grep -rn 'Core(process.cwd' src/` (no matches), new src/test/tui-runtime-cwd.test.ts plus createRuntimeCore cases in src/test/runtime-cwd.test.ts (both new suites fail against the pre-change board.ts), a PTY run where BACKLOG_CWD archived a fixture task while cwd sat in a different Backlog project, and clean bunx tsc --noEmit, bun run check ., bun run test (2065 pass / 6 skip / 0 fail).
+Routed every TUI mutation through the Core instance its caller already holds, with a single `createRuntimeCore()` factory as the only remaining construction path: it resolves the runtime working directory (--cwd/BACKLOG_CWD, else process.cwd()) and then ascends to the project root via findBacklogRoot, mirroring the CLI's requireProjectRoot; when no project is found it keeps the resolved directory so optional-core fallbacks (notably shell completions) degrade gracefully instead of exiting. All seven board.ts handlers, enhanced-views and the task-viewer fallback no longer build `new Core(process.cwd())`; the same factory covers the getTaskPath/getValidStatuses fallbacks and the completion data providers. Web server and MCP were already resolver-based and unchanged. Verified with `grep -rn 'Core(process.cwd' src/` (no matches), new src/test/tui-runtime-cwd.test.ts and createRuntimeCore/completion cases in src/test/runtime-cwd.test.ts (each new assertion confirmed failing against the pre-change code), a PTY run where BACKLOG_CWD archived a fixture task while cwd sat in a different Backlog project, a CLI completion run resolving TASK-1 from a project subdirectory, and clean bunx tsc --noEmit, bun run check ., bun run test (2071 pass / 6 skip / 0 fail).
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/completions/data-providers.ts
+++ b/src/completions/data-providers.ts
@@ -1,4 +1,4 @@
-import { Core } from "../index.ts";
+import { type Core, createRuntimeCore } from "../core/backlog.ts";
 import type { BacklogConfig } from "../types/index.ts";
 import { getPriorityValues } from "../utils/priority-config.ts";
 import { getTaskTypeValues } from "../utils/task-type-config.ts";
@@ -6,18 +6,11 @@ import { getTaskTypeValues } from "../utils/task-type-config.ts";
 type CoreCallback<T> = (core: Core) => Promise<T>;
 
 /**
- * Create a Core instance bound to the current working directory.
- */
-function createCore(): Core {
-	return new Core(process.cwd());
-}
-
-/**
  * Execute a callback with a Core instance, returning a fallback value if anything fails.
  */
 async function withCore<T>(callback: CoreCallback<T>, fallback: T): Promise<T> {
 	try {
-		const core = createCore();
+		const core = await createRuntimeCore();
 		return await callback(core);
 	} catch {
 		return fallback;

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -32,6 +32,7 @@ import {
 } from "../utils/document-path.ts";
 import { type ContentIdentityReport, detectContentIdentityIssues } from "../utils/duplicate-detection.ts";
 import { openInEditor } from "../utils/editor.ts";
+import { findBacklogRoot } from "../utils/find-backlog-root.ts";
 import { generateNextDocId } from "../utils/id-generators.ts";
 import {
 	createMilestoneFilterMatcher,
@@ -3297,11 +3298,13 @@ export class Core {
 }
 
 /**
- * Builds a Core bound to the working directory every interface resolves the same way
- * (`--cwd`/`BACKLOG_CWD`, else `process.cwd()`). Prefer passing an existing Core; use this
- * only where no instance is available.
+ * Builds a Core bound to the project every interface resolves the same way: the runtime working
+ * directory (`--cwd`/`BACKLOG_CWD`, else `process.cwd()`), then walked up to the project root just
+ * like the CLI commands do. When no project is found the resolved directory is used as-is, so
+ * callers keep degrading to their own fallbacks instead of failing.
+ * Prefer passing an existing Core; use this only where no instance is available.
  */
 export async function createRuntimeCore(options?: { enableWatchers?: boolean }): Promise<Core> {
 	const { cwd } = await resolveRuntimeCwd();
-	return new Core(cwd, options);
+	return new Core((await findBacklogRoot(cwd)) ?? cwd, options);
 }

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -48,6 +48,7 @@ import {
 	normalizeId,
 } from "../utils/prefix-config.ts";
 import { formatValidPriorityValues, normalizePriorityValue, resolvePriorityValue } from "../utils/priority-config.ts";
+import { resolveRuntimeCwd } from "../utils/runtime-cwd.ts";
 import {
 	getCanonicalStatus as resolveCanonicalStatus,
 	getValidStatuses as resolveValidStatuses,
@@ -3293,4 +3294,14 @@ export class Core {
 			identityIndex,
 		};
 	}
+}
+
+/**
+ * Builds a Core bound to the working directory every interface resolves the same way
+ * (`--cwd`/`BACKLOG_CWD`, else `process.cwd()`). Prefer passing an existing Core; use this
+ * only where no instance is available.
+ */
+export async function createRuntimeCore(options?: { enableWatchers?: boolean }): Promise<Core> {
+	const { cwd } = await resolveRuntimeCwd();
+	return new Core(cwd, options);
 }

--- a/src/test/runtime-cwd.test.ts
+++ b/src/test/runtime-cwd.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createRuntimeCore } from "../core/backlog.ts";
+import { getAssignees, getLabels, getStatuses, getTaskIds } from "../completions/data-providers.ts";
+import { Core, createRuntimeCore } from "../core/backlog.ts";
 import { BACKLOG_CWD_ENV, resolveRuntimeCwd } from "../utils/runtime-cwd.ts";
+import { initializeTestProject } from "./test-utils.ts";
 
 describe("resolveRuntimeCwd", () => {
 	let testDir: string;
@@ -98,10 +100,76 @@ describe("resolveRuntimeCwd", () => {
 			await expectCanonicalPath(core.filesystem.rootDir, projectDir);
 		});
 
+		it("ascends to the project root when BACKLOG_CWD points at a subdirectory", async () => {
+			const projectDir = join(testDir, "project");
+			const nestedDir = join(projectDir, "packages", "web", "src");
+			await initializeTestProject(new Core(projectDir), "Nested Override Project");
+			await mkdir(nestedDir, { recursive: true });
+			process.env[BACKLOG_CWD_ENV] = nestedDir;
+
+			const core = await createRuntimeCore();
+
+			await expectCanonicalPath(core.filesystem.rootDir, projectDir);
+		});
+
+		it("ascends to the project root from a subdirectory of process.cwd()", async () => {
+			const projectDir = join(testDir, "project");
+			const nestedDir = join(projectDir, "docs", "guides");
+			await initializeTestProject(new Core(projectDir), "Nested Cwd Project");
+			await mkdir(nestedDir, { recursive: true });
+			process.chdir(nestedDir);
+
+			const core = await createRuntimeCore();
+
+			await expectCanonicalPath(core.filesystem.rootDir, projectDir);
+		});
+
+		it("stays on the resolved directory when no project is found", async () => {
+			const nestedDir = join(testDir, "no-project", "nested");
+			await mkdir(nestedDir, { recursive: true });
+			process.env[BACKLOG_CWD_ENV] = nestedDir;
+
+			const core = await createRuntimeCore();
+
+			await expectCanonicalPath(core.filesystem.rootDir, nestedDir);
+		});
+
 		it("fails closed when BACKLOG_CWD points at a missing directory", async () => {
 			process.env[BACKLOG_CWD_ENV] = join(testDir, "missing");
 
 			await expect(createRuntimeCore()).rejects.toThrow(`Invalid directory from ${BACKLOG_CWD_ENV}`);
+		});
+	});
+
+	describe("shell completion data providers", () => {
+		it("reads the parent project when BACKLOG_CWD points at a subdirectory", async () => {
+			const projectDir = join(testDir, "project");
+			const nestedDir = join(projectDir, "packages", "cli");
+			const core = new Core(projectDir);
+			await initializeTestProject(core, "Completion Project");
+			await mkdir(nestedDir, { recursive: true });
+			await core.createTaskFromInput({ title: "Completion task", labels: ["ui"], assignee: ["@alex"] });
+			process.env[BACKLOG_CWD_ENV] = nestedDir;
+
+			expect(await getTaskIds()).toEqual(["TASK-1"]);
+			expect(await getLabels()).toEqual(["ui"]);
+			expect(await getAssignees()).toEqual(["@alex"]);
+		});
+
+		it("degrades to static fallbacks when no project is found", async () => {
+			const nestedDir = join(testDir, "no-project", "nested");
+			await mkdir(nestedDir, { recursive: true });
+			process.env[BACKLOG_CWD_ENV] = nestedDir;
+
+			expect(await getTaskIds()).toEqual([]);
+			expect(await getStatuses()).toEqual(["To Do", "In Progress", "Done"]);
+		});
+
+		it("degrades to static fallbacks when BACKLOG_CWD is invalid", async () => {
+			process.env[BACKLOG_CWD_ENV] = join(testDir, "missing");
+
+			expect(await getTaskIds()).toEqual([]);
+			expect(await getStatuses()).toEqual(["To Do", "In Progress", "Done"]);
 		});
 	});
 });

--- a/src/test/runtime-cwd.test.ts
+++ b/src/test/runtime-cwd.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createRuntimeCore } from "../core/backlog.ts";
 import { BACKLOG_CWD_ENV, resolveRuntimeCwd } from "../utils/runtime-cwd.ts";
 
 describe("resolveRuntimeCwd", () => {
@@ -78,5 +79,29 @@ describe("resolveRuntimeCwd", () => {
 		process.env[BACKLOG_CWD_ENV] = join(testDir, "missing");
 
 		await expect(resolveRuntimeCwd()).rejects.toThrow(`Invalid directory from ${BACKLOG_CWD_ENV}`);
+	});
+
+	describe("createRuntimeCore", () => {
+		it("binds the Core to process.cwd() when no override is provided", async () => {
+			const core = await createRuntimeCore();
+
+			await expectCanonicalPath(core.filesystem.rootDir, testDir);
+		});
+
+		it("binds the Core to BACKLOG_CWD when the override is provided", async () => {
+			const projectDir = join(testDir, "workspace", "project");
+			await mkdir(projectDir, { recursive: true });
+			process.env[BACKLOG_CWD_ENV] = projectDir;
+
+			const core = await createRuntimeCore();
+
+			await expectCanonicalPath(core.filesystem.rootDir, projectDir);
+		});
+
+		it("fails closed when BACKLOG_CWD points at a missing directory", async () => {
+			process.env[BACKLOG_CWD_ENV] = join(testDir, "missing");
+
+			await expect(createRuntimeCore()).rejects.toThrow(`Invalid directory from ${BACKLOG_CWD_ENV}`);
+		});
 	});
 });

--- a/src/test/tui-runtime-cwd.test.ts
+++ b/src/test/tui-runtime-cwd.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Core } from "../core/backlog.ts";
+import type { Task, TaskCreateInput } from "../types/index.ts";
+import { renderBoardTui } from "../ui/board.ts";
+import { createScreen } from "../ui/tui.ts";
+import { BACKLOG_CWD_ENV } from "../utils/runtime-cwd.ts";
+import { initializeTestProject, withTimeout } from "./test-utils.ts";
+
+type EmittingScreen = ReturnType<typeof createScreen> & { emit(event: string): void; destroy(): void };
+
+/**
+ * Drives the board's "new task" handler and returns the project directory the task landed in.
+ * The stubbed composer calls the handler's own `persist`, which is where the board resolves Core.
+ */
+async function createTaskFromBoardKeypress(options?: { core?: Core }): Promise<Task | null> {
+	const ttyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+	const screen = createScreen({ smartCSR: false }) as EmittingScreen;
+	let created: Task | null = null;
+	try {
+		const boardPromise = renderBoardTui([], ["To Do", "Done"], "horizontal", 20, {
+			screen,
+			core: options?.core,
+			taskComposer: async ({ persist }) => {
+				const input: TaskCreateInput = { title: "Runtime cwd task", status: "To Do" };
+				created = await persist(input);
+				return created;
+			},
+		});
+		screen.emit("key n");
+		for (let attempt = 0; attempt < 200 && created === null; attempt += 1) {
+			await Bun.sleep(10);
+		}
+		screen.emit("key q");
+		await withTimeout(boardPromise, "board close after task creation", 2000);
+	} finally {
+		screen.destroy();
+		if (ttyDescriptor) Object.defineProperty(process.stdout, "isTTY", ttyDescriptor);
+		else Reflect.deleteProperty(process.stdout, "isTTY");
+	}
+	return created;
+}
+
+describe("board TUI runtime working directory", () => {
+	let overrideDir: string;
+	let instanceDir: string;
+	let unrelatedDir: string;
+	let originalCwd: string;
+	let originalBacklogCwd: string | undefined;
+
+	beforeEach(async () => {
+		overrideDir = await mkdtemp(join(tmpdir(), "backlog-tui-cwd-override-"));
+		instanceDir = await mkdtemp(join(tmpdir(), "backlog-tui-cwd-instance-"));
+		unrelatedDir = await mkdtemp(join(tmpdir(), "backlog-tui-cwd-unrelated-"));
+		await initializeTestProject(new Core(overrideDir), "Override Project");
+		await initializeTestProject(new Core(instanceDir), "Instance Project");
+		originalCwd = process.cwd();
+		originalBacklogCwd = process.env[BACKLOG_CWD_ENV];
+		delete process.env[BACKLOG_CWD_ENV];
+		// The board must never fall back to the shell's directory.
+		process.chdir(unrelatedDir);
+	});
+
+	afterEach(async () => {
+		process.chdir(originalCwd);
+		if (originalBacklogCwd === undefined) delete process.env[BACKLOG_CWD_ENV];
+		else process.env[BACKLOG_CWD_ENV] = originalBacklogCwd;
+		await rm(overrideDir, { recursive: true, force: true });
+		await rm(instanceDir, { recursive: true, force: true });
+		await rm(unrelatedDir, { recursive: true, force: true });
+	});
+
+	it("writes into BACKLOG_CWD when no Core instance is supplied", async () => {
+		process.env[BACKLOG_CWD_ENV] = overrideDir;
+
+		const created = await createTaskFromBoardKeypress();
+
+		expect(created?.title).toBe("Runtime cwd task");
+		expect(await new Core(overrideDir).filesystem.listTasks()).toHaveLength(1);
+		expect(await new Core(unrelatedDir).filesystem.listTasks()).toHaveLength(0);
+	});
+
+	it("reuses the supplied Core instance instead of resolving again", async () => {
+		process.env[BACKLOG_CWD_ENV] = overrideDir;
+
+		const created = await createTaskFromBoardKeypress({ core: new Core(instanceDir) });
+
+		expect(created?.title).toBe("Runtime cwd task");
+		expect(await new Core(instanceDir).filesystem.listTasks()).toHaveLength(1);
+		expect(await new Core(overrideDir).filesystem.listTasks()).toHaveLength(0);
+	});
+});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -6,7 +6,7 @@ import {
 	generateKanbanBoardWithMetadata,
 	generateMilestoneGroupedBoard,
 } from "../board.ts";
-import { Core } from "../core/backlog.ts";
+import { type Core, createRuntimeCore } from "../core/backlog.ts";
 import type { Milestone, Task, TaskCreateInput } from "../types/index.ts";
 import { copyToClipboard } from "../utils/clipboard.ts";
 import { areLabelSelectionsEqual, collectAvailableLabels } from "../utils/label-filter.ts";
@@ -247,6 +247,8 @@ export async function renderBoardTui(
 	_layout: BoardLayout,
 	_maxColumnWidth: number,
 	options?: {
+		/** Core instance the board mutates through. Falls back to the runtime working directory. */
+		core?: Core;
 		viewSwitcher?: import("./view-switcher.ts").ViewSwitcher;
 		onTaskSelect?: (task: Task) => void;
 		onTabPress?: () => Promise<void>;
@@ -330,6 +332,13 @@ export async function renderBoardTui(
 		let pendingSearchWrap: "to-first" | "to-last" | null = null;
 		let programmaticColumnSelection = false;
 		let renderingView = false;
+		let fallbackCore: Core | null = null;
+		// Board mutations reuse the caller's Core so every surface reads the same project root.
+		const getCore = async (): Promise<Core> => {
+			if (options?.core) return options.core;
+			fallbackCore ??= await createRuntimeCore({ enableWatchers: true });
+			return fallbackCore;
+		};
 		const configuredTaskTypes = getTaskTypeValues(options?.types);
 		const sharedFilters = {
 			searchQuery: options?.filters?.searchQuery ?? "",
@@ -1022,7 +1031,7 @@ export async function renderBoardTui(
 						priorities: options?.priorities,
 						persist: async (input) => {
 							if (options?.createTask) return options.createTask(input);
-							const core = new Core(process.cwd(), { enableWatchers: true });
+							const core = await getCore();
 							const config = await core.fs.loadConfig();
 							return (await core.createTaskFromInput(input, config?.autoCommit ?? false)).task;
 						},
@@ -1212,7 +1221,7 @@ export async function renderBoardTui(
 
 		const openTaskEditor = async (task: Task) => {
 			try {
-				const core = new Core(process.cwd(), { enableWatchers: true });
+				const core = await getCore();
 				const result = await core.editTaskInTui(task.id, screen, task);
 				if (result.reason === "read_only") {
 					const branchInfo = result.task?.branch ? ` from branch "${result.task.branch}"` : "";
@@ -1306,7 +1315,7 @@ export async function renderBoardTui(
 
 				if (confirmed) {
 					try {
-						const core = new Core(process.cwd(), { enableWatchers: true });
+						const core = await getCore();
 						const result = await completeTaskFromTui(core, task);
 
 						if (result.success) {
@@ -1344,7 +1353,7 @@ export async function renderBoardTui(
 
 				if (confirmed) {
 					try {
-						const core = new Core(process.cwd(), { enableWatchers: true });
+						const core = await getCore();
 						const config = await core.fs.loadConfig();
 						const success = await core.archiveTask(task.id, config?.autoCommit ?? false);
 
@@ -1393,7 +1402,7 @@ export async function renderBoardTui(
 			}
 
 			try {
-				const core = new Core(process.cwd(), { enableWatchers: true });
+				const core = await getCore();
 				const config = await core.fs.loadConfig();
 
 				// Get the final state from the projection
@@ -1551,7 +1560,7 @@ export async function renderBoardTui(
 
 			if (confirmed) {
 				try {
-					const core = new Core(process.cwd(), { enableWatchers: true });
+					const core = await getCore();
 					const result = await completeTaskFromTui(core, task);
 
 					if (result.success) {
@@ -1594,7 +1603,7 @@ export async function renderBoardTui(
 
 			if (confirmed) {
 				try {
-					const core = new Core(process.cwd(), { enableWatchers: true });
+					const core = await getCore();
 					const config = await core.fs.loadConfig();
 					const success = await core.archiveTask(task.id, config?.autoCommit ?? false);
 

--- a/src/ui/enhanced-views.ts
+++ b/src/ui/enhanced-views.ts
@@ -102,6 +102,7 @@ export async function runEnhancedViews(options: EnhancedViewOptions): Promise<vo
 
 				// Now show the kanban board
 				await renderBoardTuiWithSwitching(tasks, statuses, {
+					core: options.core,
 					viewSwitcher,
 					onTaskSelect: (task) => {
 						// When user selects a task in kanban, prepare for potential switch back
@@ -119,6 +120,7 @@ export async function runEnhancedViews(options: EnhancedViewOptions): Promise<vo
 		} else {
 			// Data is ready, show kanban board immediately
 			await renderBoardTuiWithSwitching(state.kanbanData.tasks, state.kanbanData.statuses, {
+				core: options.core,
 				viewSwitcher,
 				onTaskSelect: (task) => {
 					viewSwitcher?.updateState({
@@ -171,13 +173,14 @@ async function viewTaskEnhancedWithSwitching(
 async function renderBoardTuiWithSwitching(
 	tasks: Task[],
 	statuses: string[],
-	_options: {
+	options: {
+		core: Core;
 		viewSwitcher?: ViewSwitcher;
 		onTaskSelect?: (task: Task) => void;
 	},
 ): Promise<void> {
 	// Get config for layout and column width
-	const core = new (await import("../core/backlog.ts")).Core(process.cwd());
+	const core = options.core;
 	const config = await core.filesystem.loadConfig();
 	const layout = "horizontal" as const; // Default layout
 	const maxColumnWidth = config?.maxColumnWidth || 20;
@@ -185,6 +188,7 @@ async function renderBoardTuiWithSwitching(
 	// For now, use the original function but we'll need to modify it to support Tab switching
 	// This is a placeholder - we'll need to modify the actual board.ts
 	return renderBoardTui(tasks, statuses, layout, maxColumnWidth, {
+		core,
 		dateFormat: config?.dateFormat,
 		projectName: config?.projectName,
 		priorities: config?.priorities,

--- a/src/ui/simple-unified-view.ts
+++ b/src/ui/simple-unified-view.ts
@@ -114,6 +114,7 @@ export async function runSimpleUnifiedView(options: SimpleUnifiedViewOptions): P
 
 		// Show kanban board with simple view switching
 		await renderBoardTui(kanbanTasks, statuses, layout, maxColumnWidth, {
+			core: options.core,
 			onTaskSelect: (task) => {
 				selectedTask = task;
 			},

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -3,7 +3,7 @@
 import { stdout as output } from "node:process";
 import type { BoxInterface, LineInterface, ScreenInterface, ScrollableTextInterface } from "neo-neo-bblessed";
 import { box, line, scrollabletext } from "neo-neo-bblessed";
-import { Core } from "../core/backlog.ts";
+import { type Core, createRuntimeCore } from "../core/backlog.ts";
 import {
 	buildAcceptanceCriteriaItems,
 	buildDefinitionOfDoneItems,
@@ -220,9 +220,8 @@ export async function viewTaskEnhanced(
 		return;
 	}
 
-	// Get project root and setup services
-	const cwd = process.cwd();
-	const core = options.core || new Core(cwd, { enableWatchers: true });
+	// Reuse the caller's Core so every surface reads the same project root.
+	const core = options.core || (await createRuntimeCore({ enableWatchers: true }));
 
 	// Show loading screen while loading tasks (can be slow with cross-branch loading)
 	let allTasks: Task[];

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -483,6 +483,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 				};
 
 				renderBoardTui(kanbanTasks, statuses, layout, maxColumnWidth, {
+					core: options.core,
 					onTaskSelect: (task) => {
 						selectedTask = task;
 					},

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_STATUSES } from "../constants/index.ts";
-import { Core } from "../core/backlog.ts";
+import { type Core, createRuntimeCore } from "../core/backlog.ts";
 
 type StatusConfigReader = Pick<Core, "filesystem">;
 
@@ -7,7 +7,7 @@ type StatusConfigReader = Pick<Core, "filesystem">;
  * Load valid statuses from project configuration.
  */
 export async function getValidStatuses(core?: StatusConfigReader): Promise<string[]> {
-	const c = core ?? new Core(process.cwd());
+	const c = core ?? (await createRuntimeCore());
 	const config = await c.filesystem.loadConfig();
 	return config?.statuses && config.statuses.length > 0 ? config.statuses : [...DEFAULT_STATUSES];
 }

--- a/src/utils/task-path.ts
+++ b/src/utils/task-path.ts
@@ -1,5 +1,5 @@
 import { basename, join } from "node:path";
-import { Core } from "../core/backlog.ts";
+import { type Core, createRuntimeCore } from "../core/backlog.ts";
 import type { Task } from "../types/index.ts";
 import { AmbiguousIdError } from "./entity-id.ts";
 import {
@@ -76,7 +76,7 @@ export function extractTaskIdFromFilename(filename: string): string | null {
  * For numeric-only IDs, automatically detects the prefix from existing files.
  */
 export async function getTaskPath(taskId: string, core?: Core | TaskPathContext): Promise<string | null> {
-	const coreInstance = core || new Core(process.cwd());
+	const coreInstance = core || (await createRuntimeCore());
 	const activeMatches = await findMatchingTaskPaths(coreInstance.filesystem.tasksDir, taskId);
 	const completedMatches = coreInstance.filesystem.completedDir
 		? await findMatchingTaskPaths(coreInstance.filesystem.completedDir, taskId)


### PR DESCRIPTION
## Problem

The board TUI built its own `Core` from `process.cwd()` in every mutation handler:

```
src/ui/board.ts:1025  new Core(process.cwd(), { enableWatchers: true })   # create task
src/ui/board.ts:1215  ...                                                # edit task
src/ui/board.ts:1309  ...                                                # complete (details popup)
src/ui/board.ts:1347  ...                                                # archive (details popup)
src/ui/board.ts:1396  ...                                                # reorder / move
src/ui/board.ts:1554  ...                                                # complete (board key)
src/ui/board.ts:1597  ...                                                # archive (board key)
```

That bypasses the runtime-cwd resolution every CLI entry point goes through
(`resolveRuntimeCwd`/`requireRuntimeCwd`, added for #854 in BACK-581), so `BACKLOG_CWD`
was silently ignored by the board's own operations. It also diverged from the project root
the board *renders* from (`requireProjectRoot()`), which means the same bug appeared
whenever the TUI was launched from a subdirectory: the board showed one project and `n`/`e`/`c`/`a`/`m`
wrote to another. `src/ui/enhanced-views.ts` and the `src/ui/task-viewer-with-search.ts`
fallback had the same construction, and three non-TUI call sites resolved their own cwd too.

Direction from Alex: all interfaces go via core and read the same core logic — one
resolution path, no per-interface divergence.

## Fix

Pure plumbing; no TUI feature or UX changes.

- **One resolution path.** New `createRuntimeCore(options?)` exported next to `Core` in
  `src/core/backlog.ts` builds a `Core` from `resolveRuntimeCwd()`, so `--cwd`/`BACKLOG_CWD`
  (else `process.cwd()`) is honoured in exactly one place, and an invalid override fails
  closed like the CLI does.
- **Board reuses the caller's instance.** `renderBoardTui` accepts `core?: Core`; all seven
  handlers now go through a single `getCore()` closure that returns the supplied instance.
  A memoised `createRuntimeCore({ enableWatchers: true })` fallback covers only direct
  callers with no instance (the existing TUI tests). `unified-view.ts`,
  `simple-unified-view.ts` and `enhanced-views.ts` pass the `Core` they already hold, so
  production constructs fewer Cores than before, not more.
- **Remaining TUI sites.** `enhanced-views.ts` uses the threaded instance;
  `task-viewer-with-search.ts`'s optional-core fallback uses `createRuntimeCore`.

## Interface audit

Aligned on the shared factory:

| Site | Was |
| --- | --- |
| `src/utils/task-path.ts` `getTaskPath` fallback | `new Core(process.cwd())` |
| `src/utils/status.ts` `getValidStatuses` fallback | `new Core(process.cwd())` |
| `src/completions/data-providers.ts` | local `createCore()` on `process.cwd()` |

Already resolver-based, unchanged:

- **Web server** — `new BacklogServer(cwd)` (`src/cli.ts:5230`) with `cwd` from
  `requireProjectRoot()` → `requireRuntimeCwd()` → `resolveRuntimeCwd()`.
- **MCP** — `createMcpServer(runtimeCwd.cwd)` from `src/commands/mcp.ts`, which calls
  `resolveRuntimeCwd({ cwd: options.cwd })`.
- Every `new Core(cwd)` in `src/cli.ts` takes `cwd` from `requireProjectRoot()`/`requireRuntimeCwd()`.

`process.cwd()` uses deliberately left alone, because they are not project resolution:

- `src/server/index.ts:483` — saves/restores the process cwd around the bundled-asset `chdir`; builds no Core.
- `src/readme.ts` — writes `README.md` and a temp board file relative to `process.cwd()` (output path).
- `src/commands/help-schema.ts:183` — output-directory override for schema generation.

## Evidence

**No Core is built from `process.cwd()` any more:**

```
$ grep -rn "Core(process.cwd" src/
$ echo $?
1
```

**Regression tests.** `src/test/tui-runtime-cwd.test.ts` drives the board's `n` handler
through the handler's own `persist` with `process.cwd()` pointed at an unrelated directory:
one case asserts the task lands in `BACKLOG_CWD`, the other asserts a supplied `Core`
instance wins over `BACKLOG_CWD`. Both fail against the pre-change `board.ts`:

```
$ git checkout src/ui/board.ts && bun test --timeout=20000 src/test/tui-runtime-cwd.test.ts
error: expect(received).toHaveLength(expected)
Expected length: 1
Received length: 0
(fail) board TUI runtime working directory > writes into BACKLOG_CWD when no Core instance is supplied
(fail) board TUI runtime working directory > reuses the supplied Core instance instead of resolving again
 0 pass
 2 fail
```

and pass with the fix:

```
$ bun test --timeout=20000 src/test/tui-runtime-cwd.test.ts
 2 pass
 0 fail
```

`src/test/runtime-cwd.test.ts` adds `createRuntimeCore` cases for the `process.cwd()`
default, the `BACKLOG_CWD` override, and rejection of an invalid override.

**End-to-end PTY run of a real mutation.** cwd = this repo worktree (a different Backlog
project, `BACK-` prefix); `BACKLOG_CWD` = a `/tmp` fixture project holding one task.

```
$ BACKLOG_CWD=$FIXTURE bun src/cli.ts board          # rendered from an unrelated cwd
Project: Project
| To Do | In Progress | Done |
| **TASK-1** - Fixture only task |  |  |

$ BACKLOG_CWD=$FIXTURE expect -f board-archive.expect   # spawn board, send "a", Enter, "q"
ARCHIVED footer seen
$ find $FIXTURE/backlog -name "*.md"
$FIXTURE/backlog/archive/tasks/task-1 - Second-fixture-task.md
```

The same script against the pre-change `board.ts` timed out waiting for the footer and left
the file in `backlog/tasks/` (the board resolved the repo's project, where `TASK-1` does not exist):

```
TIMEOUT waiting for archived footer
$ ls $FIXTURE/backlog/tasks
task-1 - Second-fixture-task.md
```

**Checks:**

```
$ bunx tsc --noEmit      # clean
$ bun run check .        # Checked 367 files. No fixes applied.
$ bun run test           # 2065 pass, 6 skip, 0 fail (2071 tests, 223 files)
```

Behaviour is unchanged when `BACKLOG_CWD` is unset: `resolveRuntimeCwd()` returns
`process.cwd()`, and in the CLI-driven TUI the board now shares the very `Core` the task
viewer was already using.

Task record: `BACK-605` (plan, notes, checked acceptance criteria and Definition of Done are in this branch).
