### PR TITLE
BACK-607 - Resolve bare numeric task IDs consistently across all commands

### DIFF
--- a/backlog/tasks/back-607 - Resolve-bare-numeric-task-IDs-consistently-across-all-commands.md
+++ b/backlog/tasks/back-607 - Resolve-bare-numeric-task-IDs-consistently-across-all-commands.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-607
 title: Resolve bare numeric task IDs consistently across all commands
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-08 15:56'
+updated_date: '2026-08-08 19:55'
 labels: []
 dependencies: []
 ordinal: 246000
@@ -17,14 +19,56 @@ With a non-default ID prefix configured, backlog task 597 resolves the task but 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 task edit accepts bare numeric IDs wherever task view does, including with a custom ID prefix
-- [ ] #2 All ID-accepting commands share a single resolution path
-- [ ] #3 Tests with a custom prefix cover view, edit, and the other ID-accepting commands
+- [x] #1 task edit accepts bare numeric IDs wherever task view does, including with a custom ID prefix
+- [x] #2 All ID-accepting commands share a single resolution path
+- [x] #3 Tests with a custom prefix cover view, edit, and the other ID-accepting commands
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce with a BACK-prefixed project: 'backlog task 1' resolves, 'backlog task edit 1' prints 'Task 1 not found.'. Root cause: CLI pre-normalizes user input with normalizeTaskId(), which stamps the DEFAULT 'task' prefix onto bare numeric IDs before the shared resolver ever sees them, so 'task-1' never matches 'BACK-1'.
+2. Map every ID-accepting surface and record which ones pre-normalize: task view / task <id> / task archive / task complete / task demote / MCP already pass raw input into Core (shared resolver); task edit (+ its wizard), task list --parent, and --depends-on/--dep pre-normalize and break.
+3. Fix by deleting the premature normalization so all commands hand the raw argument to the one shared resolver (Core.getTask -> ContentStore.resolveTaskForRead / loadLocalTaskForMutation -> TaskIdentityIndex, which already fails closed with AmbiguousTaskIdError):
+   - task edit: drop canonicalId, resolve raw via core.loadTaskById, then use the resolved task.id for editTask and error formatting (also un-masks ambiguity, which currently degrades to 'not found').
+   - task edit wizard: drop normalizeTaskId on the taskId argument.
+   - task list --parent: match on the raw value via taskIdsEqual; use canonicalTaskId(input, configured task prefix) for display only so 'not found' text stays correct under any prefix.
+   - dependencies: delete normalizeDependencies (it applied the default prefix) in favour of the existing parseDelimitedStringList; validateDependencies already canonicalizes to real IDs via taskIdsEqual. Make removeDependencies compare with taskIdsEqual instead of exact strings.
+   - task demote: resolve first like archive/complete, echo the resolved ID, and exit 1 when unresolved.
+   - Use resolved IDs (not re-normalized raw input) in complete/demote commit messages and in the create --parent not-found message.
+4. Delete the now-unused normalizeTaskId import from cli.ts; no new resolver and no new flags.
+5. Prove it with a table-driven test over every ID-accepting command in a BACK-prefixed project, each run twice (bare numeric + prefixed), plus draft commands, plus a duplicate-ID case asserting task edit now reports the fail-closed ambiguity error.
+6. Verify: bunx tsc --noEmit, bun run check ., full bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: nothing was wrong with the resolver. The CLI pre-normalized user input with normalizeTaskId(), which stamps the DEFAULT 'task' prefix onto a bare numeric ID, so 'backlog task edit 597' asked the shared resolver for TASK-597 in a project whose tasks are BACK-597. Commands that passed the raw argument through to Core (task view, task <id>, task archive, task complete, and every MCP tool) already worked, which is why the two surfaces disagreed.
+
+Command map (custom prefix BACK, bare numeric '1'):
+- Already correct, raw input into Core's resolver: task <id>, task view, task archive, task complete, task demote (resolution only), task create --parent, draft <id>, draft view, draft archive/promote (resolution only).
+- Broken: task edit ('Task 1 not found.'), task edit wizard, task list --parent ('Parent task TASK-1 not found.'), task create --dep / task edit --dep ('dependencies do not exist: TASK-1').
+- Misreported the target even when resolution worked: task demote and draft archive/promote echoed the raw argument ('Demoted task 1'), and complete/demote commit messages used normalizeTaskId(raw input), writing 'TASK-1' into history for a BACK project.
+
+Fix: removed the premature normalization instead of adding a resolver. Every ID-accepting command now hands the raw argument to the one shared path (Core.getTask -> ContentStore.resolveTaskForRead / loadLocalTaskForMutation -> TaskIdentityIndex) and uses the resolved task.id for output, commit messages, and follow-up mutations. Deleted normalizeDependencies() (32 lines, whose entire job was the buggy default-prefix stamping) in favour of the existing parseDelimitedStringList; validateDependencies already canonicalizes to real IDs via taskIdsEqual, so stored dependencies stay canonical. removeDependencies now compares with taskIdsEqual rather than exact strings. --parent keeps a display-only canonicalTaskId(input, configured prefix) so 'not found' text names BACK-999, not TASK-999.
+
+Side effect worth noting: 'task edit <ambiguous id>' used to report 'Task 1 not found.' because the mangled ID matched nothing, masking a duplicate-ID collision. It now surfaces the same fail-closed AmbiguousTaskIdError as every other command. task demote and draft archive/promote also now exit 1 when the ID does not resolve; previously they printed an error and exited 0.
+
+Fail-closed behavior is unchanged: no new resolver, no new ID forms, no change to ID generation, and the AmbiguousIdError shape is untouched.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Bare numeric task IDs now resolve identically on every ID-accepting command under any configured ID prefix. The bug was premature normalization, not resolution: the CLI rewrote user input with the default 'task' prefix before the shared resolver saw it, so 'task edit 597' looked for TASK-597 in a BACK project. Removed that normalization from task edit (and its wizard), task list --parent, and the dependency flags; deleted normalizeDependencies() in favour of the existing parseDelimitedStringList; and made task demote plus draft archive/promote resolve first so their output, commit messages, and exit codes name the real task. No new resolver, no new ID forms, no change to ID generation, and AmbiguousTaskIdError is untouched.
+
+Verified with src/test/cli-custom-prefix-id-resolution.test.ts: a table over 14 ID-accepting commands run with both a bare numeric and a prefixed ID in a BACK-prefixed project (31 tests), plus a duplicate-ID case asserting all six task commands still fail closed with 'is ambiguous' and leave both files in place. Confirmed the table fails 10 tests against the pre-fix code via git stash. Also checked by hand that every ID form that resolved before (task-1, TASK-1, Task-1, 1, 001, task-001) still resolves on the default prefix. bunx tsc --noEmit and bun run check . clean; full bun run test green at 2113 pass / 0 fail (two earlier runs each hit a different watcher/timing test under concurrent load, both green in isolation).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,7 +80,7 @@ import {
 	runMcpClientSetupCommand,
 } from "./utils/mcp-client-setup.ts";
 import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
-import { hasAnyPrefix } from "./utils/prefix-config.ts";
+import { DRAFT_PREFIX, hasAnyPrefix, normalizeId } from "./utils/prefix-config.ts";
 import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
 import { type ReadOutputMode, resolveReadOutputMode } from "./utils/read-output-mode.ts";
 import { getTaskReadiness, loadReadinessGraph } from "./utils/readiness.ts";
@@ -94,7 +94,7 @@ import {
 	toStringArray,
 } from "./utils/task-builders.ts";
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
-import { canonicalTaskId, taskIdsEqual } from "./utils/task-path.ts";
+import { AmbiguousTaskIdError, canonicalTaskId, taskIdsEqual } from "./utils/task-path.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
 import { formatValidTaskTypeValues, getTaskTypeValues, resolveTaskTypeValues } from "./utils/task-type-config.ts";
 import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
@@ -548,6 +548,28 @@ function validateClearableListInput(input: {
 		return `Cannot use an empty value with ${input.setterFlags}. ${guidance}`;
 	}
 	return undefined;
+}
+
+/**
+ * Resolve a --parent argument to the single task it names, before any child task is read.
+ *
+ * Identity fails closed here exactly as it does for a targeted task ID: a value matching several
+ * files must not silently filter on whichever one came first. Returns the resolved canonical ID so
+ * filtering never runs on the raw input.
+ */
+function resolveParentFilterId(tasks: Task[], parentId: string, parentDisplayId: string): string {
+	const matches = tasks.filter((task) => taskIdsEqual(parentId, task.id));
+	if (matches.length > 1) {
+		throw new AmbiguousTaskIdError(
+			parentDisplayId,
+			matches.map((task) => task.filePath ?? task.id),
+		);
+	}
+	const parent = matches[0];
+	if (!parent) {
+		throw new Error(`Parent task ${parentDisplayId} not found.`);
+	}
+	return parent.id;
 }
 
 /**
@@ -2510,6 +2532,24 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 
 		if (outputMode !== "interactive") {
+			// Resolve the parent before reading children so an ambiguous ID never emits task data.
+			let resolvedParentId: string | undefined;
+			if (parentId) {
+				try {
+					resolvedParentId = resolveParentFilterId(
+						await core.queryTasks({ includeCrossBranch: false }),
+						parentId,
+						parentDisplayId ?? parentId,
+					);
+				} catch (error) {
+					console.error(error instanceof Error ? error.message : String(error));
+					process.exitCode = 1;
+					cleanup();
+					return;
+				}
+				baseFilters.parentTaskId = resolvedParentId;
+			}
+
 			let tasks = await core.queryTasks({
 				query: searchQuery || undefined,
 				filters: Object.keys(baseFilters).length > 0 ? baseFilters : undefined,
@@ -2520,18 +2560,6 @@ addHelpSchema(taskCmd.command("list"), {
 			if (options.ready) {
 				const readinessGraph = await loadReadinessGraph(core);
 				tasks = tasks.filter((task) => getTaskReadiness(task, readinessGraph).isReady);
-			}
-
-			if (parentId) {
-				const parentExists = (await core.queryTasks({ includeCrossBranch: false })).some((task) =>
-					taskIdsEqual(parentId, task.id),
-				);
-				if (!parentExists) {
-					console.error(`Parent task ${parentDisplayId} not found.`);
-					process.exitCode = 1;
-					cleanup();
-					return;
-				}
 			}
 
 			let sortedTasks = tasks;
@@ -2549,8 +2577,9 @@ addHelpSchema(taskCmd.command("list"), {
 			}
 
 			let filtered = sortedTasks;
-			if (parentId) {
-				filtered = filtered.filter((task) => task.parentTaskId && taskIdsEqual(parentId, task.parentTaskId));
+			if (resolvedParentId) {
+				const parent = resolvedParentId;
+				filtered = filtered.filter((task) => task.parentTaskId && taskIdsEqual(parent, task.parentTaskId));
 			}
 			if (labelFilters.length > 0) {
 				filtered = filtered.filter((task) => taskMatchesAllLabels(task, labelFilters));
@@ -2565,7 +2594,7 @@ addHelpSchema(taskCmd.command("list"), {
 			}
 
 			if (filtered.length === 0) {
-				if (parentId) {
+				if (resolvedParentId) {
 					console.log(`No child tasks found for parent task ${parentDisplayId}.`);
 				} else {
 					console.log("No tasks found.");
@@ -2718,12 +2747,11 @@ addHelpSchema(taskCmd.command("list"), {
 					parentId ? core.queryTasks() : Promise.resolve(undefined),
 				]);
 
-				if (parentId && allTasksForParentCheck) {
-					const parentExists = allTasksForParentCheck.some((task) => taskIdsEqual(parentId, task.id));
-					if (!parentExists) {
-						throw new Error(`Parent task ${parentDisplayId} not found.`);
-					}
-				}
+				// Throws before anything is displayed when the parent is missing or ambiguous.
+				const resolvedParentId =
+					parentId && allTasksForParentCheck
+						? resolveParentFilterId(allTasksForParentCheck, parentId, parentDisplayId ?? parentId)
+						: undefined;
 
 				let sortedTasks = tasks;
 				if (options.sort) {
@@ -2737,8 +2765,8 @@ addHelpSchema(taskCmd.command("list"), {
 				}
 
 				let filtered = sortedTasks;
-				if (parentId) {
-					filtered = filtered.filter((task) => task.parentTaskId && taskIdsEqual(parentId, task.parentTaskId));
+				if (resolvedParentId) {
+					filtered = filtered.filter((task) => task.parentTaskId && taskIdsEqual(resolvedParentId, task.parentTaskId));
 				}
 
 				return {
@@ -3670,9 +3698,10 @@ draftCmd
 	.action(async (taskId: string) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
-		const draft = await core.filesystem.loadDraft(taskId);
-		if (draft && (await core.archiveDraft(draft.id))) {
-			console.log(`Archived draft ${draft.id}`);
+		// The argument itself selects the draft file; re-resolving by its frontmatter ID could
+		// target a different file when a draft filename and its ID have drifted apart.
+		if (await core.archiveDraft(taskId)) {
+			console.log(`Archived draft ${normalizeId(taskId, DRAFT_PREFIX)}`);
 		} else {
 			console.error(`Draft ${taskId} not found.`);
 			process.exitCode = 1;
@@ -3686,9 +3715,9 @@ draftCmd
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		try {
-			const draft = await core.filesystem.loadDraft(taskId);
-			if (draft && (await core.promoteDraft(draft.id))) {
-				console.log(`Promoted draft ${draft.id}`);
+			// Same as archive: the argument selects the file, so it must not be re-resolved by ID.
+			if (await core.promoteDraft(taskId)) {
+				console.log(`Promoted draft ${normalizeId(taskId, DRAFT_PREFIX)}`);
 			} else {
 				console.error(`Draft ${taskId} not found.`);
 				process.exitCode = 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -556,13 +556,12 @@ function validateClearableListInput(input: {
  * Identity fails closed here exactly as it does for a targeted task ID: a value matching several
  * files must not silently filter on whichever one came first. Returns the resolved canonical ID so
  * filtering never runs on the raw input.
+ *
+ * The corpus is loaded here rather than passed in, so every output mode resolves the parent from the
+ * same local task list that produces the displayed children and cannot drift apart.
  */
-async function resolveParentFilterId(
-	core: Core,
-	tasks: Task[],
-	parentId: string,
-	parentDisplayId: string,
-): Promise<string> {
+async function resolveParentFilterId(core: Core, parentId: string, parentDisplayId: string): Promise<string> {
+	const tasks = await core.queryTasks({ includeCrossBranch: false });
 	const matches = tasks.filter((task) => taskIdsEqual(parentId, task.id));
 	if (matches.length > 1) {
 		throw new AmbiguousTaskIdError(
@@ -2544,12 +2543,7 @@ addHelpSchema(taskCmd.command("list"), {
 			let resolvedParentId: string | undefined;
 			if (parentId) {
 				try {
-					resolvedParentId = await resolveParentFilterId(
-						core,
-						await core.queryTasks({ includeCrossBranch: false }),
-						parentId,
-						parentDisplayId ?? parentId,
-					);
+					resolvedParentId = await resolveParentFilterId(core, parentId, parentDisplayId ?? parentId);
 				} catch (error) {
 					console.error(error instanceof Error ? error.message : String(error));
 					process.exitCode = 1;
@@ -2748,19 +2742,15 @@ addHelpSchema(taskCmd.command("list"), {
 
 				// Now query with filters - this will use the already-populated ContentStore
 				updateProgress("Applying filters...");
-				const [tasks, allTasksForParentCheck] = await Promise.all([
-					core.queryTasks({
-						filters: Object.keys(interactiveLoaderFilters).length > 0 ? interactiveLoaderFilters : undefined,
-						includeCrossBranch: false,
-					}),
-					parentId ? core.queryTasks() : Promise.resolve(undefined),
-				]);
+				const tasks = await core.queryTasks({
+					filters: Object.keys(interactiveLoaderFilters).length > 0 ? interactiveLoaderFilters : undefined,
+					includeCrossBranch: false,
+				});
 
 				// Throws before anything is displayed when the parent is missing or ambiguous.
-				const resolvedParentId =
-					parentId && allTasksForParentCheck
-						? await resolveParentFilterId(core, allTasksForParentCheck, parentId, parentDisplayId ?? parentId)
-						: undefined;
+				const resolvedParentId = parentId
+					? await resolveParentFilterId(core, parentId, parentDisplayId ?? parentId)
+					: undefined;
 
 				let sortedTasks = tasks;
 				if (options.sort) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -557,7 +557,12 @@ function validateClearableListInput(input: {
  * files must not silently filter on whichever one came first. Returns the resolved canonical ID so
  * filtering never runs on the raw input.
  */
-function resolveParentFilterId(tasks: Task[], parentId: string, parentDisplayId: string): string {
+async function resolveParentFilterId(
+	core: Core,
+	tasks: Task[],
+	parentId: string,
+	parentDisplayId: string,
+): Promise<string> {
 	const matches = tasks.filter((task) => taskIdsEqual(parentId, task.id));
 	if (matches.length > 1) {
 		throw new AmbiguousTaskIdError(
@@ -569,6 +574,9 @@ function resolveParentFilterId(tasks: Task[], parentId: string, parentDisplayId:
 	if (!parent) {
 		throw new Error(`Parent task ${parentDisplayId} not found.`);
 	}
+	// Called for its ambiguity check: it raises AmbiguousTaskIdError when several files claim this
+	// ID, which the corpus cannot report because it keeps one entry per ID.
+	await core.getTask(parent.id);
 	return parent.id;
 }
 
@@ -2536,7 +2544,8 @@ addHelpSchema(taskCmd.command("list"), {
 			let resolvedParentId: string | undefined;
 			if (parentId) {
 				try {
-					resolvedParentId = resolveParentFilterId(
+					resolvedParentId = await resolveParentFilterId(
+						core,
 						await core.queryTasks({ includeCrossBranch: false }),
 						parentId,
 						parentDisplayId ?? parentId,
@@ -2750,7 +2759,7 @@ addHelpSchema(taskCmd.command("list"), {
 				// Throws before anything is displayed when the parent is missing or ambiguous.
 				const resolvedParentId =
 					parentId && allTasksForParentCheck
-						? resolveParentFilterId(allTasksForParentCheck, parentId, parentDisplayId ?? parentId)
+						? await resolveParentFilterId(core, allTasksForParentCheck, parentId, parentDisplayId ?? parentId)
 						: undefined;
 
 				let sortedTasks = tasks;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,7 +87,6 @@ import { getTaskReadiness, loadReadinessGraph } from "./utils/readiness.ts";
 import { resolveRuntimeCwd } from "./utils/runtime-cwd.ts";
 import { formatValidStatuses, getCanonicalStatus, getCanonicalStatuses, getValidStatuses } from "./utils/status.ts";
 import {
-	normalizeDependencies,
 	parseClearableStringList,
 	parseDelimitedStringList,
 	parsePositiveIndexList,
@@ -95,7 +94,7 @@ import {
 	toStringArray,
 } from "./utils/task-builders.ts";
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
-import { normalizeTaskId, taskIdsEqual } from "./utils/task-path.ts";
+import { canonicalTaskId, taskIdsEqual } from "./utils/task-path.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
 import { formatValidTaskTypeValues, getTaskTypeValues, resolveTaskTypeValues } from "./utils/task-type-config.ts";
 import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
@@ -565,7 +564,7 @@ function validateTaskListFlags(
 		validateClearableListInput({
 			rawValues: [...toStringArray(options.dependsOn), ...toStringArray(options.dep)],
 			cleared: Boolean(options.clearDeps),
-			isBlank: (value) => normalizeDependencies([value]).length === 0,
+			isBlank: isBlankListValue,
 			setterFlags: "--depends-on or --dep",
 			clearFlag: clearFlag("--clear-deps"),
 			subject: "task dependencies",
@@ -1910,7 +1909,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 			return;
 		}
 
-		const dependencies = [...toStringArray(options.dependsOn), ...toStringArray(options.dep)];
+		const dependencies = parseDelimitedStringList([...toStringArray(options.dependsOn), ...toStringArray(options.dep)]);
 
 		try {
 			const criteria = processAcceptanceCriteriaOptions(options);
@@ -1922,7 +1921,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 				status: createAsDraft ? "Draft" : options.status ? String(options.status) : undefined,
 				assignee: parseClearableStringList(options.assignee),
 				labels: parseDelimitedStringList(options.labels),
-				dependencies: dependencies.length > 0 ? normalizeDependencies(dependencies) : undefined,
+				dependencies,
 				references: parseDelimitedStringList(options.ref),
 				documentation: parseDelimitedStringList(options.doc),
 				modifiedFiles: parseDelimitedStringList(options.modifiedFile),
@@ -2482,11 +2481,15 @@ addHelpSchema(taskCmd.command("list"), {
 			taskLimit = parsedLimit;
 		}
 
+		// The raw argument reaches identity comparison untouched so bare numeric IDs resolve under any
+		// configured prefix; the canonical form is only used for display.
 		let parentId: string | undefined;
+		let parentDisplayId: string | undefined;
 		if (options.parent) {
-			const parentInput = String(options.parent);
-			parentId = normalizeTaskId(parentInput);
-			baseFilters.parentTaskId = parentInput;
+			parentId = String(options.parent).trim();
+			baseFilters.parentTaskId = parentId;
+			const config = await core.filesystem.loadConfig();
+			parentDisplayId = canonicalTaskId(parentId, config?.prefixes?.task ?? "task");
 		}
 
 		if (options.sort) {
@@ -2517,7 +2520,7 @@ addHelpSchema(taskCmd.command("list"), {
 					taskIdsEqual(parentId, task.id),
 				);
 				if (!parentExists) {
-					console.error(`Parent task ${parentId} not found.`);
+					console.error(`Parent task ${parentDisplayId} not found.`);
 					process.exitCode = 1;
 					cleanup();
 					return;
@@ -2556,8 +2559,7 @@ addHelpSchema(taskCmd.command("list"), {
 
 			if (filtered.length === 0) {
 				if (options.parent) {
-					const canonicalParent = normalizeTaskId(String(options.parent));
-					console.log(`No child tasks found for parent task ${canonicalParent}.`);
+					console.log(`No child tasks found for parent task ${parentDisplayId}.`);
 				} else {
 					console.log("No tasks found.");
 				}
@@ -2621,7 +2623,7 @@ addHelpSchema(taskCmd.command("list"), {
 		if (options.unassigned) activeFilters.push("Unassigned");
 		if (options.ready) activeFilters.push("Ready");
 		if (options.parent) {
-			activeFilters.push(`Parent: ${normalizeTaskId(String(options.parent))}`);
+			activeFilters.push(`Parent: ${parentDisplayId}`);
 		}
 		if (options.milestone) activeFilters.push(`Milestone: ${options.milestone}`);
 		if (baseFilters.priority) activeFilters.push(`Priority: ${baseFilters.priority}`);
@@ -2712,7 +2714,7 @@ addHelpSchema(taskCmd.command("list"), {
 				if (parentId && allTasksForParentCheck) {
 					const parentExists = allTasksForParentCheck.some((task) => taskIdsEqual(parentId, task.id));
 					if (!parentExists) {
-						throw new Error(`Parent task ${parentId} not found.`);
+						throw new Error(`Parent task ${parentDisplayId} not found.`);
 					}
 				}
 
@@ -2973,7 +2975,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		const core = new Core(cwd);
 
 		if (shouldUseWizard) {
-			let selectedTaskId = taskId ? normalizeTaskId(taskId) : undefined;
+			let selectedTaskId = taskId?.trim() || undefined;
 			if (!selectedTaskId) {
 				const localTasks = await core.queryTasks({ includeCrossBranch: false });
 				const taskOptions = localTasks.map((candidate) => ({
@@ -3021,8 +3023,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			return;
 		}
 
-		const canonicalId = normalizeTaskId(taskId ?? "");
-		const existingTask = await core.loadTaskById(canonicalId);
+		const existingTask = await core.loadTaskById(taskId ?? "");
 
 		if (!existingTask) {
 			console.error(`Task ${taskId} not found.`);
@@ -3110,7 +3111,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 				uncheckDod = dodUnchecks;
 			}
 		} catch (error) {
-			console.error(formatTaskEditError(error, canonicalId));
+			console.error(formatTaskEditError(error, existingTask.id));
 			process.exitCode = 1;
 			return;
 		}
@@ -3166,7 +3167,6 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			.map((value) => String(value).trim())
 			.filter((value) => value.length > 0);
 
-		const combinedDependencies = [...toStringArray(options.dependsOn), ...toStringArray(options.dep)];
 		const clearableListError = validateTaskListFlags(options, { supportsClearFlags: true });
 		if (clearableListError) {
 			console.error(clearableListError);
@@ -3181,7 +3181,10 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			process.exitCode = 1;
 			return;
 		}
-		const dependencyValues = combinedDependencies.length > 0 ? normalizeDependencies(combinedDependencies) : undefined;
+		const dependencyValues = parseDelimitedStringList([
+			...toStringArray(options.dependsOn),
+			...toStringArray(options.dep),
+		]);
 
 		const normalizedReferences = parseDelimitedStringList(options.ref);
 		const addReferenceValues = parseDelimitedStringList(options.addRef) ?? [];
@@ -3315,9 +3318,9 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		let updatedTask: Task;
 		try {
 			const updateInput = buildTaskUpdateInput(editArgs);
-			updatedTask = await core.editTask(canonicalId, updateInput);
+			updatedTask = await core.editTask(existingTask.id, updateInput);
 		} catch (error) {
-			console.error(formatTaskEditError(error, canonicalId));
+			console.error(formatTaskEditError(error, existingTask.id));
 			process.exitCode = 1;
 			return;
 		}
@@ -3490,11 +3493,12 @@ taskCmd
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		try {
-			const success = await core.demoteTask(taskId);
-			if (success) {
-				console.log(`Demoted task ${taskId}`);
+			const task = await core.loadTaskById(taskId);
+			if (task && (await core.demoteTask(task.id))) {
+				console.log(`Demoted task ${task.id}`);
 			} else {
 				console.error(`Task ${taskId} not found.`);
+				process.exitCode = 1;
 			}
 		} catch (error) {
 			console.error(error instanceof Error ? error.message : String(error));
@@ -3659,11 +3663,12 @@ draftCmd
 	.action(async (taskId: string) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
-		const success = await core.archiveDraft(taskId);
-		if (success) {
-			console.log(`Archived draft ${taskId}`);
+		const draft = await core.filesystem.loadDraft(taskId);
+		if (draft && (await core.archiveDraft(draft.id))) {
+			console.log(`Archived draft ${draft.id}`);
 		} else {
 			console.error(`Draft ${taskId} not found.`);
+			process.exitCode = 1;
 		}
 	});
 
@@ -3674,11 +3679,12 @@ draftCmd
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		try {
-			const success = await core.promoteDraft(taskId);
-			if (success) {
-				console.log(`Promoted draft ${taskId}`);
+			const draft = await core.filesystem.loadDraft(taskId);
+			if (draft && (await core.promoteDraft(draft.id))) {
+				console.log(`Promoted draft ${draft.id}`);
 			} else {
 				console.error(`Draft ${taskId} not found.`);
+				process.exitCode = 1;
 			}
 		} catch (error) {
 			console.error(error instanceof Error ? error.message : String(error));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2485,8 +2485,15 @@ addHelpSchema(taskCmd.command("list"), {
 		// configured prefix; the canonical form is only used for display.
 		let parentId: string | undefined;
 		let parentDisplayId: string | undefined;
-		if (options.parent) {
+		if (options.parent !== undefined) {
 			parentId = String(options.parent).trim();
+			if (parentId === "") {
+				// A blank value must not silently degrade into "no parent filter" and list every task.
+				console.error("Cannot use an empty value with --parent. Omit the flag to list every task.");
+				process.exitCode = 1;
+				cleanup();
+				return;
+			}
 			baseFilters.parentTaskId = parentId;
 			const config = await core.filesystem.loadConfig();
 			parentDisplayId = canonicalTaskId(parentId, config?.prefixes?.task ?? "task");
@@ -2558,7 +2565,7 @@ addHelpSchema(taskCmd.command("list"), {
 			}
 
 			if (filtered.length === 0) {
-				if (options.parent) {
+				if (parentId) {
 					console.log(`No child tasks found for parent task ${parentDisplayId}.`);
 				} else {
 					console.log("No tasks found.");
@@ -2622,7 +2629,7 @@ addHelpSchema(taskCmd.command("list"), {
 		if (options.assignee) activeFilters.push(`Assignee: ${options.assignee}`);
 		if (options.unassigned) activeFilters.push("Unassigned");
 		if (options.ready) activeFilters.push("Ready");
-		if (options.parent) {
+		if (parentId) {
 			activeFilters.push(`Parent: ${parentDisplayId}`);
 		}
 		if (options.milestone) activeFilters.push(`Milestone: ${options.milestone}`);

--- a/src/commands/task-wizard.ts
+++ b/src/commands/task-wizard.ts
@@ -4,7 +4,7 @@ import picocolors from "picocolors";
 import { DEFAULT_STATUSES } from "../constants/index.ts";
 import type { AcceptanceCriterion, Task, TaskCreateInput, TaskUpdateInput } from "../types/index.ts";
 import { getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
-import { normalizeDependencies, normalizeStringList } from "../utils/task-builders.ts";
+import { normalizeStringList } from "../utils/task-builders.ts";
 import { getTaskTypeValues, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 
 interface TaskWizardValues {
@@ -635,7 +635,7 @@ export async function runTaskCreateWizard(
 	const labels = parseListInput(values.labels);
 	const references = parseListInput(values.references);
 	const documentation = parseListInput(values.documentation);
-	const dependencies = normalizeDependencies(parseListInput(values.dependencies));
+	const dependencies = parseListInput(values.dependencies);
 	const acceptanceCriteria = parseChecklistInput(values.acceptanceCriteria).map((entry) => ({
 		text: entry.text,
 		checked: false,
@@ -708,8 +708,8 @@ export async function runTaskEditWizard(
 		updateInput.labels = nextLabels;
 	}
 
-	const initialDependencies = normalizeDependencies(parseListInput(initial.dependencies));
-	const nextDependencies = normalizeDependencies(parseListInput(values.dependencies));
+	const initialDependencies = parseListInput(initial.dependencies);
+	const nextDependencies = parseListInput(values.dependencies);
 	if (!areStringArraysEqual(initialDependencies, nextDependencies)) {
 		updateInput.dependencies = nextDependencies;
 	}

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -58,12 +58,19 @@ import {
 import { executeStatusCallback } from "../utils/status-callback.ts";
 import {
 	buildDefinitionOfDoneItems,
-	normalizeDependencies,
 	normalizeStringList,
+	parseDelimitedStringList,
 	stringArraysEqual,
 	validateDependencies,
 } from "../utils/task-builders.ts";
-import { AmbiguousTaskIdError, getDraftPath, getTaskPath, normalizeTaskId, taskIdsEqual } from "../utils/task-path.ts";
+import {
+	AmbiguousTaskIdError,
+	canonicalTaskId,
+	getDraftPath,
+	getTaskPath,
+	normalizeTaskId,
+	taskIdsEqual,
+} from "../utils/task-path.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { formatValidTaskTypeValues, matchesTaskTypeFilter, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
@@ -1295,7 +1302,7 @@ export class Core {
 
 		const normalizedLabels = normalizeStringList(input.labels) ?? [];
 		const normalizedAssignees = normalizeStringList(input.assignee) ?? [];
-		const normalizedDependencies = normalizeDependencies(input.dependencies);
+		const normalizedDependencies = parseDelimitedStringList(input.dependencies) ?? [];
 		const normalizedReferences = normalizeStringList(input.references) ?? [];
 		const normalizedDocumentation = normalizeStringList(input.documentation) ?? [];
 		const normalizedModifiedFiles = normalizeStringList(input.modifiedFiles) ?? [];
@@ -1436,9 +1443,10 @@ export class Core {
 	private async resolveParentTaskIdForCreate(parentTaskId: string): Promise<string> {
 		const parentTask = await this.loadTaskById(parentTaskId);
 		if (!parentTask) {
-			const normalizedParent = normalizeTaskId(parentTaskId);
+			const config = await this.fs.loadConfig();
+			const canonicalParent = canonicalTaskId(parentTaskId, config?.prefixes?.task ?? "task");
 			throw new Error(
-				`Parent task ${normalizedParent} not found. Use an existing task ID with --parent; use --milestone to assign a task to a milestone.`,
+				`Parent task ${canonicalParent} not found. Use an existing task ID with --parent; use --milestone to assign a task to a milestone.`,
 			);
 		}
 		return parentTask.id;
@@ -1624,7 +1632,7 @@ export class Core {
 			let currentDependencies = [...(task.dependencies ?? [])];
 
 			if (input.dependencies !== undefined) {
-				const normalized = normalizeDependencies(input.dependencies);
+				const normalized = parseDelimitedStringList(input.dependencies) ?? [];
 				const { valid, invalid } = await validateDependencies(normalized, this);
 				if (invalid.length > 0) {
 					throw new Error(
@@ -1638,7 +1646,7 @@ export class Core {
 			}
 
 			if (input.addDependencies && input.addDependencies.length > 0) {
-				const additions = normalizeDependencies(input.addDependencies);
+				const additions = parseDelimitedStringList(input.addDependencies) ?? [];
 				const { valid, invalid } = await validateDependencies(additions, this);
 				if (invalid.length > 0) {
 					throw new Error(
@@ -1656,8 +1664,8 @@ export class Core {
 			}
 
 			if (input.removeDependencies && input.removeDependencies.length > 0) {
-				const removals = new Set(normalizeDependencies(input.removeDependencies));
-				const filtered = currentDependencies.filter((dep) => !removals.has(dep));
+				const removals = parseDelimitedStringList(input.removeDependencies) ?? [];
+				const filtered = currentDependencies.filter((dep) => !removals.some((removal) => taskIdsEqual(removal, dep)));
 				if (!stringArraysEqual(filtered, currentDependencies)) {
 					currentDependencies = filtered;
 					mutated = true;
@@ -2585,7 +2593,7 @@ export class Core {
 		if (await this.shouldAutoCommit(autoCommit)) {
 			// Stage the file move for proper Git tracking
 			const repoRoot = await this.git.stageFileMove(fromPath, toPath);
-			await this.git.commitFiles(`backlog: Complete task ${normalizeTaskId(taskId)}`, [fromPath, toPath], repoRoot);
+			await this.git.commitFiles(`backlog: Complete task ${task.id}`, [fromPath, toPath], repoRoot);
 		}
 
 		return true;
@@ -2690,11 +2698,7 @@ export class Core {
 		const moved = movedPaths[0];
 
 		if (success && moved && (await this.shouldAutoCommit(autoCommit))) {
-			await this.commitWrittenFile(
-				`backlog: Demote task ${normalizeTaskId(taskId)}`,
-				[moved.previousPath],
-				moved.savedPath,
-			);
+			await this.commitWrittenFile(`backlog: Demote task ${task.id}`, [moved.previousPath], moved.savedPath);
 		}
 
 		return success;

--- a/src/test/cli-custom-prefix-id-resolution.test.ts
+++ b/src/test/cli-custom-prefix-id-resolution.test.ts
@@ -265,6 +265,79 @@ describe("CLI task ID resolution with a custom ID prefix", () => {
 		expect(await core.filesystem.loadTask("BACK-3")).toBeNull();
 	});
 
+	it("fails closed when a dependency ID matches two files declaring the exact same ID", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+		await createTask(core, "BACK-2", "Dependent task");
+		// Two files spelling the ID identically still collide. The task corpus keeps one entry per
+		// ID, so only the identity index can see this; dependency writes must consult it.
+		const tasksDir = core.filesystem.tasksDir;
+		await Bun.write(
+			join(tasksDir, "back-1 - Duplicate-file.md"),
+			await Bun.file(join(tasksDir, "back-1 - Target-task.md")).text(),
+		);
+
+		for (const args of [
+			["task", "edit", "2", "--dep", "1"],
+			["task", "edit", "2", "--dep", "BACK-1"],
+			["task", "create", "Dependent", "--dep", "1"],
+		]) {
+			const result = await $`bun ${CLI_PATH} ${args}`.cwd(TEST_DIR).nothrow().quiet();
+
+			expect(result.exitCode).not.toBe(0);
+			const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+			expect(output).toContain("Task ID BACK-1 is ambiguous");
+		}
+
+		expect((await core.filesystem.loadTask("BACK-2"))?.dependencies ?? []).toEqual([]);
+		expect(await core.filesystem.loadTask("BACK-3")).toBeNull();
+	});
+
+	it("fails closed instead of listing children when a parent filter ID is ambiguous", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+		await createTask(core, "BACK-1.1", "Child task", { parentTaskId: "BACK-1" });
+		const tasksDir = core.filesystem.tasksDir;
+		await Bun.write(
+			join(tasksDir, "back-01 - Duplicate-identity.md"),
+			(await Bun.file(join(tasksDir, "back-1 - Target-task.md")).text()).replace("id: BACK-1", "id: BACK-01"),
+		);
+
+		for (const parent of ["1", "BACK-1"]) {
+			const result = await $`bun ${CLI_PATH} task list --parent ${parent} --plain`.cwd(TEST_DIR).nothrow().quiet();
+
+			expect(result.exitCode).not.toBe(0);
+			const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+			expect(output).toContain("Task ID BACK-1 is ambiguous");
+			// The command must fail before emitting any child task data.
+			expect(result.stdout.toString()).not.toContain("BACK-1.1 - Child task");
+		}
+	});
+
+	it("archives and promotes the draft file named by the argument, not by its frontmatter ID", async () => {
+		// A drifted draft file (filename draft-1, frontmatter DRAFT-2) alongside a real draft-2 must
+		// not redirect the mutation onto the other file.
+		const core = await initCustomPrefixProject();
+		await createDraft(core, "DRAFT-2", "Two");
+		const draftsDir = await core.filesystem.getDraftsDir();
+		await Bun.write(
+			join(draftsDir, "draft-1 - One.md"),
+			(await Bun.file(join(draftsDir, "draft-2 - Two.md")).text()).replace("title: Two", "title: One"),
+		);
+
+		const archived = await $`bun ${CLI_PATH} draft archive 1`.cwd(TEST_DIR).nothrow().quiet();
+		expect(archived.exitCode).toBe(0);
+		expect(archived.stdout.toString()).toContain("Archived draft DRAFT-1");
+		expect(await Bun.file(join(draftsDir, "draft-1 - One.md")).exists()).toBe(false);
+		expect(await Bun.file(join(draftsDir, "draft-2 - Two.md")).exists()).toBe(true);
+
+		// Same for promote: the remaining draft-2 file must be the one promoted when asked for 2.
+		const promoted = await $`bun ${CLI_PATH} draft promote 2`.cwd(TEST_DIR).nothrow().quiet();
+		expect(promoted.exitCode).toBe(0);
+		expect(promoted.stdout.toString()).toContain("Promoted draft DRAFT-2");
+		expect(await Bun.file(join(draftsDir, "draft-2 - Two.md")).exists()).toBe(false);
+	});
+
 	it("fails closed when a bare dependency ID matches both a task and a draft", async () => {
 		const core = await initCustomPrefixProject();
 		await createTask(core, "BACK-1", "Target task");

--- a/src/test/cli-custom-prefix-id-resolution.test.ts
+++ b/src/test/cli-custom-prefix-id-resolution.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+
+const CLI_PATH = getTestCliPath();
+let TEST_DIR: string;
+
+/**
+ * Every command that takes a task or draft ID must resolve it through the same identity path,
+ * so a bare numeric ID works wherever a prefixed ID works - including under a custom ID prefix.
+ */
+async function initCustomPrefixProject(): Promise<Core> {
+	const core = new Core(TEST_DIR);
+	await initializeFilesystemTestProject(core, "Custom Prefix ID Resolution");
+	const config = await core.filesystem.loadConfig();
+	if (!config) throw new Error("Expected config to be loaded");
+	await core.filesystem.saveConfig({ ...config, prefixes: { ...config.prefixes, task: "BACK" } });
+	return core;
+}
+
+async function createTask(
+	core: Core,
+	id: string,
+	title: string,
+	extra: { status?: string; parentTaskId?: string } = {},
+): Promise<void> {
+	await core.filesystem.saveTask({
+		id,
+		title,
+		status: extra.status ?? "To Do",
+		assignee: [],
+		labels: [],
+		dependencies: [],
+		createdDate: "2026-08-08",
+		rawContent: "",
+		...(extra.parentTaskId ? { parentTaskId: extra.parentTaskId } : {}),
+	});
+}
+
+async function createDraft(core: Core, id: string, title: string): Promise<void> {
+	await core.filesystem.saveDraft({
+		id,
+		title,
+		status: "Draft",
+		assignee: [],
+		labels: [],
+		dependencies: [],
+		createdDate: "2026-08-08",
+		rawContent: "",
+	});
+}
+
+/** One case per ID-accepting command, run once with a bare numeric ID and once with a prefixed ID. */
+interface IdCommandCase {
+	name: string;
+	/** Receives the ID form under test and returns the CLI arguments to run. */
+	args: (id: string) => string[];
+	/** Fresh fixtures, because most of these commands move or rewrite the task they target. */
+	setup: (core: Core) => Promise<void>;
+	/** Expected on stdout for both ID forms. */
+	expected: string;
+}
+
+const idCommandCases: IdCommandCase[] = [
+	{
+		name: "task <id>",
+		args: (id) => ["task", id, "--plain"],
+		setup: async (core) => createTask(core, "BACK-1", "Target task"),
+		expected: "BACK-1 - Target task",
+	},
+	{
+		name: "task view",
+		args: (id) => ["task", "view", id, "--plain"],
+		setup: async (core) => createTask(core, "BACK-1", "Target task"),
+		expected: "BACK-1 - Target task",
+	},
+	{
+		name: "task edit",
+		args: (id) => ["task", "edit", id, "-s", "In Progress"],
+		setup: async (core) => createTask(core, "BACK-1", "Target task"),
+		expected: "Updated task BACK-1",
+	},
+	{
+		name: "task archive",
+		args: (id) => ["task", "archive", id],
+		setup: async (core) => createTask(core, "BACK-1", "Target task"),
+		expected: "Archived task BACK-1",
+	},
+	{
+		name: "task complete",
+		args: (id) => ["task", "complete", id],
+		setup: async (core) => createTask(core, "BACK-1", "Target task", { status: "Done" }),
+		expected: "Completed task BACK-1.",
+	},
+	{
+		name: "task demote",
+		args: (id) => ["task", "demote", id],
+		setup: async (core) => createTask(core, "BACK-1", "Target task"),
+		expected: "Demoted task BACK-1",
+	},
+	{
+		name: "task list --parent",
+		args: (id) => ["task", "list", "--parent", id, "--plain"],
+		setup: async (core) => {
+			await createTask(core, "BACK-1", "Target task");
+			await createTask(core, "BACK-1.1", "Child task", { parentTaskId: "BACK-1" });
+		},
+		expected: "BACK-1.1 - Child task",
+	},
+	{
+		name: "task create --parent",
+		args: (id) => ["task", "create", "Child", "--parent", id],
+		setup: async (core) => createTask(core, "BACK-1", "Target task"),
+		expected: "Created task BACK-1.1",
+	},
+	{
+		name: "task create --dep",
+		args: (id) => ["task", "create", "Dependent", "--dep", id],
+		setup: async (core) => createTask(core, "BACK-1", "Target task"),
+		expected: "Created task BACK-2",
+	},
+	{
+		name: "task edit --dep",
+		args: (id) => ["task", "edit", "BACK-2", "--dep", id],
+		setup: async (core) => {
+			await createTask(core, "BACK-1", "Target task");
+			await createTask(core, "BACK-2", "Dependent task");
+		},
+		expected: "Updated task BACK-2",
+	},
+];
+
+const draftCommandCases: IdCommandCase[] = [
+	{
+		name: "draft <id>",
+		args: (id) => ["draft", id, "--plain"],
+		setup: async (core) => createDraft(core, "DRAFT-1", "Target draft"),
+		expected: "DRAFT-1 - Target draft",
+	},
+	{
+		name: "draft view",
+		args: (id) => ["draft", "view", id, "--plain"],
+		setup: async (core) => createDraft(core, "DRAFT-1", "Target draft"),
+		expected: "DRAFT-1 - Target draft",
+	},
+	{
+		name: "draft archive",
+		args: (id) => ["draft", "archive", id],
+		setup: async (core) => createDraft(core, "DRAFT-1", "Target draft"),
+		expected: "Archived draft DRAFT-1",
+	},
+	{
+		name: "draft promote",
+		args: (id) => ["draft", "promote", id],
+		setup: async (core) => createDraft(core, "DRAFT-1", "Target draft"),
+		expected: "Promoted draft DRAFT-1",
+	},
+];
+
+describe("CLI task ID resolution with a custom ID prefix", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-custom-prefix-id-resolution");
+		await mkdir(TEST_DIR, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	for (const testCase of idCommandCases) {
+		for (const [form, id] of [
+			["bare numeric", "1"],
+			["prefixed", "BACK-1"],
+		] as const) {
+			it(`resolves a ${form} ID for ${testCase.name}`, async () => {
+				const core = await initCustomPrefixProject();
+				await testCase.setup(core);
+
+				const result = await $`bun ${CLI_PATH} ${testCase.args(id)}`.cwd(TEST_DIR).nothrow().quiet();
+
+				expect(result.stderr.toString()).not.toContain("not found");
+				expect(result.exitCode).toBe(0);
+				expect(result.stdout.toString()).toContain(testCase.expected);
+			});
+		}
+	}
+
+	for (const testCase of draftCommandCases) {
+		for (const [form, id] of [
+			["bare numeric", "1"],
+			["prefixed", "DRAFT-1"],
+		] as const) {
+			it(`resolves a ${form} ID for ${testCase.name}`, async () => {
+				const core = await initCustomPrefixProject();
+				await testCase.setup(core);
+
+				const result = await $`bun ${CLI_PATH} ${testCase.args(id)}`.cwd(TEST_DIR).nothrow().quiet();
+
+				expect(result.stderr.toString()).not.toContain("not found");
+				expect(result.exitCode).toBe(0);
+				expect(result.stdout.toString()).toContain(testCase.expected);
+			});
+		}
+	}
+
+	it("stores the canonical dependency ID when a bare numeric ID is supplied", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+		await createTask(core, "BACK-2", "Dependent task");
+
+		const result = await $`bun ${CLI_PATH} task edit 2 --dep 1`.cwd(TEST_DIR).nothrow().quiet();
+
+		expect(result.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("BACK-2"))?.dependencies).toEqual(["BACK-1"]);
+	});
+
+	it("reports missing IDs with the configured prefix instead of the default one", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+
+		const parentFilter = await $`bun ${CLI_PATH} task list --parent 999 --plain`.cwd(TEST_DIR).nothrow().quiet();
+		expect(parentFilter.exitCode).toBe(1);
+		expect(parentFilter.stderr.toString()).toContain("Parent task BACK-999 not found.");
+
+		const parentCreate = await $`bun ${CLI_PATH} task create Child --parent 999`.cwd(TEST_DIR).nothrow().quiet();
+		expect(parentCreate.exitCode).toBe(1);
+		expect(parentCreate.stderr.toString()).toContain("Parent task BACK-999 not found.");
+	});
+
+	it("fails closed on every ID-accepting command when the ID is ambiguous", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+		// A zero-padded twin claims the same identity, so nothing may guess a winner.
+		const tasksDir = core.filesystem.tasksDir;
+		await Bun.write(
+			join(tasksDir, "back-01 - Duplicate.md"),
+			await Bun.file(join(tasksDir, "back-1 - Target-task.md")).text(),
+		);
+
+		for (const args of [
+			["task", "1", "--plain"],
+			["task", "view", "1", "--plain"],
+			["task", "edit", "1", "-s", "In Progress"],
+			["task", "archive", "1"],
+			["task", "complete", "1"],
+			["task", "demote", "1"],
+		]) {
+			const result = await $`bun ${CLI_PATH} ${args}`.cwd(TEST_DIR).nothrow().quiet();
+
+			expect(result.exitCode).not.toBe(0);
+			const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+			expect(output).toContain("is ambiguous");
+			expect(output).toContain("back-01 - Duplicate.md");
+		}
+
+		// The mutation attempts above must have left the conflicting files untouched.
+		expect(await Bun.file(join(tasksDir, "back-1 - Target-task.md")).exists()).toBe(true);
+		expect(await Bun.file(join(tasksDir, "back-01 - Duplicate.md")).exists()).toBe(true);
+	});
+});

--- a/src/test/cli-custom-prefix-id-resolution.test.ts
+++ b/src/test/cli-custom-prefix-id-resolution.test.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
 import { getTestCliPath } from "./test-cli.ts";
-import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+import {
+	commitSamePathBranchTaskVariant,
+	createUniqueTestDir,
+	initializeFilesystemTestProject,
+	initializeTestProject,
+	safeCleanup,
+} from "./test-utils.ts";
 
 const CLI_PATH = getTestCliPath();
 let TEST_DIR: string;
@@ -323,6 +329,68 @@ describe("CLI task ID resolution with a custom ID prefix", () => {
 			}
 		});
 	}
+
+	it("resolves the parent filter from the local corpus in every output mode", async () => {
+		// A branch variant spelling BACK-1 as BACK-001 sits at its own path. The cross-branch corpus
+		// therefore holds two entries for identity BACK-1 while the local corpus holds one, so the
+		// parent filter must not resolve from a cross-branch list: whichever corpus a mode used would
+		// otherwise decide whether the same argument is accepted.
+		const core = new Core(TEST_DIR);
+		await $`git init -b main`.cwd(TEST_DIR).quiet();
+		await $`git config user.email test@example.com`.cwd(TEST_DIR).quiet();
+		await $`git config user.name Test`.cwd(TEST_DIR).quiet();
+		await initializeTestProject(core, "Cross Branch Parent Filter");
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Expected config to be loaded");
+		await core.filesystem.saveConfig({
+			...config,
+			prefixes: { ...config.prefixes, task: "BACK" },
+			checkActiveBranches: true,
+			remoteOperations: false,
+		});
+		await createTask(core, "BACK-1.1", "Child task", { parentTaskId: "BACK-1" });
+		await commitSamePathBranchTaskVariant(
+			core,
+			{
+				id: "BACK-1",
+				title: "Parent local",
+				status: "To Do",
+				assignee: [],
+				labels: [],
+				dependencies: [],
+				createdDate: "2026-08-09",
+				rawContent: "",
+			},
+			{
+				id: "BACK-001",
+				title: "Parent branch variant",
+				status: "To Do",
+				assignee: [],
+				labels: [],
+				dependencies: [],
+				createdDate: "2026-08-09",
+				rawContent: "",
+			},
+			join(core.filesystem.tasksDir, "back-001 - Parent-branch-variant.md"),
+		);
+
+		// The corpus the resolver reads sees one BACK-1; a cross-branch corpus would see two.
+		const localMatches = (await core.queryTasks({ includeCrossBranch: false })).filter((task) =>
+			["BACK-1", "BACK-001"].includes(task.id),
+		);
+		const crossBranchMatches = (await core.queryTasks()).filter((task) => ["BACK-1", "BACK-001"].includes(task.id));
+		expect(localMatches).toHaveLength(1);
+		expect(crossBranchMatches.length).toBeGreaterThan(1);
+
+		// Selecting the parent from the local corpus finds exactly one candidate, and the shared
+		// identity check then fails closed because the branch variant claims the same identity.
+		const result = await $`bun ${CLI_PATH} task list --parent 1 --plain`.cwd(TEST_DIR).nothrow().quiet();
+		const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+		expect(result.exitCode).not.toBe(0);
+		expect(output).toContain("Task ID BACK-1 is ambiguous");
+		expect(output).not.toContain("Parent task BACK-1 not found.");
+		expect(result.stdout.toString()).not.toContain("BACK-1.1 - Child task");
+	});
 
 	it("archives and promotes the draft file named by the argument, not by its frontmatter ID", async () => {
 		// A drifted draft file (filename draft-1, frontmatter DRAFT-2) alongside a real draft-2 must

--- a/src/test/cli-custom-prefix-id-resolution.test.ts
+++ b/src/test/cli-custom-prefix-id-resolution.test.ts
@@ -218,6 +218,99 @@ describe("CLI task ID resolution with a custom ID prefix", () => {
 		expect((await core.filesystem.loadTask("BACK-2"))?.dependencies).toEqual(["BACK-1"]);
 	});
 
+	it("stores one dependency when equivalent ID forms name the same task", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+		await createTask(core, "BACK-2", "Dependent task");
+
+		const edited = await $`bun ${CLI_PATH} task edit 2 --dep 1,BACK-1`.cwd(TEST_DIR).nothrow().quiet();
+		expect(edited.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("BACK-2"))?.dependencies).toEqual(["BACK-1"]);
+
+		const created = await $`bun ${CLI_PATH} task create Dependent --dep BACK-1,1,back-001`
+			.cwd(TEST_DIR)
+			.nothrow()
+			.quiet();
+		expect(created.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("BACK-3"))?.dependencies).toEqual(["BACK-1"]);
+	});
+
+	it("fails closed when a dependency ID matches two files claiming one identity", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+		await createTask(core, "BACK-2", "Dependent task");
+		// BACK-01 is the same identity as BACK-1, so no dependency write may guess between them.
+		// saveTask deletes same-identity files by design, so the twin is written straight to disk.
+		const tasksDir = core.filesystem.tasksDir;
+		await Bun.write(
+			join(tasksDir, "back-01 - Duplicate-identity.md"),
+			(await Bun.file(join(tasksDir, "back-1 - Target-task.md")).text()).replace("id: BACK-1", "id: BACK-01"),
+		);
+
+		for (const args of [
+			["task", "edit", "2", "--dep", "1"],
+			["task", "edit", "2", "--dep", "BACK-1"],
+			["task", "create", "Dependent", "--dep", "1"],
+		]) {
+			const result = await $`bun ${CLI_PATH} ${args}`.cwd(TEST_DIR).nothrow().quiet();
+
+			expect(result.exitCode).not.toBe(0);
+			const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+			// The colliding identity is named, not the bare input the user typed.
+			expect(output).toContain("Task ID BACK-1 is ambiguous");
+			expect(output).toContain("backlog doctor");
+		}
+
+		expect((await core.filesystem.loadTask("BACK-2"))?.dependencies ?? []).toEqual([]);
+		expect(await core.filesystem.loadTask("BACK-3")).toBeNull();
+	});
+
+	it("fails closed when a bare dependency ID matches both a task and a draft", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+		await createTask(core, "BACK-2", "Dependent task");
+		// Task and draft IDs come from separate counters, so a bare 1 names two different tasks.
+		await createDraft(core, "DRAFT-1", "Target draft");
+
+		const ambiguous = await $`bun ${CLI_PATH} task edit 2 --dep 1`.cwd(TEST_DIR).nothrow().quiet();
+		expect(ambiguous.exitCode).not.toBe(0);
+		const output = `${ambiguous.stdout.toString()}${ambiguous.stderr.toString()}`;
+		expect(output).toContain("Dependency ID 1 is ambiguous");
+		expect(output).toContain("back-1 - Target-task.md");
+		expect(output).toContain("draft-1 - Target-draft.md");
+		expect((await core.filesystem.loadTask("BACK-2"))?.dependencies ?? []).toEqual([]);
+
+		// A fully qualified ID still names exactly one of them, in either namespace.
+		const onTask = await $`bun ${CLI_PATH} task edit 2 --dep BACK-1`.cwd(TEST_DIR).nothrow().quiet();
+		expect(onTask.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("BACK-2"))?.dependencies).toEqual(["BACK-1"]);
+
+		const onDraft = await $`bun ${CLI_PATH} task edit 2 --dep DRAFT-1`.cwd(TEST_DIR).nothrow().quiet();
+		expect(onDraft.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("BACK-2"))?.dependencies).toEqual(["DRAFT-1"]);
+	});
+
+	it("rejects a blank parent filter instead of listing every task", async () => {
+		const core = await initCustomPrefixProject();
+		await createTask(core, "BACK-1", "Target task");
+		await createTask(core, "BACK-2", "Other task");
+
+		for (const parent of ["   ", ""]) {
+			const result = await $`bun ${CLI_PATH} task list --parent ${parent} --plain`.cwd(TEST_DIR).nothrow().quiet();
+
+			expect(result.exitCode).toBe(1);
+			expect(result.stderr.toString()).toContain(
+				"Cannot use an empty value with --parent. Omit the flag to list every task.",
+			);
+			expect(result.stdout.toString()).not.toContain("BACK-2 - Other task");
+		}
+
+		// Omitting the flag still lists everything.
+		const unfiltered = await $`bun ${CLI_PATH} task list --plain`.cwd(TEST_DIR).nothrow().quiet();
+		expect(unfiltered.exitCode).toBe(0);
+		expect(unfiltered.stdout.toString()).toContain("BACK-2 - Other task");
+	});
+
 	it("reports missing IDs with the configured prefix instead of the default one", async () => {
 		const core = await initCustomPrefixProject();
 		await createTask(core, "BACK-1", "Target task");

--- a/src/test/cli-custom-prefix-id-resolution.test.ts
+++ b/src/test/cli-custom-prefix-id-resolution.test.ts
@@ -293,26 +293,36 @@ describe("CLI task ID resolution with a custom ID prefix", () => {
 		expect(await core.filesystem.loadTask("BACK-3")).toBeNull();
 	});
 
-	it("fails closed instead of listing children when a parent filter ID is ambiguous", async () => {
-		const core = await initCustomPrefixProject();
-		await createTask(core, "BACK-1", "Target task");
-		await createTask(core, "BACK-1.1", "Child task", { parentTaskId: "BACK-1" });
-		const tasksDir = core.filesystem.tasksDir;
-		await Bun.write(
-			join(tasksDir, "back-01 - Duplicate-identity.md"),
-			(await Bun.file(join(tasksDir, "back-1 - Target-task.md")).text()).replace("id: BACK-1", "id: BACK-01"),
-		);
+	// Both collision shapes: a differently spelled twin (BACK-01) and an identically spelled one.
+	for (const [shape, twinFile, rewrite] of [
+		[
+			"a zero-padded twin",
+			"back-01 - Duplicate-identity.md",
+			(text: string) => text.replace("id: BACK-1", "id: BACK-01"),
+		],
+		["an identical ID", "back-1 - Duplicate-file.md", (text: string) => text],
+	] as const) {
+		it(`fails closed instead of listing children when the parent filter ID collides with ${shape}`, async () => {
+			const core = await initCustomPrefixProject();
+			await createTask(core, "BACK-1", "Target task");
+			await createTask(core, "BACK-1.1", "Child task", { parentTaskId: "BACK-1" });
+			const tasksDir = core.filesystem.tasksDir;
+			await Bun.write(
+				join(tasksDir, twinFile),
+				rewrite(await Bun.file(join(tasksDir, "back-1 - Target-task.md")).text()),
+			);
 
-		for (const parent of ["1", "BACK-1"]) {
-			const result = await $`bun ${CLI_PATH} task list --parent ${parent} --plain`.cwd(TEST_DIR).nothrow().quiet();
+			for (const parent of ["1", "BACK-1"]) {
+				const result = await $`bun ${CLI_PATH} task list --parent ${parent} --plain`.cwd(TEST_DIR).nothrow().quiet();
 
-			expect(result.exitCode).not.toBe(0);
-			const output = `${result.stdout.toString()}${result.stderr.toString()}`;
-			expect(output).toContain("Task ID BACK-1 is ambiguous");
-			// The command must fail before emitting any child task data.
-			expect(result.stdout.toString()).not.toContain("BACK-1.1 - Child task");
-		}
-	});
+				expect(result.exitCode).not.toBe(0);
+				const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+				expect(output).toContain("Task ID BACK-1 is ambiguous");
+				// The command must fail before emitting any child task data.
+				expect(result.stdout.toString()).not.toContain("BACK-1.1 - Child task");
+			}
+		});
+	}
 
 	it("archives and promotes the draft file named by the argument, not by its frontmatter ID", async () => {
 		// A drifted draft file (filename draft-1, frontmatter DRAFT-2) alongside a real draft-2 must

--- a/src/test/cli-init-no-git.test.ts
+++ b/src/test/cli-init-no-git.test.ts
@@ -108,7 +108,7 @@ describe("CLI init without Git", () => {
 
 		const promotedResult = await $`bun ${CLI_PATH} draft promote draft-1`.cwd(TEST_DIR).quiet();
 		expect(promotedResult.exitCode).toBe(0);
-		expect(promotedResult.stdout.toString()).toContain("Promoted draft draft-1");
+		expect(promotedResult.stdout.toString()).toContain("Promoted draft DRAFT-1");
 
 		const milestone = await core.filesystem.createMilestone("No Git Milestone");
 		const archiveMilestoneResult = await core.archiveMilestone(milestone.id, true);

--- a/src/test/task-wizard.test.ts
+++ b/src/test/task-wizard.test.ts
@@ -75,7 +75,9 @@ describe("task wizard", () => {
 		expect(input?.implementationNotes).toBe("Decision notes");
 		expect(input?.references).toEqual(["src/cli.ts", "docs/plan.md"]);
 		expect(input?.documentation).toEqual(["docs/spec.md"]);
-		expect(input?.dependencies).toEqual(["TASK-1", "TASK-2"]);
+		// Dependency IDs stay exactly as typed; Core resolves them against real task IDs, which is the
+		// only place the configured ID prefix is known.
+		expect(input?.dependencies).toEqual(["task-1", "2"]);
 	});
 
 	it("builds prefilled edit update input", async () => {
@@ -136,7 +138,7 @@ describe("task wizard", () => {
 		expect(updateInput?.type).toBe("Epic");
 		expect(updateInput?.assignee).toEqual(["alice", "bob"]);
 		expect(updateInput?.labels).toEqual(["existing", "cli"]);
-		expect(updateInput?.dependencies).toEqual(["TASK-2", "TASK-3"]);
+		expect(updateInput?.dependencies).toEqual(["task-2", "3"]);
 		expect(updateInput?.references).toEqual(["docs/new.md", "src/cli.ts"]);
 		expect(updateInput?.documentation).toEqual(["docs/spec.md"]);
 		expect(updateInput?.implementationPlan).toBe("New plan");

--- a/src/utils/task-builders.ts
+++ b/src/utils/task-builders.ts
@@ -1,6 +1,6 @@
 import type { Core } from "../core/backlog.ts";
 import type { AcceptanceCriterion } from "../types/index.ts";
-import { normalizeTaskId, taskIdsEqual } from "./task-path.ts";
+import { taskIdsEqual } from "./task-path.ts";
 
 /**
  * Shared utilities for building tasks and validating dependencies
@@ -8,33 +8,9 @@ import { normalizeTaskId, taskIdsEqual } from "./task-path.ts";
  */
 
 /**
- * Normalize dependencies to proper task-X format
- * Handles both array and comma-separated string inputs
- */
-export function normalizeDependencies(dependencies: unknown): string[] {
-	if (!dependencies) return [];
-	const normalizeList = (values: string[]): string[] =>
-		values
-			.map((value) => value.trim())
-			.filter((value): value is string => value.length > 0)
-			.map((value) => normalizeTaskId(value));
-
-	if (Array.isArray(dependencies)) {
-		return normalizeList(
-			dependencies.flatMap((dep) =>
-				String(dep)
-					.split(",")
-					.map((d) => d.trim()),
-			),
-		);
-	}
-
-	return normalizeList(String(dependencies).split(","));
-}
-
-/**
- * Validate that all dependencies exist in the current project
- * Returns arrays of valid and invalid dependency IDs
+ * Validate that all dependencies exist in the current project.
+ * Inputs are matched by task identity, so bare numeric IDs resolve under any configured prefix.
+ * Returns the matched canonical IDs plus the inputs that matched nothing.
  */
 export async function validateDependencies(
 	dependencies: string[],

--- a/src/utils/task-builders.ts
+++ b/src/utils/task-builders.ts
@@ -9,21 +9,19 @@ import { AmbiguousTaskIdError, canonicalTaskId, taskIdsEqual } from "./task-path
  */
 
 /**
- * Resolve one dependency input to the single task it names.
+ * Reject a dependency input that names more than one entity in the corpus.
  *
- * Identity fails closed here exactly as it does for the task a command targets: an input that
- * could mean more than one task never picks a winner. Matching several distinct IDs means the
- * input is underspecified (bare numbers span the separate task and draft counters), while one
- * identity claimed by several files is the duplicate-ID defect `backlog doctor` repairs.
+ * Several canonical identities mean the input is underspecified, because bare numbers span the
+ * separate task and draft counters. Several spellings of one identity (BACK-1 and BACK-01) are the
+ * duplicate-ID defect `backlog doctor` repairs.
  */
 function resolveUniqueDependency(dependency: string, matches: Task[]): string | null {
-	const distinctIds = [...new Set(matches.map((match) => match.id))];
-	if (distinctIds.length <= 1) {
-		return distinctIds[0] ?? null;
-	}
+	const [first, ...rest] = matches;
+	if (!first) return null;
+	if (rest.length === 0) return first.id;
 
 	const candidates = matches.map((match) => match.filePath ?? match.id);
-	const [canonicalId, ...otherIdentities] = [...new Set(distinctIds.map((id) => canonicalTaskId(id)))];
+	const [canonicalId, ...otherIdentities] = [...new Set(matches.map((match) => canonicalTaskId(match.id)))];
 	if (canonicalId && otherIdentities.length === 0) {
 		// Name the colliding identity rather than the input, which may be a bare number.
 		throw new AmbiguousTaskIdError(canonicalId, candidates);
@@ -38,7 +36,13 @@ function resolveUniqueDependency(dependency: string, matches: Task[]): string | 
 
 /**
  * Validate that all dependencies exist in the current project.
- * Inputs are matched by task identity, so bare numeric IDs resolve under any configured prefix.
+ *
+ * Inputs are matched by task identity, so bare numeric IDs resolve under any configured prefix, and
+ * identity fails closed exactly as it does for the task a command targets. That takes two checks,
+ * mirroring the identity index itself: the corpus answers whether the input names more than one
+ * identity, and `Core.getTask` answers whether that identity is claimed by more than one file -
+ * which the corpus cannot, because it keeps one entry per ID.
+ *
  * Returns the matched canonical IDs, deduplicated, plus the inputs that matched nothing.
  */
 export async function validateDependencies(
@@ -63,6 +67,9 @@ export async function validateDependencies(
 			invalid.push(dependency);
 			continue;
 		}
+		// Called for its ambiguity check: it raises AmbiguousTaskIdError when several files claim
+		// this ID. Drafts resolve to null here and keep their own local-only lookup.
+		await core.getTask(resolved);
 		// Equivalent spellings of one task (1 and BACK-1) must not persist twice.
 		if (!valid.some((existing) => taskIdsEqual(existing, resolved))) {
 			valid.push(resolved);

--- a/src/utils/task-builders.ts
+++ b/src/utils/task-builders.ts
@@ -1,6 +1,7 @@
 import type { Core } from "../core/backlog.ts";
-import type { AcceptanceCriterion } from "../types/index.ts";
-import { taskIdsEqual } from "./task-path.ts";
+import type { AcceptanceCriterion, Task } from "../types/index.ts";
+import { AmbiguousIdError } from "./entity-id.ts";
+import { AmbiguousTaskIdError, canonicalTaskId, taskIdsEqual } from "./task-path.ts";
 
 /**
  * Shared utilities for building tasks and validating dependencies
@@ -8,9 +9,37 @@ import { taskIdsEqual } from "./task-path.ts";
  */
 
 /**
+ * Resolve one dependency input to the single task it names.
+ *
+ * Identity fails closed here exactly as it does for the task a command targets: an input that
+ * could mean more than one task never picks a winner. Matching several distinct IDs means the
+ * input is underspecified (bare numbers span the separate task and draft counters), while one
+ * identity claimed by several files is the duplicate-ID defect `backlog doctor` repairs.
+ */
+function resolveUniqueDependency(dependency: string, matches: Task[]): string | null {
+	const distinctIds = [...new Set(matches.map((match) => match.id))];
+	if (distinctIds.length <= 1) {
+		return distinctIds[0] ?? null;
+	}
+
+	const candidates = matches.map((match) => match.filePath ?? match.id);
+	const [canonicalId, ...otherIdentities] = [...new Set(distinctIds.map((id) => canonicalTaskId(id)))];
+	if (canonicalId && otherIdentities.length === 0) {
+		// Name the colliding identity rather than the input, which may be a bare number.
+		throw new AmbiguousTaskIdError(canonicalId, candidates);
+	}
+	throw new AmbiguousIdError(
+		"Dependency",
+		dependency,
+		candidates,
+		`Use a full task ID instead of ${dependency.trim()} to choose one.`,
+	);
+}
+
+/**
  * Validate that all dependencies exist in the current project.
  * Inputs are matched by task identity, so bare numeric IDs resolve under any configured prefix.
- * Returns the matched canonical IDs plus the inputs that matched nothing.
+ * Returns the matched canonical IDs, deduplicated, plus the inputs that matched nothing.
  */
 export async function validateDependencies(
 	dependencies: string[],
@@ -24,13 +53,19 @@ export async function validateDependencies(
 	// Task dependencies should honor cross-branch visibility when enabled in config,
 	// while draft dependencies remain local-only.
 	const [tasks, drafts] = await Promise.all([core.queryTasks(), core.filesystem.listDrafts()]);
-	const knownIds = [...tasks.map((t) => t.id), ...drafts.map((d) => d.id)];
-	for (const dep of dependencies) {
-		const match = knownIds.find((id) => taskIdsEqual(dep, id));
-		if (match) {
-			valid.push(match);
-		} else {
-			invalid.push(dep);
+	const known = [...tasks, ...drafts];
+	for (const dependency of dependencies) {
+		const resolved = resolveUniqueDependency(
+			dependency,
+			known.filter((candidate) => taskIdsEqual(dependency, candidate.id)),
+		);
+		if (resolved === null) {
+			invalid.push(dependency);
+			continue;
+		}
+		// Equivalent spellings of one task (1 and BACK-1) must not persist twice.
+		if (!valid.some((existing) => taskIdsEqual(existing, resolved))) {
+			valid.push(resolved);
 		}
 	}
 	return { valid, invalid };


### PR DESCRIPTION
## Problem

In a project with a non-default ID prefix (`prefixes.task: BACK`), the same bare numeric ID worked on some commands and not others:

```
$ backlog task 597          # works
$ backlog task view 597     # works
$ backlog task edit 597     # Task 597 not found.
```

Nothing was wrong with the resolver. The CLI pre-normalized the user's argument with `normalizeTaskId()`, which stamps the **default** `task` prefix onto a bare numeric ID. So `task edit 597` asked the shared resolver for `TASK-597` in a project whose tasks are `BACK-597`. Commands that passed the raw argument straight into `Core` — `task view`, `task <id>`, `task archive`, `task complete`, and every MCP tool — already worked, which is why the surfaces disagreed.

Full map of what a bare numeric ID did under a `BACK` prefix before this change:

| Command | Before |
| --- | --- |
| `task <id>`, `task view`, `task archive`, `task complete`, `task create --parent` | resolved (raw input reached `Core`) |
| `draft <id>`, `draft view` | resolved |
| `task edit`, `task edit` wizard | **`Task 1 not found.`** |
| `task list --parent` | **`Parent task TASK-1 not found.`** |
| `task create --dep`, `task edit --dep` | **`The following dependencies do not exist: TASK-1.`** |
| `task demote` | resolved, but echoed `Demoted task 1` and committed `backlog: Complete/Demote task TASK-1` |
| `draft archive`, `draft promote` | resolved, but echoed `Archived draft 1` |

Worse, `task edit <ambiguous-id>` reported `Task 1 not found.` — the mangled ID matched nothing, so a duplicate-ID collision was masked as a missing task instead of failing closed like every other command.

## Fix

Deleted the premature normalization rather than adding a resolver. Every ID-accepting command now hands the **raw** argument to the one shared path — `Core.getTask` → `ContentStore.resolveTaskForRead` / `loadLocalTaskForMutation` → `TaskIdentityIndex` — and uses the resolved `task.id` for output, commit messages, and follow-up mutations.

- `task edit` (and its wizard): dropped `canonicalId`; resolve the raw argument, then use `existingTask.id`.
- `task list --parent`: match on the raw value via `taskIdsEqual`; canonical form is display-only, via `canonicalTaskId(input, configured prefix)`, so "not found" names `BACK-999` instead of `TASK-999`.
- Dependencies: deleted `normalizeDependencies()` (32 lines whose whole job was the buggy default-prefix stamping) in favour of the existing `parseDelimitedStringList`. `validateDependencies` already canonicalizes to real IDs via `taskIdsEqual`, so stored dependencies stay canonical. `removeDependencies` now compares with `taskIdsEqual` instead of exact strings.
- `task demote` and `draft archive`/`draft promote`: resolve first, like `archive`/`complete`, so their output names the real ID.
- `completeTask`/`demoteTask` commit messages and the `--parent` create error use the resolved/configured-prefix ID instead of re-normalizing raw input.

No new resolver, no new ID formats, no change to ID generation or the numeric-ID scheme, no new flags, and `AmbiguousIdError`/`AmbiguousTaskIdError` shapes are untouched. `AmbiguousTaskIdError` already extends the shared `AmbiguousIdError` from `src/utils/entity-id.ts`, so ambiguity still fails closed everywhere.

Two deliberate behavior changes on IDs that **don't** resolve, both consistency fixes worth flagging:

1. `task edit <ambiguous-id>` now surfaces the fail-closed ambiguity error instead of `Task 1 not found.`
2. `task demote` and `draft archive`/`draft promote` now exit `1` when the ID doesn't resolve; previously they printed an error and exited `0`.

## Evidence

New table-driven test: `src/test/cli-custom-prefix-id-resolution.test.ts` — 31 tests over 14 ID-accepting commands in a `BACK`-prefixed project, each run with both a bare numeric and a prefixed ID, plus a duplicate-ID case asserting all six task commands still report `is ambiguous` and leave both conflicting files in place.

Confirmed the table catches the bug: with the source changes stashed, 10 of the 31 tests fail (`task edit`, `task demote`, `task list --parent`, `task create --dep`, `task edit --dep`, `draft archive`, `draft promote`, canonical-dependency storage, prefixed error text, fail-closed ambiguity).

No regression for IDs that already resolved — verified by hand on the default prefix that `task-1`, `TASK-1`, `Task-1`, `1`, `001`, and `task-001` all still resolve and print `Updated task TASK-1`.

Two existing assertions were updated because they pinned the old behavior: `task-wizard.test.ts` asserted the wizard's intermediate input carried pre-normalized deps (the wizard is a pure unit and cannot know the configured prefix, so canonicalization belongs in `Core`), and `cli-init-no-git.test.ts` asserted the raw echo `Promoted draft draft-1`, now the canonical `DRAFT-1`.

Checks: `bunx tsc --noEmit` clean, `bun run check .` clean, full `bun run test` green at **2119 pass / 6 skip / 0 fail** after rebasing onto `origin/main` (2f747cd7).

Closes BACK-607.
