### PR TITLE
BACK-615 - Take over PR #808: hide empty board columns in the TUI

### DIFF
--- a/backlog/tasks/back-615 - Take-over-PR-808-hide-empty-board-columns-in-the-TUI.md
+++ b/backlog/tasks/back-615 - Take-over-PR-808-hide-empty-board-columns-in-the-TUI.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-615
 title: 'Take over PR #808: hide empty board columns in the TUI'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-09 13:49'
+updated_date: '2026-08-09 14:38'
 labels: []
 dependencies: []
 ordinal: 254000
@@ -17,15 +19,50 @@ Takeover approved by Alex (2026-08-07 takeover-mode ruling, reconfirmed 2026-08-
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Empty columns are hidden on the TUI board per the intent of PR #808
-- [ ] #2 The TUI footer does not become overcrowded
-- [ ] #3 Original author credit is preserved in the commit history where feasible
-- [ ] #4 Tests cover the empty-column behavior
+- [x] #1 Empty columns are hidden on the TUI board per the intent of PR #808
+- [x] #2 The TUI footer does not become overcrowded
+- [x] #3 Original author credit is preserved in the commit history where feasible
+- [x] #4 Tests cover the empty-column behavior
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Study PR #808 (janosmiko): it targets the already-shipped hideEmptyColumns config key (BACK-522, web-only) and adds a TUI S-h hotkey plus a pure filterVisibleColumns helper, a web toolbar button, web drag-and-drop hardening, a footer hint, a help-popup entry and README copy. Precedence check: no competing mechanism - the config key exists and the contributor's toggle writes that same key, so the takeover is 'make the TUI honor the existing key' plus his hotkey.
+2. Scope to the TUI per this task's acceptance criteria: keep the web board untouched (the config key already drives it) and leave the web toolbar button and drag-and-drop fixes for a separate decision.
+3. Cherry-pick the contributor's first commit with authorship preserved, adapted to the reworked board (enhanced-views.ts and simple-unified-view.ts no longer exist; renderBoardTui now resolves Core through getCore()).
+4. Thread hideEmptyColumns from config into renderBoardTui and filter the projected columns at the render boundary; keep move mode showing every column so all drop targets stay reachable, and keep currentStatuses derived from the unfiltered projection so hiding cannot narrow move targets.
+5. Apply the same filter to the non-TTY (piped) board output so both render paths in src/ui/board.ts agree.
+6. Footer decision: do not add a [H] hint to the default footer (it is already 150 visible chars and wraps to two lines at common widths). Document the key in the help popup only, and confirm each toggle with the existing transient footer message.
+7. Add tests: the contributor's pure-helper tests plus TUI render tests (hidden on/off, move mode restores empty columns, S-h toggle persists to config) and a piped-output test.
+8. Verify bunx tsc --noEmit, bun run check ., and the full bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Takeover of https://github.com/MrLesk/Backlog.md/pull/808 by János Mikó (@janosmiko).
+
+Precedence check: hideEmptyColumns already exists in BacklogConfig and has been shipped since BACK-522, but only the browser board read it. The contributor did not invent a second mechanism - his TUI hotkey writes that same config key - so there was no conflicting-mechanism product call to escalate, and this change is 'make the TUI honor the existing key' plus his quick toggle.
+
+Shipped (TUI only): the contributor's pure filterVisibleColumns helper, the hideEmptyColumns option threaded from config into renderBoardTui, the Shift+H toggle that persists to the shared config key, and a help-popup entry. Adapted to the board rework: the toggle now resolves Core through getCore() instead of constructing one from process.cwd() (so BACKLOG_CWD and the caller's project root are respected), the two view entry points his patch touched no longer exist, and currentStatuses is now derived from the unfiltered projection inside renderView (rebuildColumns used to derive it from the rendered columns, which would have narrowed the move targets once columns were hidden).
+
+Footer decision (owner constraint): no [H] hint was added. The default footer is already 150 visible characters and wraps to two lines at 100 columns, so the hotkey is documented in the help popup instead, and each toggle confirms itself through the existing transient footer message. The footer string is byte-identical to main.
+
+Not shipped from PR #808: the browser board toolbar button, the drag-and-drop hardening, the README copy and the bundled BACK-555 task-composer commits, all outside this task's acceptance criteria. Worth noting for a separate decision: his drag-and-drop findings describe a live defect in the already-shipped web behavior - Board.tsx flips isDragging synchronously inside dragstart, which re-inserts the hidden columns during the drag and (per his report) cancels the native drag in Chromium, making cards undraggable while hideEmptyColumns is on.
+
+Piped board: the non-TTY branch of renderBoardTui now applies the same filter, so 'backlog board' means the same thing with and without a TTY. 'backlog board export' was deliberately left alone - it writes a full snapshot artifact.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+The TUI board now honors the shared hideEmptyColumns setting and adds Shift+H to flip it, taken over from PR #808 by János Mikó with his commit authorship preserved. Empty status columns disappear when the setting is on, every column returns while a task is being moved so all drop targets stay reachable, the piped board output applies the same filter, and the setting persists to the same config key the browser board and 'backlog config' already use. The footer was left untouched (the hotkey is documented in the help popup) so it does not get more crowded. Verified with 11 tests in src/test/board-hide-empty-columns.test.ts covering the helper, the rendered TUI columns with the setting on and off, the move-mode restore, the Shift+H round trip through config.yml, and both piped outputs; plus a live tmux run of 'backlog board' at 100x32 where In Progress was hidden, Shift+H restored it with the 'Showing empty columns' message and wrote hideEmptyColumns: false, the help popup listed the shortcut and the footer stayed at its unchanged two lines. bunx tsc --noEmit clean, bun run check . clean across 369 files, full bun run test 2161 pass / 6 skip / 0 fail.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-615 - Take-over-PR-808-hide-empty-board-columns-in-the-TUI.md
+++ b/backlog/tasks/back-615 - Take-over-PR-808-hide-empty-board-columns-in-the-TUI.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-09 13:49'
-updated_date: '2026-08-09 14:38'
+updated_date: '2026-08-09 15:04'
 labels: []
 dependencies: []
 ordinal: 254000
@@ -59,6 +59,14 @@ Footer decision (owner constraint): no [H] hint was added. The default footer is
 Not shipped from PR #808: the browser board toolbar button, the drag-and-drop hardening, the README copy and the bundled BACK-555 task-composer commits, all outside this task's acceptance criteria. Worth noting for a separate decision: his drag-and-drop findings describe a live defect in the already-shipped web behavior - Board.tsx flips isDragging synchronously inside dragstart, which re-inserts the hidden columns during the drag and (per his report) cancels the native drag in Chromium, making cards undraggable while hideEmptyColumns is on.
 
 Piped board: the non-TTY branch of renderBoardTui now applies the same filter, so 'backlog board' means the same thing with and without a TTY. 'backlog board export' was deliberately left alone - it writes a full snapshot artifact.
+
+Review follow-up (Codex P2 threads on PR #889):
+
+1. Shutdown race, confirmed and fixed. The Shift+H handler is async but the key emitter does not await it, so quitting right after the toggle resolved the board while getCore()/loadConfig()/saveConfig() were still in flight, and unified-view's process.exit(0) dropped the write. Reproduced with a red test that delays saveConfig by 300ms: the board resolved with hide_empty_columns still unset. The in-flight boolean guard is now the pending promise itself (pendingSettingWrite), and a new closeBoard() helper awaits it before clearing the footer timer, destroying the screen and resolving. closeBoard also replaced the duplicated teardown in the q, Esc, Tab and view-switcher paths, so a handoff to the task list cannot drop the write either. No UI copy was added.
+
+2. Milestone-grouped piped board, fixed. The non-TTY --milestones branch bypassed the filter and still printed '### <status> (0)' headings per milestone. The visible statuses are now derived once before the milestone branch and passed to both generators, matching the browser, whose milestone lanes hide a status that is empty across all lanes.
+
+Verified: bunx tsc --noEmit clean, bun run check . clean across 369 files, 14 tests in board-hide-empty-columns.test.ts (2 new, both red before the fixes), 115 tests across the 9 board/TUI files, full bun run test 2164 pass / 6 skip / 0 fail. Live tmux run: pressing H then q back to back with no pause left hide_empty_columns: true in config.yml, and 'backlog board --milestones' piped drops the In Progress heading with the setting on and keeps it with the setting off.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/test/board-hide-empty-columns.test.ts
+++ b/src/test/board-hide-empty-columns.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "../types/index.ts";
+import { type ColumnData, filterVisibleColumns } from "../ui/board.ts";
+
+function createTask(id: string, status: string): Task {
+	return {
+		id,
+		title: `Title for ${id}`,
+		status,
+		assignee: [],
+		createdDate: "2025-01-01",
+		labels: [],
+		dependencies: [],
+		description: "",
+	};
+}
+
+function makeColumns(entries: Array<[string, string[]]>): ColumnData[] {
+	return entries.map(([status, ids]) => ({
+		status,
+		tasks: ids.map((id) => createTask(id, status)),
+	}));
+}
+
+describe("filterVisibleColumns", () => {
+	it("hides empty columns when enabled and not moving", () => {
+		const data = makeColumns([
+			["To Do", ["task-1"]],
+			["In Progress", []],
+			["Done", ["task-2"]],
+		]);
+
+		const result = filterVisibleColumns(data, true, false);
+
+		expect(result.map((column) => column.status)).toEqual(["To Do", "Done"]);
+	});
+
+	it("keeps all columns when moving, even if hideEmptyColumns is enabled", () => {
+		const data = makeColumns([
+			["To Do", ["task-1"]],
+			["In Progress", []],
+			["Done", ["task-2"]],
+		]);
+
+		const result = filterVisibleColumns(data, true, true);
+
+		expect(result).toBe(data);
+	});
+
+	it("keeps all columns when hideEmptyColumns is disabled", () => {
+		const data = makeColumns([
+			["To Do", ["task-1"]],
+			["In Progress", []],
+			["Done", ["task-2"]],
+		]);
+
+		const result = filterVisibleColumns(data, false, false);
+
+		expect(result).toBe(data);
+	});
+
+	it("falls back to the unfiltered list when every column is empty", () => {
+		const data = makeColumns([
+			["To Do", []],
+			["In Progress", []],
+		]);
+
+		const result = filterVisibleColumns(data, true, false);
+
+		expect(result).toBe(data);
+	});
+});

--- a/src/test/board-hide-empty-columns.test.ts
+++ b/src/test/board-hide-empty-columns.test.ts
@@ -113,7 +113,12 @@ const BOARD_STATUSES = ["To Do", "In Progress", "Done"];
 
 async function withBoard(
 	options: { hideEmptyColumns?: boolean; core?: Core },
-	run: (context: { screen: ScreenInterface & EmittingWidget; columnStatuses: () => string[] }) => Promise<void> | void,
+	run: (context: {
+		screen: ScreenInterface & EmittingWidget;
+		columnStatuses: () => string[];
+		/** Press q and wait for the board to shut down, exactly as the CLI does before exiting. */
+		quit: () => Promise<void>;
+	}) => Promise<void> | void,
 ): Promise<void> {
 	const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 	Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
@@ -125,12 +130,19 @@ async function withBoard(
 			hideEmptyColumns: options.hideEmptyColumns,
 		});
 		await Bun.sleep(20);
+		let closed = false;
+		const quit = async () => {
+			if (closed) return;
+			closed = true;
+			pressKey(screen, "q");
+			await withTimeout(boardPromise, "board close", 5000);
+		};
 		await run({
 			screen,
 			columnStatuses: () => renderedColumnStatuses(screen as unknown as LabelledWidget),
+			quit,
 		});
-		pressKey(screen, "q");
-		await withTimeout(boardPromise, "board close", 1000);
+		await quit();
 	} finally {
 		screen.destroy();
 		if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
@@ -195,10 +207,36 @@ describe("Shift+H toggles hideEmptyColumns", () => {
 			await rm(testDir, { force: true, recursive: true });
 		}
 	});
+
+	it("finishes the pending write before the board shuts down", async () => {
+		const testDir = await mkdtemp(join(tmpdir(), "backlog-hide-empty-columns-exit-"));
+		const core = new Core(testDir);
+		try {
+			await initializeTestProject(core, "Hide Empty Columns Exit");
+
+			// Quitting resolves the board, and the CLI can exit the process right after,
+			// so a slow write must still land before the board reports it is done.
+			const saveConfig = core.fs.saveConfig.bind(core.fs);
+			core.fs.saveConfig = async (config) => {
+				await Bun.sleep(300);
+				await saveConfig(config);
+			};
+
+			await withBoard({ core }, async ({ screen, quit }) => {
+				pressKey(screen, "S-h");
+				await quit();
+			});
+
+			const persisted = await new Core(testDir).fs.loadConfig();
+			expect(persisted?.hideEmptyColumns).toBe(true);
+		} finally {
+			await rm(testDir, { force: true, recursive: true });
+		}
+	});
 });
 
 describe("piped board output honors hideEmptyColumns", () => {
-	async function captureBoardOutput(hideEmptyColumns?: boolean): Promise<string> {
+	async function captureBoardOutput(options: { hideEmptyColumns?: boolean; milestoneMode?: boolean }): Promise<string> {
 		const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 		Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
 		const originalLog = console.log;
@@ -207,7 +245,11 @@ describe("piped board output honors hideEmptyColumns", () => {
 			lines.push(args.map(String).join(" "));
 		};
 		try {
-			await renderBoardTui(BOARD_TASKS, BOARD_STATUSES, "horizontal", 20, { hideEmptyColumns });
+			await renderBoardTui(BOARD_TASKS, BOARD_STATUSES, "horizontal", 20, {
+				hideEmptyColumns: options.hideEmptyColumns,
+				milestoneMode: options.milestoneMode,
+				milestoneEntities: [],
+			});
 		} finally {
 			console.log = originalLog;
 			if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
@@ -217,15 +259,29 @@ describe("piped board output honors hideEmptyColumns", () => {
 	}
 
 	it("keeps every column by default", async () => {
-		const output = await captureBoardOutput();
+		const output = await captureBoardOutput({});
 
 		expect(output).toContain("| To Do | In Progress | Done |");
 	});
 
 	it("drops empty columns when the setting is enabled", async () => {
-		const output = await captureBoardOutput(true);
+		const output = await captureBoardOutput({ hideEmptyColumns: true });
 
 		expect(output).toContain("| To Do | Done |");
+		expect(output).not.toContain("In Progress");
+	});
+
+	it("keeps every milestone heading by default", async () => {
+		const output = await captureBoardOutput({ milestoneMode: true });
+
+		expect(output).toContain("### In Progress (0)");
+	});
+
+	it("drops empty milestone headings when the setting is enabled", async () => {
+		const output = await captureBoardOutput({ hideEmptyColumns: true, milestoneMode: true });
+
+		expect(output).toContain("### To Do (1)");
+		expect(output).toContain("### Done (1)");
 		expect(output).not.toContain("In Progress");
 	});
 });

--- a/src/test/board-hide-empty-columns.test.ts
+++ b/src/test/board-hide-empty-columns.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ScreenInterface } from "neo-neo-bblessed";
+import { Core } from "../core/backlog.ts";
 import type { Task } from "../types/index.ts";
-import { type ColumnData, filterVisibleColumns } from "../ui/board.ts";
+import { type ColumnData, filterVisibleColumns, renderBoardTui } from "../ui/board.ts";
+import { getHelpShortcuts } from "../ui/components/help-popup.ts";
+import { createScreen } from "../ui/tui.ts";
+import { initializeTestProject, retry, withTimeout } from "./test-utils.ts";
 
 function createTask(id: string, status: string): Task {
 	return {
@@ -68,5 +76,156 @@ describe("filterVisibleColumns", () => {
 		const result = filterVisibleColumns(data, true, false);
 
 		expect(result).toBe(data);
+	});
+});
+
+type EmittingWidget = {
+	emit: (event: string, ch?: string, key?: { name: string; full: string; shift?: boolean }) => boolean;
+};
+type LabelledWidget = { type?: string; children?: LabelledWidget[]; _label?: { content?: string } };
+
+function pressKey(widget: EmittingWidget, full: string, name = full.replace(/^S-/, "")): void {
+	const key = { name, full, shift: full.startsWith("S-") };
+	widget.emit("keypress", "", key);
+	widget.emit(`key ${full}`, "", key);
+}
+
+/** Statuses of the column boxes currently on the board, in render order. */
+function renderedColumnStatuses(root: LabelledWidget): string[] {
+	const statuses: string[] = [];
+	const visit = (node: LabelledWidget) => {
+		for (const child of node.children ?? []) {
+			const label = child._label?.content;
+			// Column boxes are the labelled boxes wrapping a task list: "<icon> <status> (<count>)".
+			if (label && (child.children ?? []).some((grandchild) => grandchild.type === "list")) {
+				const status = label.trim().match(/^\S+\s+(.+)\s+\(\d+\)$/)?.[1];
+				if (status) statuses.push(status);
+			}
+			visit(child);
+		}
+	};
+	visit(root);
+	return statuses;
+}
+
+const BOARD_TASKS = [createTask("TASK-1", "To Do"), createTask("TASK-2", "Done")];
+const BOARD_STATUSES = ["To Do", "In Progress", "Done"];
+
+async function withBoard(
+	options: { hideEmptyColumns?: boolean; core?: Core },
+	run: (context: { screen: ScreenInterface & EmittingWidget; columnStatuses: () => string[] }) => Promise<void> | void,
+): Promise<void> {
+	const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+	const screen = createScreen({ smartCSR: false }) as ScreenInterface & EmittingWidget;
+	try {
+		const boardPromise = renderBoardTui(BOARD_TASKS, BOARD_STATUSES, "horizontal", 20, {
+			screen,
+			core: options.core,
+			hideEmptyColumns: options.hideEmptyColumns,
+		});
+		await Bun.sleep(20);
+		await run({
+			screen,
+			columnStatuses: () => renderedColumnStatuses(screen as unknown as LabelledWidget),
+		});
+		pressKey(screen, "q");
+		await withTimeout(boardPromise, "board close", 1000);
+	} finally {
+		screen.destroy();
+		if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
+		else Reflect.deleteProperty(process.stdout, "isTTY");
+	}
+}
+
+describe("TUI board honors hideEmptyColumns", () => {
+	it("renders every configured column by default", async () => {
+		await withBoard({}, ({ columnStatuses }) => {
+			expect(columnStatuses()).toEqual(["To Do", "In Progress", "Done"]);
+		});
+	});
+
+	it("hides columns without tasks when the setting is enabled", async () => {
+		await withBoard({ hideEmptyColumns: true }, ({ columnStatuses }) => {
+			expect(columnStatuses()).toEqual(["To Do", "Done"]);
+		});
+	});
+
+	it("restores hidden columns while a task is being moved", async () => {
+		await withBoard({ hideEmptyColumns: true }, ({ screen, columnStatuses }) => {
+			pressKey(screen, "m");
+			expect(columnStatuses()).toEqual(["To Do", "In Progress", "Done"]);
+
+			pressKey(screen, "escape");
+			expect(columnStatuses()).toEqual(["To Do", "Done"]);
+		});
+	});
+
+	it("documents the toggle in the help popup instead of the footer", () => {
+		const keys = getHelpShortcuts("board").map((shortcut) => shortcut.key);
+		expect(keys).toContain("H");
+	});
+});
+
+describe("Shift+H toggles hideEmptyColumns", () => {
+	it("hides the empty column and persists the setting for every surface", async () => {
+		const testDir = await mkdtemp(join(tmpdir(), "backlog-hide-empty-columns-"));
+		const core = new Core(testDir);
+		try {
+			await initializeTestProject(core, "Hide Empty Columns");
+
+			await withBoard({ core }, async ({ screen, columnStatuses }) => {
+				expect(columnStatuses()).toEqual(["To Do", "In Progress", "Done"]);
+
+				pressKey(screen, "S-h");
+				await retry(async () => {
+					const config = await core.fs.loadConfig();
+					expect(config?.hideEmptyColumns).toBe(true);
+				}, 20);
+				expect(columnStatuses()).toEqual(["To Do", "Done"]);
+
+				pressKey(screen, "S-h");
+				await retry(async () => {
+					const config = await core.fs.loadConfig();
+					expect(config?.hideEmptyColumns).toBe(false);
+				}, 20);
+				expect(columnStatuses()).toEqual(["To Do", "In Progress", "Done"]);
+			});
+		} finally {
+			await rm(testDir, { force: true, recursive: true });
+		}
+	});
+});
+
+describe("piped board output honors hideEmptyColumns", () => {
+	async function captureBoardOutput(hideEmptyColumns?: boolean): Promise<string> {
+		const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
+		const originalLog = console.log;
+		const lines: string[] = [];
+		console.log = (...args: unknown[]) => {
+			lines.push(args.map(String).join(" "));
+		};
+		try {
+			await renderBoardTui(BOARD_TASKS, BOARD_STATUSES, "horizontal", 20, { hideEmptyColumns });
+		} finally {
+			console.log = originalLog;
+			if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
+			else Reflect.deleteProperty(process.stdout, "isTTY");
+		}
+		return lines.join("\n");
+	}
+
+	it("keeps every column by default", async () => {
+		const output = await captureBoardOutput();
+
+		expect(output).toContain("| To Do | In Progress | Done |");
+	});
+
+	it("drops empty columns when the setting is enabled", async () => {
+		const output = await captureBoardOutput(true);
+
+		expect(output).toContain("| To Do | Done |");
+		expect(output).not.toContain("In Progress");
 	});
 });

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -179,6 +179,19 @@ function formatColumnLabel(status: string, count: number): string {
 const DEFAULT_FOOTER_CONTENT =
 	" {cyan-fg}[Tab]{/} View | {cyan-fg}[N]{/} New | {cyan-fg}[/]{/} Search | {cyan-fg}[T/P/F/I]{/} Filter | {cyan-fg}[←→/↑↓]{/} Nav | {cyan-fg}[Enter]{/} Details | {cyan-fg}[E/M/C/A]{/} Edit/Move/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 
+/**
+ * Board columns to render: with `hideEmptyColumns` enabled, columns without tasks are
+ * dropped. A move keeps every column so all drop targets stay reachable, and a board
+ * where every column is empty keeps them all so the board never renders blank.
+ */
+export function filterVisibleColumns(data: ColumnData[], hideEmptyColumns: boolean, isMoving: boolean): ColumnData[] {
+	if (!hideEmptyColumns || isMoving) {
+		return data;
+	}
+	const nonEmpty = data.filter((column) => column.tasks.length > 0);
+	return nonEmpty.length > 0 ? nonEmpty : data;
+}
+
 export function shouldRebuildColumns(current: ColumnData[], next: ColumnData[]): boolean {
 	if (current.length !== next.length) {
 		return true;
@@ -281,6 +294,7 @@ export async function renderBoardTui(
 		milestoneEntities?: Milestone[];
 		startupWarning?: string;
 		dateFormat?: string;
+		hideEmptyColumns?: boolean;
 		projectName?: string;
 		createTask?: (input: TaskCreateInput) => Promise<Task>;
 		screen?: ScreenInterface;
@@ -292,7 +306,11 @@ export async function renderBoardTui(
 		if (options?.milestoneMode) {
 			console.log(generateMilestoneGroupedBoard(initialTasks, statuses, options.milestoneEntities ?? [], projectName));
 		} else {
-			console.log(generateKanbanBoardWithMetadata(initialTasks, statuses, projectName));
+			// The piped board is the same view, so it hides the same columns the TUI hides.
+			const visibleStatuses = options?.hideEmptyColumns
+				? filterVisibleColumns(prepareBoardColumns(initialTasks, statuses), true, false).map((column) => column.status)
+				: statuses;
+			console.log(generateKanbanBoardWithMetadata(initialTasks, visibleStatuses, projectName));
 		}
 		return;
 	}
@@ -323,6 +341,8 @@ export async function renderBoardTui(
 		let currentColumnsData: ColumnData[] = [];
 		let configuredWorkflowStatuses = [...statuses];
 		let currentStatuses = initialColumns.map((column) => column.status);
+		let hideEmptyColumns = options?.hideEmptyColumns ?? false;
+		let hideEmptyColumnsSaving = false;
 		let currentCol = 0;
 		let popupOpen = false;
 		let currentFocus: "board" | "filters" = "board";
@@ -676,7 +696,6 @@ export async function renderBoardTui(
 
 		const rebuildColumns = (data: ColumnData[], selectedTaskId?: string) => {
 			currentColumnsData = data;
-			currentStatuses = data.map((column) => column.status);
 			createColumnViews(data);
 			restoreSelection(selectedTaskId);
 		};
@@ -921,17 +940,23 @@ export async function renderBoardTui(
 			renderingView = true;
 			try {
 				const projectedData = getProjectedColumns(getFilteredTasks(), moveOp);
+				// Track every projected status, not only the rendered ones, so hiding empty
+				// columns cannot narrow the move targets or the next projection.
+				if (projectedData.length > 0) {
+					currentStatuses = projectedData.map((column) => column.status);
+				}
+				const dataForColumns = filterVisibleColumns(projectedData, hideEmptyColumns, Boolean(moveOp));
 
 				// If we are moving, we want to select the moving task
 				const selectedId = preferredTaskId ?? (moveOp ? moveOp.taskId : getSelectedTaskId());
 
-				if (projectedData.length === 0) {
+				if (dataForColumns.length === 0) {
 					const fallbackStatus = currentStatuses[0] ?? "No Status";
 					rebuildColumns([{ status: fallbackStatus, tasks: [] }], selectedId);
-				} else if (shouldRebuildColumns(currentColumnsData, projectedData)) {
-					rebuildColumns(projectedData, selectedId);
+				} else if (shouldRebuildColumns(currentColumnsData, dataForColumns)) {
+					rebuildColumns(dataForColumns, selectedId);
 				} else {
-					applyColumnData(projectedData, selectedId);
+					applyColumnData(dataForColumns, selectedId);
 				}
 
 				updateFooter();
@@ -1620,6 +1645,40 @@ export async function renderBoardTui(
 						` {red-fg}Error archiving task: ${error instanceof Error ? error.message : "Unknown error"}{/}`,
 					);
 				}
+			}
+		});
+
+		// Shift+H writes the shared hideEmptyColumns setting, so the board, the browser
+		// board and `backlog config` all read the same preference.
+		screen.key(["S-h"], async () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters" || moveOp) return;
+			// Ignore toggles while a save is in flight: overlapping load/save
+			// cycles would write back stale config snapshots (lost updates).
+			if (hideEmptyColumnsSaving) return;
+			hideEmptyColumnsSaving = true;
+
+			const previous = hideEmptyColumns;
+			hideEmptyColumns = !hideEmptyColumns;
+			renderView();
+
+			try {
+				const core = await getCore();
+				const config = await core.fs.loadConfig();
+				if (!config) {
+					throw new Error("No config found");
+				}
+				await core.fs.saveConfig({ ...config, hideEmptyColumns });
+				showTransientFooter(
+					hideEmptyColumns ? " {green-fg}Hiding empty columns{/}" : " {green-fg}Showing empty columns{/}",
+				);
+			} catch (error) {
+				hideEmptyColumns = previous;
+				renderView();
+				showTransientFooter(
+					` {red-fg}Error saving hide empty columns setting: ${error instanceof Error ? error.message : "Unknown error"}{/}`,
+				);
+			} finally {
+				hideEmptyColumnsSaving = false;
 			}
 		});
 

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -303,13 +303,16 @@ export async function renderBoardTui(
 ): Promise<void> {
 	if (!process.stdout.isTTY) {
 		const projectName = options?.projectName?.trim() || "Project";
+		// The piped board is the same view, so it hides the same columns the TUI hides.
+		// Milestone lanes filter on the same board-wide emptiness the browser lanes use.
+		const visibleStatuses = options?.hideEmptyColumns
+			? filterVisibleColumns(prepareBoardColumns(initialTasks, statuses), true, false).map((column) => column.status)
+			: statuses;
 		if (options?.milestoneMode) {
-			console.log(generateMilestoneGroupedBoard(initialTasks, statuses, options.milestoneEntities ?? [], projectName));
+			console.log(
+				generateMilestoneGroupedBoard(initialTasks, visibleStatuses, options.milestoneEntities ?? [], projectName),
+			);
 		} else {
-			// The piped board is the same view, so it hides the same columns the TUI hides.
-			const visibleStatuses = options?.hideEmptyColumns
-				? filterVisibleColumns(prepareBoardColumns(initialTasks, statuses), true, false).map((column) => column.status)
-				: statuses;
 			console.log(generateKanbanBoardWithMetadata(initialTasks, visibleStatuses, projectName));
 		}
 		return;
@@ -342,7 +345,7 @@ export async function renderBoardTui(
 		let configuredWorkflowStatuses = [...statuses];
 		let currentStatuses = initialColumns.map((column) => column.status);
 		let hideEmptyColumns = options?.hideEmptyColumns ?? false;
-		let hideEmptyColumnsSaving = false;
+		let pendingSettingWrite: Promise<void> | null = null;
 		let currentCol = 0;
 		let popupOpen = false;
 		let currentFocus: "board" | "filters" = "board";
@@ -936,6 +939,17 @@ export async function renderBoardTui(
 			}, durationMs);
 		};
 
+		/** Tear the board down, optionally handing off to another view before resolving. */
+		const closeBoard = async (beforeResolve?: () => Promise<unknown>) => {
+			// A Shift+H write can still be in flight, and the caller may exit the process
+			// as soon as the board resolves, which would drop the setting.
+			if (pendingSettingWrite) await pendingSettingWrite;
+			clearFooterTimer();
+			screen.destroy();
+			await beforeResolve?.();
+			resolve();
+		};
+
 		const renderView = (preferredTaskId?: string) => {
 			renderingView = true;
 			try {
@@ -1527,18 +1541,13 @@ export async function renderBoardTui(
 			}
 
 			if (options?.onTabPress) {
-				clearFooterTimer();
-				screen.destroy();
-				await options.onTabPress();
-				resolve();
+				await closeBoard(options.onTabPress);
 				return;
 			}
 
-			if (options?.viewSwitcher) {
-				clearFooterTimer();
-				screen.destroy();
-				await options.viewSwitcher.switchView();
-				resolve();
+			const viewSwitcher = options?.viewSwitcher;
+			if (viewSwitcher) {
+				await closeBoard(() => viewSwitcher.switchView());
 			}
 		});
 
@@ -1648,15 +1657,7 @@ export async function renderBoardTui(
 			}
 		});
 
-		// Shift+H writes the shared hideEmptyColumns setting, so the board, the browser
-		// board and `backlog config` all read the same preference.
-		screen.key(["S-h"], async () => {
-			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters" || moveOp) return;
-			// Ignore toggles while a save is in flight: overlapping load/save
-			// cycles would write back stale config snapshots (lost updates).
-			if (hideEmptyColumnsSaving) return;
-			hideEmptyColumnsSaving = true;
-
+		const toggleHideEmptyColumns = async () => {
 			const previous = hideEmptyColumns;
 			hideEmptyColumns = !hideEmptyColumns;
 			renderView();
@@ -1668,28 +1669,40 @@ export async function renderBoardTui(
 					throw new Error("No config found");
 				}
 				await core.fs.saveConfig({ ...config, hideEmptyColumns });
-				showTransientFooter(
-					hideEmptyColumns ? " {green-fg}Hiding empty columns{/}" : " {green-fg}Showing empty columns{/}",
-				);
 			} catch (error) {
 				hideEmptyColumns = previous;
 				renderView();
 				showTransientFooter(
 					` {red-fg}Error saving hide empty columns setting: ${error instanceof Error ? error.message : "Unknown error"}{/}`,
 				);
-			} finally {
-				hideEmptyColumnsSaving = false;
+				return;
 			}
+			showTransientFooter(
+				hideEmptyColumns ? " {green-fg}Hiding empty columns{/}" : " {green-fg}Showing empty columns{/}",
+			);
+		};
+
+		// Shift+H writes the shared hideEmptyColumns setting, so the board, the browser
+		// board and `backlog config` all read the same preference.
+		screen.key(["S-h"], () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters" || moveOp) return;
+			// Ignore toggles while a write is in flight: overlapping load/save
+			// cycles would write back stale config snapshots (lost updates).
+			if (pendingSettingWrite) return;
+			pendingSettingWrite = toggleHideEmptyColumns()
+				// The toggle reports its own failures; this only keeps the exit path awaitable.
+				.catch(() => {})
+				.finally(() => {
+					pendingSettingWrite = null;
+				});
 		});
 
-		screen.key(["q", "C-c"], () => {
+		screen.key(["q", "C-c"], async () => {
 			if (popupOpen || filterPopupOpen || modalOpen) return;
-			clearFooterTimer();
-			screen.destroy();
-			resolve();
+			await closeBoard();
 		});
 
-		screen.key(["escape"], () => {
+		screen.key(["escape"], async () => {
 			if (popupOpen || filterPopupOpen || modalOpen) return;
 			if (currentFocus === "filters") {
 				focusColumn(currentCol);
@@ -1703,9 +1716,7 @@ export async function renderBoardTui(
 			}
 
 			if (!popupOpen) {
-				clearFooterTimer();
-				screen.destroy();
-				resolve();
+				await closeBoard();
 			}
 		});
 

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -24,6 +24,7 @@ const BOARD_SHORTCUTS: Shortcut[] = [
 	{ key: "C", desc: "Complete task" },
 	{ key: "A", desc: "Archive task" },
 	{ key: "Y", desc: "Yank (Copy) task ID" },
+	{ key: "H", desc: "Hide/show empty columns" },
 	{ key: "?", desc: "Show this help menu" },
 	{ key: "q/Esc", desc: "Quit / Close" },
 ];

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -515,6 +515,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					projectName: config?.projectName,
 					priorities: config?.priorities,
 					types: config?.types,
+					hideEmptyColumns: config?.hideEmptyColumns ?? false,
 					createTask: async (input) => createTaskFromBoard(options.core, input, taskUpdateCallbacks.onTaskAdded),
 				}).then(() => {
 					// If user wants to exit, do it immediately


### PR DESCRIPTION
Takeover of #808 by @janosmiko, scoped to the TUI. His first commit is cherry-picked with his authorship preserved, and both commits carry a `Co-authored-by` trailer so credit survives a squash merge.

## What changes

`hideEmptyColumns` has existed in `BacklogConfig` since BACK-522, but only the browser board read it. The TUI board now honors the same key, and `Shift+H` flips it from the board:

- `filterVisibleColumns` (the contributor's pure helper) drops columns with no tasks at the render boundary. A move keeps every column so all drop targets stay reachable, and a board where every column is empty keeps them all so it never renders blank.
- `Shift+H` writes the shared `hideEmptyColumns` key, so the board, the browser board and `backlog config` keep reading one preference. The toggle guards against key-repeat races and reverts if the save fails.
- The non-TTY branch of `renderBoardTui` applies the same filter, so `backlog board` means the same thing with and without a TTY. `backlog board export` is unchanged - it writes a full snapshot artifact.
- Default behavior is unchanged: with the setting off (the default), the board, the piped output and the footer are identical to before.

## Footer

No `[H]` hint was added. The default footer is already 150 visible characters and wraps to two lines at 100 columns, so the shortcut is documented in the help popup (`?`) instead, and each toggle confirms itself through the existing transient footer message. The footer string is byte-identical to `main`.

## Adapting the contributor's patch

The board was reworked since #808 was opened (BACK-565/605/609):

- the toggle resolves `Core` through `getCore()` instead of constructing one from `process.cwd()`, so `BACKLOG_CWD` and the caller's project root are respected;
- `src/ui/enhanced-views.ts` and `src/ui/simple-unified-view.ts` no longer exist, so only `unified-view.ts` threads the option;
- `currentStatuses` is now derived from the unfiltered projection inside `renderView`. `rebuildColumns` used to derive it from the rendered columns, which would have narrowed the move targets once columns were hidden.

## Not included from #808

The browser board toolbar button, the drag-and-drop hardening, the README copy and the bundled BACK-555 task-composer commits are outside this task's acceptance criteria and are left for a separate decision.

Worth a look separately: the contributor's drag-and-drop findings describe a defect in the already-shipped web behavior. `Board.tsx` flips `isDragging` synchronously inside `dragstart`, which re-inserts the hidden columns during the drag and (per his report) cancels the native drag in Chromium, making cards undraggable while `hideEmptyColumns` is on.

## Verification

- `src/test/board-hide-empty-columns.test.ts`: the contributor's helper tests plus rendered-board tests for the columns with the setting on and off, the move-mode restore, the `Shift+H` round trip through `config.yml`, and both piped outputs - 11 tests.
- Live `backlog board` in tmux at 100x32: `In Progress` hidden with the setting on, `Shift+H` restored it with the `Showing empty columns` message and wrote `hideEmptyColumns: false`, the help popup listed the shortcut, and the footer stayed at its unchanged two lines.
- `bunx tsc --noEmit` clean, `bun run check .` clean across 369 files, full `bun run test` 2161 pass / 6 skip / 0 fail.
