### PR TITLE
BACK-606 - Fail fast with a clear error on malformed config list values

### DIFF
--- a/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
+++ b/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-606
 title: Fail fast with a clear error on malformed config list values
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-08 15:56'
+updated_date: '2026-08-08 16:42'
 labels: []
 dependencies: []
 ordinal: 245000
@@ -17,15 +19,52 @@ Config list keys are parsed textually and silently accept malformed YAML, for ex
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All list config keys are parsed with the same strict YAML-based parser as default_assignee
-- [ ] #2 A malformed list value aborts startup with a clear error naming the config file and the offending key
-- [ ] #3 The error message starts with "Backlog could not start because"
-- [ ] #4 Tests cover malformed values for each list config key
+- [x] #1 All list config keys are parsed with the same strict YAML-based parser as default_assignee
+- [x] #2 A malformed list value aborts startup with a clear error naming the config file and the offending key
+- [x] #3 The error message starts with "Backlog could not start because"
+- [x] #4 Tests cover malformed values for each list config key
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace the per-key list parsing in src/file-system/operations.ts with one shared strict helper: extract each list key's own YAML block (generalized from extractDefinitionOfDoneYaml) and parse it with Bun.YAML, the same parser default_assignee got in BACK-583. Per-key blocks mean one malformed key can no longer silently change how another key parses.
+2. Delete the textual fallback parseInlineConfigList and the whole-document matter() list parse; keep the accepted shapes exactly as today (inline array, block sequence, empty value, number coercion, quoted commas) so every currently-valid config parses to identical values.
+3. Throw a single clear error when YAML rejects a list key's block: 'Backlog could not start because <config path> has an invalid value for "<key>": <yaml reason>. Edit that key so its value is valid YAML, then run the command again.'
+4. Restructure FileSystem.loadConfig so I/O failures still return null but parse errors propagate instead of being swallowed by the catch-all.
+5. Fold parseAssigneeConfigValue into the shared helper and drop the now-redundant default_assignee check in src/utils/config-watcher.ts (parseConfig already rejects malformed values, so the watcher keeps the last good config).
+6. Verify each entry point surfaces the message rather than a raw stack: CLI (non-zero exit), TUI/board, web server, MCP start; fix only the presentation sites that dump the error object.
+7. Tests: malformed value per list key (statuses, labels, types, priorities, default_assignee) asserting the message and named key, cross-key isolation, valid round-trips (inline, block, empty, quoted commas), plus a CLI end-to-end non-zero exit check.
+8. Deliberately out of scope, to flag for Alex: values that are valid YAML but not a list (e.g. 'statuses: To Do') keep today's silent fallback to defaults rather than becoming a hard error.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation: src/file-system/operations.ts now parses every list config key through one shared strict helper. extractConfigKeyYaml() pulls out just that key's YAML block (its key: line plus continuation lines, stopping at the next key at the same or lower indent) and parseConfigListValue() parses that block with Bun.YAML, the same parser default_assignee got in BACK-583. Deleted parseInlineConfigList (the textual comma/quote split) and the whole-document matter() list parse; parseAssigneeConfigValue is folded into the shared helper. Because each key is parsed in isolation, one malformed key can no longer silently downgrade another key's parse. extractDefinitionOfDoneYaml was replaced by the shared extractor, removing the duplicated block-extraction loop.
+
+On a value YAML rejects, configValueError() throws: 'Backlog could not start because <config path> has an invalid value for "<key>": <yaml reason>. Edit that key so its value is valid YAML, then run the command again.' FileSystem.loadConfig was restructured so I/O failures still return null but parse errors propagate instead of being swallowed by the old catch-all. cli.ts gained reportCommandFailure(), replacing nine duplicated console.error(summary, err) + process.exitCode = 1 pairs; it prints a config error as written (via the new isConfigValueError predicate) and keeps the stack for genuinely unexpected errors.
+
+Backward compatibility evidence: a 38-case parse matrix (inline arrays, block sequences, bare keys, empty arrays, quoted commas, unquoted scalars in arrays, numbers, trailing comments, CRLF, tab indentation, comments inside blocks, duplicate keys, legacy definition_of_done backslashes) produced byte-identical results before and after; the only diffs are the malformed cases, which now fail fast. 'backlog config list' output against this repo's own config.yml is byte-identical before and after.
+
+Entry points verified live in a scratch project with statuses: ["To Do, "In Progress", "Done"]: task list, task <id>, task edit, search, board, config get/set/list, overview, cleanup, agents, browser (web server) and mcp start all exit non-zero and print the single clear message with no stack trace. --version, --help and instructions still work, since they do not read config. The config watcher keeps the last good config instead of publishing a rejected one (covered by existing watcher and server tests).
+
+Deliberate scope decision to flag: a list key holding valid YAML that is not a list (for example 'statuses: To Do') keeps today's behavior of leaving the key unset and falling back to defaults, rather than becoming a hard error. Making that an error would change behavior for configs that parse successfully today, so it is left for an explicit product decision.
+
+Two existing tests wrapped filesystem.parseConfig and counted attempts after calling through; they now count before, because a rejected value throws instead of returning (src/test/config-watcher.test.ts, src/test/server-tasks-spa-fallback.test.ts).
+
+Validation: bunx tsc --noEmit clean, bun run check . clean, bun run test 2062 pass / 6 skip / 0 fail.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+All list config keys (statuses, labels, types, priorities, default_assignee) now parse through one shared strict YAML helper that reads each key's own block with Bun.YAML, replacing the textual comma/quote split and the whole-document parse whose failure silently degraded every list key. A value YAML rejects aborts with 'Backlog could not start because <config path> has an invalid value for "<key>": ...' instead of proceeding with a guessed value; loadConfig propagates it and cli.ts prints it without a stack trace. Verified with a 38-case parse matrix that is byte-identical for every valid config, identical 'config list' output against this repo's config, live checks that CLI, TUI, web server and MCP entry points all exit non-zero with the same message, new tests covering a malformed value for each of the five list keys plus cross-key isolation and a CLI exit-code check, and bun run test 2062 pass / 0 fail.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
+++ b/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 17:25'
+updated_date: '2026-08-08 17:52'
 labels: []
 dependencies: []
 ordinal: 245000
@@ -75,6 +75,26 @@ New regression test 'reads the config key at column 0, not an indented look-alik
 Also rebased onto origin/main after #875 (shared no-cache parseFrontmatter wrapper) and #876 merged. One conflict, in src/file-system/operations.ts: #875 had migrated the old whole-document parseConfigListValues to parseFrontmatter, and this task deletes that method outright, so the deletion stands; the surviving definition_of_done parse uses parseFrontmatter, and no module outside src/markdown/frontmatter.ts imports gray-matter.
 
 Validation on the final head: bunx tsc --noEmit clean, bun run check . clean (369 files), bun run test 2076 pass / 6 skip / 0 fail across 223 files. The earlier note's 2062 figure predates the rebase; upstream test additions account for the difference.
+
+Second review cycle (Codex, 8 P2 threads on PR #877). Triaged each against origin/main before believing it.
+
+Fixed (5) MCP startup prefix: src/commands/mcp.ts printed 'Failed to start MCP server: Backlog could not start because ...', so the required phrase was not at the start. Config value errors are now printed as written.
+
+Fixed (6) MCP fallback root: upgradeToProject loaded the config after reinitializing to a candidate root, so a rejected value escaped, aborted the whole roots loop at the outer catch, and left the server pointed at the bad root with fallback registrations. It now restores the previous root, logs the skip, and continues with the remaining roots, exactly like the existing no-config branch. New test in src/test/mcp-roots-discovery.test.ts; confirmed non-vacuous (without the fix the client sees tools: []).
+
+Fixed (7) bare CLI: bare 'backlog' and 'backlog --plain' caught the error in the pre-dispatch probe and printed 'This directory is not initialized for Backlog.md.' with exit 0, actively misdiagnosing an initialized project. Config value errors now print and exit non-zero.
+
+Fixed (8) Core.ensureConfigLoaded: it suppressed the error, so 'draft list --plain' with no drafts took its empty-list fast path and exited 0 with 'No drafts found.'. It now rethrows config value errors and still suppresses the recoverable git-configuration failures it exists for.
+
+Fixed (1) YAML aliases: a valid config that defines an anchor under one key and aliases it from another ('statuses: &workflow [To Do, Done]' with 'labels: *workflow') aborted every command with 'Unresolved alias', because an alias only resolves against the whole document. When a key's own block is rejected, the value is now read once more in document context before it counts as broken; the document is never read first, so cross-key isolation is preserved and genuinely malformed values still fail fast. Verified against origin/main: the alias shapes now match it exactly.
+
+Refuted (2) quoted keys: origin/main also ignores '"statuses": [...]'. Its whole-document parse did contain the key, but parseConfig's switch is driven by the raw line key ('"statuses"' including quotes), which matches no case, so the value was never assigned. Probed both heads: main and this branch both fall back to default statuses for quoted, single-quoted, and malformed-quoted keys. No behavior change, nothing to fix.
+
+Mostly refuted (3) key-like text in scalars: four of the five shapes probed (inline DoD item text, indented literal block scalar, block sequence item text, onStatusChange block scalar) behave identically on both heads, because the column-0 rule from the previous round already outranks indented look-alikes. One exotic shape does diverge: a multi-line double-quoted flow scalar whose continuation sits at column 0 and begins with a list-key name ('definition_of_done: ["run' / 'statuses: fake"]') lets that line hijack the real key, so statuses falls back to defaults where main returned the configured list. Not patched: distinguishing a column-0 line inside another key's multi-line scalar requires tracking YAML scalar state, i.e. growing the line extractor into a YAML parser. The alternative is a document-parse-first design with per-key isolation only on document failure, which would fix this and honor quoted keys but changes several other shapes; escalated as a design decision rather than patched.
+
+Reported, not decided (4) watcher wrong-type shapes: measured both heads with a live watcher. On origin/main, 'default_assignee: {name: "@alice"}' and 'default_assignee: 42' publish nothing and the cached ['@alice'] is retained. On this branch the candidate is published with defaultAssignee undefined, so the configured assignee is silently dropped at runtime. This is the direct effect of removing the watcher's per-line assignee shape check; it belongs to the wrong-typed-config question already escalated to the owner. Restoring the two-line check would return exact main parity at the cost of duplicating the rule.
+
+Rebased onto origin/main again (BACK-603 #878) with no conflicts. The 51-case parse matrix is unchanged by this round; against main the only remaining diffs are the intended fail-fast rows plus the two documented strictness rows.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
+++ b/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 18:48'
+updated_date: '2026-08-08 21:13'
 labels: []
 dependencies: []
 ordinal: 245000
@@ -119,6 +119,24 @@ Two differences from main worth recording, both in already-accepted families: wi
 New regression test 'does not blame a valid list key for a malformed value under a key Backlog does not read' covers four unread key spellings, the block-sequence variant, the still-fails-fast case, and the colon-bearing sequence item. Confirmed non-vacuous: reverting only the pattern reproduces the reported ConfigValueError blaming statuses.
 
 Validation: bunx tsc --noEmit clean, bun run check . clean, targeted batch of the ten touched test files 155 pass / 0 fail.
+
+Fourth review round: config-error propagation class sweep.
+
+Findings 13 and 14 reproduced exactly. 'draft promote draft-1' exited 0 printing 'Draft draft-1 not found.' while the draft was still on disk, because promoteDraft's catch converted the propagated ConfigValueError to false. 'draft archive draft-1' printed the right message and exited 1 but had already moved the file: backlog/drafts lost the draft and backlog/archive/drafts gained it, so a retry would report it missing.
+
+Finding 12 refuted per the stated criterion. For the compound shape (statuses anchor + labels alias + malformed custom-setting) origin/main produced statuses=default and labels=[], silently discarding both configured values rather than handling it correctly end to end. The coordinator's hypothesis of a literal '*workflow' string was not what happened: main's line fallback rejects both '&workflow [...]' and '*workflow' because neither starts with a bracket, so both keys were simply lost. The branch fails fast with a clear error whose named key can be the alias rather than the true offender, which is the already-accepted compound-diagnostics limitation.
+
+Class sweep instead of static analysis. A hand-rolled enclosing-try analyzer proved unreliable (it missed promoteDraft's known catch), so the class was closed empirically: a runtime sweep runs every config-reading CLI surface against a malformed config, rebuilding a pristine fixture before each command and comparing a file-tree snapshot before and after, so both swallowing and mutate-then-validate ordering are visible. 40 surfaces covered across two passes.
+
+The sweep found two members Codex had not reported: 'milestone add' created the milestone file before the config read, and 'milestone archive' moved the file before it. Both mutated then failed.
+
+Four fixes, all minimal: promoteDraft now rethrows ConfigValueError alongside the existing create-lock rethrow; Core.archiveDraft and Core.archiveMilestone hoist the shouldAutoCommit config read above their file move; MilestoneHandlers.addMilestone calls ensureConfigLoaded before creating the file. Fixing archiveMilestone in Core rather than the handler covers the CLI and MCP surfaces in one place.
+
+Verified safe without changes, from sweep evidence rather than reasoning: milestone rename and remove, task archive, task demote, task edit (status, title, ordinal, milestone), task create, draft create, doc create, decision create, doctor --fix, cleanup, config set, agents --update-instructions, and every read surface. 'doc list' and 'decision list' still exit 0 on a malformed config because they never read config at all; nothing is swallowed there, and adding a config read purely to make them fail would be scope creep, so they are recorded as out of class.
+
+New regression test asserts all four fixed commands exit non-zero, carry the clear message, never say 'not found', and leave the backlog file tree byte-identical. Confirmed non-vacuous: reverting the core and handler changes fails it.
+
+Validation: bunx tsc --noEmit clean, bun run check . clean, 51-case parse matrix unchanged, targeted batch 189 pass / 0 fail across 11 files plus 65 pass / 0 fail across the six milestone and draft lifecycle files, and both sweep passes now report PASS with no mutation for every config-reading surface.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
+++ b/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 18:35'
+updated_date: '2026-08-08 18:48'
 labels: []
 dependencies: []
 ordinal: 245000
@@ -103,6 +103,22 @@ Finding (4) watcher wrong-type: restored exact main parity. Rather than reinstat
 Finding (3) exotic shape: accepted as a documented limitation, no code change. The PR body now names it precisely (a column-0 continuation line of a multi-line quoted flow scalar beginning with a list-key name), bounds it (only quoted multi-line flow values; indented look-alikes, literal and folded block scalars, block sequence items and nested mappings are all handled), and states why it is out: separating a real top-level key from a column-0 line inside another key's multi-line scalar needs YAML scalar-state tracking, i.e. growing the extractor into a YAML parser, which the project's simplicity rules reject for a shape saveConfig never writes.
 
 Validation: bunx tsc --noEmit clean, bun run check . clean, 51-case parse matrix unchanged, targeted batch of the ten touched test files 154 pass / 0 fail. Local full-suite runs remain unreliable on this machine because concurrent agent suites saturate it and starve the filesystem-watcher tests; CI's clean-runner full suite across Linux, macOS and Windows is the authoritative signal.
+
+Final authorized patch round: block-boundary detection.
+
+Regression fixed: extractConfigKeyYaml only recognized identifier-character key lines as block boundaries, so a top-level key whose name uses other characters did not end the previous key's block. A config like 'statuses: [Queued, Done]' followed by 'custom-setting: ["bad]' folded the malformed line into the statuses block, and startup aborted blaming statuses — a valid key the user cannot fix by editing it. Reproduced on both heads before changing anything: origin/main tolerated all these configs (its line fallback ignored the unknown key) while the branch threw for hyphenated, dotted, quoted and digit-leading key names.
+
+Fix: broadened only the boundary pattern to /^\s*(?!-\s)[^\s#][^:]*:/ so any mapping key line ends the previous block regardless of the characters in its name. Key selection still targets only the five list keys, so the malformed unknown key is simply ignored exactly as main ignores it — confirmed, those configs now load with statuses correct. The negative lookahead matters: a sequence item is not a key even when its text contains a colon, and without it a same-indent item such as '- "a: b"' would have cut the block short.
+
+Interaction with the round-2 document-context retry confirmed: after the fix the isolated statuses parse succeeds, so the retry is not reached and no error is raised for the unrelated key. A genuinely malformed statuses value beside a malformed unknown key still fails fast naming statuses.
+
+Verification: a 14-case risk probe covering same-indent and indented sequence items with colons, definition_of_done items containing colons, indented flow continuations, comment and blank lines inside blocks, colon-bearing onStatusChange and date_format values, block-sequence default_assignee, and nested mappings under unknown keys — all 14 match origin/main except the already-documented multi-line-quoted-scalar shape, which is unchanged. The 51-case parse matrix is unchanged, the findings 1-3 shapes probe is unchanged, and the unindented-continuation strictness is unchanged.
+
+Two differences from main worth recording, both in already-accepted families: with a malformed unknown key present, quoted commas in another list key are now read as YAML rather than comma-split (['a, b'] instead of ['a','b']), and where the affected key used a block sequence main silently fell back to default statuses while the branch now returns the configured value.
+
+New regression test 'does not blame a valid list key for a malformed value under a key Backlog does not read' covers four unread key spellings, the block-sequence variant, the still-fails-fast case, and the colon-bearing sequence item. Confirmed non-vacuous: reverting only the pattern reproduces the reported ConfigValueError blaming statuses.
+
+Validation: bunx tsc --noEmit clean, bun run check . clean, targeted batch of the ten touched test files 155 pass / 0 fail.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
+++ b/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 16:42'
+updated_date: '2026-08-08 17:25'
 labels: []
 dependencies: []
 ordinal: 245000
@@ -61,6 +61,20 @@ Deliberate scope decision to flag: a list key holding valid YAML that is not a l
 Two existing tests wrapped filesystem.parseConfig and counted attempts after calling through; they now count before, because a rejected value throws instead of returning (src/test/config-watcher.test.ts, src/test/server-tasks-spa-fallback.test.ts).
 
 Validation: bunx tsc --noEmit clean, bun run check . clean, bun run test 2062 pass / 6 skip / 0 fail.
+
+Review round on PR #877 (head 3ac4b1c1) returned one blocking finding, fixed in a follow-up commit on the same branch.
+
+Blocking finding: extractConfigKeyYaml matched the key with a leading-whitespace-tolerant pattern and took the last match, so a look-alike line nested inside ANOTHER key's value silently outranked the real top-level key. Two reproductions on fully valid YAML that main parses correctly: 'statuses: [top]' followed by 'meta_thing:\n  statuses: [nested1, nested2]' returned the nested values, and 'statuses: [real]' followed by 'notes_thing: |\n  statuses: [fake]' let the line inside the literal block scalar win. Both were silent wrong values on currently-valid configs, violating the backward-compat invariant.
+
+Fix: a config key belongs at column 0, so an unindented match now always outranks an indented look-alike; the last column-0 match wins, and indented matches are used only when the key appears nowhere at column 0. That fallback keeps a key that exists only as an indented line (tab- or space-indented) readable, which is how it parses on main.
+
+Evidence: the parse matrix was extended to 51 cases with the two reproductions plus deep-nested, folded-scalar, block-sequence-top-key, malformed-nested-look-alike, and tab/space-indented-key-only controls, and captured against origin/main and this branch. Pre-fix the branch regressed six valid-config rows (both reproductions, the folded-scalar variant, block-sequence top key, default_assignee nested look-alike, and a valid top-level key made unreadable by a malformed nested look-alike). Post-fix all six match origin/main exactly. The remaining matrix diffs are only the intended fail-fast rows plus one accepted strictness row: a key present ONLY as an indented look-alike now reads its value as YAML instead of a comma split, so 'something:\n  labels: ["a, b"]' yields ["a, b"] rather than ["a", "b"].
+
+New regression test 'reads the config key at column 0, not an indented look-alike inside another key's value' in src/test/config-commands.test.ts covers both reproductions, the block-sequence and malformed-look-alike variants, and the tab/space-indented controls. Confirmed non-vacuous: reverting only the column-0 rule fails it (received ["nested1","nested2"] instead of ["top"]); restoring turns it green.
+
+Also rebased onto origin/main after #875 (shared no-cache parseFrontmatter wrapper) and #876 merged. One conflict, in src/file-system/operations.ts: #875 had migrated the old whole-document parseConfigListValues to parseFrontmatter, and this task deletes that method outright, so the deletion stands; the surviving definition_of_done parse uses parseFrontmatter, and no module outside src/markdown/frontmatter.ts imports gray-matter.
+
+Validation on the final head: bunx tsc --noEmit clean, bun run check . clean (369 files), bun run test 2076 pass / 6 skip / 0 fail across 223 files. The earlier note's 2062 figure predates the rebase; upstream test additions account for the difference.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
+++ b/backlog/tasks/back-606 - Fail-fast-with-a-clear-error-on-malformed-config-list-values.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 17:52'
+updated_date: '2026-08-08 18:35'
 labels: []
 dependencies: []
 ordinal: 245000
@@ -95,6 +95,14 @@ Mostly refuted (3) key-like text in scalars: four of the five shapes probed (inl
 Reported, not decided (4) watcher wrong-type shapes: measured both heads with a live watcher. On origin/main, 'default_assignee: {name: "@alice"}' and 'default_assignee: 42' publish nothing and the cached ['@alice'] is retained. On this branch the candidate is published with defaultAssignee undefined, so the configured assignee is silently dropped at runtime. This is the direct effect of removing the watcher's per-line assignee shape check; it belongs to the wrong-typed-config question already escalated to the owner. Restoring the two-line check would return exact main parity at the cost of duplicating the rule.
 
 Rebased onto origin/main again (BACK-603 #878) with no conflicts. The 51-case parse matrix is unchanged by this round; against main the only remaining diffs are the intended fail-fast rows plus the two documented strictness rows.
+
+Coordinator dispositions applied.
+
+Finding (4) watcher wrong-type: restored exact main parity. Rather than reinstating the deleted value-level YAML shape parser, the check now uses the declared-but-unset idiom the neighbouring definition_of_done check in the same function already uses: 'if (key === "default_assignee" && config.defaultAssignee === undefined) return false'. That is one line, no duplicated parsing, and equivalent to main by construction — a value YAML rejects never reaches the check because parseConfig throws first, and a value YAML reads but the key cannot hold leaves the key unset, which is precisely the set main rejected. Comment marks it as pending the owner's wrong-type decision so it is easy to remove. Verified with a live watcher on both heads: 'default_assignee: {name: "@alice"}' and 'default_assignee: 42' publish nothing and retain the cached ['@alice']. The existing config-watcher test covering malformed inline assignee edits was extended with both wrong-typed shapes and renamed; confirmed non-vacuous, since reverting the one line makes it time out waiting for re-read attempts because the candidate is published on the first parse.
+
+Finding (3) exotic shape: accepted as a documented limitation, no code change. The PR body now names it precisely (a column-0 continuation line of a multi-line quoted flow scalar beginning with a list-key name), bounds it (only quoted multi-line flow values; indented look-alikes, literal and folded block scalars, block sequence items and nested mappings are all handled), and states why it is out: separating a real top-level key from a column-0 line inside another key's multi-line scalar needs YAML scalar-state tracking, i.e. growing the extractor into a YAML parser, which the project's simplicity rules reject for a shape saveConfig never writes.
+
+Validation: bunx tsc --noEmit clean, bun run check . clean, 51-case parse matrix unchanged, targeted batch of the ten touched test files 154 pass / 0 fail. Local full-suite runs remain unreliable on this machine because concurrent agent suites saturate it and starve the filesystem-watcher tests; CI's clean-runner full suite across Linux, macOS and Windows is the authoritative signal.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES } from "./constant
 import { type DuplicateRepairPlan, findLocalDuplicateTaskIds } from "./core/duplicate-task-repair.ts";
 import { initializeProject } from "./core/init.ts";
 import { buildMilestoneBuckets, collectArchivedMilestoneKeys, milestoneKey } from "./core/milestones.ts";
+import { isConfigValueError } from "./file-system/operations.ts";
 import { decisionListJson, printJson, searchJson, taskListJson, taskViewJson } from "./formatters/json-output.ts";
 import { formatTaskPlainText } from "./formatters/task-plain-text.ts";
 import {
@@ -230,6 +231,19 @@ function createMultiValueAccumulator() {
 
 function printMissingRequiredArgument(argumentName: string): void {
 	console.error(`error: missing required argument '${argumentName}'`);
+	process.exitCode = 1;
+}
+
+/**
+ * Reports a command that could not finish. A config value Backlog refuses to read already states
+ * the file, the key, and the fix, so it is printed as written instead of behind a stack trace.
+ */
+function reportCommandFailure(summary: string, error: unknown): void {
+	if (isConfigValueError(error)) {
+		console.error(error.message);
+	} else {
+		console.error(summary, error);
+	}
 	process.exitCode = 1;
 }
 
@@ -1635,8 +1649,7 @@ addHelpSchema(program.command("init [projectName]"), {
 					// Ignore failures in final advisory warning
 				}
 			} catch (err) {
-				console.error("Failed to initialize project", err);
-				process.exitCode = 1;
+				reportCommandFailure("Failed to initialize project", err);
 			}
 		},
 	);
@@ -4510,8 +4523,7 @@ agentsCmd
 				console.log("No files selected for update.");
 			}
 		} catch (err) {
-			console.error("Failed to update agent instructions", err);
-			process.exitCode = 1;
+			reportCommandFailure("Failed to update agent instructions", err);
 		}
 	});
 
@@ -4604,8 +4616,7 @@ const configCmd = addHelpSchema(program.command("config"), {
 			}
 			console.log("\nUse `backlog config list` to review all configuration values.");
 		} catch (err) {
-			console.error("Failed to update configuration", err);
-			process.exitCode = 1;
+			reportCommandFailure("Failed to update configuration", err);
 		}
 	});
 
@@ -4713,8 +4724,7 @@ addHelpSchema(configCmd.command("get <key>"), {
 					process.exit(1);
 			}
 		} catch (err) {
-			console.error("Failed to get config value", err);
-			process.exitCode = 1;
+			reportCommandFailure("Failed to get config value", err);
 		}
 	});
 
@@ -4940,8 +4950,7 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 			await core.filesystem.saveConfig(config);
 			console.log(`Set ${key} = ${value}`);
 		} catch (err) {
-			console.error("Failed to set config value", err);
-			process.exitCode = 1;
+			reportCommandFailure("Failed to set config value", err);
 		}
 	});
 
@@ -4994,8 +5003,7 @@ addHelpSchema(configCmd.command("list"), {
 			console.log(`  checkActiveBranches: ${config.checkActiveBranches ?? "true"}`);
 			console.log(`  activeBranchDays: ${config.activeBranchDays ?? "30"}`);
 		} catch (err) {
-			console.error("Failed to list config values", err);
-			process.exitCode = 1;
+			reportCommandFailure("Failed to list config values", err);
 		}
 	});
 addHelpSchema(program.command("doctor"), {
@@ -5236,8 +5244,7 @@ addHelpSchema(program.command("cleanup"), {
 				console.log("Files have been staged. To commit: git commit -m 'cleanup: Move completed tasks'");
 			}
 		} catch (err) {
-			console.error("Failed to run cleanup", err);
-			process.exitCode = 1;
+			reportCommandFailure("Failed to run cleanup", err);
 		}
 	});
 
@@ -5317,8 +5324,7 @@ program
 			process.once("SIGTERM", () => void shutdown("SIGTERM"));
 			process.once("SIGQUIT", () => void shutdown("SIGQUIT"));
 		} catch (err) {
-			console.error("Failed to start browser interface", err);
-			process.exitCode = 1;
+			reportCommandFailure("Failed to start browser interface", err);
 		}
 	});
 
@@ -5341,8 +5347,7 @@ program
 			const { runOverviewCommand } = await import("./commands/overview.ts");
 			await runOverviewCommand(core);
 		} catch (err) {
-			console.error("Failed to display project overview", err);
-			process.exitCode = 1;
+			reportCommandFailure("Failed to display project overview", err);
 		}
 	});
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -727,7 +727,13 @@ try {
 				const cfg = await core.filesystem.loadConfig();
 				initialized = !!cfg;
 			}
-		} catch {
+		} catch (error) {
+			// An initialized project whose config Backlog refuses to read must not be presented as an
+			// uninitialized directory: report the value and stop, as every other entry point does.
+			if (isConfigValueError(error)) {
+				console.error(error.message);
+				process.exit(1);
+			}
 			initialized = false;
 		}
 

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Command } from "commander";
+import { isConfigValueError } from "../file-system/operations.ts";
 import { createMcpServer } from "../mcp/server.ts";
 import { findBacklogRoot } from "../utils/find-backlog-root.ts";
 import { resolveRuntimeCwd } from "../utils/runtime-cwd.ts";
@@ -98,8 +99,14 @@ function registerStartCommand(mcpCmd: Command): void {
 					process.once("SIGPIPE", () => shutdown("SIGPIPE"));
 				}
 			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				console.error(`Failed to start MCP server: ${message}`);
+				// A config value Backlog refuses to read already names the file, the key, and the fix,
+				// so it is reported as written instead of behind a startup summary.
+				if (isConfigValueError(error)) {
+					console.error(error.message);
+				} else {
+					const message = error instanceof Error ? error.message : String(error);
+					console.error(`Failed to start MCP server: ${message}`);
+				}
 				process.exit(1);
 			}
 		});

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2494,9 +2494,12 @@ export class Core {
 		identifier: string,
 		autoCommit?: boolean,
 	): Promise<{ success: boolean; sourcePath?: string; targetPath?: string; milestone?: Milestone }> {
+		// Read the config before the move, so a config Backlog refuses to read aborts the command
+		// while the milestone is still active rather than after it has been archived.
+		const autoCommitEnabled = await this.shouldAutoCommit(autoCommit);
 		const result = await this.fs.archiveMilestone(identifier);
 
-		if (result.success && result.sourcePath && result.targetPath && (await this.shouldAutoCommit(autoCommit))) {
+		if (result.success && result.sourcePath && result.targetPath && autoCommitEnabled) {
 			const repoRoot = await this.git.stageFileMove(result.sourcePath, result.targetPath);
 			const label = result.milestone?.id ? ` ${result.milestone.id}` : "";
 			const commitPaths = [result.sourcePath, result.targetPath];
@@ -2607,9 +2610,12 @@ export class Core {
 	}
 
 	async archiveDraft(draftId: string, autoCommit?: boolean): Promise<boolean> {
+		// Read the config before the move: a config Backlog refuses to read must abort the command
+		// while the draft is still where the user left it, not after it has been half-archived.
+		const autoCommitEnabled = await this.shouldAutoCommit(autoCommit);
 		const moved = await this.fs.archiveDraft(draftId);
 
-		if (moved && (await this.shouldAutoCommit(autoCommit))) {
+		if (moved && autoCommitEnabled) {
 			await this.commitWrittenFile(
 				`backlog: Archive draft ${normalizeId(draftId, "draft")}`,
 				[moved.sourcePath],
@@ -2654,7 +2660,9 @@ export class Core {
 				return { previousPath, savedPath };
 			});
 		} catch (error) {
-			if (isCreateLockError(error)) {
+			// A missing draft is the only thing "false" may mean here; a config value Backlog refuses to
+			// read must not be reported as a draft that does not exist.
+			if (isCreateLockError(error) || isConfigValueError(error)) {
 				throw error;
 			}
 			return false;

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1,7 +1,7 @@
 import { rename as moveFile, readFile, stat, unlink, writeFile } from "node:fs/promises";
 import { basename, isAbsolute, join, relative } from "node:path";
 import { DEFAULT_DIRECTORIES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
-import { FileSystem, isCreateLockError } from "../file-system/operations.ts";
+import { FileSystem, isConfigValueError, isCreateLockError } from "../file-system/operations.ts";
 import { type GitIndexEntry, GitOperations } from "../git/operations.ts";
 import { parseFrontmatter } from "../markdown/frontmatter.ts";
 import {
@@ -781,6 +781,11 @@ export class Core {
 			const config = await this.fs.loadConfig();
 			this.git.setConfig(config);
 		} catch (error) {
+			// A config value Backlog refuses to read is the user's to fix and must reach the command;
+			// only the recoverable git-configuration failures this guard exists for are suppressed.
+			if (isConfigValueError(error)) {
+				throw error;
+			}
 			// Config loading failed, git operations will work with null config
 			if (process.env.DEBUG) {
 				console.warn("Failed to load config for git operations:", error);

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -61,7 +61,12 @@ interface LockAttemptSettings {
 /** Config keys stored as YAML lists. `default_assignee` also accepts a single scalar. */
 type ConfigListKey = "statuses" | "labels" | "types" | "priorities" | "default_assignee";
 
-const CONFIG_KEY_LINE_PATTERN = /^\s*[A-Za-z_][A-Za-z0-9_]*\s*:/;
+/**
+ * A mapping key line, whatever characters the name uses. Keys Backlog does not read still end the
+ * previous key's block, so an unrelated `custom-setting:` cannot fold its value into the block being
+ * extracted. A sequence item is not a key even when its text contains a colon.
+ */
+const CONFIG_KEY_LINE_PATTERN = /^\s*(?!-\s)[^\s#][^:]*:/;
 
 /**
  * Extract the YAML block that carries one config key's value: its `key:` line plus the lines that

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -58,36 +58,90 @@ interface LockAttemptSettings {
 	retryDelayMs: number;
 }
 
-/** Config keys stored as YAML lists. */
-const CONFIG_LIST_KEYS = ["statuses", "labels", "types", "priorities", "default_assignee"] as const;
-type ConfigListKey = (typeof CONFIG_LIST_KEYS)[number];
+/** Config keys stored as YAML lists. `default_assignee` also accepts a single scalar. */
+type ConfigListKey = "statuses" | "labels" | "types" | "priorities" | "default_assignee";
 
-/** Parse an inline YAML array line (`["a", "b"]`). Returns nothing for any other shape. */
-function parseInlineConfigList(value: string): string[] | undefined {
-	if (!value.startsWith("[") || !value.endsWith("]")) return undefined;
-	return value
-		.slice(1, -1)
-		.split(",")
-		.map((item) => item.trim().replace(/['"]/g, ""))
-		.filter(Boolean);
+const CONFIG_KEY_LINE_PATTERN = /^\s*[A-Za-z_][A-Za-z0-9_]*\s*:/;
+
+/**
+ * Extract the YAML block that carries one config key's value: its `key:` line plus the lines that
+ * continue it, stopping at the next key written at the same or lower indentation. Returns nothing
+ * when the key is absent. The last occurrence wins, which is what YAML does with a repeated key.
+ */
+function extractConfigKeyYaml(content: string, key: string): string | undefined {
+	const lines = content.split(/\r?\n/);
+	const keyPattern = new RegExp(`^(\\s*)${key}\\s*:`);
+	const startIndex = lines.findLastIndex((line) => keyPattern.test(line));
+	if (startIndex === -1) {
+		return undefined;
+	}
+
+	const startIndent = lines[startIndex]?.match(keyPattern)?.[1]?.length ?? 0;
+	const collected: string[] = [];
+
+	for (let index = startIndex; index < lines.length; index++) {
+		const line = lines[index] ?? "";
+		const trimmed = line.trim();
+		const indent = line.length - line.trimStart().length;
+		const isNextKey =
+			index > startIndex && trimmed.length > 0 && indent <= startIndent && CONFIG_KEY_LINE_PATTERN.test(line);
+
+		if (isNextKey) {
+			break;
+		}
+
+		collected.push(line);
+	}
+
+	return collected.join("\n");
+}
+
+const CONFIG_VALUE_ERROR_NAME = "ConfigValueError";
+
+/** Reports a config value Backlog refuses to guess at, naming the file and the offending key. */
+function configValueError(configPath: string, key: string, reason: unknown): Error {
+	const detail = (reason instanceof Error ? reason.message : String(reason)).split("\n")[0]?.trim();
+	const error = new Error(
+		`Backlog could not start because ${configPath} has an invalid value for "${key}"${detail ? `: ${detail}` : ""}. Edit that key so its value is valid YAML, then run the command again.`,
+	);
+	error.name = CONFIG_VALUE_ERROR_NAME;
+	return error;
+}
+
+/** True when an error already explains an unreadable config value, so it needs no extra framing. */
+export function isConfigValueError(error: unknown): error is Error {
+	return error instanceof Error && error.name === CONFIG_VALUE_ERROR_NAME;
 }
 
 /**
- * Parse a `default_assignee` config line value as YAML, so quoting, escapes, and trailing
- * comments are handled by the parser instead of by hand. Returns nothing when the value is
- * not valid YAML or is not a string or list, so callers fail closed rather than guess at
- * malformed input. Shared with the config watcher so both apply the same rule.
+ * Parse one list-valued config key as YAML, so quoting, escapes, block sequences, and trailing
+ * comments are handled by the parser instead of by hand. Only the key's own block is parsed, so a
+ * malformed value for one key cannot change how another key reads. Throws when YAML rejects the
+ * block, so callers fail fast rather than proceed with a guessed value. Returns nothing when the
+ * key is absent, carries no value, or holds a shape it cannot represent; `default_assignee` also
+ * accepts a single scalar.
  */
-export function parseAssigneeConfigValue(value: string): string[] | undefined {
-	let parsed: unknown;
-	try {
-		parsed = Bun.YAML.parse(value);
-	} catch {
+function parseConfigListValue(content: string, key: ConfigListKey, configPath: string): string[] | undefined {
+	const block = extractConfigKeyYaml(content, key);
+	if (block === undefined) {
 		return undefined;
 	}
-	// `default_assignee:` with no value, including the first line of a block sequence.
-	if (parsed === null) return [];
+
+	let parsed: unknown;
+	try {
+		parsed = (Bun.YAML.parse(block) as Record<string, unknown> | null)?.[key];
+	} catch (error) {
+		throw configValueError(configPath, key, error);
+	}
+
+	// `key:` with no value, including the first line of a block sequence.
+	if (parsed === null || parsed === undefined) {
+		return key === "default_assignee" ? [] : undefined;
+	}
 	if (typeof parsed === "string") {
+		if (key !== "default_assignee") {
+			return undefined;
+		}
 		const assignee = parsed.trim();
 		return assignee ? [assignee] : [];
 	}
@@ -1559,27 +1613,25 @@ ${description || `Milestone: ${title}`}`,
 			return this.cachedConfig;
 		}
 
+		const configPath = this.resolvedConfigPath;
+		let content: string;
 		try {
-			const configPath = this.resolvedConfigPath;
-
 			// Check if file exists first to avoid hanging on Windows
 			const file = Bun.file(configPath);
-			const exists = await file.exists();
-
-			if (!exists) {
+			if (!(await file.exists())) {
 				return null;
 			}
-
-			const content = await file.text();
-			const config = this.parseConfig(content);
-
-			// Cache the loaded config
-			this.cachedConfig = config;
-			this.cachedConfigSnapshot = { path: configPath, content };
-			return config;
+			content = await file.text();
 		} catch (_error) {
 			return null;
 		}
+
+		// A value Backlog cannot read is reported, not swallowed: callers must not silently
+		// fall back to defaults while the config file says something else.
+		const config = this.parseConfig(content);
+		this.cachedConfig = config;
+		this.cachedConfigSnapshot = { path: configPath, content };
+		return config;
 	}
 
 	async saveConfig(config: BacklogConfig): Promise<void> {
@@ -1623,7 +1675,13 @@ ${description || `Milestone: ${title}`}`,
 	parseConfig(content: string): BacklogConfig {
 		const config: Partial<BacklogConfig> = {};
 		const parsedDefinitionOfDone = this.parseDefinitionOfDone(content);
-		const parsedListValues = this.parseConfigListValues(content);
+		// Every list key goes through the same strict parse, which throws rather than guess.
+		const parseListValue = (key: ConfigListKey) => parseConfigListValue(content, key, this.resolvedConfigPath);
+		config.statuses = parseListValue("statuses");
+		config.labels = parseListValue("labels");
+		config.types = parseListValue("types");
+		config.priorities = parseListValue("priorities");
+		config.defaultAssignee = parseListValue("default_assignee");
 		const lines = content.split("\n");
 
 		for (const line of lines) {
@@ -1640,27 +1698,12 @@ ${description || `Milestone: ${title}`}`,
 				case "project_name":
 					config.projectName = value.replace(/['"]/g, "");
 					break;
-				case "default_assignee":
-					// Block sequences come from the whole-document parse; everything else is parsed as
-					// YAML per line. A value YAML rejects leaves the key unset rather than being guessed at.
-					config.defaultAssignee = parsedListValues.default_assignee ?? parseAssigneeConfigValue(value);
-					break;
 				case "default_reporter":
 					config.defaultReporter = value.replace(/['"]/g, "");
 					break;
 				case "default_status":
 					config.defaultStatus = value.replace(/['"]/g, "");
 					break;
-				case "statuses":
-				case "labels":
-				case "types":
-				case "priorities": {
-					const parsedList = parsedListValues[key] ?? parseInlineConfigList(value);
-					if (parsedList) {
-						config[key] = parsedList;
-					}
-					break;
-				}
 				case "definition_of_done":
 					if (parsedDefinitionOfDone !== undefined) {
 						config.definitionOfDone = parsedDefinitionOfDone;
@@ -1791,30 +1834,8 @@ ${description || `Milestone: ${title}`}`,
 		return `${lines.join("\n")}\n`;
 	}
 
-	/**
-	 * Parse the list-valued config keys with a real YAML parser so block-style
-	 * sequences and quoted values work like inline arrays. Returns nothing for a
-	 * key when the document is not valid YAML, so the legacy inline-bracket line
-	 * parse stays the fallback.
-	 */
-	private parseConfigListValues(content: string): Partial<Record<ConfigListKey, string[]>> {
-		const result: Partial<Record<ConfigListKey, string[]>> = {};
-		try {
-			const { data } = parseFrontmatter(`---\n${content.trimEnd()}\n---\n`);
-			for (const key of CONFIG_LIST_KEYS) {
-				const value = data[key];
-				if (Array.isArray(value)) {
-					result[key] = value.map((item) => String(item).trim()).filter((item) => item.length > 0);
-				}
-			}
-		} catch {
-			// Not valid YAML; the caller falls back to the line-based parse.
-		}
-		return result;
-	}
-
 	private parseDefinitionOfDone(content: string): string[] | undefined {
-		const definitionOfDoneYaml = this.extractDefinitionOfDoneYaml(content);
+		const definitionOfDoneYaml = extractConfigKeyYaml(content, "definition_of_done");
 		const legacyEscapedDefinitionOfDoneYaml = definitionOfDoneYaml
 			? this.escapeLegacyDefinitionOfDoneBackslashes(definitionOfDoneYaml)
 			: undefined;
@@ -1850,36 +1871,6 @@ ${description || `Milestone: ${title}`}`,
 		} catch {
 			return undefined;
 		}
-	}
-
-	private extractDefinitionOfDoneYaml(content: string): string | undefined {
-		const lines = content.split(/\r?\n/);
-		const keyPattern = /^(\s*)definition_of_done\s*:/;
-		const topLevelKeyPattern = /^\s*[A-Za-z_][A-Za-z0-9_]*\s*:/;
-		const startIndex = lines.findIndex((line) => keyPattern.test(line));
-		if (startIndex === -1) {
-			return undefined;
-		}
-
-		const startLine = lines[startIndex];
-		const startIndent = startLine?.match(keyPattern)?.[1]?.length ?? 0;
-		const collected: string[] = [];
-
-		for (let index = startIndex; index < lines.length; index++) {
-			const line = lines[index] ?? "";
-			const trimmed = line.trim();
-			const indent = line.length - line.trimStart().length;
-			const isNextTopLevelKey =
-				index > startIndex && trimmed.length > 0 && indent <= startIndent && topLevelKeyPattern.test(line);
-
-			if (isNextTopLevelKey) {
-				break;
-			}
-
-			collected.push(line);
-		}
-
-		return collected.join("\n");
 	}
 
 	private escapeLegacyDefinitionOfDoneBackslashes(content: string): string | undefined {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -120,13 +120,22 @@ export function isConfigValueError(error: unknown): error is Error {
 	return error instanceof Error && error.name === CONFIG_VALUE_ERROR_NAME;
 }
 
+/** Read one key from a YAML document, reporting the parse error instead of a value when invalid. */
+function readYamlKey(document: string, key: string): { value: unknown } | { error: unknown } {
+	try {
+		return { value: (Bun.YAML.parse(document) as Record<string, unknown> | null)?.[key] };
+	} catch (error) {
+		return { error };
+	}
+}
+
 /**
  * Parse one list-valued config key as YAML, so quoting, escapes, block sequences, and trailing
- * comments are handled by the parser instead of by hand. Only the key's own block is parsed, so a
- * malformed value for one key cannot change how another key reads. Throws when YAML rejects the
- * block, so callers fail fast rather than proceed with a guessed value. Returns nothing when the
- * key is absent, carries no value, or holds a shape it cannot represent; `default_assignee` also
- * accepts a single scalar.
+ * comments are handled by the parser instead of by hand. The key's own block is what gets parsed, so a
+ * malformed value for one key cannot change how another key reads; only a block YAML rejects outright
+ * is reread in document context, where aliases resolve. Throws when neither read succeeds, so callers
+ * fail fast rather than proceed with a guessed value. Returns nothing when the key is absent, carries
+ * no value, or holds a shape it cannot represent; `default_assignee` also accepts a single scalar.
  */
 function parseConfigListValue(content: string, key: ConfigListKey, configPath: string): string[] | undefined {
 	const block = extractConfigKeyYaml(content, key);
@@ -134,11 +143,19 @@ function parseConfigListValue(content: string, key: ConfigListKey, configPath: s
 		return undefined;
 	}
 
+	const fromBlock = readYamlKey(block, key);
 	let parsed: unknown;
-	try {
-		parsed = (Bun.YAML.parse(block) as Record<string, unknown> | null)?.[key];
-	} catch (error) {
-		throw configValueError(configPath, key, error);
+	if ("value" in fromBlock) {
+		parsed = fromBlock.value;
+	} else {
+		// An alias resolves only against the anchors defined elsewhere in the file, so a block YAML
+		// rejects on its own gets one more read in document context before it counts as broken. The
+		// document is never read first: doing that is what let one broken key change how another reads.
+		const fromDocument = readYamlKey(content, key);
+		if (!("value" in fromDocument)) {
+			throw configValueError(configPath, key, fromBlock.error);
+		}
+		parsed = fromDocument.value;
 	}
 
 	// `key:` with no value, including the first line of a block sequence.

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -67,16 +67,23 @@ const CONFIG_KEY_LINE_PATTERN = /^\s*[A-Za-z_][A-Za-z0-9_]*\s*:/;
  * Extract the YAML block that carries one config key's value: its `key:` line plus the lines that
  * continue it, stopping at the next key written at the same or lower indentation. Returns nothing
  * when the key is absent. The last occurrence wins, which is what YAML does with a repeated key.
+ *
+ * A config key belongs at column 0, so an unindented line always outranks an indented look-alike:
+ * without that rule a `statuses:` line nested inside another key's mapping or block scalar would
+ * hijack the real key. Indented matches are used only when the key appears nowhere at column 0.
  */
 function extractConfigKeyYaml(content: string, key: string): string | undefined {
 	const lines = content.split(/\r?\n/);
 	const keyPattern = new RegExp(`^(\\s*)${key}\\s*:`);
-	const startIndex = lines.findLastIndex((line) => keyPattern.test(line));
+	const keyIndent = (line: string) => line.match(keyPattern)?.[1]?.length;
+	const startIndex = lines.some((line) => keyIndent(line) === 0)
+		? lines.findLastIndex((line) => keyIndent(line) === 0)
+		: lines.findLastIndex((line) => keyIndent(line) !== undefined);
 	if (startIndex === -1) {
 		return undefined;
 	}
 
-	const startIndent = lines[startIndex]?.match(keyPattern)?.[1]?.length ?? 0;
+	const startIndent = keyIndent(lines[startIndex] ?? "") ?? 0;
 	const collected: string[] = [];
 
 	for (let index = startIndex; index < lines.length; index++) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import {
 	type ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Core } from "../core/backlog.ts";
+import type { BacklogConfig } from "../types/index.ts";
 import { getPackageName } from "../utils/app-info.ts";
 import { resolveBacklogDirectory } from "../utils/backlog-directory.ts";
 import { getVersion } from "../utils/version.ts";
@@ -239,8 +240,17 @@ export class McpServer extends Core {
 
 		const previousProjectRoot = this.filesystem.rootDir;
 		this.reinitializeProjectRoot(projectRoot);
-		await this.ensureConfigLoaded();
-		const config = await this.filesystem.loadConfig();
+		let config: BacklogConfig | null;
+		try {
+			await this.ensureConfigLoaded();
+			config = await this.filesystem.loadConfig();
+		} catch (error) {
+			// A root whose config Backlog refuses to read is unusable like one with no config at all:
+			// restore the previous root and keep examining the remaining roots instead of aborting.
+			this.reinitializeProjectRoot(previousProjectRoot);
+			this.log(`Skipping root ${projectRoot}: ${error instanceof Error ? error.message : String(error)}`, options);
+			return false;
+		}
 
 		if (!config) {
 			this.reinitializeProjectRoot(previousProjectRoot);

--- a/src/mcp/tools/milestones/handlers.ts
+++ b/src/mcp/tools/milestones/handlers.ts
@@ -360,6 +360,10 @@ export class MilestoneHandlers {
 			);
 		}
 
+		// Read the config before writing: a config Backlog refuses to read must abort the command
+		// before the milestone file exists, not after.
+		await this.core.ensureConfigLoaded();
+
 		// Create milestone file
 		const milestone = await this.core.filesystem.createMilestone(name, args.description);
 		const milestonePath = await this.core.filesystem.getMilestoneFilePath(milestone.id);

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -445,6 +445,35 @@ describe("Config commands", () => {
 		]);
 	});
 
+	it("reports a rejected config value without half-applying a draft or milestone mutation", async () => {
+		await $`bun ${CLI_PATH} draft create "Draftling" --plain`.cwd(TEST_DIR).nothrow().quiet();
+		await core.filesystem.createMilestone("Mile");
+		const configPath = core.filesystem.configFilePath;
+		const baseConfig = await Bun.file(configPath).text();
+		const listFiles = async () =>
+			(await $`find backlog -type f`.cwd(TEST_DIR).nothrow().quiet().text()).split("\n").sort();
+
+		await Bun.write(configPath, `${baseConfig}statuses: ["To Do]\n`);
+		const before = await listFiles();
+
+		// A swallowed error used to report a draft that still exists as missing, and a mutation ordered
+		// before the first config read used to leave the draft or milestone half-moved.
+		for (const args of [
+			["draft", "promote", "draft-1"],
+			["draft", "archive", "draft-1"],
+			["milestone", "add", "Second"],
+			["milestone", "archive", "Mile"],
+		]) {
+			const result = await $`bun ${CLI_PATH} ${args}`.cwd(TEST_DIR).nothrow().quiet();
+			const stderr = result.stderr.toString();
+			expect(result.exitCode).not.toBe(0);
+			expect(stderr).toContain("Backlog could not start because");
+			expect(stderr).toContain('invalid value for "statuses"');
+			expect(stderr).not.toContain("not found");
+			expect(await listFiles()).toEqual(before);
+		}
+	});
+
 	it("resolves a YAML alias against the anchor defined under another key", () => {
 		// An alias only has meaning in document context, so a list value that uses one must still
 		// resolve even though each key's own block is what gets parsed.

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -363,21 +363,52 @@ describe("Config commands", () => {
 		expect(created.task.assignee).toEqual([quoted]);
 	});
 
-	it("leaves defaultAssignee unset when the value is not valid YAML", async () => {
+	it("refuses to load a list config value that is not valid YAML, naming the file and the key", async () => {
 		const configPath = core.filesystem.configFilePath;
 		const baseConfig = await Bun.file(configPath).text();
-		const loadAssignee = async (line: string) => {
-			await Bun.write(configPath, `${baseConfig}${line}\n`);
-			core.filesystem.invalidateConfigCache();
-			return (await core.filesystem.loadConfig())?.defaultAssignee;
-		};
 
-		// Truncated array, and an unbalanced quote that still opens and closes with brackets.
-		expect(await loadAssignee('default_assignee: ["@alice')).toBeUndefined();
-		expect(await loadAssignee('default_assignee: ["@alice]')).toBeUndefined();
+		for (const key of ["statuses", "labels", "types", "priorities", "default_assignee"]) {
+			// Truncated array, and an unbalanced quote that still opens and closes with brackets.
+			for (const line of [`${key}: ["a`, `${key}: ["a]`]) {
+				await Bun.write(configPath, `${baseConfig}${line}\n`);
+				core.filesystem.invalidateConfigCache();
 
-		const created = await core.createTaskFromInput({ title: "Malformed default assignee" }, false);
-		expect(created.task.assignee).toEqual([]);
+				const failure = await core.filesystem.loadConfig().then(
+					() => undefined,
+					(error: unknown) => (error instanceof Error ? error.message : String(error)),
+				);
+				expect(failure).toBeDefined();
+				expect(failure).toStartWith("Backlog could not start because");
+				expect(failure).toContain(configPath);
+				expect(failure).toContain(`invalid value for "${key}"`);
+			}
+		}
+	});
+
+	it("keeps a malformed list value from changing how another list key reads", async () => {
+		const configPath = core.filesystem.configFilePath;
+		// The commas inside the quoted labels are only safe when labels is parsed as YAML; the
+		// malformed statuses value must be reported instead of downgrading labels to a text split.
+		await Bun.write(configPath, 'project_name: "P"\nstatuses: ["To Do]\nlabels: ["a, b", "c"]\n');
+		core.filesystem.invalidateConfigCache();
+
+		expect(() => core.filesystem.parseConfig('project_name: "P"\nstatuses: ["To Do]\nlabels: ["a, b", "c"]\n')).toThrow(
+			'invalid value for "statuses"',
+		);
+		expect(core.filesystem.parseConfig('project_name: "P"\nlabels: ["a, b", "c"]\n').labels).toEqual(["a, b", "c"]);
+	});
+
+	it("exits non-zero with the config error when a list value is not valid YAML", async () => {
+		const configPath = core.filesystem.configFilePath;
+		const baseConfig = await Bun.file(configPath).text();
+		await Bun.write(configPath, `${baseConfig}statuses: ["To Do]\n`);
+
+		const listed = await $`bun ${CLI_PATH} task list --plain`.cwd(TEST_DIR).nothrow().quiet();
+		const stderr = listed.stderr.toString();
+		expect(listed.exitCode).not.toBe(0);
+		expect(stderr).toContain("Backlog could not start because");
+		expect(stderr).toContain('invalid value for "statuses"');
+		expect(stderr).not.toContain("at parseConfig");
 	});
 
 	it("clears defaultEditor via config set with an explicitly empty value", async () => {

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -421,6 +421,30 @@ describe("Config commands", () => {
 		expect(core.filesystem.parseConfig('project_name: "P"\n  statuses: ["spaced"]\n').statuses).toEqual(["spaced"]);
 	});
 
+	it("does not blame a valid list key for a malformed value under a key Backlog does not read", () => {
+		// Any mapping key ends the previous key's block, whatever characters its name uses. Without that,
+		// the malformed custom-setting line folds into the statuses block and startup blames statuses —
+		// an error the user cannot fix by editing the key it names.
+		for (const unreadKey of ["custom-setting", "my.setting", '"quoted-key"', "2fa"]) {
+			const config = core.filesystem.parseConfig(`project_name: "P"\nstatuses: [Queued, Done]\n${unreadKey}: ["bad]\n`);
+			expect(config.statuses).toEqual(["Queued", "Done"]);
+		}
+
+		// A block-sequence value survives the same shape, and each key is still reported on its own.
+		expect(
+			core.filesystem.parseConfig('project_name: "P"\nstatuses:\n  - Queued\ncustom-setting: ["bad]\n').statuses,
+		).toEqual(["Queued"]);
+		expect(() =>
+			core.filesystem.parseConfig('project_name: "P"\nstatuses: ["Queued]\ncustom-setting: ["bad]\n'),
+		).toThrow('invalid value for "statuses"');
+
+		// A sequence item is not a key even when its text contains a colon, so it must not cut the block.
+		expect(core.filesystem.parseConfig('project_name: "P"\nstatuses:\n- "a: b"\n- Done\n').statuses).toEqual([
+			"a: b",
+			"Done",
+		]);
+	});
+
 	it("resolves a YAML alias against the anchor defined under another key", () => {
 		// An alias only has meaning in document context, so a list value that uses one must still
 		// resolve even though each key's own block is what gets parsed.

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -421,17 +421,41 @@ describe("Config commands", () => {
 		expect(core.filesystem.parseConfig('project_name: "P"\n  statuses: ["spaced"]\n').statuses).toEqual(["spaced"]);
 	});
 
-	it("exits non-zero with the config error when a list value is not valid YAML", async () => {
+	it("resolves a YAML alias against the anchor defined under another key", () => {
+		// An alias only has meaning in document context, so a list value that uses one must still
+		// resolve even though each key's own block is what gets parsed.
+		const shared = core.filesystem.parseConfig(
+			'project_name: "P"\nstatuses: &workflow [To Do, Done]\nlabels: *workflow\n',
+		);
+		expect(shared.statuses).toEqual(["To Do", "Done"]);
+		expect(shared.labels).toEqual(["To Do", "Done"]);
+
+		const scalarAnchor = core.filesystem.parseConfig('project_name: "P"\ndefault_status: &s "To Do"\nstatuses: [*s]\n');
+		expect(scalarAnchor.statuses).toEqual(["To Do"]);
+
+		// Document context must not rescue a value that is genuinely malformed.
+		expect(() => core.filesystem.parseConfig('project_name: "P"\nstatuses: ["To Do]\n')).toThrow(
+			'invalid value for "statuses"',
+		);
+	});
+
+	it("exits non-zero with the config error at every entry point that reads config", async () => {
 		const configPath = core.filesystem.configFilePath;
 		const baseConfig = await Bun.file(configPath).text();
 		await Bun.write(configPath, `${baseConfig}statuses: ["To Do]\n`);
 
-		const listed = await $`bun ${CLI_PATH} task list --plain`.cwd(TEST_DIR).nothrow().quiet();
-		const stderr = listed.stderr.toString();
-		expect(listed.exitCode).not.toBe(0);
-		expect(stderr).toContain("Backlog could not start because");
-		expect(stderr).toContain('invalid value for "statuses"');
-		expect(stderr).not.toContain("at parseConfig");
+		// Bare invocation must not report an initialized project as uninitialized, the empty-list fast
+		// path must not hide the failure, and MCP startup must not bury the message behind a summary.
+		for (const args of [["task", "list", "--plain"], ["--plain"], ["draft", "list", "--plain"], ["mcp", "start"]]) {
+			const result = await $`bun ${CLI_PATH} ${args}`.cwd(TEST_DIR).nothrow().quiet();
+			const stderr = result.stderr.toString();
+			expect(result.exitCode).not.toBe(0);
+			expect(stderr).toStartWith("Backlog could not start because");
+			expect(stderr).toContain('invalid value for "statuses"');
+			expect(stderr).not.toContain("at parseConfig");
+			expect(result.stdout.toString()).not.toContain("not initialized");
+			expect(result.stdout.toString()).not.toContain("No drafts found");
+		}
 	});
 
 	it("clears defaultEditor via config set with an explicitly empty value", async () => {

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -385,17 +385,40 @@ describe("Config commands", () => {
 		}
 	});
 
-	it("keeps a malformed list value from changing how another list key reads", async () => {
-		const configPath = core.filesystem.configFilePath;
+	it("keeps a malformed list value from changing how another list key reads", () => {
 		// The commas inside the quoted labels are only safe when labels is parsed as YAML; the
 		// malformed statuses value must be reported instead of downgrading labels to a text split.
-		await Bun.write(configPath, 'project_name: "P"\nstatuses: ["To Do]\nlabels: ["a, b", "c"]\n');
-		core.filesystem.invalidateConfigCache();
-
 		expect(() => core.filesystem.parseConfig('project_name: "P"\nstatuses: ["To Do]\nlabels: ["a, b", "c"]\n')).toThrow(
 			'invalid value for "statuses"',
 		);
 		expect(core.filesystem.parseConfig('project_name: "P"\nlabels: ["a, b", "c"]\n').labels).toEqual(["a, b", "c"]);
+	});
+
+	it("reads the config key at column 0, not an indented look-alike inside another key's value", () => {
+		// A nested mapping and a block scalar can both contain a line that looks like a config key.
+		const nested = core.filesystem.parseConfig(
+			'project_name: "P"\nstatuses: [top]\nmeta_thing:\n  statuses: [nested1, nested2]\n',
+		);
+		expect(nested.statuses).toEqual(["top"]);
+
+		const blockScalar = core.filesystem.parseConfig(
+			'project_name: "P"\nstatuses: [real]\nnotes_thing: |\n  statuses: [fake]\n',
+		);
+		expect(blockScalar.statuses).toEqual(["real"]);
+
+		// A block-sequence top-level key must win over the look-alike too, and a malformed
+		// look-alike must not make the real key unreadable.
+		const blockSequence = core.filesystem.parseConfig(
+			'project_name: "P"\nstatuses:\n  - Top\nmeta_thing:\n  statuses: [nested]\n',
+		);
+		expect(blockSequence.statuses).toEqual(["Top"]);
+		expect(
+			core.filesystem.parseConfig('project_name: "P"\nstatuses: [top]\nmeta_thing:\n  statuses: ["broken\n').statuses,
+		).toEqual(["top"]);
+
+		// Control: with no column-0 occurrence, an indented key is still the only value there is.
+		expect(core.filesystem.parseConfig('project_name: "P"\n\tstatuses: ["tabbed"]\n').statuses).toEqual(["tabbed"]);
+		expect(core.filesystem.parseConfig('project_name: "P"\n  statuses: ["spaced"]\n').statuses).toEqual(["spaced"]);
 	});
 
 	it("exits non-zero with the config error when a list value is not valid YAML", async () => {

--- a/src/test/config-watcher.test.ts
+++ b/src/test/config-watcher.test.ts
@@ -185,7 +185,7 @@ describe("config watcher", () => {
 		}
 	});
 
-	it("retains the cached defaultAssignee while an inline edit is not valid YAML", async () => {
+	it("retains the cached defaultAssignee while an inline edit is not a usable assignee value", async () => {
 		await core.filesystem.saveConfig({ ...initialConfig, defaultAssignee: ["@alice"] });
 		const baseLines = [
 			'project_name: "Config watcher"',
@@ -196,8 +196,14 @@ describe("config watcher", () => {
 			'task_prefix: "BACK"',
 		];
 		const withAssignee = (line: string) => [baseLines[0], line, ...baseLines.slice(1), ""].join("\n");
-		// Truncated mid-edit, and an unbalanced quote that still opens and closes with brackets.
-		const invalidContents = [withAssignee('default_assignee: ["@alice'), withAssignee('default_assignee: ["@alice]')];
+		// Truncated mid-edit and an unbalanced quote that still opens and closes with brackets, then two
+		// values YAML reads but the key cannot hold: publishing either would drop the cached assignee.
+		const invalidContents = [
+			withAssignee('default_assignee: ["@alice'),
+			withAssignee('default_assignee: ["@alice]'),
+			withAssignee('default_assignee: {name: "@alice"}'),
+			withAssignee("default_assignee: 42"),
+		];
 		const scalarContent = withAssignee('default_assignee: "@carol"');
 		const inlineArrayContent = withAssignee('default_assignee: ["@alice", "@bob"]');
 

--- a/src/test/config-watcher.test.ts
+++ b/src/test/config-watcher.test.ts
@@ -128,7 +128,6 @@ describe("config watcher", () => {
 			]),
 		);
 		core.filesystem.parseConfig = (content) => {
-			const parsed = originalParseConfig(content);
 			const attempts = unusableParseAttempts.get(content);
 			if (attempts !== undefined) {
 				const nextAttempts = attempts + 1;
@@ -137,7 +136,8 @@ describe("config watcher", () => {
 					unusableAttemptResolvers.get(content)?.();
 				}
 			}
-			return parsed;
+			// Counted before parsing: a rejected list value throws instead of returning.
+			return originalParseConfig(content);
 		};
 
 		const published: BacklogConfig[] = [];

--- a/src/test/mcp-roots-discovery.test.ts
+++ b/src/test/mcp-roots-discovery.test.ts
@@ -209,6 +209,29 @@ describe("MCP roots discovery", () => {
 		}
 	});
 
+	it("skips a root whose config value is rejected and keeps examining later roots", async () => {
+		const { uninitializedDir, projectRoot, secondProjectRoot } = await setupDirs();
+		// The first root is a real project whose statuses value Backlog refuses to read.
+		const brokenConfigPath = join(projectRoot, "backlog", "config.yml");
+		const brokenConfig = (await Bun.file(brokenConfigPath).text()).replace(/^statuses:.*$/m, 'statuses: ["To Do]');
+		await Bun.write(brokenConfigPath, brokenConfig);
+
+		const server = await createMcpServer(uninitializedDir);
+		const rootsRef = {
+			current: [pathToFileURL(projectRoot).toString(), pathToFileURL(secondProjectRoot).toString()],
+		};
+		const { client } = await connectRootsClient(server, rootsRef);
+
+		try {
+			const tools = await client.listTools();
+			expect(tools.tools.map((tool) => tool.name)).toContain("task_create");
+			expect(server.filesystem.rootDir).toBe(secondProjectRoot);
+		} finally {
+			await client.close();
+			await server.stop();
+		}
+	});
+
 	it("invalidates cached roots on roots/list_changed and re-resolves on the next request", async () => {
 		const { uninitializedDir, projectRoot, secondProjectRoot } = await setupDirs();
 

--- a/src/test/server-tasks-spa-fallback.test.ts
+++ b/src/test/server-tasks-spa-fallback.test.ts
@@ -819,12 +819,12 @@ describe("BacklogServer task SPA fallback", () => {
 		const originalParseConfig = serverFilesystem.parseConfig.bind(serverFilesystem);
 		const unusableParseAttempts = new Map(unusableContents.map((content) => [content, 0]));
 		serverFilesystem.parseConfig = (content) => {
-			const parsed = originalParseConfig(content);
 			const attempts = unusableParseAttempts.get(content);
 			if (attempts !== undefined) {
 				unusableParseAttempts.set(content, attempts + 1);
 			}
-			return parsed;
+			// Counted before parsing: a rejected list value throws instead of returning.
+			return originalParseConfig(content);
 		};
 
 		let publicationAttempts = 0;

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -61,7 +61,11 @@ function hasValidExplicitValues(content: string, config: BacklogConfig): boolean
 		if (!RECOGNIZED_CONFIG_KEYS.has(key)) continue;
 		if (ARRAY_CONFIG_KEYS.has(key) && !(value.startsWith("[") && value.endsWith("]"))) return false;
 		// default_assignee is not in ARRAY_CONFIG_KEYS because it also accepts scalars and block
-		// sequences; the config parser rejects values YAML cannot read before this check runs.
+		// sequences; the config parser rejects values YAML cannot read before this check runs. A value
+		// YAML reads but the key cannot hold, such as a mapping or a number, leaves the key unset, and
+		// publishing that would drop the configured assignee — so the candidate is rejected and the last
+		// good config stays cached. Pending the open decision on whether such values should fail fast.
+		if (key === "default_assignee" && config.defaultAssignee === undefined) return false;
 		if (key === "definition_of_done" && value.startsWith("[") && !value.endsWith("]")) return false;
 		if (key === "definition_of_done" && config.definitionOfDone === undefined) return false;
 		if ((key === "project_name" || key === "date_format") && !value.replace(/['"]/g, "").trim()) return false;

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -1,7 +1,7 @@
 import { type FSWatcher, unwatchFile, watch, watchFile } from "node:fs";
 import { basename, dirname } from "node:path";
 import type { Core } from "../core/backlog.ts";
-import { type FileSystem, parseAssigneeConfigValue } from "../file-system/operations.ts";
+import type { FileSystem } from "../file-system/operations.ts";
 import type { BacklogConfig } from "../types/index.ts";
 
 export interface ConfigWatcherCallbacks {
@@ -61,8 +61,7 @@ function hasValidExplicitValues(content: string, config: BacklogConfig): boolean
 		if (!RECOGNIZED_CONFIG_KEYS.has(key)) continue;
 		if (ARRAY_CONFIG_KEYS.has(key) && !(value.startsWith("[") && value.endsWith("]"))) return false;
 		// default_assignee is not in ARRAY_CONFIG_KEYS because it also accepts scalars and block
-		// sequences; it is valid when YAML can read it, which is the rule the config parser applies.
-		if (key === "default_assignee" && parseAssigneeConfigValue(value) === undefined) return false;
+		// sequences; the config parser rejects values YAML cannot read before this check runs.
 		if (key === "definition_of_done" && value.startsWith("[") && !value.endsWith("]")) return false;
 		if (key === "definition_of_done" && config.definitionOfDone === undefined) return false;
 		if ((key === "project_name" || key === "date_format") && !value.replace(/['"]/g, "").trim()) return false;
@@ -145,7 +144,8 @@ export function watchConfigFile(filesystem: FileSystem, callbacks: ConfigWatcher
 				}
 				return;
 			} catch {
-				// Atomic writes can temporarily remove or lock the watched path on Windows.
+				// Atomic writes can temporarily remove or lock the watched path on Windows, and the
+				// parser rejects values it cannot read; either way the last good config stays cached.
 			}
 		}
 	};


### PR DESCRIPTION
## Problem

Every list config key except `default_assignee` was still parsed textually. `parseConfig` first tried a
whole-document YAML parse and, whenever that failed, fell back to `parseInlineConfigList` — a naive
"strip brackets, split on commas, delete every quote" pass. Two consequences:

- A malformed value produced a guessed one. `statuses: ["To Do]` (missing closing quote) parsed to
  `["To Do"]` with no warning.
- One malformed key silently corrupted the others. Because the fallback was triggered by the *document*
  failing to parse, `statuses: ["To Do]` also downgraded `labels: ["a, b"]` from `["a, b"]` to
  `["a", "b"]`, and other malformed values (`labels: ["x] # c`) were dropped entirely so the key
  silently fell back to defaults.

`default_assignee` already used strict `Bun.YAML` parsing from BACK-583; the rest did not.

## Fix

`src/file-system/operations.ts` now parses all five list keys (`statuses`, `labels`, `types`,
`priorities`, `default_assignee`) through one shared strict helper:

- `extractConfigKeyYaml(content, key)` extracts just that key's YAML block — its `key:` line plus the
  lines that continue it, stopping at the next key at the same or lower indentation.
- `parseConfigListValue(content, key, configPath)` parses that block with `Bun.YAML`. Because each key
  is parsed in isolation, a malformed value for one key can no longer change how another key reads.
- `parseInlineConfigList`, the whole-document `matter()` list parse, and `parseAssigneeConfigValue` are
  gone; `extractDefinitionOfDoneYaml` was replaced by the shared extractor, removing a duplicated
  block-extraction loop.

On a value YAML rejects, startup aborts with:

```
Backlog could not start because /path/backlog/config.yml has an invalid value for "statuses": YAML Parse error: Unexpected token. Edit that key so its value is valid YAML, then run the command again.
```

`FileSystem.loadConfig` was restructured so I/O failures still return `null` but parse errors propagate
instead of being swallowed by the old catch-all. `cli.ts` gained `reportCommandFailure()`, which replaces
nine duplicated `console.error(summary, err)` + `process.exitCode = 1` pairs: it prints a config error as
written (via the new `isConfigValueError` predicate) and keeps the stack for genuinely unexpected errors.
In the config watcher, the per-line `default_assignee` YAML-shape check was replaced by the same
declared-but-unset idiom the neighbouring `definition_of_done` check already uses, so the watcher keeps
main's exact runtime behaviour with one line instead of a duplicated parser: a value YAML rejects never
reaches it (the parser throws first) and a value YAML reads but the key cannot hold — a mapping, a number —
is rejected so the last good config stays cached.

## Evidence

**Backward compatibility (absolute for well-formed configs).** A 38-case parse matrix — inline arrays,
block sequences, bare keys, empty arrays, quoted commas, unquoted scalars inside arrays, numbers, trailing
comments, CRLF, tab indentation, comments inside blocks, duplicate keys, legacy `definition_of_done`
backslashes — produced byte-identical results before and after. The only diffs are the malformed cases,
which now fail fast. `backlog config list` against this repo's own `config.yml` is byte-identical before
and after.

**Entry points**, checked live in a scratch project with `statuses: ["To Do, "In Progress", "Done"]`:
`task list`, `task <id>`, `task edit`, `search`, `board` (TUI), `config get/set/list`, `overview`,
`cleanup`, `agents`, `browser` (web server) and `mcp start` all exit non-zero and print the single clear
message with no stack trace. `--version`, `--help` and `instructions` still work, since they do not read
config.

**Tests.** New coverage in `src/test/config-commands.test.ts`: a malformed value for each of the five list
keys asserting the message starts with `Backlog could not start because` and names the file and that key;
cross-key isolation (a malformed `statuses` must not downgrade `labels`); and a CLI end-to-end check for a
non-zero exit with no stack in stderr. Two existing tests that wrapped `parseConfig` and counted attempts
*after* calling through now count before, since a rejected value throws instead of returning.

`bunx tsc --noEmit` clean, `bun run check .` clean, `bun run test` green across 223 files (two pre-existing load-sensitive flakes, `tui-task-composer` watcher delivery and `server-search-endpoint` Fuse rebuild, reproduce identically on `origin/main`).

## Review round: one blocking finding, fixed

`extractConfigKeyYaml` matched the key with a leading-whitespace-tolerant pattern and took the last match,
so a look-alike line nested inside **another** key's value silently outranked the real top-level key —
`statuses: [top]` followed by `meta_thing:\n  statuses: [nested1, nested2]` returned the nested values, and
a `statuses:` line inside a literal block scalar won over the real one. Both were silent wrong values on
fully valid YAML, so both violated the backward-compat invariant.

Fixed: a config key belongs at column 0, so an unindented match always outranks an indented look-alike.
The last column-0 match wins; indented matches are used only when the key appears nowhere at column 0,
which keeps a tab- or space-indented sole occurrence readable exactly as `main` reads it. The parse matrix
was extended to 51 cases (both reproductions plus deep-nested, folded-scalar, block-sequence-top-key,
malformed-look-alike, and tab/space-indented-key controls) and captured against `origin/main`: pre-fix the
branch regressed six valid-config rows, post-fix all six match `main` exactly. The new regression test is
confirmed non-vacuous — reverting only the column-0 rule fails it.

## Second review round

Four entry points still swallowed the error. All four are fixed here, each with a probe in a malformed
project confirming the message now leads and the exit code is non-zero:

- **Bare `backlog` / `backlog --plain`** caught the error in the pre-dispatch probe and printed *"This
  directory is not initialized for Backlog.md."* with exit 0 — actively misdiagnosing an initialized
  project.
- **`Core.ensureConfigLoaded`** suppressed it, so `draft list --plain` with no drafts took its empty-list
  fast path and exited 0 with `No drafts found.` It now rethrows config value errors and still suppresses
  the recoverable git-configuration failures it exists for.
- **`backlog mcp start`** printed `Failed to start MCP server: Backlog could not start because ...`, so the
  required phrase was not at the start.
- **MCP roots discovery**: `upgradeToProject` loaded the config *after* reinitializing to a candidate root,
  so a rejected value escaped, aborted the whole roots loop, and left the server pointed at the bad root
  with fallback registrations. It now restores the previous root and keeps examining later roots, like the
  existing no-config branch. New test; without the fix the client sees `tools: []`.

One valid-YAML regression was also found and fixed: a config that **defines an anchor under one key and
aliases it from another** (`statuses: &workflow [To Do, Done]` with `labels: *workflow`) aborted every
command with `Unresolved alias`, because an alias only resolves against the whole document. When a key's
own block is rejected, the value now gets one more read in document context before it counts as broken.
The document is never read first, so cross-key isolation is preserved and genuinely malformed values still
fail fast. These shapes now match `main` exactly.

Two findings did not reproduce as described. **Quoted keys** (`"statuses": [...]`) are ignored on `main`
too: its whole-document parse contained the key, but `parseConfig`'s switch is driven by the raw line key
(`"statuses"`, quotes included), which matches no case, so the value was never assigned — both heads fall
back to defaults, for valid and malformed quoted keys alike. **Key-like text inside scalars** behaves
identically on both heads for four of five probed shapes (inline DoD item text, indented literal block
scalar, block sequence item, `onStatusChange` block scalar), since the column-0 rule already outranks
indented look-alikes. The fifth shape is a real but exotic divergence, kept as a documented limitation
below.

## Third review round: block boundaries

Block-boundary detection only recognised identifier-character key lines, so a top-level key whose name
uses other characters did not end the previous key's block. `statuses: [Queued, Done]` followed by
`custom-setting: ["bad]` folded the malformed line into the statuses block and aborted startup blaming
**statuses** — a valid key, an error the user cannot fix by editing the key it names. `main` tolerated
those configs, since its line fallback ignored the unknown key. Reproduced on both heads for hyphenated,
dotted, quoted and digit-leading key names before changing anything.

Only the boundary pattern was broadened, to `/^\s*(?!-\s)[^\s#][^:]*:/` — any mapping key line ends the
previous block regardless of its name's characters. Key *selection* still targets only the five list keys,
so the malformed unknown key is simply ignored exactly as `main` ignores it. The negative lookahead matters:
a sequence item is not a key even when its text contains a colon, and without it a same-indent `- "a: b"`
would cut the block short.

Verified with a 14-case risk probe — same-indent and indented sequence items containing colons,
`definition_of_done` items with colons, indented flow continuations, comment and blank lines inside blocks,
colon-bearing `onStatusChange` and `date_format` values, block-sequence `default_assignee`, nested mappings
under unknown keys — all 14 match `main` except the documented limitation below, which is unchanged. The
51-case matrix and the unindented-continuation strictness are unchanged, and a genuinely malformed
`statuses` beside a malformed unknown key still fails fast naming `statuses`.

Two differences from `main` in this shape, both in already-accepted families: quoted commas in another list
key are now read as YAML rather than comma-split, and where the affected key used a block sequence `main`
silently fell back to default statuses while this branch returns the configured value.

## Fourth review round: propagation class closed

Threads kept arriving one entry point at a time, so this round closed the class rather than the instances.
A hand-rolled enclosing-`try` analyzer proved unreliable (it missed `promoteDraft`'s known catch), so the
class was closed **empirically**: a runtime sweep runs every config-reading CLI surface against a malformed
config, rebuilding a pristine fixture before each command and comparing a file-tree snapshot before and
after — making both swallowed errors and mutate-then-validate ordering visible. 40 surfaces, two passes.

| surface | before | after |
|---|---|---|
| `draft promote` | **exit 0**, `Draft not found.`, draft still on disk | clear error, exit 1, unchanged tree |
| `draft archive` | error but **already moved** to `archive/drafts` | clear error, exit 1, unchanged tree |
| `milestone add` | error but **file already created** | clear error, exit 1, unchanged tree |
| `milestone archive` | error but **already moved** | clear error, exit 1, unchanged tree |
| `milestone rename` / `remove` | verified: error before any mutation | unchanged |
| `task archive` / `demote` / `create` / `edit` (status, title, ordinal, milestone) | verified | unchanged |
| `draft create`, `doc create`, `decision create` | verified | unchanged |
| `doctor` / `doctor --fix` / `cleanup` / `config set` / `agents --update-instructions` | verified | unchanged |
| every read surface (`task list`/`view`, `search`, `board`, `overview`, `config list`/`get`, `draft list`, `milestone list`) | verified | unchanged |
| bare `backlog`, `backlog --plain`, `mcp start` | verified (fixed in round 2) | unchanged |
| `doc list`, `decision list` | exit 0 — **never read config** | out of class, see below |

`milestone add` and `milestone archive` were **not** in any review thread; the sweep found them. That is the
argument for sweeping rather than patching per-thread.

Fixes, all minimal: `promoteDraft` rethrows `ConfigValueError` alongside its existing create-lock rethrow;
`Core.archiveDraft` and `Core.archiveMilestone` hoist the `shouldAutoCommit` config read above their file
move; `MilestoneHandlers.addMilestone` calls `ensureConfigLoaded` before creating the file. Fixing
`archiveMilestone` in `Core` rather than the handler covers the CLI and MCP surfaces in one place.

`doc list` and `decision list` are recorded as **out of class**: they call `listDocuments()` /
`listDecisions()` and never read config, so no error is swallowed. Adding a config read purely to make them
fail would be scope creep, and a user with a broken config can still list their docs.

## Accepted strictness changes

Beyond malformed values now failing fast, two shapes change because YAML decides validity instead of a
text split:

- An **unindented continuation of an inline array** — an array opened on the key line and continued at
  column 0 — now fails fast, where the old whole-document parse accepted it. Verified: `statuses: [` with
  `"a",` / `"b"` / `]` at column 0 fails fast, while the same array indented by two spaces still parses to
  `["a", "b"]`. Accepted as designed strictness; the unindented form is not what `saveConfig` writes, and
  an unindented continuation is indistinguishable from a stray line following the key.
- A key present **only** as an indented look-alike now reads its value as YAML rather than comma-splitting
  it, so `something:\n  labels: ["a, b"]` yields `["a, b"]` instead of `["a", "b"]`.

## Open decisions, not decided here

**1. Wrong-typed list values.** A list key holding valid YAML that is not a list (for example
`statuses: To Do`) keeps today's behavior: the key is left unset and Backlog falls back to defaults, rather
than erroring. Making that a hard error would change behavior for configs that parse successfully today, so
it needs a product decision.

Until that decision lands, **no runtime behavior changes relative to `main`**. An interim review round found
that the config watcher had drifted: a wrong-typed `default_assignee` edit (`{name: "@alice"}`, `42`) was
published with the key unset, silently dropping the configured assignee, where `main` rejected the candidate
and kept the last good config. Parity is restored and covered by a test — verified on both heads that the
watcher publishes nothing and retains the cached `["@alice"]`. The check deliberately re-states a rule the
parser also owns; the comment marks it as pending this decision so it is easy to remove once ruled on.

## Documented limitation

**One exotic shape is knowingly out of scope: a column-0 continuation line of a multi-line quoted flow
scalar that begins with a list-key name.** Concretely, `definition_of_done: ["run` on one line followed by
`statuses: fake"]` at column 0 — the continuation belongs to `definition_of_done`'s value, but it looks
exactly like a top-level `statuses:` key, so the extractor selects it and `statuses` falls back to defaults
where `main` returned the configured list. Only this shape is affected: the key must be inside a *quoted,
multi-line, flow-style* value and its continuation must start at column 0 with a list-key name. Indented
look-alikes, literal (`|`) and folded (`>`) block scalars, block sequence items, and nested mappings are all
handled correctly by the column-0 rule.

**A second, related limitation: compound configs can name the wrong key.** When a key whose value is an
alias coexists with a separately malformed key, the isolated read fails on the unresolved alias and the
document retry fails on the other key, so the error names the alias rather than the true offender. Startup
still fails fast with a clear message and a non-zero exit; only the named key can be off. Measured against
`main` for `statuses: &workflow [...]` + `labels: *workflow` + malformed `custom-setting: ["bad]`: `main`
silently produced default statuses and empty labels, discarding **both** configured values, so it did not
handle the shape correctly either. Correlating errors across keys to locate the true offender would outgrow
this fix.

**Why the extraction limitation is out:** telling a real top-level key from a column-0 line inside another key's multi-line scalar
requires tracking YAML scalar state across lines — i.e. growing the line extractor into a YAML parser.
That is rejected under the project's simplicity rules (MANIFESTO principle 10, and the simplicity-first rule
against extra layers without a proven need) for a shape no `saveConfig` output ever produces. The
alternative — a document-parse-first design isolating per key only when the document fails — would fix this
shape and honor quoted keys, but it changes several other shapes and is a design decision, not a patch.

