### PR TITLE
BACK-603 - Align create and draft flag handling with the edit path

### DIFF
--- a/backlog/tasks/back-603 - Align-create-and-draft-flag-handling-with-the-edit-path.md
+++ b/backlog/tasks/back-603 - Align-create-and-draft-flag-handling-with-the-edit-path.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-603
 title: Align create and draft flag handling with the edit path
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-08 15:56'
+updated_date: '2026-08-08 17:05'
 labels: []
 dependencies: []
 ordinal: 242000
@@ -17,15 +19,52 @@ The create path diverges from the hardened edit path: repeated -l/--labels flags
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Repeated label flags on task create and draft create collect all values, matching edit
-- [ ] #2 Empty --dep and --ref values on create and draft fail with the same clear validation error as edit
-- [ ] #3 Create, draft and edit share the same helpers for these validations (no duplicated logic)
-- [ ] #4 Tests cover the create and draft parity cases
+- [x] #1 Repeated label flags on task create and draft create collect all values, matching edit
+- [x] #2 Empty --dep and --ref values on create and draft fail with the same clear validation error as edit
+- [x] #3 Create, draft and edit share the same helpers for these validations (no duplicated logic)
+- [x] #4 Tests cover the create and draft parity cases
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the three defects live against a scratch project (done): `task create -l a -l b` and `draft create -l a -l b` keep only the last label; `task create --dep ""` / `--ref ""` / `--doc ""` exit 0 and silently drop the value; `task create --depends-on TASK-1 --dep TASK-2` stores only TASK-1 because the create path uses `options.dependsOn || options.dep` while edit concatenates both.
+2. Make `-l, --labels` collecting on `task create` and `draft create` with the shared `createMultiValueAccumulator()`; `parseDelimitedStringList` already splits commas, so comma-separated values keep working.
+3. Replace the create path's `options.dependsOn || options.dep` alias merge with the edit path's `[...toStringArray(options.dependsOn), ...toStringArray(options.dep)]` so both spellings merge instead of one silently winning.
+4. Reuse `validateClearableListInput` on the create path for dependencies, --ref and --doc (the three lists edit validates; --modified-file is left alone because edit does not validate it either). Make `clearFlag` optional in that helper so create keeps edit's identical problem sentence without advertising --clear-* flags create does not have.
+5. Leave `draft create` flag surface unchanged (it has no --dep/--ref/--doc), so the draft parity case for empty list values is `task create --draft`.
+6. Align the create help schema label wording with the edit convention (repeat -l or use label1,label2).
+7. Tests: repeated + comma labels on create (cli-init-create.test.ts) and draft create (draft-create-consistency.test.ts); empty --dep/--ref/--doc rejection on create and on create --draft asserting the same problem sentence as edit (cli-dependency.test.ts, cli-refs-docs.test.ts); dependsOn/dep merge on create.
+8. Verify with bunx tsc --noEmit, bun run check ., bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root causes found in src/cli.ts:
+- `task create` and `draft create` declared `-l, --labels <labels>` without a Commander collector, so Commander overwrote the value on each repetition and only the last label survived. `parseDelimitedStringList` already split commas, which is why comma-separated values worked and repeated flags did not.
+- The create path never validated list flag values. `--dep ""`, `--ref ""` and `--doc ""` normalized to an empty list and were dropped silently with exit code 0, while the edit path rejected them through `validateClearableListInput`.
+- The dependsOn/dep alias quirk: create merged the two spellings with `options.dependsOn || options.dep`. Because the collectors always produce a non-empty array when the flag is present, `--depends-on` always won and every `--dep` value was silently discarded (`--depends-on TASK-1 --dep TASK-2` stored only TASK-1). Worse, `--depends-on "" --dep TASK-2` selected `[""]`, so the valid `--dep` value vanished and the task was created with no dependencies. The edit path already concatenated both spellings.
+
+Changes:
+- `-l, --labels` now uses the shared `createMultiValueAccumulator()` on `task create` and `draft create`; `parseDelimitedStringList` keeps splitting commas, so comma-separated, repeated and mixed forms all collect.
+- The create path now merges dependency spellings exactly like edit: `[...toStringArray(options.dependsOn), ...toStringArray(options.dep)]`.
+- Extracted `validateTaskListFlags(options, { supportsClearFlags })` so create and edit run one implementation of the dependency/reference/documentation list validations. Edit passes true, create false. `validateClearableListInput` now takes an optional `clearFlag`: create keeps the identical problem sentence ("Cannot use an empty value with --depends-on or --dep") but ends with "Omit the flag to leave task dependencies unset." instead of pointing at --clear-deps, which create does not have.
+- `--doc` is validated on create too because edit validates it; `--modified-file` is deliberately left alone because edit does not validate it either.
+- `draft create` exposes no --dep/--ref/--doc flags (Commander rejects them as unknown options), so no flags were added; the draft parity case for empty list values is `task create --draft`, which shares the create action and is covered by tests.
+
+Verification: all 8 new assertions confirmed failing with src/cli.ts stashed and passing with the fix. Live checks in a scratch project covered repeated/comma/mixed labels on create and draft create, empty --dep/--depends-on/--ref/--doc on create and on create --draft, --depends-on + --dep merging, and an edit-path regression sweep (empty --dep/--ref/--doc/--add-ref/--remove-ref, all three --clear-* conflicts, --ref with --add-ref, repeated labels, clear flags) confirming edit messages and behavior are byte-identical to before.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Aligned task create and draft create with the hardened edit path in src/cli.ts. -l/--labels now collects repeated flags on both create commands (comma-separated values unchanged), create merges --depends-on and --dep instead of letting --depends-on silently discard --dep, and create rejects empty --dep/--ref/--doc values through the same validation used by edit, extracted into a shared validateTaskListFlags helper. The create error keeps edit's exact problem sentence and swaps only the remedy, because create has no --clear-* flags. Verified with new tests in cli-init-create, draft-create-consistency, cli-dependency and cli-refs-docs (all 8 new assertions confirmed failing before the fix), live CLI scenarios on a scratch project, an edit-path regression sweep showing unchanged messages, bunx tsc --noEmit and bun run check . clean, and bun run test green (2069 pass, 6 skip, 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -514,22 +514,80 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 /**
  * Validate a clearable list option pair such as --ref/--clear-refs.
  * Returns an error message when the clear flag conflicts with a setter or a setter value is blank.
+ * Omit `clearFlag` on surfaces without a clear flag (task create) so the guidance stays accurate.
  */
 function validateClearableListInput(input: {
 	rawValues: string[];
-	cleared: boolean;
+	cleared?: boolean;
 	isBlank: (value: string) => boolean;
 	setterFlags: string;
-	clearFlag: string;
+	clearFlag?: string;
 	subject: string;
 }): string | undefined {
-	if (input.cleared && input.rawValues.length > 0) {
+	if (input.clearFlag && input.cleared && input.rawValues.length > 0) {
 		return `Cannot combine ${input.clearFlag} with ${input.setterFlags}. Use ${input.clearFlag} by itself.`;
 	}
 	if (input.rawValues.some(input.isBlank)) {
-		return `Cannot use an empty value with ${input.setterFlags}. Use ${input.clearFlag} to remove all ${input.subject}.`;
+		const guidance = input.clearFlag
+			? `Use ${input.clearFlag} to remove all ${input.subject}.`
+			: `Omit the flag to leave ${input.subject} unset.`;
+		return `Cannot use an empty value with ${input.setterFlags}. ${guidance}`;
 	}
 	return undefined;
+}
+
+/**
+ * Validate the dependency, reference, and documentation list flags shared by task create and task edit.
+ * `supportsClearFlags` is false for task create, which has no --clear-deps/--clear-refs/--clear-docs flags.
+ */
+function validateTaskListFlags(
+	options: Record<string, unknown>,
+	{ supportsClearFlags }: { supportsClearFlags: boolean },
+): string | undefined {
+	const isBlankListValue = (value: string) => parseDelimitedStringList(value) === undefined;
+	const clearFlag = (flag: string) => (supportsClearFlags ? flag : undefined);
+	return (
+		validateClearableListInput({
+			rawValues: [...toStringArray(options.dependsOn), ...toStringArray(options.dep)],
+			cleared: Boolean(options.clearDeps),
+			isBlank: (value) => normalizeDependencies([value]).length === 0,
+			setterFlags: "--depends-on or --dep",
+			clearFlag: clearFlag("--clear-deps"),
+			subject: "task dependencies",
+		}) ??
+		validateClearableListInput({
+			rawValues: toStringArray(options.ref),
+			cleared: Boolean(options.clearRefs),
+			isBlank: isBlankListValue,
+			setterFlags: "--ref",
+			clearFlag: clearFlag("--clear-refs"),
+			subject: "references",
+		}) ??
+		validateClearableListInput({
+			rawValues: toStringArray(options.addRef),
+			cleared: Boolean(options.clearRefs),
+			isBlank: isBlankListValue,
+			setterFlags: "--add-ref",
+			clearFlag: clearFlag("--clear-refs"),
+			subject: "references",
+		}) ??
+		validateClearableListInput({
+			rawValues: toStringArray(options.removeRef),
+			cleared: Boolean(options.clearRefs),
+			isBlank: isBlankListValue,
+			setterFlags: "--remove-ref",
+			clearFlag: clearFlag("--clear-refs"),
+			subject: "references",
+		}) ??
+		validateClearableListInput({
+			rawValues: toStringArray(options.doc),
+			cleared: Boolean(options.clearDocs),
+			isBlank: isBlankListValue,
+			setterFlags: "--doc",
+			clearFlag: clearFlag("--clear-docs"),
+			subject: "documentation",
+		})
+	);
 }
 
 async function resolveCliMilestoneInput(core: Core, milestone: string): Promise<string> {
@@ -1750,7 +1808,11 @@ addHelpSchema(taskCmd.command("create [title]"), {
 			description:
 				"Assign one or more @names; repeat -a or use @name1,@name2; omitting it applies the configured defaultAssignee",
 		},
-		{ name: "labels", type: "Comma-separated strings", description: "Task labels" },
+		{
+			name: "labels",
+			type: "Comma-separated strings",
+			description: "Task labels; repeat -l or use label1,label2",
+		},
 		{ name: "priority", type: priorityType, description: "Task priority" },
 		{ name: "type", type: taskType, description: "Task type; case-insensitive" },
 		{ name: "acceptanceCriteria", type: "Markdown list item text", description: "Repeat --ac for multiple criteria" },
@@ -1785,7 +1847,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 		createMultiValueAccumulator(),
 	)
 	.option("-s, --status <status>")
-	.option("-l, --labels <labels>")
+	.option("-l, --labels <labels>", "add task labels (comma-separated or repeatable)", createMultiValueAccumulator())
 	.option("--priority <priority>", "set task priority (configured priorities)")
 	.option("--type <type>", "set task type (configured task types)")
 	.option("--plain", "use plain text output after creating")
@@ -1889,6 +1951,15 @@ addHelpSchema(taskCmd.command("create [title]"), {
 			ordinalValue = parsed;
 		}
 
+		const listFlagError = validateTaskListFlags(options, { supportsClearFlags: false });
+		if (listFlagError) {
+			console.error(listFlagError);
+			process.exitCode = 1;
+			return;
+		}
+
+		const dependencies = [...toStringArray(options.dependsOn), ...toStringArray(options.dep)];
+
 		try {
 			const criteria = processAcceptanceCriteriaOptions(options);
 			const milestone =
@@ -1899,8 +1970,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 				status: createAsDraft ? "Draft" : options.status ? String(options.status) : undefined,
 				assignee: parseDelimitedStringList(options.assignee),
 				labels: parseDelimitedStringList(options.labels),
-				dependencies:
-					options.dependsOn || options.dep ? normalizeDependencies(options.dependsOn || options.dep) : undefined,
+				dependencies: dependencies.length > 0 ? normalizeDependencies(dependencies) : undefined,
 				references: parseDelimitedStringList(options.ref),
 				documentation: parseDelimitedStringList(options.doc),
 				modifiedFiles: parseDelimitedStringList(options.modifiedFile),
@@ -3145,52 +3215,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			.filter((value) => value.length > 0);
 
 		const combinedDependencies = [...toStringArray(options.dependsOn), ...toStringArray(options.dep)];
-		const rawReferences = toStringArray(options.ref);
-		const rawAddReferences = toStringArray(options.addRef);
-		const rawRemoveReferences = toStringArray(options.removeRef);
-		const rawDocumentation = toStringArray(options.doc);
-		const isBlankListValue = (value: string) => parseDelimitedStringList(value) === undefined;
-		const clearableListError =
-			validateClearableListInput({
-				rawValues: combinedDependencies,
-				cleared: Boolean(options.clearDeps),
-				isBlank: (value) => normalizeDependencies([value]).length === 0,
-				setterFlags: "--depends-on or --dep",
-				clearFlag: "--clear-deps",
-				subject: "task dependencies",
-			}) ??
-			validateClearableListInput({
-				rawValues: rawReferences,
-				cleared: Boolean(options.clearRefs),
-				isBlank: isBlankListValue,
-				setterFlags: "--ref",
-				clearFlag: "--clear-refs",
-				subject: "references",
-			}) ??
-			validateClearableListInput({
-				rawValues: rawAddReferences,
-				cleared: Boolean(options.clearRefs),
-				isBlank: isBlankListValue,
-				setterFlags: "--add-ref",
-				clearFlag: "--clear-refs",
-				subject: "references",
-			}) ??
-			validateClearableListInput({
-				rawValues: rawRemoveReferences,
-				cleared: Boolean(options.clearRefs),
-				isBlank: isBlankListValue,
-				setterFlags: "--remove-ref",
-				clearFlag: "--clear-refs",
-				subject: "references",
-			}) ??
-			validateClearableListInput({
-				rawValues: rawDocumentation,
-				cleared: Boolean(options.clearDocs),
-				isBlank: isBlankListValue,
-				setterFlags: "--doc",
-				clearFlag: "--clear-docs",
-				subject: "documentation",
-			});
+		const clearableListError = validateTaskListFlags(options, { supportsClearFlags: true });
 		if (clearableListError) {
 			console.error(clearableListError);
 			process.exitCode = 1;
@@ -3655,7 +3680,7 @@ draftCmd
 		createMultiValueAccumulator(),
 	)
 	.option("-s, --status <status>")
-	.option("-l, --labels <labels>")
+	.option("-l, --labels <labels>", "add draft labels (comma-separated or repeatable)", createMultiValueAccumulator())
 	.action(async (title: string, options) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);

--- a/src/test/cli-dependency.test.ts
+++ b/src/test/cli-dependency.test.ts
@@ -62,6 +62,48 @@ describe("CLI dependency options", () => {
 		expect((await core.filesystem.loadTask("TASK-3"))?.dependencies).toEqual(["TASK-1", "TASK-2"]);
 	});
 
+	it("merges --depends-on and --dep on task create", async () => {
+		await $`bun ${CLI_PATH} task create "Base task one"`.cwd(testDir).quiet();
+		await $`bun ${CLI_PATH} task create "Base task two"`.cwd(testDir).quiet();
+
+		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1 --dep TASK-2`.cwd(testDir).quiet();
+
+		expect((await core.filesystem.loadTask("TASK-3"))?.dependencies).toEqual(["TASK-1", "TASK-2"]);
+	});
+
+	it("rejects empty dependency values on task create and draft create without creating anything", async () => {
+		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
+
+		const emptyDependsOn = await $`bun ${CLI_PATH} task create "Empty depends-on" --depends-on ""`
+			.cwd(testDir)
+			.quiet()
+			.nothrow();
+		expect(emptyDependsOn.exitCode).toBe(1);
+		expect(emptyDependsOn.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+
+		const emptyDep = await $`bun ${CLI_PATH} task create "Empty dep" --dep ""`.cwd(testDir).quiet().nothrow();
+		expect(emptyDep.exitCode).toBe(1);
+		expect(emptyDep.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+
+		const emptyAlongsideValue =
+			await $`bun ${CLI_PATH} task create "Empty alongside value" --depends-on "" --dep TASK-1`
+				.cwd(testDir)
+				.quiet()
+				.nothrow();
+		expect(emptyAlongsideValue.exitCode).toBe(1);
+		expect(emptyAlongsideValue.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+
+		const emptyDraftDep = await $`bun ${CLI_PATH} task create "Empty draft dep" --draft --dep ""`
+			.cwd(testDir)
+			.quiet()
+			.nothrow();
+		expect(emptyDraftDep.exitCode).toBe(1);
+		expect(emptyDraftDep.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+
+		expect(await core.filesystem.loadTask("TASK-2")).toBeNull();
+		expect(await core.filesystem.listDrafts()).toHaveLength(0);
+	});
+
 	it("clears dependencies with --clear-deps", async () => {
 		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
 		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1`.cwd(testDir).quiet();

--- a/src/test/cli-init-create.test.ts
+++ b/src/test/cli-init-create.test.ts
@@ -542,6 +542,22 @@ describe("CLI Integration", () => {
 			expect(task?.assignee).toEqual(["@alice", "@bob", "@carol"]);
 		});
 
+		it("should split comma-separated labels on task create", async () => {
+			await $`bun ${CLI_PATH} task create "Comma label task" -l "ui,bug"`.cwd(TEST_DIR).quiet();
+
+			const core = new Core(TEST_DIR);
+			const task = await core.filesystem.loadTask("task-1");
+			expect(task?.labels).toEqual(["ui", "bug"]);
+		});
+
+		it("should collect repeated label flags on task create", async () => {
+			await $`bun ${CLI_PATH} task create "Repeated label task" -l ui -l bug,api`.cwd(TEST_DIR).quiet();
+
+			const core = new Core(TEST_DIR);
+			const task = await core.filesystem.loadTask("task-1");
+			expect(task?.labels).toEqual(["ui", "bug", "api"]);
+		});
+
 		it("should apply the configured defaultAssignee when task create has no -a", async () => {
 			await $`bun ${CLI_PATH} config set defaultAssignee ${"@alice,@bob"}`.cwd(TEST_DIR).quiet();
 			await $`bun ${CLI_PATH} task create "Default assignee task"`.cwd(TEST_DIR).quiet();

--- a/src/test/cli-refs-docs.test.ts
+++ b/src/test/cli-refs-docs.test.ts
@@ -130,6 +130,42 @@ await import(${JSON.stringify(pathToFileURL(cliPath).href)});
 		});
 	});
 
+	describe("task create with empty --ref and --doc values", () => {
+		it("rejects an empty reference without creating the task", async () => {
+			const result = await $`bun ${cliPath} task create "Feature" --ref ""`.cwd(TEST_DIR).quiet().nothrow();
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr.toString()).toContain("Cannot use an empty value with --ref");
+			expect(await new Core(TEST_DIR).filesystem.loadTask("TASK-1")).toBeNull();
+		});
+
+		it("rejects an empty reference alongside a valid one", async () => {
+			const result = await $`bun ${cliPath} task create "Feature" --ref "" --ref src/api.ts`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr.toString()).toContain("Cannot use an empty value with --ref");
+		});
+
+		it("rejects an empty documentation entry without creating the task", async () => {
+			const result = await $`bun ${cliPath} task create "Feature" --doc ""`.cwd(TEST_DIR).quiet().nothrow();
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr.toString()).toContain("Cannot use an empty value with --doc");
+			expect(await new Core(TEST_DIR).filesystem.loadTask("TASK-1")).toBeNull();
+		});
+
+		it("rejects an empty reference on task create --draft without creating the draft", async () => {
+			const result = await $`bun ${cliPath} task create "Feature" --draft --ref ""`.cwd(TEST_DIR).quiet().nothrow();
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr.toString()).toContain("Cannot use an empty value with --ref");
+			expect(await new Core(TEST_DIR).filesystem.listDrafts()).toHaveLength(0);
+		});
+	});
+
 	describe("task edit with --ref flag", () => {
 		it("sets references on existing task", async () => {
 			await $`bun ${cliPath} task create "Feature"`.cwd(TEST_DIR).quiet();

--- a/src/test/draft-create-consistency.test.ts
+++ b/src/test/draft-create-consistency.test.ts
@@ -51,6 +51,15 @@ describe("Draft creation consistency", () => {
 		expect((await core.filesystem.loadDraft("draft-2"))?.assignee).toEqual(["@alice", "@bob", "@carol"]);
 	});
 
+	it("splits comma-separated and repeated labels on draft create", async () => {
+		await $`bun ${CLI_PATH} draft create "Comma labels" -l "ui,bug"`.cwd(TEST_DIR).quiet();
+		await $`bun ${CLI_PATH} draft create "Repeated labels" -l ui -l bug,api`.cwd(TEST_DIR).quiet();
+
+		const core = new Core(TEST_DIR);
+		expect((await core.filesystem.loadDraft("draft-1"))?.labels).toEqual(["ui", "bug"]);
+		expect((await core.filesystem.loadDraft("draft-2"))?.labels).toEqual(["ui", "bug", "api"]);
+	});
+
 	it("applies the configured defaultAssignee to drafts created without -a", async () => {
 		await $`bun ${CLI_PATH} config set defaultAssignee ${"@alice,@bob"}`.cwd(TEST_DIR).quiet();
 		await $`bun ${CLI_PATH} draft create "Default assignees"`.cwd(TEST_DIR).quiet();


### PR DESCRIPTION
## Problem

`task create` and `draft create` diverged from the hardened `task edit` path in three ways, all reproduced live before the fix:

1. **Repeated `-l/--labels` lost values.** Both create commands declared `-l, --labels <labels>` without a Commander collector, so each repetition overwrote the previous one. `task create "T" -l a -l b` stored only `b`; same on `draft create`. Comma-separated values worked because `parseDelimitedStringList` splits them.
2. **Empty list values were silently swallowed.** `task create "T" --dep ""`, `--ref ""` and `--doc ""` all exited 0 and created the task with the list empty. `task edit` rejects the same input with a clear error.
3. **The `dependsOn || dep` alias quirk.** Create merged the two spellings with `options.dependsOn || options.dep`. Because Commander's collector always yields a non-empty array when the flag is present, `--depends-on` always won and every `--dep` value was silently discarded: `--depends-on TASK-1 --dep TASK-2` stored only `TASK-1`. Worse, `--depends-on "" --dep TASK-2` selected `[""]`, so the valid `--dep` value vanished too and the task was created with no dependencies. `task edit` already concatenated both spellings.

## Fix

- `-l, --labels` uses the shared `createMultiValueAccumulator()` on `task create` and `draft create`. `parseDelimitedStringList` still splits commas, so comma-separated, repeated, and mixed forms all collect and dedupe.
- Create merges dependency spellings exactly like edit: `[...toStringArray(options.dependsOn), ...toStringArray(options.dep)]`.
- Extracted `validateTaskListFlags(options, { supportsClearFlags })` so create and edit run **one** implementation of the dependency/reference/documentation list validations (edit's previous inline chain moved into it verbatim). Edit passes `true`, create `false`.
- `validateClearableListInput` now takes an optional `clearFlag`. Create keeps edit's identical problem sentence and only swaps the remedy, because create has no `--clear-*` flags:
  - edit: `Cannot use an empty value with --depends-on or --dep. Use --clear-deps to remove all task dependencies.`
  - create: `Cannot use an empty value with --depends-on or --dep. Omit the flag to leave task dependencies unset.`
- `--doc` is validated on create too, because edit validates it. `--modified-file` is deliberately left alone, because edit does not validate it either.
- No new flags. `draft create` exposes no `--dep/--ref/--doc` (Commander rejects them as unknown options), so the draft parity case for empty list values is `task create --draft`, which shares the create action and is covered by tests.
- Create's help schema label wording now follows the existing edit convention (`repeat -l or use label1,label2`).

The interactive-wizard gate (`hasCreateFieldFlags`) already tracked `labels`, `dependsOn`, `dep`, `ref`, and `doc`, and keeps working unchanged since no flag names changed.

## Evidence

Before/after on a scratch project:

| Invocation | Before | After |
| --- | --- | --- |
| `task create "T" -l a -l b` | `labels: [b]` | `labels: [a, b]` |
| `draft create "T" -l a -l b` | `labels: [b]` | `labels: [a, b]` |
| `task create "T" -l a -l "b,c"` | `labels: [b, c]` | `labels: [a, b, c]` |
| `task create "T" -l "a,b"` (control) | `labels: [a, b]` | `labels: [a, b]` (unchanged) |
| `task create "T" --dep ""` | exit 0, no deps | exit 1, same problem sentence as edit |
| `task create "T" --draft --ref ""` | exit 0, no refs | exit 1, same problem sentence as edit |
| `task create "T" --depends-on TASK-1 --dep TASK-2` | `[TASK-1]` | `[TASK-1, TASK-2]` |
| `task create "T" --depends-on "" --dep TASK-2` | exit 0, no deps | exit 1 |

Tests added to `src/test/cli-init-create.test.ts`, `src/test/draft-create-consistency.test.ts`, `src/test/cli-dependency.test.ts`, and `src/test/cli-refs-docs.test.ts` covering repeated labels, comma-separated labels (control), empty `--dep`/`--depends-on`/`--ref`/`--doc` rejection on create and on `create --draft` (asserting nothing is written), and the `--depends-on` + `--dep` merge. All 8 new assertions were confirmed failing with `src/cli.ts` stashed and passing with the fix; the comma-separated control passed in both states.

Edit-path regression sweep (messages and behavior byte-identical to before): empty `--dep`, `--ref`, `--doc`, `--add-ref`, `--remove-ref`; all three `--clear-*` conflict errors; `--ref` with `--add-ref`; repeated `-l`; `--clear-refs` and `--clear-deps` happy paths; `--depends-on` + `--dep` merge.

`bunx tsc --noEmit` clean, `bun run check .` clean, `bun run test` green (2082 pass, 6 skip, 0 fail) after rebasing onto current `main`.

Task record: BACK-603 (plan, notes, checked criteria, and final summary are in this branch).
