### PR TITLE
BACK-610 - Fail fast on wrong-typed config values

### DIFF
--- a/backlog/tasks/back-610 - Fail-fast-on-wrong-typed-config-values.md
+++ b/backlog/tasks/back-610 - Fail-fast-on-wrong-typed-config-values.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-610
 title: Fail fast on wrong-typed config values
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-08 21:52'
+updated_date: '2026-08-08 22:06'
 labels: []
 dependencies: []
 ordinal: 249000
@@ -17,15 +19,52 @@ Follow-up to BACK-606 by owner decision (Alex, 2026-08-08: "strict"). Wrong-type
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A wrong-typed value for any list config key aborts startup with the "Backlog could not start because" error naming the key
-- [ ] #2 The config watcher rejects wrong-typed edits via the shared parser; the interim per-key parity check is removed
-- [ ] #3 Valid configs and the malformed-YAML error paths from BACK-606 are unchanged
-- [ ] #4 Tests cover a wrong-typed value per list key at startup and via the watcher
+- [x] #1 A wrong-typed value for any list config key aborts startup with the "Backlog could not start because" error naming the key
+- [x] #2 The config watcher rejects wrong-typed edits via the shared parser; the interim per-key parity check is removed
+- [x] #3 Valid configs and the malformed-YAML error paths from BACK-606 are unchanged
+- [x] #4 Tests cover a wrong-typed value per list key at startup and via the watcher
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. In src/file-system/operations.ts, split the error builder so it can state a type problem as well as a YAML syntax problem: configValueError keeps the established 'Backlog could not start because <file> has an invalid value for "<key>": <problem>. <remedy>' shape, with the remedy matching the problem (valid YAML vs a YAML list).
+2. Convert the return-undefined branches of parseConfigListValue into a throw naming the type: a scalar, number, boolean or mapping where a list belongs. Keep the two branches that are not wrong types: an explicit empty value (key: with no value) still leaves the key unset, and default_assignee still accepts a single scalar name.
+3. Remove the interim parity check in src/utils/config-watcher.ts marked pending the owner decision, keeping the comment that explains why default_assignee is not in ARRAY_CONFIG_KEYS. The shared parser now rejects wrong types before the watcher's usability check, so the last good config is still retained.
+4. Verify the 51-case parse matrix: byte-identical for every valid shape, with changes confined to the wrong-typed rows that are the point of this task. Report any other row that moves.
+5. Spot-check entry points from the BACK-606 sweep table (a read, a mutation, bare CLI, mcp start) for the same prefix and non-zero exit on a wrong-typed value.
+6. Tests: a wrong-typed value per list key at startup asserting the message names the key and the type problem, the default_assignee scalar and empty-value shapes still accepted, and a watcher test that a wrong-typed edit keeps the last good config through the shared parser.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implementation: the two hooks BACK-606 left, nothing else.
+
+src/file-system/operations.ts. The error builder now takes a problem and a remedy so a type failure reads as sensibly as a syntax failure, with the same 'Backlog could not start because <file> has an invalid value for "<key>": <problem>. <remedy>' shape. configSyntaxError keeps the YAML wording ('Edit that key so its value is valid YAML'); configTypeError states the mismatch ('expected a list, got a scalar') and a matching remedy ('Edit that key so its value is a list'). default_assignee says 'a list or a single name' because a single name is its legacy spelling. The return-undefined branches of parseConfigListValue are now a single throw at the end, so the function returns undefined only for a key that is absent or explicitly empty.
+
+Two branches deliberately kept, since they are valid rather than wrong-typed: 'key:' with no value still leaves the key unset (bare 'statuses:' still falls back to defaults, 'default_assignee:' still clears), and default_assignee still accepts a single scalar name. Numbers inside a list are still coerced to their written form rather than rejected.
+
+src/utils/config-watcher.ts. The interim per-key parity check is removed along with its pending-decision comment; the comment explaining why default_assignee is not in ARRAY_CONFIG_KEYS is kept and updated. Proved the removal is safe rather than assumed: with the check removed the watcher test still passes, and with the parser change reverted while the check stays removed the same test fails ('Timed out waiting for invalid default_assignee read attempts'), so the shared parser is what now rejects wrong-typed edits and the last good config is still retained.
+
+Matrix: the 51-case parse matrix moved on exactly three rows, all wrong-typed and all the point of this task — 'statuses: To Do', 'statuses: "To Do"' and 'statuses: {a: 1}'. The other 48 rows, valid and malformed-YAML alike, are byte-identical. The boundary, boundary-risk, compound and unindented-continuation probes from BACK-606 are unchanged except one row: the documented multi-line-quoted-scalar limitation now fails fast instead of silently falling back to defaults, because the hijacked line reads as a scalar. That is the strict ruling applied consistently, and it is a move from silent default to visible error.
+
+Wrong-type coverage verified per key: scalar, mapping, number and boolean rejected for statuses, labels, types and priorities; mapping, number and boolean rejected for default_assignee, which still accepts a scalar.
+
+Entry points spot-checked with a wrong-typed value ('statuses: To Do') against the BACK-606 sweep table: task list, board, config list, task create, draft promote, draft archive, bare backlog --plain and mcp start all exit non-zero, lead with the established prefix, carry the 'expected a list, got a scalar' detail, and leave the backlog file tree unchanged.
+
+Validation: bunx tsc --noEmit clean, bun run check . clean, targeted batch 174 pass / 0 fail across 12 files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Wrong-typed but syntactically valid list config values now abort startup with the BACK-606 error shape instead of being silently ignored: parseConfigListValue's return-undefined branches became a single throw that names the mismatch ('expected a list, got a scalar'), and the interim per-key parity check in the config watcher was removed because the shared parser now rejects wrong types for every surface. Explicitly empty values and default_assignee's legacy single name stay valid. Verified with per-key wrong-type coverage at startup and through the watcher, a non-vacuity check proving the parser rather than the removed check does the rejecting, a 51-case matrix that moved on exactly the three wrong-typed rows and is byte-identical on the other 48, an eight-surface entry-point spot check confirming prefix, exit code and no mutation, and targeted tests 174 pass / 0 fail.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -111,13 +111,49 @@ function extractConfigKeyYaml(content: string, key: string): string | undefined 
 const CONFIG_VALUE_ERROR_NAME = "ConfigValueError";
 
 /** Reports a config value Backlog refuses to guess at, naming the file and the offending key. */
-function configValueError(configPath: string, key: string, reason: unknown): Error {
-	const detail = (reason instanceof Error ? reason.message : String(reason)).split("\n")[0]?.trim();
+function configValueError(configPath: string, key: string, problem: string, remedy: string): Error {
 	const error = new Error(
-		`Backlog could not start because ${configPath} has an invalid value for "${key}"${detail ? `: ${detail}` : ""}. Edit that key so its value is valid YAML, then run the command again.`,
+		`Backlog could not start because ${configPath} has an invalid value for "${key}"${problem ? `: ${problem}` : ""}. ${remedy}`,
 	);
 	error.name = CONFIG_VALUE_ERROR_NAME;
 	return error;
+}
+
+/** Reports a value YAML could not read at all. */
+function configSyntaxError(configPath: string, key: string, reason: unknown): Error {
+	const detail = (reason instanceof Error ? reason.message : String(reason)).split("\n")[0]?.trim();
+	return configValueError(
+		configPath,
+		key,
+		detail ?? "",
+		"Edit that key so its value is valid YAML, then run the command again.",
+	);
+}
+
+/** Names the shape a rejected value turned out to have, for an error a person has to act on. */
+function describeConfigValue(value: unknown): string {
+	if (value === undefined) return "no value Backlog could read";
+	switch (typeof value) {
+		case "string":
+			return "a scalar";
+		case "number":
+			return "a number";
+		case "boolean":
+			return "a boolean";
+		default:
+			return "a mapping";
+	}
+}
+
+/** Reports a value YAML read fine but the key cannot hold, such as a scalar where a list belongs. */
+function configTypeError(configPath: string, key: ConfigListKey, value: unknown): Error {
+	const expected = key === "default_assignee" ? "a list or a single name" : "a list";
+	return configValueError(
+		configPath,
+		key,
+		`expected ${expected}, got ${describeConfigValue(value)}`,
+		`Edit that key so its value is ${expected}, then run the command again.`,
+	);
 }
 
 /** True when an error already explains an unreadable config value, so it needs no extra framing. */
@@ -138,9 +174,10 @@ function readYamlKey(document: string, key: string): { value: unknown } | { erro
  * Parse one list-valued config key as YAML, so quoting, escapes, block sequences, and trailing
  * comments are handled by the parser instead of by hand. The key's own block is what gets parsed, so a
  * malformed value for one key cannot change how another key reads; only a block YAML rejects outright
- * is reread in document context, where aliases resolve. Throws when neither read succeeds, so callers
- * fail fast rather than proceed with a guessed value. Returns nothing when the key is absent, carries
- * no value, or holds a shape it cannot represent; `default_assignee` also accepts a single scalar.
+ * is reread in document context, where aliases resolve. Throws when neither read succeeds, and when the
+ * value YAML read is not a shape the key can hold, so callers fail fast rather than proceed with a
+ * guessed value. Returns nothing when the key is absent or carries no value; `default_assignee` also
+ * accepts a single scalar name.
  */
 function parseConfigListValue(content: string, key: ConfigListKey, configPath: string): string[] | undefined {
 	const block = extractConfigKeyYaml(content, key);
@@ -158,26 +195,24 @@ function parseConfigListValue(content: string, key: ConfigListKey, configPath: s
 		// document is never read first: doing that is what let one broken key change how another reads.
 		const fromDocument = readYamlKey(content, key);
 		if (!("value" in fromDocument)) {
-			throw configValueError(configPath, key, fromBlock.error);
+			throw configSyntaxError(configPath, key, fromBlock.error);
 		}
 		parsed = fromDocument.value;
 	}
 
 	// `key:` with no value, including the first line of a block sequence.
-	if (parsed === null || parsed === undefined) {
+	if (parsed === null) {
 		return key === "default_assignee" ? [] : undefined;
-	}
-	if (typeof parsed === "string") {
-		if (key !== "default_assignee") {
-			return undefined;
-		}
-		const assignee = parsed.trim();
-		return assignee ? [assignee] : [];
 	}
 	if (Array.isArray(parsed)) {
 		return parsed.map((item) => String(item).trim()).filter((item) => item.length > 0);
 	}
-	return undefined;
+	// A single name is the legacy spelling of a one-entry default_assignee.
+	if (typeof parsed === "string" && key === "default_assignee") {
+		const assignee = parsed.trim();
+		return assignee ? [assignee] : [];
+	}
+	throw configTypeError(configPath, key, parsed);
 }
 
 const DEFAULT_CREATE_LOCK_TIMEOUT_MS = 30_000;

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -3,6 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { $ } from "bun";
 import type { PromptRunner } from "../commands/advanced-config-wizard.ts";
 import { configureAdvancedSettings } from "../commands/configure-advanced-settings.ts";
+import { DEFAULT_STATUSES } from "../constants/index.ts";
 import { Core } from "../core/backlog.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
@@ -383,6 +384,53 @@ describe("Config commands", () => {
 				expect(failure).toContain(`invalid value for "${key}"`);
 			}
 		}
+	});
+
+	it("refuses to load a list config value YAML reads but the key cannot hold, naming the type problem", async () => {
+		const configPath = core.filesystem.configFilePath;
+		const baseConfig = await Bun.file(configPath).text();
+
+		for (const key of ["statuses", "labels", "types", "priorities", "default_assignee"]) {
+			// A single name is the legacy spelling of default_assignee, so only that key accepts a scalar.
+			const wrongTyped = [
+				[`${key}: {name: "@alice"}`, "a mapping"],
+				[`${key}: 42`, "a number"],
+				[`${key}: true`, "a boolean"],
+				...(key === "default_assignee" ? [] : [[`${key}: To Do`, "a scalar"]]),
+			];
+			const expected = key === "default_assignee" ? "a list or a single name" : "a list";
+
+			for (const [line, shape] of wrongTyped) {
+				await Bun.write(configPath, `${baseConfig}${line}\n`);
+				core.filesystem.invalidateConfigCache();
+
+				const failure = await core.filesystem.loadConfig().then(
+					() => undefined,
+					(error: unknown) => (error instanceof Error ? error.message : String(error)),
+				);
+				expect(failure).toBeDefined();
+				expect(failure).toStartWith("Backlog could not start because");
+				expect(failure).toContain(configPath);
+				expect(failure).toContain(`invalid value for "${key}"`);
+				expect(failure).toContain(`expected ${expected}, got ${shape}`);
+			}
+		}
+	});
+
+	it("still accepts the value shapes a list key legitimately has", () => {
+		// Strictness must not reach an explicitly empty value, a legacy single assignee name, or a list.
+		expect(core.filesystem.parseConfig('project_name: "P"\nstatuses:\n').statuses).toEqual([...DEFAULT_STATUSES]);
+		expect(core.filesystem.parseConfig('project_name: "P"\nstatuses: []\n').statuses).toEqual([]);
+		expect(core.filesystem.parseConfig('project_name: "P"\nlabels:\n').labels).toEqual([]);
+		expect(core.filesystem.parseConfig('project_name: "P"\ndefault_assignee: "@alex"\n').defaultAssignee).toEqual([
+			"@alex",
+		]);
+		expect(core.filesystem.parseConfig('project_name: "P"\ndefault_assignee:\n').defaultAssignee).toEqual([]);
+		expect(core.filesystem.parseConfig('project_name: "P"\ndefault_assignee:\n  - "@a"\n').defaultAssignee).toEqual([
+			"@a",
+		]);
+		// Numbers inside a list are still coerced to their written form rather than rejected.
+		expect(core.filesystem.parseConfig('project_name: "P"\nstatuses: [1, 2]\n').statuses).toEqual(["1", "2"]);
 	});
 
 	it("keeps a malformed list value from changing how another list key reads", () => {

--- a/src/test/config-watcher.test.ts
+++ b/src/test/config-watcher.test.ts
@@ -197,7 +197,9 @@ describe("config watcher", () => {
 		];
 		const withAssignee = (line: string) => [baseLines[0], line, ...baseLines.slice(1), ""].join("\n");
 		// Truncated mid-edit and an unbalanced quote that still opens and closes with brackets, then two
-		// values YAML reads but the key cannot hold: publishing either would drop the cached assignee.
+		// values YAML reads but the key cannot hold. default_assignee is the key that proves the shared
+		// parser rejects wrong types: the other list keys are also screened by the inline-array check,
+		// but this one accepts scalars and block sequences, so only the parser can judge it.
 		const invalidContents = [
 			withAssignee('default_assignee: ["@alice'),
 			withAssignee('default_assignee: ["@alice]'),

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -61,11 +61,8 @@ function hasValidExplicitValues(content: string, config: BacklogConfig): boolean
 		if (!RECOGNIZED_CONFIG_KEYS.has(key)) continue;
 		if (ARRAY_CONFIG_KEYS.has(key) && !(value.startsWith("[") && value.endsWith("]"))) return false;
 		// default_assignee is not in ARRAY_CONFIG_KEYS because it also accepts scalars and block
-		// sequences; the config parser rejects values YAML cannot read before this check runs. A value
-		// YAML reads but the key cannot hold, such as a mapping or a number, leaves the key unset, and
-		// publishing that would drop the configured assignee — so the candidate is rejected and the last
-		// good config stays cached. Pending the open decision on whether such values should fail fast.
-		if (key === "default_assignee" && config.defaultAssignee === undefined) return false;
+		// sequences; the config parser rejects every value it cannot hold, malformed or wrong-typed,
+		// before this check runs, so the last good config stays cached without a rule repeated here.
 		if (key === "definition_of_done" && value.startsWith("[") && !value.endsWith("]")) return false;
 		if (key === "definition_of_done" && config.definitionOfDone === undefined) return false;
 		if ((key === "project_name" || key === "date_format") && !value.replace(/['"]/g, "").trim()) return false;


### PR DESCRIPTION
## Problem

BACK-606 made malformed YAML in a list config key fail fast, but a value that is *valid* YAML of the wrong
shape was still silently ignored. `statuses: To Do` (a scalar where a list belongs) or
`default_assignee: {name: "@alice"}` left the key unset and Backlog carried on with defaults, so the file
said one thing and the tool did another. Alex ruled **strict** on this, and BACK-606 deliberately left the
two hooks needed.

## Fix

**Hook 1 — `src/file-system/operations.ts`.** The `return undefined` branches of `parseConfigListValue`
became a single throw. The error builder now takes a *problem* and a *remedy*, so a type failure reads as
sensibly as a syntax failure while keeping the established shape:

```
Backlog could not start because /p/backlog/config.yml has an invalid value for "statuses":
expected a list, got a scalar. Edit that key so its value is a list, then run the command again.
```

`configSyntaxError` keeps the YAML wording; `configTypeError` names the mismatch (`a scalar`, `a number`,
`a boolean`, `a mapping`). `default_assignee` says *a list or a single name*, because a single name is its
documented legacy spelling. The function now returns `undefined` only for a key that is absent or
explicitly empty.

Two branches are deliberately **kept** — they are valid, not wrong-typed:

- `key:` with no value still leaves the key unset, so bare `statuses:` still falls back to defaults and
  `default_assignee:` still clears.
- `default_assignee: "@alex"` (legacy single name) still parses.
- Numbers inside a list are still coerced to their written form rather than rejected.

**Hook 2 — `src/utils/config-watcher.ts`.** The interim per-key parity check added under BACK-606 (marked
pending this decision) is removed, along with its comment; the note explaining why `default_assignee` is
not in `ARRAY_CONFIG_KEYS` stays. The shared parser now rejects wrong-typed edits for every surface, and
the watcher still retains the last good config.

I proved that rather than assuming it: with the check removed the watcher test still passes, and with the
**parser change reverted while the check stays removed** the same test fails (`Timed out waiting for
invalid default_assignee read attempts`). So the parser is what does the rejecting now.

## Evidence

**Matrix.** The 51-case parse matrix moved on exactly **three** rows, all wrong-typed and all the point of
this task: `statuses: To Do`, `statuses: "To Do"`, `statuses: {a: 1}`. The other **48 rows — valid and
malformed-YAML alike — are byte-identical.**

**Per-key coverage.** Scalar, mapping, number and boolean are rejected for `statuses`, `labels`, `types`
and `priorities`; mapping, number and boolean for `default_assignee`, which still accepts a scalar.

**Entry points**, spot-checked against the BACK-606 sweep table with `statuses: To Do`: `task list`,
`board`, `config list`, `task create`, `draft promote`, `draft archive`, bare `backlog --plain` and
`mcp start` all exit non-zero, lead with the established prefix, carry the `expected a list, got a scalar`
detail, and leave the backlog file tree unchanged.

**Tests.** New: a wrong-typed value per list key at startup asserting the key *and* the type problem; a
companion test pinning the shapes that must stay valid (empty value, legacy scalar assignee, block
sequence, numbers in a list). The watcher's existing wrong-typed cases now exercise the shared parser.
`bunx tsc --noEmit` clean, `bun run check .` clean, targeted batch **174 pass / 0 fail** across 12 files;
full suite via CI.

## One consequence worth flagging

The multi-line-quoted-scalar limitation documented in BACK-606 — a column-0 continuation line of a
multi-line quoted flow scalar beginning with a list-key name — now **fails fast** instead of silently
falling back to defaults, because the hijacked line reads as a scalar. That is the strict ruling applied
consistently, and it moves the shape from a silent default to a visible error; the named key can still be
the misattributed one, which remains the accepted compound-diagnostics limitation.
