### PR TITLE
BACK-612 - Deduplicate generateNextDecisionId and remove the core-to-CLI dynamic import

### DIFF
--- a/backlog/tasks/back-612 - Deduplicate-generateNextDecisionId-and-remove-the-core-to-CLI-dynamic-import.md
+++ b/backlog/tasks/back-612 - Deduplicate-generateNextDecisionId-and-remove-the-core-to-CLI-dynamic-import.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-612
 title: Deduplicate generateNextDecisionId and remove the core-to-CLI dynamic import
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-08 22:14'
+updated_date: '2026-08-08 22:49'
 labels: []
 dependencies: []
 ordinal: 251000
@@ -17,14 +19,46 @@ Follow-up to BACK-611 under the standing owner approval for deleting duplicated 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One generateNextDecisionId remains, in src/utils/id-generators.ts, with both former callers repointed to it
-- [ ] #2 The dynamic await import("../cli.js") in src/core/backlog.ts is gone
-- [ ] #3 decision create via CLI and POST /api/decisions via the built web server both still allocate sequential decision IDs
+- [x] #1 One generateNextDecisionId remains, in src/utils/id-generators.ts, with both former callers repointed to it
+- [x] #2 The dynamic await import("../cli.js") in src/core/backlog.ts is gone
+- [x] #3 decision create via CLI and POST /api/decisions via the built web server both still allocate sequential decision IDs
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-verify on current origin/main: confirm the two generateNextDecisionId bodies are byte-identical (diff the extracted ranges, cli.ts:1664-1730 vs id-generators.ts:81-147), enumerate every caller, and confirm src/core/backlog.ts:2876 is the only 'cli.js' import in the source tree.
+2. Confirm the cycle hypothesis before changing the import shape: cli.ts imports Core from ./index.ts, which re-exports core/backlog.ts, so a static core->cli import would close a runtime cycle - that is why the import was dynamic. utils/id-generators.ts only carries a type-only 'import type { Core }', so it has no runtime edge, and core/backlog.ts already statically imports generateNextDocId from it. Repointing therefore cannot reintroduce the cycle; tsc and the bundler are the check.
+3. src/core/backlog.ts: extend the existing line-37 import to '{ generateNextDecisionId, generateNextDocId }' and replace the dynamic-import body of createDecisionWithTitle with a direct call, deleting the now-false 'Import the generateNextDecisionId function from CLI' comment.
+4. src/cli.ts: add the static import from ./utils/id-generators.ts (sorted between find-backlog-root and label-filter) so the decision create action at cli.ts:4342 keeps working, then delete the local copy at 1664-1730.
+5. Verify: repo-wide grep proving one definition and zero 'cli.js' imports; bunx tsc --noEmit; bun run check .; bun run build; targeted decision/doc tests; and the reviewer's probe pattern - built dist/backlog in a scratch project, 'dist/backlog browser', POST /api/decisions twice, asserting decision-1 then decision-2, since that route is the only thing exercising the dynamic import today. Also exercise CLI 'decision create' for the other caller.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Confirmed on current origin/main before changing anything: the two generateNextDecisionId bodies are byte-identical (diffed cli.ts:1664-1730 against id-generators.ts:81-147), the cli.ts copy had exactly two callers (cli.ts decision create and the dynamic import in core/backlog.ts), the utils copy had zero importers, and core/backlog.ts:2876 was the only 'cli.js' reference anywhere in src/.
+
+Why the import was dynamic, and why repointing is safe: cli.ts statically imports Core from ./index.ts, which re-exports core/backlog.ts, so a static core->cli import would have closed a runtime cycle. utils/id-generators.ts carries only 'import type { Core }', which is erased, so it has no runtime edge, and core/backlog.ts already imported generateNextDocId from it statically. Repointing therefore reuses an existing acyclic edge rather than creating one; bunx tsc --noEmit and a successful bun run build confirm no cycle was reintroduced. The stale '// Import the generateNextDecisionId function from CLI' comment was the only workaround comment tied to this and is gone; a grep for other circular/cycle/lazy-import comments in src/ found nothing else related.
+
+Changes: core/backlog.ts line 37 now imports { generateNextDecisionId, generateNextDocId } and createDecisionWithTitle calls the helper directly; cli.ts gains a static import from ./utils/id-generators.ts (sorted between find-backlog-root and label-filter) and loses its 67-line local copy. Net -71/+2 lines across the two files. One definition remains, in src/utils/id-generators.ts.
+
+Behavioral proof through the BUILT bundle, since the removed dynamic import was only exercised by the web route: in a scratch project, dist/backlog browser then three POSTs to /api/decisions returned decision-1, decision-2 and decision-3 (HTTP 201 each), GET /api/decisions listed all three, and CLI 'decision create' then continued the same sequence with decision-4 and decision-5 - proving both former callers now share one allocator. Re-ran with zeroPaddedIds=3, the helper's only config-dependent branch: the web POST returned decision-006 and the CLI returned decision-007, so the web route still reads config through the shared helper.
+
+Checks: bunx tsc --noEmit clean, bun run check . clean (367 files), bun run build succeeds, targeted tests 47 pass / 0 fail across cli-doc-decision-board, server-documents-endpoint, documentation, docs-recursive, cli-doc-view and cli-doc-search.
+
+Full-suite flake, investigated rather than assumed: the first full run showed 2099 pass / 1 fail, the failure being 'BacklogServer search endpoint > rebuilds the Fuse index when markdown content changes'. That test writes a document and polls the search endpoint 40 times at 125ms for the filesystem watcher to reindex, a bounded 5s budget, and it timed out under full-suite load rather than asserting a wrong value. It passes in isolation on this branch (25/25), the full suite on this branch's exact parent commit 2588b4a6 passes 2100/6/0, and a full re-run on this branch also passes 2100/6/0. The changed code is decision-ID allocation and has no path to the document watcher or the Fuse index, so the failure is a pre-existing watcher-timing flake, not a regression.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Collapsed the two byte-identical generateNextDecisionId copies onto the shared one in src/utils/id-generators.ts and removed the core-to-CLI dynamic import. src/core/backlog.ts now takes the helper from the same static utils import it already used for generateNextDocId, and createDecisionWithTitle calls it directly instead of doing await import('../cli.js'); src/cli.ts imports the shared helper for its decision create action and drops its 67-line local copy. The dynamic import existed because a static core-to-cli edge would have closed a cycle through index.ts, but utils/id-generators.ts only type-imports Core, so repointing reuses an existing acyclic edge - confirmed by clean tsc and a successful build. The stale comment describing the workaround is gone with it. Verified through the built bundle on both former call paths: three POSTs to /api/decisions returned decision-1 through decision-3 and CLI decision create continued the same sequence with decision-4 and decision-5, and with zeroPaddedIds=3 the web route returned decision-006 and the CLI decision-007, exercising the helper's only config branch. Also clean bunx tsc --noEmit, bun run check ., bun run build, and 47 targeted decision/doc tests. The full suite is 2100 pass / 6 skip / 0 fail; an earlier single failure in the Fuse-index watcher test was shown to be a pre-existing timing flake, passing in isolation, on the parent commit, and on a full re-run.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,7 @@ import {
 } from "./utils/duplicate-detection.ts";
 import { isAmbiguousIdError } from "./utils/entity-id.ts";
 import { findBacklogRoot } from "./utils/find-backlog-root.ts";
+import { generateNextDecisionId } from "./utils/id-generators.ts";
 import { labelsToLower } from "./utils/label-filter.ts";
 import {
 	formatMcpClientSetupCommand,
@@ -1660,74 +1661,6 @@ addHelpSchema(program.command("init [projectName]"), {
 			}
 		},
 	);
-
-export async function generateNextDecisionId(core: Core): Promise<string> {
-	const config = await core.filesystem.loadConfig();
-	// Load local decisions
-	const decisions = await core.filesystem.listDecisions();
-	const allIds: string[] = [];
-
-	try {
-		const backlogDir = core.filesystem.backlogDirName;
-
-		// Skip remote operations if disabled
-		if (config?.remoteOperations === false) {
-			if (process.env.DEBUG) {
-				console.log("Remote operations disabled - generating ID from local decisions only");
-			}
-		} else {
-			await core.gitOps.fetch();
-		}
-
-		const branches = await core.gitOps.listAllBranches();
-
-		// Load files from all branches in parallel
-		const branchFilePromises = branches.map(async (branch) => {
-			const files = await core.gitOps.listFilesInTree(branch, `${backlogDir}/decisions`);
-			return files
-				.map((file) => {
-					const match = file.match(/decision-(\d+)/);
-					return match ? `decision-${match[1]}` : null;
-				})
-				.filter((id): id is string => id !== null);
-		});
-
-		const branchResults = await Promise.all(branchFilePromises);
-		for (const branchIds of branchResults) {
-			allIds.push(...branchIds);
-		}
-	} catch (error) {
-		// Suppress errors for offline mode or other git issues
-		if (process.env.DEBUG) {
-			console.error("Could not fetch remote decision IDs:", error);
-		}
-	}
-
-	// Add local decision IDs
-	for (const decision of decisions) {
-		allIds.push(decision.id);
-	}
-
-	// Find the highest numeric ID
-	let max = 0;
-	for (const id of allIds) {
-		const match = id.match(/^decision-(\d+)$/);
-		if (match) {
-			const num = Number.parseInt(match[1] || "0", 10);
-			if (num > max) max = num;
-		}
-	}
-
-	const nextIdNumber = max + 1;
-	const padding = config?.zeroPaddedIds;
-
-	if (padding && typeof padding === "number" && padding > 0) {
-		const paddedId = String(nextIdNumber).padStart(padding, "0");
-		return `decision-${paddedId}`;
-	}
-
-	return `decision-${nextIdNumber}`;
-}
 
 const taskCmd = program.command("task").aliases(["tasks"]);
 

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -34,7 +34,7 @@ import {
 import { type ContentIdentityReport, detectContentIdentityIssues } from "../utils/duplicate-detection.ts";
 import { openInEditor } from "../utils/editor.ts";
 import { findBacklogRoot } from "../utils/find-backlog-root.ts";
-import { generateNextDocId } from "../utils/id-generators.ts";
+import { generateNextDecisionId, generateNextDocId } from "../utils/id-generators.ts";
 import {
 	createMilestoneFilterMatcher,
 	createMilestoneFilterValueResolver,
@@ -2872,8 +2872,6 @@ export class Core {
 	}
 
 	async createDecisionWithTitle(title: string, autoCommit?: boolean): Promise<Decision> {
-		// Import the generateNextDecisionId function from CLI
-		const { generateNextDecisionId } = await import("../cli.js");
 		const id = await generateNextDecisionId(this);
 
 		const decision: Decision = {


### PR DESCRIPTION
Closes BACK-612. Follow-up to #883, from the asymmetry flagged there.

After #883 removed the duplicated `generateNextDocId` from `src/cli.ts`, the decision helper was the mirror image of that problem: the live copy sat in `cli.ts` while the byte-identical `src/utils/id-generators.ts` copy had zero importers, and `src/core/backlog.ts` reached back into the CLI through `await import("../cli.js")` to use it.

End state: one definition, in `src/utils/id-generators.ts`, and no core-to-CLI import.

## Changes

- `src/core/backlog.ts` — line 37 now imports `{ generateNextDecisionId, generateNextDocId }` from the utils helper it already used for docs; `createDecisionWithTitle` calls it directly.
- `src/cli.ts` — imports the shared helper for the `decision create` action and drops its 67-line local copy.

Net −71/+2 lines of source. The two bodies were confirmed byte-identical before the change by diffing the extracted ranges (`cli.ts:1664-1730` vs `id-generators.ts:81-147`).

## Why the import was dynamic, and why this is safe

The dynamic import was a cycle workaround: `cli.ts` statically imports `Core` from `./index.ts`, which re-exports `core/backlog.ts`, so a static core→cli edge would have closed a runtime cycle.

`utils/id-generators.ts` carries only `import type { Core }`, which is erased at compile time, so it has no runtime edge — and `core/backlog.ts` already imported `generateNextDocId` from it statically. Repointing reuses an existing acyclic edge rather than creating one. Clean `tsc` and a successful bundle build confirm no cycle was reintroduced.

The stale `// Import the generateNextDecisionId function from CLI` comment dies with it. A grep for other circular/cycle/lazy-import workaround comments in `src/` found nothing else related.

## Behavioral proof (built bundle)

The removed dynamic import is only exercised by the web route today, so the probe runs against `dist/backlog` in a scratch project rather than against source.

```
### POST /api/decisions x3 (built bundle, dist/backlog browser)
{"id":"decision-1","title":"First web decision",...}  [HTTP 201]
{"id":"decision-2","title":"Second web decision",...} [HTTP 201]
{"id":"decision-3","title":"Third web decision",...}  [HTTP 201]

### CLI decision create -- the other former caller, continuing the same sequence
Created decision decision-4
Created decision decision-5
```

Both former callers now share one allocator: the CLI picks up where the web route left off. `GET /api/decisions` listed all three web decisions, and the on-disk files matched (`decision-1` … `decision-5`).

Re-run with `zeroPaddedIds=3`, the helper's only config-dependent branch, to confirm the web route still reads config through the shared helper:

```
### POST /api/decisions  -> {"id":"decision-006", ...}
### CLI decision create  -> Created decision decision-007
```

## Checks

- `bunx tsc --noEmit` — clean
- `bun run check .` — clean, 367 files
- `bun run build` — succeeds
- Targeted tests — **47 pass, 0 fail** across `cli-doc-decision-board`, `server-documents-endpoint`, `documentation`, `docs-recursive`, `cli-doc-view`, `cli-doc-search`
- Full suite — **2100 pass, 6 skip, 0 fail**

### Note on one flaky full-suite run

The first full run came back 2099/1, failing `BacklogServer search endpoint > rebuilds the Fuse index when markdown content changes`. That test writes a document and polls the search endpoint 40 times at 125ms waiting for the filesystem watcher to reindex — a bounded 5s budget — and it timed out under load rather than asserting a wrong value.

Rather than assume, I checked it three ways: it passes in isolation on this branch (25/25), the full suite on this branch's exact parent commit `2588b4a6` passes 2100/6/0, and a full re-run on this branch also passes 2100/6/0. The changed code is decision-ID allocation and has no path to the document watcher or the Fuse index. Pre-existing watcher-timing flake, not a regression.
