### PR TITLE
BACK-609 - Fix small CLI and TUI polish defects from the Aug 2026 review rounds

### DIFF
--- a/backlog/tasks/back-609 - Fix-small-CLI-and-TUI-polish-defects-from-the-Aug-2026-review-rounds.md
+++ b/backlog/tasks/back-609 - Fix-small-CLI-and-TUI-polish-defects-from-the-Aug-2026-review-rounds.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 17:20'
+updated_date: '2026-08-08 17:51'
 labels: []
 dependencies: []
 ordinal: 248000
@@ -59,6 +59,8 @@ Item 4 - piped board header: renderBoardTui's non-TTY branch passed the literal 
 Verification. Item 1: reproduced 'error: unknown option --plain' before the change; after it, 'backlog doc create "Plain Doc" --plain' exits 0 and prints the created id and path. Item 2: against a project holding both a legacy title-only file (API-Guidelines.md) and a current nested file (guides/api/doc-2 - Nested-Doc.md), the old id-to-filename matcher resolved neither ('OPENED NOTHING' for both) while the new reader opens both. Item 3: verified under a real PTY (script -q). Before, teardown emitted no title sequence at all and the shell title stayed 'Acme Website - Board'. After, open emits ESC[22;2t then the rename, and teardown emits ESC]0;BEL then ESC[23;2t exactly once - confirmed on both clean exit and the SIGINT path. Item 4: piped 'backlog board' and 'backlog board --milestones' now print 'Project: Acme Website' instead of 'Project: Project'. Checks: bunx tsc --noEmit clean, bun run check . clean, bun run test green with 2078 pass / 6 skip / 0 fail across 223 files.
 
 Out of scope, surfaced while researching item 2 and left unfixed: the document watcher in src/core/content-store.ts retries forever for a file named doc-1.md (it passes the doc- prefix gate but its split(" - ") id never matches the frontmatter id) and compares ids with raw equality where the rest of the codebase uses documentIdsEqual; and src/cli.ts carries an unused duplicate of generateNextDocId that also lives in src/utils/id-generators.ts.
+
+Review follow-up (PR #879, Codex P2 on the title-restore fix): the title stack push and pop were written with program.write, which is blessed's raw _owrite, while setTitle goes through _twrite. Inside tmux _twrite wraps output in the DCS passthrough (ESC P tmux ; ESC <data> ESC \\) that reaches the outer terminal, so the outer terminal received the title set and the clear but never the push or pop, and could not restore the title it started with even when it supports the stack. Verified against node_modules/neo-neo-bblessed/lib/program.ts: setTitle calls _twrite, and _twrite wraps when program.tmux (set from process.env.TMUX) is true. Both controls now go through _twrite as well, and the flush moved after the pop so the clear and the pop share one buffer flush. Outside tmux the emitted bytes are unchanged, confirmed byte-for-byte against the pre-change PTY capture. Also dropped write from the hand-written ProgramInterface declaration, since _twrite replaced its only use.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-609 - Fix-small-CLI-and-TUI-polish-defects-from-the-Aug-2026-review-rounds.md
+++ b/backlog/tasks/back-609 - Fix-small-CLI-and-TUI-polish-defects-from-the-Aug-2026-review-rounds.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-08 15:56'
-updated_date: '2026-08-08 17:51'
+updated_date: '2026-08-08 19:07'
 labels: []
 dependencies: []
 ordinal: 248000
@@ -61,6 +61,10 @@ Verification. Item 1: reproduced 'error: unknown option --plain' before the chan
 Out of scope, surfaced while researching item 2 and left unfixed: the document watcher in src/core/content-store.ts retries forever for a file named doc-1.md (it passes the doc- prefix gate but its split(" - ") id never matches the frontmatter id) and compares ids with raw equality where the rest of the codebase uses documentIdsEqual; and src/cli.ts carries an unused duplicate of generateNextDocId that also lives in src/utils/id-generators.ts.
 
 Review follow-up (PR #879, Codex P2 on the title-restore fix): the title stack push and pop were written with program.write, which is blessed's raw _owrite, while setTitle goes through _twrite. Inside tmux _twrite wraps output in the DCS passthrough (ESC P tmux ; ESC <data> ESC \\) that reaches the outer terminal, so the outer terminal received the title set and the clear but never the push or pop, and could not restore the title it started with even when it supports the stack. Verified against node_modules/neo-neo-bblessed/lib/program.ts: setTitle calls _twrite, and _twrite wraps when program.tmux (set from process.env.TMUX) is true. Both controls now go through _twrite as well, and the flush moved after the pop so the clear and the pop share one buffer flush. Outside tmux the emitted bytes are unchanged, confirmed byte-for-byte against the pre-change PTY capture. Also dropped write from the hand-written ProgramInterface declaration, since _twrite replaced its only use.
+
+Review follow-up 2 (PR 879, Codex P1+P2 on the title work). P1 verified empirically in a real tmux 3.6a session with no test priming: blessed _twrite defers every tmux write until output.bytesWritten moves, which Bun never does, so it waits out a 50x100ms poll. Measured a titled screen opened and torn down: natural return took 5.139s and all four sequences arrived, but quitting with process.exit(0) right after destroy took 0.048s and none of the four reached the terminal, so the restore was lost exactly where it matters. The 5s latency is pre-existing, not introduced here: unmodified origin/main at 36c0f65c measured 5.144s for the same script, since blessed setTitle defers identically. Outside tmux the same script runs in 0.042s.
+
+Simplified rather than layering another workaround: one helper, writeTerminalControl, writes a single control sequence straight to the output through the raw write path and applies the same tmux DCS transform blessed uses (BEL-for-ST substitution inside an ESC Ptmux envelope) when program.tmux is set. Push, clear and pop all use it, so setTitle, flush and _twrite are no longer needed here and the type declaration drops back to write plus tmux. One sequence per call, because the DCS envelope escapes only a single leading ESC. P2 folded in: the stack controls moved from 22;2t/23;2t to 22;0t/23;0t so they save and restore both values OSC 0 overwrites, leaving no blank icon title. Re-measured after the change: the process.exit path now delivers push, clear and pop in 0.048s, a realistic 6s session delivers all four in push then set then clear then pop order, and outside tmux the bytes stay unwrapped with the pop emitted exactly once on clean exit and on SIGINT.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-609 - Fix-small-CLI-and-TUI-polish-defects-from-the-Aug-2026-review-rounds.md
+++ b/backlog/tasks/back-609 - Fix-small-CLI-and-TUI-polish-defects-from-the-Aug-2026-review-rounds.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-609
 title: Fix small CLI and TUI polish defects from the Aug 2026 review rounds
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-08 15:56'
+updated_date: '2026-08-08 17:20'
 labels: []
 dependencies: []
 ordinal: 248000
@@ -17,16 +19,50 @@ Batch of small confirmed defects surfaced during the Aug 2026 reviews, approved 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 doc create --plain succeeds and prints plain output
-- [ ] #2 doc list works on projects using the older docs output path
-- [ ] #3 The TUI restores the previous terminal title on exit
-- [ ] #4 Piped board output shows the real project name in the header
-- [ ] #5 Tests cover the doc command and board header fixes
+- [x] #1 doc create --plain succeeds and prints plain output
+- [x] #2 doc list works on projects using the older docs output path
+- [x] #3 The TUI restores the previous terminal title on exit
+- [x] #4 Piped board output shows the real project name in the header
+- [x] #5 Tests cover the doc command and board header fixes
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce all four defects against a scratch project driven by src/cli.ts.
+2. doc create --plain: register the flag on the doc create subcommand and document it in the help schema, mirroring the existing 'decision create --plain' precedent (create output is already plain text).
+3. doc list: replace the ad-hoc glob-and-string-match document lookup in the interactive branch with the shared Core document resolution that 'doc view' already uses, so both the legacy id-only filename layout and the current 'id - Title.md' layout (including subdirectories) resolve.
+4. TUI terminal title: in createScreen, push the terminal window title onto the terminal title stack before blessed renames the window, and on the screen 'destroy' event clear the title and pop the stack. blessed already routes its exit, SIGINT/SIGTERM/SIGQUIT and uncaughtException teardown through screen.destroy(), so no new global signal handlers are added.
+5. Piped board header: renderBoardTui's non-TTY branch passes a hardcoded "Project" to the board generators; pass the resolved options.projectName that the TUI path already uses for the window title.
+6. Tests: CLI test for 'doc create --plain'; document resolution test for nested and legacy id-only doc filenames; unit test for the non-TTY board header project name; stdout capture test for the TUI title push/pop.
+7. Verify with bunx tsc --noEmit, bun run check ., and the full bun run test suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Item 1 - doc create --plain: the doc create subcommand never registered --plain, so commander rejected it with "error: unknown option '--plain'". Registered the flag and documented it in the help schema, following the existing 'decision create --plain' precedent: create output is already plain text, so the flag is accepted rather than switching formats.
+
+Item 2 - doc list on the older docs output path: the interactive branch of doc list resolved the picked document by matching its id against filenames (`<id> - `, `/<id>.md`, `<id>.md`) instead of using the document's own path. Documents written before commit 87324692 (2025-07-12) are stored as `backlog/docs/<Title>.md" with no id in the filename, so they matched nothing and selecting one showed an empty viewer. The same matcher also missed the current nested form `<subdir>/<id> - <title>.md` that has been produced since ff4e88b6 (2025-09-06). Commit f1d0bc30 had already replaced this exact matcher in doc view with core resolution but left the copy in doc list; doc list now calls the same core.getDocumentContent reader, so there is one document reader again and both layouts resolve.
+
+Item 3 - TUI terminal title: blessed writes ESC ] 0 ; <title> BEL when the screen title is set and never puts the old title back; its own restore code is commented out in lib/program.ts. createScreen now pushes the current window title onto the terminal's title stack (ESC [ 22 ; 2 t) before blessed renames the window, and on the screen 'destroy' event clears the title and pops the stack (ESC ] 0 ; BEL then ESC [ 23 ; 2 t). Clearing first means terminals without a title stack fall back to their own default instead of keeping a stale view name, while terminals that support the stack restore the exact previous title. No new global signal handlers were added: blessed already routes its exit, SIGINT/SIGTERM/SIGQUIT and uncaughtException teardown through screen.destroy(). The handler is guarded by a once flag because blessed emits 'destroy' twice per screen (Screen.destroy emits it, then Node.destroy emits it again via forDescendants), and one push must not be popped twice.
+
+Item 4 - piped board header: renderBoardTui's non-TTY branch passed the literal string "Project" to the board generators, so piped output always read 'Project: Project'. It now passes options.projectName, the value the TTY branch already resolves for the window title, and keeps "Project" only as the fallback for an unnamed project. Both the status board and the --milestones board are fixed.
+
+Verification. Item 1: reproduced 'error: unknown option --plain' before the change; after it, 'backlog doc create "Plain Doc" --plain' exits 0 and prints the created id and path. Item 2: against a project holding both a legacy title-only file (API-Guidelines.md) and a current nested file (guides/api/doc-2 - Nested-Doc.md), the old id-to-filename matcher resolved neither ('OPENED NOTHING' for both) while the new reader opens both. Item 3: verified under a real PTY (script -q). Before, teardown emitted no title sequence at all and the shell title stayed 'Acme Website - Board'. After, open emits ESC[22;2t then the rename, and teardown emits ESC]0;BEL then ESC[23;2t exactly once - confirmed on both clean exit and the SIGINT path. Item 4: piped 'backlog board' and 'backlog board --milestones' now print 'Project: Acme Website' instead of 'Project: Project'. Checks: bunx tsc --noEmit clean, bun run check . clean, bun run test green with 2078 pass / 6 skip / 0 fail across 223 files.
+
+Out of scope, surfaced while researching item 2 and left unfixed: the document watcher in src/core/content-store.ts retries forever for a file named doc-1.md (it passes the doc- prefix gate but its split(" - ") id never matches the frontmatter id) and compares ids with raw equality where the rest of the codebase uses documentIdsEqual; and src/cli.ts carries an unused duplicate of generateNextDocId that also lives in src/utils/id-generators.ts.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed four independent polish defects. doc create now accepts --plain instead of rejecting it as an unknown option. doc list's interactive branch resolves the picked document through the same core reader as doc view, so documents stored under the older title-only filenames and documents in subdirectories both open instead of showing nothing. The TUI saves the terminal window title before renaming the window and clears and restores it during the teardown blessed already performs, so the shell title survives a session. Piped board output prints the configured project name instead of the literal 'Project'. Verified by reproducing each defect first: CLI runs for the doc and board commands, an old-versus-new resolution run over a project holding both doc layouts, and PTY captures of the title escape sequences on clean exit and on SIGINT. Covered by tests for items 1, 2, 3 and 4; bunx tsc --noEmit and bun run check . are clean and bun run test is green at 2078 pass / 6 skip / 0 fail.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4172,6 +4172,7 @@ addHelpSchema(docCmd.command("create <title>"), {
 			description: "Subdirectory under backlog/docs; absolute paths and .. are rejected",
 		},
 		{ name: "type", type: choiceType(DOCUMENT_TYPE_VALUES), description: "Document type" },
+		{ name: "plain", type: "Boolean", description: "Use plain text output" },
 	],
 	writes: "Creates a document markdown file under the configured docs directory",
 	output: "Created document ID and path",
@@ -4179,6 +4180,8 @@ addHelpSchema(docCmd.command("create <title>"), {
 })
 	.option("-p, --path <path>")
 	.option("-t, --type <type>", `document type (${DOCUMENT_TYPE_VALUES.join(", ")})`)
+	// Accepted so agent guidance that always passes --plain works; create output is already plain text.
+	.option("--plain", "use plain text output")
 	.action(async (title: string, options) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
@@ -4265,16 +4268,11 @@ addHelpSchema(docCmd.command("list"), {
 		// Interactive UI
 		const selected = await genericSelectList("Select a document", docs);
 		if (selected) {
-			// Show document details (recursive search)
-			const files = await Array.fromAsync(
-				new Bun.Glob("**/*.md").scan({ cwd: core.filesystem.docsDir, followSymlinks: true }),
-			);
-			const docFile = files.find(
-				(f) => f.startsWith(`${selected.id} -`) || f.endsWith(`/${selected.id}.md`) || f === `${selected.id}.md`,
-			);
-			if (docFile) {
-				const filePath = join(core.filesystem.docsDir, docFile);
-				const content = await Bun.file(filePath).text();
+			// Resolve through the same reader as `doc view`. Matching filenames against the id
+			// only found `<id> - <title>.md` at the top level, so documents written under the
+			// older title-only filenames, or in a subdirectory, opened as nothing.
+			const content = await core.getDocumentContent(selected.id);
+			if (content !== null) {
 				await scrollableViewer(content);
 			}
 		}

--- a/src/test/cli-doc-decision-board.test.ts
+++ b/src/test/cli-doc-decision-board.test.ts
@@ -57,6 +57,15 @@ describe("CLI Integration", () => {
 			expect(docs[0]?.path).toBe("guides/setup/doc-1 - Setup-Guide.md");
 		});
 
+		it("should accept --plain on doc create and print the plain result", async () => {
+			const result = await $`bun ${CLI_PATH} doc create "Setup Guide" --plain`.cwd(TEST_DIR).quiet().nothrow();
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr.toString()).not.toContain("unknown option");
+			const stdout = result.stdout.toString();
+			expect(stdout).toContain("Created document doc-1");
+			expect(stdout).toContain("Path: backlog/docs/doc-1 - Setup-Guide.md");
+		});
+
 		it("should reject unsafe document paths", async () => {
 			const result = await $`bun ${CLI_PATH} doc create "Unsafe" -p ../outside`.cwd(TEST_DIR).quiet().nothrow();
 			expect(result.exitCode).not.toBe(0);
@@ -231,6 +240,28 @@ describe("CLI Integration", () => {
 
 			const core = new Core(TEST_DIR);
 			await initializeTestProject(core, "Board Test Project", true);
+		});
+
+		it("should print the configured project name in the piped board header", async () => {
+			const core = new Core(TEST_DIR);
+			await core.createTask(
+				{
+					id: "task-1",
+					title: "Todo Task",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					rawContent: "A task in todo",
+				},
+				false,
+			);
+
+			// Piping makes stdout a non-TTY, which is the plain-text board fallback.
+			const result = await $`bun ${CLI_PATH} board`.cwd(TEST_DIR).quiet().nothrow();
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toContain("Project: Board Test Project");
 		});
 
 		it("should display kanban board with tasks grouped by status", async () => {

--- a/src/test/docs-recursive.test.ts
+++ b/src/test/docs-recursive.test.ts
@@ -77,6 +77,38 @@ describe("Docs recursive listing and ID generation", () => {
 		expect(allDocs.length).toBe(4);
 	});
 
+	// `doc list` resolves the picked document through getDocumentContent, the same reader
+	// `doc view` uses. It used to match the selected id against filenames instead, which
+	// only recognised `<id> - <title>.md` at the top level.
+	it("reads document content for legacy title-only filenames and for subdirectories", async () => {
+		const core = new Core(TEST_DIR);
+
+		// Documents created before the id was added to the filename are stored as `<Title>.md`.
+		await writeFile(
+			join(core.filesystem.docsDir, "API-Guidelines.md"),
+			`---
+id: doc-1
+title: API Guidelines
+type: other
+created_date: 2020-01-01
+---
+
+Legacy title-only body
+`,
+		);
+		await core.createDocument(
+			{ id: "doc-2", title: "Nested", type: "other", createdDate: "2020-01-02", rawContent: "Nested body" },
+			false,
+			"guides/api",
+		);
+
+		const docs = await core.filesystem.listDocuments();
+		expect(docs.map((doc) => doc.path).sort()).toEqual(["API-Guidelines.md", "guides/api/doc-2 - Nested.md"]);
+
+		expect(await core.getDocumentContent("doc-1")).toContain("Legacy title-only body");
+		expect(await core.getDocumentContent("doc-2")).toContain("Nested body");
+	});
+
 	itIfSymlinks("includes documents from symlinked subdirectories", async () => {
 		const core = new Core(TEST_DIR);
 		const docsDir = core.filesystem.docsDir;

--- a/src/test/tui-window-title.test.ts
+++ b/src/test/tui-window-title.test.ts
@@ -30,22 +30,16 @@ function captureTerminalWrites(run: (record: () => string, reset: () => void) =>
 
 /**
  * Run `capture` as if the process were inside tmux. blessed reads `process.env.TMUX` when
- * the program is constructed, and it defers its tmux writes until the output stream has
- * been written to, so `bytesWritten` is primed the way a rendered session leaves it.
+ * the program is constructed. Nothing else is faked: `bytesWritten` stays at the value Bun
+ * reports, which is what makes blessed defer its own tmux writes, so these titles have to
+ * arrive without waiting on that.
  */
 function inTmux(capture: () => void): void {
 	const originalTmux = process.env.TMUX;
-	const originalBytesWritten = process.stdout.bytesWritten;
 	process.env.TMUX = "/private/tmp/tmux-501/default,1,0";
-	Object.defineProperty(process.stdout, "bytesWritten", { value: 1, configurable: true, writable: true });
 	try {
 		capture();
 	} finally {
-		Object.defineProperty(process.stdout, "bytesWritten", {
-			value: originalBytesWritten,
-			configurable: true,
-			writable: true,
-		});
 		if (originalTmux === undefined) {
 			delete process.env.TMUX;
 		} else {
@@ -111,10 +105,11 @@ describe("TUI window titles", () => {
 			// blessed buffers the title write, so drain it before checking the ordering.
 			screen.program.flush?.();
 
-			// ESC [ 22 ; 2 t pushes the title the user already had onto the terminal's stack.
+			// ESC [ 22 ; 0 t saves the icon and window titles the user already had, the pair
+			// OSC 0 goes on to overwrite.
 			const opened = record();
-			expect(opened).toContain("\x1b[22;2t");
-			expect(opened.indexOf("\x1b[22;2t")).toBeLessThan(opened.indexOf("Acme Website - Board"));
+			expect(opened).toContain("\x1b[22;0t");
+			expect(opened.indexOf("\x1b[22;0t")).toBeLessThan(opened.indexOf("Acme Website - Board"));
 
 			reset();
 			screen.destroy();
@@ -123,33 +118,36 @@ describe("TUI window titles", () => {
 			// ones that have it, so the pop must come last to win where it is supported.
 			const closed = record();
 			expect(closed).toContain("\x1b]0;\x07");
-			expect(closed).toContain("\x1b[23;2t");
-			expect(closed.indexOf("\x1b]0;\x07")).toBeLessThan(closed.indexOf("\x1b[23;2t"));
+			expect(closed).toContain("\x1b[23;0t");
+			expect(closed.indexOf("\x1b]0;\x07")).toBeLessThan(closed.indexOf("\x1b[23;0t"));
 			// blessed emits "destroy" twice per screen, and one push must not be popped twice.
-			expect(closed.split("\x1b[23;2t")).toHaveLength(2);
+			expect(closed.split("\x1b[23;0t")).toHaveLength(2);
 		});
 	});
 
-	it("forwards the title stack controls to the outer terminal inside tmux", () => {
+	it("forwards the title stack controls to the outer terminal inside tmux, without waiting", () => {
 		inTmux(() => {
 			captureTerminalWrites((record, reset) => {
 				const screen = createScreen({ smartCSR: false, title: formatTuiTitle("Board", "Acme Website") });
-				screen.program.flush?.();
 
-				// Inside tmux every one of these has to travel through the DCS passthrough,
-				// otherwise tmux consumes it and the outer terminal never sees it. blessed
-				// already does that for the title, so the push and pop must match it.
+				// Inside tmux these have to travel through the DCS passthrough, otherwise tmux
+				// consumes them and the outer terminal never sees them. They also have to be
+				// written synchronously: blessed's own tmux writes wait on a byte counter Bun
+				// never moves, and a sequence queued that way is lost when the process exits.
 				const opened = record();
-				expect(opened).toContain("\x1bPtmux;\x1b\x1b[22;2t\x1b\\");
-				expect(opened).toContain("\x1bPtmux;\x1b\x1b]0;Acme Website - Board\x07\x1b\\");
+				expect(opened).toContain("\x1bPtmux;\x1b\x1b[22;0t\x1b\\");
+				// Nothing was flushed or awaited, and blessed's deferred title has not landed.
+				expect(opened).not.toContain("Acme Website - Board");
 
 				reset();
 				screen.destroy();
 
 				const closed = record();
 				expect(closed).toContain("\x1bPtmux;\x1b\x1b]0;\x07\x1b\\");
-				expect(closed).toContain("\x1bPtmux;\x1b\x1b[23;2t\x1b\\");
-				expect(closed.indexOf("\x1b]0;\x07")).toBeLessThan(closed.indexOf("\x1b[23;2t"));
+				expect(closed).toContain("\x1bPtmux;\x1b\x1b[23;0t\x1b\\");
+				expect(closed.indexOf("\x1b]0;\x07")).toBeLessThan(closed.indexOf("\x1b[23;0t"));
+				// Each sequence needs its own envelope: the DCS escapes one leading ESC only.
+				expect(closed).not.toContain("\x1b]0;\x07\x1b[23;0t");
 			});
 		});
 	});
@@ -160,8 +158,8 @@ describe("TUI window titles", () => {
 			screen.destroy();
 
 			const written = record();
-			expect(written).not.toContain("\x1b[22;2t");
-			expect(written).not.toContain("\x1b[23;2t");
+			expect(written).not.toContain("\x1b[22;0t");
+			expect(written).not.toContain("\x1b[23;0t");
 		});
 	});
 

--- a/src/test/tui-window-title.test.ts
+++ b/src/test/tui-window-title.test.ts
@@ -8,6 +8,26 @@ function hasControlCharacters(value: string): boolean {
 	});
 }
 
+/** Collect everything the screen writes to the terminal while `run` executes. */
+function captureTerminalWrites(run: (record: () => string, reset: () => void) => void): void {
+	const chunks: string[] = [];
+	const originalWrite = process.stdout.write;
+	process.stdout.write = ((chunk: unknown) => {
+		chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+		return true;
+	}) as typeof process.stdout.write;
+	try {
+		run(
+			() => chunks.join(""),
+			() => {
+				chunks.length = 0;
+			},
+		);
+	} finally {
+		process.stdout.write = originalWrite;
+	}
+}
+
 describe("TUI window titles", () => {
 	it("prefixes the configured project name", () => {
 		expect(formatTuiTitle("Board", "Acme Website")).toBe("Acme Website - Board");
@@ -57,6 +77,42 @@ describe("TUI window titles", () => {
 		} finally {
 			screen.destroy();
 		}
+	});
+
+	it("saves the previous window title and restores it when the screen is destroyed", () => {
+		captureTerminalWrites((record, reset) => {
+			const screen = createScreen({ smartCSR: false, title: formatTuiTitle("Board", "Acme Website") });
+			// blessed buffers the title write, so drain it before checking the ordering.
+			screen.program.flush?.();
+
+			// ESC [ 22 ; 2 t pushes the title the user already had onto the terminal's stack.
+			const opened = record();
+			expect(opened).toContain("\x1b[22;2t");
+			expect(opened.indexOf("\x1b[22;2t")).toBeLessThan(opened.indexOf("Acme Website - Board"));
+
+			reset();
+			screen.destroy();
+
+			// The title is cleared for terminals without a title stack, then popped for the
+			// ones that have it, so the pop must come last to win where it is supported.
+			const closed = record();
+			expect(closed).toContain("\x1b]0;\x07");
+			expect(closed).toContain("\x1b[23;2t");
+			expect(closed.indexOf("\x1b]0;\x07")).toBeLessThan(closed.indexOf("\x1b[23;2t"));
+			// blessed emits "destroy" twice per screen, and one push must not be popped twice.
+			expect(closed.split("\x1b[23;2t")).toHaveLength(2);
+		});
+	});
+
+	it("leaves the window title alone for screens that do not set one", () => {
+		captureTerminalWrites((record) => {
+			const screen = createScreen({ smartCSR: false });
+			screen.destroy();
+
+			const written = record();
+			expect(written).not.toContain("\x1b[22;2t");
+			expect(written).not.toContain("\x1b[23;2t");
+		});
 	});
 
 	it("keeps the emitted screen title free of injected escape sequences", () => {

--- a/src/test/tui-window-title.test.ts
+++ b/src/test/tui-window-title.test.ts
@@ -28,6 +28,32 @@ function captureTerminalWrites(run: (record: () => string, reset: () => void) =>
 	}
 }
 
+/**
+ * Run `capture` as if the process were inside tmux. blessed reads `process.env.TMUX` when
+ * the program is constructed, and it defers its tmux writes until the output stream has
+ * been written to, so `bytesWritten` is primed the way a rendered session leaves it.
+ */
+function inTmux(capture: () => void): void {
+	const originalTmux = process.env.TMUX;
+	const originalBytesWritten = process.stdout.bytesWritten;
+	process.env.TMUX = "/private/tmp/tmux-501/default,1,0";
+	Object.defineProperty(process.stdout, "bytesWritten", { value: 1, configurable: true, writable: true });
+	try {
+		capture();
+	} finally {
+		Object.defineProperty(process.stdout, "bytesWritten", {
+			value: originalBytesWritten,
+			configurable: true,
+			writable: true,
+		});
+		if (originalTmux === undefined) {
+			delete process.env.TMUX;
+		} else {
+			process.env.TMUX = originalTmux;
+		}
+	}
+}
+
 describe("TUI window titles", () => {
 	it("prefixes the configured project name", () => {
 		expect(formatTuiTitle("Board", "Acme Website")).toBe("Acme Website - Board");
@@ -101,6 +127,30 @@ describe("TUI window titles", () => {
 			expect(closed.indexOf("\x1b]0;\x07")).toBeLessThan(closed.indexOf("\x1b[23;2t"));
 			// blessed emits "destroy" twice per screen, and one push must not be popped twice.
 			expect(closed.split("\x1b[23;2t")).toHaveLength(2);
+		});
+	});
+
+	it("forwards the title stack controls to the outer terminal inside tmux", () => {
+		inTmux(() => {
+			captureTerminalWrites((record, reset) => {
+				const screen = createScreen({ smartCSR: false, title: formatTuiTitle("Board", "Acme Website") });
+				screen.program.flush?.();
+
+				// Inside tmux every one of these has to travel through the DCS passthrough,
+				// otherwise tmux consumes it and the outer terminal never sees it. blessed
+				// already does that for the title, so the push and pop must match it.
+				const opened = record();
+				expect(opened).toContain("\x1bPtmux;\x1b\x1b[22;2t\x1b\\");
+				expect(opened).toContain("\x1bPtmux;\x1b\x1b]0;Acme Website - Board\x07\x1b\\");
+
+				reset();
+				screen.destroy();
+
+				const closed = record();
+				expect(closed).toContain("\x1bPtmux;\x1b\x1b]0;\x07\x1b\\");
+				expect(closed).toContain("\x1bPtmux;\x1b\x1b[23;2t\x1b\\");
+				expect(closed.indexOf("\x1b]0;\x07")).toBeLessThan(closed.indexOf("\x1b[23;2t"));
+			});
 		});
 	});
 

--- a/src/types/neo-neo-bblessed.d.ts
+++ b/src/types/neo-neo-bblessed.d.ts
@@ -6,7 +6,8 @@ declare module "neo-neo-bblessed" {
 		showCursor(): void;
 		input: NodeJS.EventEmitter;
 		setTitle(title: string): boolean;
-		write(text: string): boolean;
+		/** Writes escape sequences, wrapping them in the tmux DCS passthrough when inside tmux. */
+		_twrite(data: string): boolean;
 		pause?: () => (() => void) | undefined;
 		flush?: () => void;
 		put?: {

--- a/src/types/neo-neo-bblessed.d.ts
+++ b/src/types/neo-neo-bblessed.d.ts
@@ -5,6 +5,8 @@ declare module "neo-neo-bblessed" {
 		hideCursor(): void;
 		showCursor(): void;
 		input: NodeJS.EventEmitter;
+		setTitle(title: string): boolean;
+		write(text: string): boolean;
 		pause?: () => (() => void) | undefined;
 		flush?: () => void;
 		put?: {

--- a/src/types/neo-neo-bblessed.d.ts
+++ b/src/types/neo-neo-bblessed.d.ts
@@ -5,9 +5,10 @@ declare module "neo-neo-bblessed" {
 		hideCursor(): void;
 		showCursor(): void;
 		input: NodeJS.EventEmitter;
-		setTitle(title: string): boolean;
-		/** Writes escape sequences, wrapping them in the tmux DCS passthrough when inside tmux. */
-		_twrite(data: string): boolean;
+		/** True when the process is running inside tmux, so writes need DCS passthrough. */
+		tmux: boolean;
+		/** Writes straight to the output stream, unbuffered. */
+		write(text: string): boolean;
 		pause?: () => (() => void) | undefined;
 		flush?: () => void;
 		put?: {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -288,10 +288,11 @@ export async function renderBoardTui(
 	},
 ): Promise<void> {
 	if (!process.stdout.isTTY) {
+		const projectName = options?.projectName?.trim() || "Project";
 		if (options?.milestoneMode) {
-			console.log(generateMilestoneGroupedBoard(initialTasks, statuses, options.milestoneEntities ?? [], "Project"));
+			console.log(generateMilestoneGroupedBoard(initialTasks, statuses, options.milestoneEntities ?? [], projectName));
 		} else {
-			console.log(generateKanbanBoardWithMetadata(initialTasks, statuses, "Project"));
+			console.log(generateKanbanBoardWithMetadata(initialTasks, statuses, projectName));
 		}
 		return;
 	}

--- a/src/ui/tui.ts
+++ b/src/ui/tui.ts
@@ -111,26 +111,37 @@ export function formatTuiTitle(view: string, projectName?: string): string {
 	return stripControlCharacters(usableName ? `${usableName} - ${view}` : `Backlog ${view}`);
 }
 
-/** Push the current terminal window title onto the terminal's title stack. */
-const PUSH_WINDOW_TITLE = "\x1b[22;2t";
-/** Pop the terminal window title the matching push saved. */
-const POP_WINDOW_TITLE = "\x1b[23;2t";
+/** Save the icon and window titles onto the terminal's title stack, the pair OSC 0 sets. */
+const PUSH_WINDOW_TITLE = "\x1b[22;0t";
+/** Restore the pair the matching push saved. */
+const POP_WINDOW_TITLE = "\x1b[23;0t";
+/** Clear the title, for terminals that keep no title stack to pop from. */
+const CLEAR_WINDOW_TITLE = "\x1b]0;\x07";
+
+/**
+ * Write one terminal control sequence straight to the output, wrapping it in the tmux DCS
+ * passthrough when inside tmux so the outer terminal receives it rather than tmux itself.
+ *
+ * blessed's own `_twrite` wraps the same way, but for tmux it defers the write until the
+ * output reports bytes written, which Bun never reports, so it falls back to a five second
+ * poll. A teardown sequence queued that way is lost as soon as the process exits, which is
+ * exactly the case this restore exists for, so these are written raw and synchronously.
+ *
+ * One sequence per call: the DCS envelope escapes a single leading ESC, so two sequences
+ * cannot share one envelope.
+ */
+function writeTerminalControl(program: ProgramInterface, sequence: string): void {
+	program.write(program.tmux ? `\x1bPtmux;\x1b${sequence.replaceAll("\x1b\\", "\x07")}\x1b\\` : sequence);
+}
 
 export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterface {
 	const program: ProgramInterface = createProgram({ tput: false });
 
-	// Renaming the terminal window must not outlive the session, so save the title the
-	// user had before blessed overwrites it and put it back during teardown. Terminals
-	// without a title stack ignore the push and pop, so teardown clears the title first
-	// and they fall back to their own default instead of keeping a stale view name.
-	//
-	// These go through _twrite, the same writer setTitle uses, because inside tmux it
-	// wraps output in the DCS passthrough that reaches the outer terminal. A raw write
-	// would be consumed by tmux itself, so the outer terminal would see the title change
-	// but never the push or the pop, and could not restore the title it started with.
+	// Renaming the terminal window must not outlive the session, so save the titles the
+	// user had before blessed overwrites them and put them back during teardown.
 	const managesWindowTitle = typeof options.title === "string" && options.title.length > 0;
 	if (managesWindowTitle) {
-		program._twrite(PUSH_WINDOW_TITLE);
+		writeTerminalControl(program, PUSH_WINDOW_TITLE);
 	}
 
 	const screen = blessedScreen({ smartCSR: true, program, fullUnicode: true, ...options });
@@ -145,10 +156,11 @@ export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterf
 				return;
 			}
 			restoredWindowTitle = true;
-			program.setTitle("");
-			program._twrite(POP_WINDOW_TITLE);
-			// screen.destroy() can run from process exit, where a deferred flush never happens.
-			program.flush?.();
+			// Clear first so terminals without a title stack fall back to their own default
+			// instead of keeping a stale view name, then pop so terminals that have one
+			// restore the exact pair the push saved.
+			writeTerminalControl(program, CLEAR_WINDOW_TITLE);
+			writeTerminalControl(program, POP_WINDOW_TITLE);
 		});
 	}
 

--- a/src/ui/tui.ts
+++ b/src/ui/tui.ts
@@ -123,9 +123,14 @@ export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterf
 	// user had before blessed overwrites it and put it back during teardown. Terminals
 	// without a title stack ignore the push and pop, so teardown clears the title first
 	// and they fall back to their own default instead of keeping a stale view name.
+	//
+	// These go through _twrite, the same writer setTitle uses, because inside tmux it
+	// wraps output in the DCS passthrough that reaches the outer terminal. A raw write
+	// would be consumed by tmux itself, so the outer terminal would see the title change
+	// but never the push or the pop, and could not restore the title it started with.
 	const managesWindowTitle = typeof options.title === "string" && options.title.length > 0;
 	if (managesWindowTitle) {
-		program.write(PUSH_WINDOW_TITLE);
+		program._twrite(PUSH_WINDOW_TITLE);
 	}
 
 	const screen = blessedScreen({ smartCSR: true, program, fullUnicode: true, ...options });
@@ -141,9 +146,9 @@ export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterf
 			}
 			restoredWindowTitle = true;
 			program.setTitle("");
+			program._twrite(POP_WINDOW_TITLE);
 			// screen.destroy() can run from process exit, where a deferred flush never happens.
 			program.flush?.();
-			program.write(POP_WINDOW_TITLE);
 		});
 	}
 

--- a/src/ui/tui.ts
+++ b/src/ui/tui.ts
@@ -111,9 +111,41 @@ export function formatTuiTitle(view: string, projectName?: string): string {
 	return stripControlCharacters(usableName ? `${usableName} - ${view}` : `Backlog ${view}`);
 }
 
+/** Push the current terminal window title onto the terminal's title stack. */
+const PUSH_WINDOW_TITLE = "\x1b[22;2t";
+/** Pop the terminal window title the matching push saved. */
+const POP_WINDOW_TITLE = "\x1b[23;2t";
+
 export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterface {
 	const program: ProgramInterface = createProgram({ tput: false });
+
+	// Renaming the terminal window must not outlive the session, so save the title the
+	// user had before blessed overwrites it and put it back during teardown. Terminals
+	// without a title stack ignore the push and pop, so teardown clears the title first
+	// and they fall back to their own default instead of keeping a stale view name.
+	const managesWindowTitle = typeof options.title === "string" && options.title.length > 0;
+	if (managesWindowTitle) {
+		program.write(PUSH_WINDOW_TITLE);
+	}
+
 	const screen = blessedScreen({ smartCSR: true, program, fullUnicode: true, ...options });
+
+	if (managesWindowTitle) {
+		// blessed routes its exit, SIGINT/SIGTERM/SIGQUIT, and uncaughtException teardown
+		// through screen.destroy(), so this covers every path that already ends a session.
+		// It emits "destroy" twice per screen, and one push must not be popped twice.
+		let restoredWindowTitle = false;
+		screen.on("destroy", () => {
+			if (restoredWindowTitle) {
+				return;
+			}
+			restoredWindowTitle = true;
+			program.setTitle("");
+			// screen.destroy() can run from process exit, where a deferred flush never happens.
+			program.flush?.();
+			program.write(POP_WINDOW_TITLE);
+		});
+	}
 
 	if (process.env.DEBUG) {
 		const tputColors = (screen as unknown as { tput?: { colors?: number } }).tput?.colors;


### PR DESCRIPTION
Four independent confirmed defects from the Aug 2026 review rounds, batched into one PR. Task: BACK-609.

Each defect was reproduced first, then fixed. The fixes do not interact.

---

## 1. `backlog doc create <title> --plain` errored instead of printing plain output

**Problem.** The `doc create` subcommand never registered `--plain`, so commander rejected it:

```
$ backlog doc create "API Guidelines" --plain
error: unknown option '--plain'
Run with --help to see accepted fields and examples.
```

Agent guidance passes `--plain` on every command, so this made `doc create` unusable from that path.

**Fix.** Register the flag and document it in the help schema, following the existing `decision create --plain` precedent: create output is already plain text, so the flag is accepted rather than switching formats.

**Evidence.**

```
$ backlog doc create "Plain Doc" --plain
Created document doc-3
Path: backlog/docs/doc-3 - Plain-Doc.md
```

Covered by `should accept --plain on doc create and print the plain result` in `src/test/cli-doc-decision-board.test.ts`, which also asserts the absence of `unknown option`.

---

## 2. `backlog doc list` broke for projects using the older docs output path

**Problem.** The interactive branch of `doc list` resolved the document the user picked by matching its id against filenames rather than using the document's own path:

```ts
const docFile = files.find(
  (f) => f.startsWith(`${selected.id} -`) || f.endsWith(`/${selected.id}.md`) || f === `${selected.id}.md`,
);
```

That matcher recognises `<id> - <title>.md` only at the top level, plus an id-only `<id>.md`. Two real layouts miss it:

- **The older docs output path.** Documents written before `87324692` (2025-07-12, "handle docs & decisions in the web view") are stored as `backlog/docs/<Sanitized-Title>.md`, with no id in the filename at all. The id lives only in frontmatter.
- **The current nested form.** Since `ff4e88b6` (2025-09-06, recursive docs) documents can live at `<subdir>/<id> - <title>.md`, which none of the three clauses match either. That clause was wrong at birth: it expects `guides/doc-1.md`, but the writer had been emitting `guides/doc-1 - Title.md` since two months earlier.

The failure was silent — `docFile` came back `undefined` and the branch fell through, so selecting the document opened nothing and printed no error. `doc list --plain` was unaffected (it lists from frontmatter), so the break only showed for a human in a terminal.

`f1d0bc30` had already replaced this exact matcher in `doc view` with core resolution but left the copy in `doc list`.

**Fix.** `doc list` now reads through `core.getDocumentContent`, the same reader `doc view` uses, which resolves from the document's docs-relative path. That restores a single document reader and covers both layouts.

**Evidence.** Against a project holding a legacy title-only file and a current nested file side by side, running the old and new resolution over the same tree:

```
$ find backlog/docs -type f
backlog/docs/API-Guidelines.md
backlog/docs/guides/api/doc-2 - Nested-Doc.md

doc-1 (API-Guidelines.md)
  before: OPENED NOTHING
  after:  opened Legacy title-only body
doc-2 (guides/api/doc-2 - Nested-Doc.md)
  before: OPENED NOTHING
  after:  opened
```

Covered by `reads document content for legacy title-only filenames and for subdirectories` in `src/test/docs-recursive.test.ts`, which asserts both layouts are listed with their paths and that the reader now returns each body. Note that the picker itself cannot be driven from a test — `genericSelectList` returns `null` when stdout is not a TTY — so the test covers the reader the picker now calls.

---

## 3. The TUI changed the terminal title but never restored it

**Problem.** `createScreen` sets the blessed screen title, which writes `ESC ] 0 ; <title> BEL`. Nothing ever put the old title back — blessed's own restore is commented out in `lib/program.ts`:

```js
// Potentially reset window title on exit:
// if (program._originalTitle) {
//   program.setTitle(program._originalTitle);
// }
```

So after `backlog board` exited, the terminal kept showing `Acme Website - Board`.

**Fix.** `createScreen` pushes the current window title onto the terminal's title stack (`ESC [ 22 ; 2 t`) before blessed renames the window, and on the screen `destroy` event clears the title and pops the stack (`ESC ] 0 ; BEL`, then `ESC [ 23 ; 2 t`). Clearing first means terminals without a title stack fall back to their own default instead of keeping a stale view name, while terminals that support the stack restore the exact previous title.

No new global signal handlers: blessed already routes its `exit`, `SIGINT`/`SIGTERM`/`SIGQUIT` and `uncaughtException` teardown through `screen.destroy()`. The handler is guarded by a once flag because blessed emits `destroy` twice per screen (`Screen.destroy` emits it, then `Node.destroy` emits it again via `forDescendants`) and one push must not be popped twice. Screens created without a title — the scrollable viewer and the loading screen — are untouched.

**Evidence.** Recorded under a real PTY (`script -q`), opening and tearing down a titled screen the way `backlog board` does. `ESC` and `BEL` are shown as `ESC`/`BEL`:

Before, on the `SIGINT` teardown path:

```
"ESC]0;Acme Website - BoardBEL ESC[?1049h ... ESC[?1049l"
push present: false | clear present: false | pop present: false
```

The title is set and nothing restores it.

After, clean exit:

```
isTTY: true
on open : "ESC[22;2tESC]0;Acme Website - BoardBELESC[?1049h"
on close: "ESC[?1lESC>ESC[?12lESC[?25hESC[HESC[2JESC[?1049lESC]0;BELESC[23;2t"
```

After, `SIGINT`:

```
push: true clear: true pop: true | pop count: 1
```

Covered by `saves the previous window title and restores it when the screen is destroyed` and `leaves the window title alone for screens that do not set one` in `src/test/tui-window-title.test.ts`, which capture the terminal writes and assert the ordering (clear before pop) and that the pop happens exactly once.

`src/types/neo-neo-bblessed.d.ts` gains `setTitle` and `_twrite` on the hand-written `ProgramInterface` declaration, which lists only the methods this repo uses.

**Review follow-up (second commit).** Codex flagged that the push/pop originally went through the raw `program.write`, which bypasses blessed's tmux DCS passthrough: inside tmux the outer terminal received the OSC title set and clear (via `setTitle` -> `_twrite`) but never the title-stack push/pop, so a stack-capable outer terminal could not restore its title. Both controls now route through `_twrite`, matching `setTitle`. Outside tmux the emitted byte stream is unchanged (verified by PTY capture diff, including the SIGINT path); inside tmux all four sequences are DCS-wrapped. A new test asserts the exact tmux-wrapped bytes.

---

## 4. Piped `backlog board` printed a hardcoded `Project: Project`

**Problem.** The non-TTY branch of `renderBoardTui` passed the literal string `"Project"` to both board generators, even though `options.projectName` was already resolved and used for the TUI window title a few lines below.

```
$ backlog board | head -3
# Kanban Board Export (powered by Backlog.md)
Generated on: 2026-08-08 16:55:51
Project: Project
```

**Fix.** Pass `options.projectName`, keeping `"Project"` only as the fallback for an unnamed project.

**Evidence.** In a project named `Acme Website`:

```
$ backlog board | grep '^Project:'
Project: Acme Website
$ backlog board --milestones | grep '^Project:'
Project: Acme Website
```

Covered by `should print the configured project name in the piped board header` in `src/test/cli-doc-decision-board.test.ts`, which runs the CLI as a subprocess so stdout is genuinely not a TTY.

---

## Verification

- `bunx tsc --noEmit` — clean
- `bun run check .` — clean
- `bun run test` — 2078 pass, 6 skip, 0 fail across 223 files

Rebased onto `origin/main` at `73592673` (BACK-605) after it landed, and all four fixes plus the full suite were re-verified on the rebased tree.

## Noted, not fixed here

Two out-of-scope issues surfaced while researching item 2 and were deliberately left alone:

- `src/core/content-store.ts`: the document watcher retries forever for a file named `doc-1.md` (it passes the `doc-` prefix gate but its `split(" - ")` id never equals the frontmatter id), and it compares ids with raw equality where `findDocumentById` and `saveDocument` use `documentIdsEqual`.
- `src/cli.ts` carries an unused duplicate of `generateNextDocId` that also lives in `src/utils/id-generators.ts`.

