### PR TITLE
BACK-614 - Let the web create form express an explicitly unassigned task

### DIFF
--- a/backlog/tasks/back-614 - Let-the-web-create-form-express-an-explicitly-unassigned-task.md
+++ b/backlog/tasks/back-614 - Let-the-web-create-form-express-an-explicitly-unassigned-task.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-614
 title: Let the web create form express an explicitly unassigned task
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-09 13:49'
+updated_date: '2026-08-09 14:05'
 labels: []
 dependencies: []
 ordinal: 253000
@@ -17,15 +19,45 @@ Approved by Alex 2026-08-09. Since BACK-604, the web create modal omits the assi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With defaultAssignee configured, a user can create an explicitly unassigned task from the web create form
-- [ ] #2 Leaving the form untouched still applies defaultAssignee; projects without a default are unchanged
-- [ ] #3 Edit-mode clearing behavior is unchanged
-- [ ] #4 Tests cover the three states: default applied, explicitly unassigned, explicit assignee
+- [x] #1 With defaultAssignee configured, a user can create an explicitly unassigned task from the web create form
+- [x] #2 Leaving the form untouched still applies defaultAssignee; projects without a default are unchanged
+- [x] #3 Edit-mode clearing behavior is unchanged
+- [x] #4 Tests cover the three states: default applied, explicitly unassigned, explicit assignee
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify the mechanism is feasible: /api/config already returns the whole BacklogConfig (server handleGetConfig), App.tsx already holds it in state and passes config-derived props to TaskDetailsModal (availablePriorities, definitionOfDoneDefaults, dateFormat), so defaultAssignee reaches the modal as one more prop - no new endpoint.
+2. Add a defaultAssignee?: string[] prop to TaskDetailsModal and pass defaultAssignee={config?.defaultAssignee} from App.tsx (same shape as availablePriorities, so the prop identity stays stable across renders instead of a fresh [] each time).
+3. Prefill create mode: buildTaskDetailsFormState returns the configured default for assignee when isCreateMode and there is no task; feed the memoized default into the existing reset effect so a config that loads after the modal opens still prefills, while the existing preserveDirtyRefreshValue keeps a user edit (including a removal) untouched. No new UI: the existing ChipInput renders the prefilled values as its normal removable chips.
+4. Payload shape: in create mode send assignee explicitly whenever a default was prefilled or the field has values; omit it only when no default is configured and the field is blank. Rationale: with the prefill the field is a faithful statement of intent, so [] means unassigned, [x] means explicit, and absent only happens for projects with no default - the three states stay unambiguous, and sending the prefilled values explicitly makes the created task match what the form showed. Edit mode keeps sending the field always.
+5. Keep the create-mode unsaved-work check honest: hasCreateModeEntries must compare assignee against the prefilled default instead of length > 0, otherwise opening create with a default configured immediately looks dirty and prompts on close.
+6. Tests: new src/test/web-task-details-modal-default-assignee.test.tsx rendering the modal in create mode and capturing the onSubmit payload - default applied untouched, explicit [] after removing the chips, explicit value when typed, and the no-default control that still omits the field; drive inputs with setNativeInputValue from src/test/react-dom-input.ts.
+7. Verify: bunx tsc --noEmit, bun run check ., full bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Mechanism confirmed feasible as suggested: GET /api/config already returns the whole BacklogConfig (server handleGetConfig), App.tsx holds it in state and already derives modal props from it, so defaultAssignee reaches the create form as one more prop - no new endpoint, no new UI, no new copy. The existing assignee ChipInput renders the prefilled values as its ordinary removable chips.
+
+Payload shape decision: create sends the assignee list explicitly whenever a default was prefilled or the user typed something, and omits the field only when no default is configured and the field is blank. Sending the prefilled values rather than omitting them keeps the three create states unambiguous at the payload level ([] = unassigned, [names] = explicit, absent = project has no default) and makes the created task match exactly what the form showed, even if the config changed between page load and submit. Absent-vs-[] is already honored by core createTaskFromInput, so no server or core change was needed.
+
+Two details the prefill forced: (1) the reset effect now takes the memoized default so a config that lands after the modal mounted still prefills, while the existing preserveDirtyRefreshValue keeps a user's edit - including a removal - across the config refresh that App triggers on every reload; (2) hasCreateModeEntries compares the assignee against the prefilled default instead of length > 0, so a pristine prefilled create form is not treated as unsaved work while a removal still is.
+
+defaultAssignee is passed as config?.defaultAssignee (like availablePriorities) rather than config?.defaultAssignee ?? [], so the prop identity stays stable and the reset effect does not re-run on every App render.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+The web create form now pre-fills the assignee field with the configured defaultAssignee as ordinary removable chips, so removing them sends an explicit empty list and creates an unassigned task, while leaving them sends the default values and typing a name sends that name. Projects without a defaultAssignee still open with a blank field and still omit the field entirely. Edit mode is untouched: an opened task always shows its own assignees and an explicit empty list still clears them. Implemented by passing config.defaultAssignee from App.tsx into TaskDetailsModal (the existing /api/config response already carries it), seeding the create-mode assignee state from it, and narrowing the create payload's omit rule to 'blank field and no default configured'. Verified with a new src/test/web-task-details-modal-default-assignee.test.tsx (8 tests) that renders the modal and captures the submitted payload for every state: default applied untouched, explicit [] after the chips are removed, explicit name when typed, field omitted for a no-default project, plus the late-config prefill and the refresh-keeps-a-removal cases and an edit-mode guard. bunx tsc --noEmit clean, bun run check . clean, full bun run test green (2150 pass, 6 skip, 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/web-task-details-modal-default-assignee.test.tsx
+++ b/src/test/web-task-details-modal-default-assignee.test.tsx
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import type { Task } from "../types/index.ts";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal";
+import { apiClient } from "../web/lib/api";
+import { TaskIdIndexProvider } from "../web/contexts/TaskIdIndexContext.tsx";
+import { ThemeProvider } from "../web/contexts/ThemeContext";
+import { setNativeInputValue } from "./react-dom-input.ts";
+
+let activeRoot: Root | null = null;
+let activeDom: JSDOM | null = null;
+
+const existingTask: Task = {
+	id: "BACK-1",
+	title: "Existing task",
+	status: "To Do",
+	assignee: [],
+	createdDate: "2026-08-09",
+	labels: [],
+	dependencies: [],
+};
+
+const setupDom = () => {
+	activeDom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: "http://localhost",
+	});
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = activeDom.window as unknown as Window & typeof globalThis;
+	globalThis.document = activeDom.window.document as Document;
+	globalThis.navigator = activeDom.window.navigator as Navigator;
+	globalThis.localStorage = activeDom.window.localStorage;
+	globalThis.Element = activeDom.window.Element;
+	globalThis.HTMLElement = activeDom.window.HTMLElement;
+	globalThis.HTMLInputElement = activeDom.window.HTMLInputElement;
+	globalThis.HTMLTextAreaElement = activeDom.window.HTMLTextAreaElement;
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(callback, 0);
+	globalThis.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
+
+	window.matchMedia = () =>
+		({
+			matches: false,
+			media: "",
+			onchange: null,
+			addListener: () => {},
+			removeListener: () => {},
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			dispatchEvent: () => false,
+		}) as MediaQueryList;
+
+	const htmlElementPrototype = window.HTMLElement.prototype as unknown as {
+		attachEvent?: () => void;
+		detachEvent?: () => void;
+	};
+	htmlElementPrototype.attachEvent = () => {};
+	htmlElementPrototype.detachEvent = () => {};
+};
+
+type SubmittedPayloads = Partial<Task>[];
+
+type ModalProps = {
+	task?: Task;
+	defaultAssignee?: string[];
+	onSubmit?: (taskData: Partial<Task>) => Promise<void>;
+};
+
+const renderInto = async ({ task, defaultAssignee, onSubmit }: ModalProps): Promise<void> => {
+	await act(async () => {
+		activeRoot?.render(
+			<MemoryRouter initialEntries={["/"]}>
+				<ThemeProvider>
+					<TaskIdIndexProvider tasks={[existingTask]}>
+						<TaskDetailsModal
+							task={task}
+							isOpen={true}
+							onClose={() => {}}
+							onSubmit={onSubmit}
+							defaultAssignee={defaultAssignee}
+						/>
+					</TaskIdIndexProvider>
+				</ThemeProvider>
+			</MemoryRouter>,
+		);
+		await Promise.resolve();
+	});
+};
+
+const renderModal = async (props: ModalProps): Promise<HTMLElement> => {
+	setupDom();
+	const container = document.getElementById("root");
+	activeRoot = createRoot(container as HTMLElement);
+	await renderInto(props);
+	return container as HTMLElement;
+};
+
+/** Create mode, capturing every payload the form submits. */
+const mountCreateModal = async (defaultAssignee?: string[]) => {
+	const submitted: SubmittedPayloads = [];
+	const onSubmit = async (taskData: Partial<Task>) => {
+		submitted.push(taskData);
+	};
+	const container = await renderModal({ defaultAssignee, onSubmit });
+	/** Re-render as App does after a refresh, with a config array that is a new reference. */
+	const rerenderWithFreshConfig = (nextDefaultAssignee?: string[]) =>
+		renderInto({ defaultAssignee: nextDefaultAssignee ? [...nextDefaultAssignee] : undefined, onSubmit });
+	return { container, submitted, rerenderWithFreshConfig };
+};
+
+const click = async (element: Element) => {
+	await act(async () => {
+		element.dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
+		await Promise.resolve();
+	});
+};
+
+const findButton = (container: HTMLElement, label: string): HTMLButtonElement => {
+	const button = Array.from(container.querySelectorAll("button")).find(
+		(candidate) => candidate.textContent?.trim() === label,
+	);
+	expect(button, `button "${label}"`).toBeTruthy();
+	return button as HTMLButtonElement;
+};
+
+/** The assignee ChipInput only, so label or dependency chips can never answer for it. */
+const assigneeField = (container: HTMLElement): HTMLElement => {
+	const input = container.querySelector("#chip-input-assignee");
+	expect(input?.parentElement, "assignee chip field").toBeTruthy();
+	return input?.parentElement as HTMLElement;
+};
+
+const assigneeChips = (container: HTMLElement): string[] =>
+	Array.from(assigneeField(container).querySelectorAll('button[aria-label^="Remove "]')).map(
+		(button) => button.getAttribute("aria-label")?.replace(/^Remove /, "") ?? "",
+	);
+
+const removeChip = async (container: HTMLElement, chip: string) => {
+	const button = assigneeField(container).querySelector(`button[aria-label="Remove ${chip}"]`);
+	expect(button, `remove button for "${chip}"`).toBeTruthy();
+	await click(button as Element);
+};
+
+const typeAssignee = async (container: HTMLElement, value: string) => {
+	const input = container.querySelector("#chip-input-assignee") as HTMLInputElement | null;
+	expect(input).toBeTruthy();
+	await act(async () => {
+		setNativeInputValue(input as HTMLInputElement, value);
+		await Promise.resolve();
+	});
+	await act(async () => {
+		(input as HTMLInputElement).dispatchEvent(
+			new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+		);
+		await Promise.resolve();
+	});
+};
+
+const fillTitle = async (container: HTMLElement, title: string) => {
+	const input = container.querySelector('input[placeholder="Enter task title"]') as HTMLInputElement | null;
+	expect(input).toBeTruthy();
+	await act(async () => {
+		setNativeInputValue(input as HTMLInputElement, title);
+		await Promise.resolve();
+	});
+};
+
+const submitCreateForm = async (container: HTMLElement) => {
+	await click(findButton(container, "Create"));
+};
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => {
+			activeRoot?.unmount();
+		});
+		activeRoot = null;
+	}
+	activeDom?.window.close();
+	activeDom = null;
+});
+
+describe("Task details modal assignee on create", () => {
+	it("applies the configured default when the prefilled chips are left alone", async () => {
+		const { container, submitted } = await mountCreateModal(["@alice", "@bob"]);
+
+		expect(assigneeChips(container)).toEqual(["@alice", "@bob"]);
+
+		await fillTitle(container, "Task that keeps the default");
+		await submitCreateForm(container);
+
+		expect(submitted).toHaveLength(1);
+		expect(submitted[0]?.assignee).toEqual(["@alice", "@bob"]);
+	});
+
+	it("sends an explicit empty list once every prefilled chip is removed", async () => {
+		const { container, submitted } = await mountCreateModal(["@alice"]);
+
+		await removeChip(container, "@alice");
+		expect(assigneeChips(container)).toEqual([]);
+
+		await fillTitle(container, "Task nobody owns");
+		await submitCreateForm(container);
+
+		expect(submitted).toHaveLength(1);
+		expect(submitted[0]).toHaveProperty("assignee");
+		expect(submitted[0]?.assignee).toEqual([]);
+	});
+
+	it("sends the typed assignee when the default is replaced", async () => {
+		const { container, submitted } = await mountCreateModal(["@alice"]);
+
+		await removeChip(container, "@alice");
+		await typeAssignee(container, "@carol");
+		expect(assigneeChips(container)).toEqual(["@carol"]);
+
+		await fillTitle(container, "Task for someone else");
+		await submitCreateForm(container);
+
+		expect(submitted).toHaveLength(1);
+		expect(submitted[0]?.assignee).toEqual(["@carol"]);
+	});
+
+	it("omits the field for a project without a default when the input is left blank", async () => {
+		const { container, submitted } = await mountCreateModal();
+
+		expect(assigneeChips(container)).toEqual([]);
+
+		await fillTitle(container, "Task with no opinion on assignment");
+		await submitCreateForm(container);
+
+		expect(submitted).toHaveLength(1);
+		expect(submitted[0]).not.toHaveProperty("assignee");
+	});
+
+	it("keeps a removed default when a refresh re-renders the open form", async () => {
+		const { container, submitted, rerenderWithFreshConfig } = await mountCreateModal(["@alice"]);
+
+		await removeChip(container, "@alice");
+		await rerenderWithFreshConfig(["@alice"]);
+
+		expect(assigneeChips(container)).toEqual([]);
+
+		await fillTitle(container, "Task nobody owns, saved after a refresh");
+		await submitCreateForm(container);
+
+		expect(submitted[0]?.assignee).toEqual([]);
+	});
+
+	it("prefills once a late config arrives while the untouched form is open", async () => {
+		const { container, submitted, rerenderWithFreshConfig } = await mountCreateModal();
+
+		expect(assigneeChips(container)).toEqual([]);
+
+		await rerenderWithFreshConfig(["@alice"]);
+
+		expect(assigneeChips(container)).toEqual(["@alice"]);
+
+		await fillTitle(container, "Task created after the config landed");
+		await submitCreateForm(container);
+
+		expect(submitted[0]?.assignee).toEqual(["@alice"]);
+	});
+
+	it("still sends what was typed for a project without a default", async () => {
+		const { container, submitted } = await mountCreateModal();
+
+		await typeAssignee(container, "@carol");
+
+		await fillTitle(container, "Task with an explicit owner");
+		await submitCreateForm(container);
+
+		expect(submitted).toHaveLength(1);
+		expect(submitted[0]?.assignee).toEqual(["@carol"]);
+	});
+});
+
+describe("Task details modal assignee outside create", () => {
+	it("leaves an existing task's empty assignee alone and still clears explicitly", async () => {
+		const updates: Partial<Task>[] = [];
+		const originalUpdateTask = apiClient.updateTask;
+		(apiClient as { updateTask: typeof apiClient.updateTask }).updateTask = (async (
+			_id: string,
+			payload: Partial<Task>,
+		) => {
+			updates.push(payload);
+			return { ...existingTask, ...payload } as Task;
+		}) as typeof apiClient.updateTask;
+
+		try {
+			const container = await renderModal({
+				task: { ...existingTask, assignee: ["@dave"] },
+				defaultAssignee: ["@alice"],
+			});
+
+			// The default belongs to create only: an opened task shows its own assignees.
+			expect(assigneeChips(container)).toEqual(["@dave"]);
+
+			await removeChip(container, "@dave");
+
+			expect(updates).toHaveLength(1);
+			expect(updates[0]?.assignee).toEqual([]);
+			expect(assigneeChips(container)).toEqual([]);
+		} finally {
+			(apiClient as { updateTask: typeof apiClient.updateTask }).updateTask = originalUpdateTask;
+		}
+	});
+});

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -813,6 +813,7 @@ function AppContent() {
         archivedMilestoneEntities={archivedMilestones}
         isDraftMode={isDraftMode}
         definitionOfDoneDefaults={config?.definitionOfDone ?? []}
+        defaultAssignee={config?.defaultAssignee}
         dateFormat={config?.dateFormat}
       />
 

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -30,6 +30,7 @@ interface Props {
   milestoneEntities?: Milestone[];
   archivedMilestoneEntities?: Milestone[];
   definitionOfDoneDefaults?: string[];
+  defaultAssignee?: string[];
   dateFormat?: string;
 }
 
@@ -89,12 +90,14 @@ const buildTaskDetailsFormState = ({
   isDraftMode,
   availableStatuses,
   defaultDefinitionOfDone,
+  createModeAssignee,
 }: {
   task?: Task;
   isCreateMode: boolean;
   isDraftMode?: boolean;
   availableStatuses?: string[];
   defaultDefinitionOfDone: AcceptanceCriterion[];
+  createModeAssignee: string[];
 }): TaskDetailsFormState => ({
   title: task?.title || "",
   description: task?.description || "",
@@ -105,7 +108,7 @@ const buildTaskDetailsFormState = ({
   criteria: task?.acceptanceCriteriaItems || [],
   definitionOfDone: task?.definitionOfDoneItems || (isCreateMode ? defaultDefinitionOfDone : []),
   status: task?.status || (isDraftMode ? "Draft" : (availableStatuses?.[0] || "To Do")),
-  assignee: task?.assignee || [],
+  assignee: task?.assignee || createModeAssignee,
   labels: task?.labels || [],
   priority: task?.priority || "",
   taskType: task?.type || "",
@@ -139,6 +142,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   archivedMilestoneEntities,
   isDraftMode,
   definitionOfDoneDefaults,
+  defaultAssignee,
   dateFormat,
 }) => {
   const { theme } = useTheme();
@@ -170,6 +174,12 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const defaultDefinitionOfDone = useMemo(
     () => (definitionOfDoneDefaults ?? []).map((text, index) => ({ index: index + 1, text, checked: false })),
     [definitionOfDoneDefaults],
+  );
+  // Create mode starts with the configured defaultAssignee already in the field, as ordinary
+  // removable chips, so emptying it says "unassigned" instead of "no opinion".
+  const createModeAssignee = useMemo(
+    () => (isCreateMode ? (defaultAssignee ?? []) : []),
+    [isCreateMode, defaultAssignee],
   );
   const initialDefinitionOfDone = task?.definitionOfDoneItems ?? (isCreateMode ? defaultDefinitionOfDone : []);
   const [definitionOfDone, setDefinitionOfDone] = useState<AcceptanceCriterion[]>(initialDefinitionOfDone);
@@ -311,7 +321,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
 
   // Sidebar metadata (inline edit)
   const [status, setStatus] = useState(task?.status || (isDraftMode ? "Draft" : (availableStatuses?.[0] || "To Do")));
-  const [assignee, setAssignee] = useState<string[]>(task?.assignee || []);
+  const [assignee, setAssignee] = useState<string[]>(task?.assignee || createModeAssignee);
   const [labels, setLabels] = useState<string[]>(task?.labels || []);
   const [priority, setPriority] = useState<string>(task?.priority || "");
   const [taskType, setTaskType] = useState<string>(task?.type || "");
@@ -446,6 +456,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
       isDraftMode,
       availableStatuses,
       defaultDefinitionOfDone,
+      createModeAssignee,
     });
     const previousFormState = formBaselineRef.current;
     const sameOpenModalRefresh =
@@ -532,7 +543,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
     previousIsOpen.current = isOpen;
     formBaselineRef.current = nextFormState;
     setError(null);
-  }, [task, isOpen, isCreateMode, isDraftMode, availableStatuses, defaultDefinitionOfDone]);
+  }, [task, isOpen, isCreateMode, isDraftMode, availableStatuses, defaultDefinitionOfDone, createModeAssignee]);
 
   const refreshAfterCommentChange = useCallback(() => {
     if (!commentsChanged) return;
@@ -548,7 +559,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
       taskType.trim() !== "" ||
       priority.trim() !== "" ||
       milestone.trim() !== "" ||
-      assignee.length > 0 ||
+      // The prefilled default is not the user's work, but removing or replacing it is.
+      !areJsonEqual(assignee, createModeAssignee) ||
       labels.length > 0 ||
       dependencies.length > 0 ||
       references.length > 0);
@@ -709,9 +721,11 @@ export const TaskDetailsModal: React.FC<Props> = ({
         finalSummary,
         acceptanceCriteriaItems: criteria,
         status,
-        // A blank assignee field on create means "no opinion", so the configured
-        // defaultAssignee still applies; on edit an explicit empty list clears the assignees.
-        ...(isCreateMode && assignee.length === 0 ? {} : { assignee }),
+        // Create starts with the configured defaultAssignee in the field, so what the field
+        // holds is what the user meant: empty is an explicit "unassigned". Only a project
+        // without a default has nothing to remove, so there a blank field still omits the
+        // field. On edit an explicit empty list clears the assignees.
+        ...(isCreateMode && assignee.length === 0 && createModeAssignee.length === 0 ? {} : { assignee }),
         labels,
         priority: priority === "" ? undefined : priority,
         dependencies,


### PR DESCRIPTION
## Summary

Since BACK-604 (#880) the web create modal omits the assignee field when the chip input is blank, so `defaultAssignee` still applies — which left the create form unable to express "explicitly unassigned" while a default is configured. Edit mode could already do it via an explicit empty list.

The create form now pre-fills the assignee field with the configured `defaultAssignee` as ordinary removable chips:

- chips left alone → those values are sent → the default applies
- chips removed → explicit `assignee: []` → unassigned
- a name typed → that name is sent
- no `defaultAssignee` configured → blank field, field omitted, unchanged

No new UI, controls, or copy: the existing `ChipInput` renders the prefilled values exactly as it renders any other chips. Edit mode is untouched — an opened task always shows its own assignees, and clearing them still sends an explicit empty list.

## Why this payload shape

The create payload sends the assignee list explicitly whenever a default was prefilled or the user typed something, and omits the field only when no default is configured and the field is blank. That keeps the three states unambiguous at the payload level (`[]` = unassigned, `[names]` = explicit, absent = the project has no default), and the created task matches exactly what the form showed even if the config changed between page load and submit. `absent` vs `[]` is already honored by `createTaskFromInput`, so no server or core change was needed.

## Details

- `defaultAssignee` reaches the client on the existing `GET /api/config` response (it returns the whole `BacklogConfig`), so `App.tsx` just passes `config?.defaultAssignee` down like `availablePriorities` — no new endpoint. Passing it unwrapped keeps the prop identity stable so the modal's reset effect does not re-run on every `App` render.
- The reset effect takes the memoized default, so a config that lands after the modal mounted still prefills, while the existing `preserveDirtyRefreshValue` keeps a user's edit — including a removal — across the config refresh `App` triggers on every reload.
- `hasCreateModeEntries` now compares the assignee against the prefilled default instead of `length > 0`, so a pristine prefilled create form is not treated as unsaved work while a removal still is.

## Test plan

New `src/test/web-task-details-modal-default-assignee.test.tsx` renders the modal and captures the submitted payload for each state:

- default applied when the prefilled chips are left alone
- explicit `[]` once every prefilled chip is removed
- explicit name when the default is replaced
- field omitted for a project with no default and a blank input, and still sent when typed there
- a removal survives a refresh that re-renders the open form with a fresh config array
- a late-arriving config prefills an untouched open form
- edit-mode guard: an opened task shows its own assignees (not the default) and clearing still sends `[]`

`bunx tsc --noEmit` clean, `bun run check .` clean, full `bun run test` green (2150 pass, 6 skip, 0 fail).

Task: BACK-614
