### PR TITLE
BACK-618 - Accept an explicit empty value as a clear on task edit list flags

### DIFF
--- a/backlog/tasks/back-618 - Accept-an-explicit-empty-value-as-a-clear-on-task-edit-list-flags.md
+++ b/backlog/tasks/back-618 - Accept-an-explicit-empty-value-as-a-clear-on-task-edit-list-flags.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-618
 title: Accept an explicit empty value as a clear on task edit list flags
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-09 16:05'
+updated_date: '2026-08-09 16:26'
 labels: []
 dependencies: []
 ordinal: 257000
@@ -17,16 +19,57 @@ Owner decision (Alex, 2026-08-09): accept --dep "" as a second clear spelling on
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 task edit --dep "" clears dependencies, equivalent to --clear-deps
-- [ ] #2 task edit --ref "" and --doc "" clear their lists the same way
-- [ ] #3 task create with an empty value for these flags still errors with the BACK-603 message
-- [ ] #4 Combining an empty value with the corresponding --clear-* flag is not an error (same meaning), and --clear-* flags keep working alone
-- [ ] #5 Tests cover clear-via-empty on edit for all three families plus the create-path error
+- [x] #1 task edit --dep "" clears dependencies, equivalent to --clear-deps
+- [x] #2 task edit --ref "" and --doc "" clear their lists the same way
+- [x] #3 task create with an empty value for these flags still errors with the BACK-603 message
+- [x] #4 Combining an empty value with the corresponding --clear-* flag is not an error (same meaning), and --clear-* flags keep working alone
+- [x] #5 Tests cover clear-via-empty on edit for all three families plus the create-path error
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Red: add failing tests for edit-path clear-via-empty (--dep/--depends-on "", --ref "", --doc ""), empty + matching --clear-* coexistence, and the mixed empty+value rule; keep the create-path error tests as the unchanged baseline.
+2. Green in validateClearableListInput (src/cli.ts): add an emptyClears input, passed as supportsClearFlags only for the three replacement families (--depends-on/--dep, --ref, --doc). When emptyClears is on, a blank raw value stops counting as a setter value: it no longer trips the --clear-* conflict check and no longer produces the BACK-603 empty-value error. --add-ref/--remove-ref and the whole create path keep today's behavior byte-for-byte.
+3. Mixed input (empty value plus a non-empty value in the same family) stays an error with a message written for the new semantics, because an empty value is now exactly the --clear-* flag and --clear-deps --dep X already errors.
+4. Make the edit path actually clear: swap parseDelimitedStringList for parseClearableStringList on options.ref/options.doc and on the merged --depends-on/--dep input (guarded on flag presence so an absent flag stays undefined). Existing 'if (values) editArgs.X = values' branches already treat [] as clear, which is the same path --clear-* uses.
+5. Document the second spelling in task edit --help for --depends-on/--dep/--ref/--doc, mirroring the existing -a "" wording.
+6. Verify: bunx tsc --noEmit, bun run check ., full bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented in the shared helpers, as scoped.
+
+validateClearableListInput (src/cli.ts) gained an emptyClears input. When it is on, a blank raw value is not a setter value: it is filtered out before the --clear-* conflict check and it no longer produces the BACK-603 empty-value error. validateTaskListFlags passes emptyClears: supportsClearFlags for the three replacement families only (--depends-on/--dep, --ref, --doc), so task create and the incremental --add-ref/--remove-ref flags keep today's messages byte for byte.
+
+The edit path now reads those three through parseClearableStringList instead of parseDelimitedStringList, so an explicit empty value yields [] where an absent flag still yields undefined. The existing 'if (values) editArgs.X = values' branches already treat [] as a clear (an empty array is truthy), which is the same assignment --clear-deps/--clear-refs/--clear-docs make, so serialization is identical between the two spellings. Verified in a scratch project: task edit --dep "" --ref "" --doc "" leaves dependencies: [] and drops references/documentation, matching --clear-*.
+
+parseClearableStringList now treats an empty array as absent. That lets the merged --depends-on/--dep input pass straight through instead of needing a call-site length guard, and makes the three families read identically. No current caller passes [] (Commander accumulators give undefined when a flag is absent), so assignee behavior is unchanged.
+
+MIXED-INPUT DECISION: an empty value alongside a non-empty value in the same family (--dep "" --dep TASK-1) sets the non-empty value; the blank is dropped and no error is raised. This mirrors BACK-604, verified empirically on main before implementing: task edit -a "" -a @bob sets @bob today. It also matches how blanks already normalize away inside a single value (--dep "TASK-1," is accepted today and yields [TASK-1]), so blank handling no longer depends on whether the blank landed in the same argv token. The alternative reading, treating the blank as a clear operation and erroring like --clear-deps --dep TASK-1 does, was rejected: the flag and the empty value are not the same kind of thing. --clear-deps is a standalone operation, while an empty --dep is an option that was supplied with no values, which is exactly the parseClearableStringList contract BACK-604 established. The --clear-* conflict checks are unchanged for value-bearing setters.
+
+Message surface: unchanged everywhere. The only new copy is CLI help, where --depends-on/--ref/--doc on task edit now carry the same 'pass "" to clear' note -a already had. No new error strings were added.
+
+Empty value plus the matching --clear-* flag is now accepted (AC 4) because the blank is filtered before the conflict check. --clear-refs --add-ref "" still reports the conflict message it reports on main, since add-ref does not opt into emptyClears.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+task edit now accepts an explicit empty value as a second spelling of clear for the three replacement list families: --depends-on/--dep, --ref, and --doc all behave exactly like --clear-deps/--clear-refs/--clear-docs when passed "", aligning them with the -a "" convention from BACK-604. The --clear-* flags remain and are unchanged. task create still rejects an empty value with the BACK-603 message, since a new task has no list to clear.
+
+The change lives in the two shared helpers it was scoped to. validateClearableListInput takes an emptyClears input that validateTaskListFlags sets from supportsClearFlags for the three replacement families only; with it on, a blank value is filtered out before the --clear-* conflict check and is no longer rejected. The edit path reads those three through parseClearableStringList, so an explicit empty value produces the same [] assignment the --clear-* flags already make. No new error strings; the only new copy is the 'pass "" to clear' note added to task edit --help for the three flags.
+
+Mixed input (--dep "" --dep TASK-1) sets TASK-1 and drops the blank, mirroring -a "" -a @bob, which was verified against main before implementing, and matching how blank segments already normalize away inside a single value.
+
+Verified with new CLI tests for clear-via-empty across all three families, empty plus the matching --clear-* flag, and the mixed-input rule; create-path error tests were strengthened to pin the full BACK-603 message. bunx tsc --noEmit clean, bun run check . clean, full bun run test green at 2181 pass / 6 skip / 0 fail across 226 files. Behavior was also exercised by hand in a scratch project, confirming the cleared frontmatter matches what --clear-* produces.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -530,6 +530,11 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
  * Validate a clearable list option pair such as --ref/--clear-refs.
  * Returns an error message when the clear flag conflicts with a setter or a setter value is blank.
  * Omit `clearFlag` on surfaces without a clear flag (task create) so the guidance stays accurate.
+ *
+ * Set `emptyClears` where an explicit empty value is a second spelling of the clear flag, as it is for
+ * `-a ""`. A blank value is then not a setter value at all: it cannot conflict with the clear flag and
+ * needs no rejecting. Task create leaves it off because there is nothing to clear on a new task, and so
+ * do the incremental --add-ref/--remove-ref flags, which have no list to replace.
  */
 function validateClearableListInput(input: {
 	rawValues: string[];
@@ -538,11 +543,13 @@ function validateClearableListInput(input: {
 	setterFlags: string;
 	clearFlag?: string;
 	subject: string;
+	emptyClears?: boolean;
 }): string | undefined {
-	if (input.clearFlag && input.cleared && input.rawValues.length > 0) {
+	const settingValues = input.emptyClears ? input.rawValues.filter((value) => !input.isBlank(value)) : input.rawValues;
+	if (input.clearFlag && input.cleared && settingValues.length > 0) {
 		return `Cannot combine ${input.clearFlag} with ${input.setterFlags}. Use ${input.clearFlag} by itself.`;
 	}
-	if (input.rawValues.some(input.isBlank)) {
+	if (!input.emptyClears && input.rawValues.some(input.isBlank)) {
 		const guidance = input.clearFlag
 			? `Use ${input.clearFlag} to remove all ${input.subject}.`
 			: `Omit the flag to leave ${input.subject} unset.`;
@@ -582,7 +589,8 @@ async function resolveParentFilterId(core: Core, parentId: string, parentDisplay
 
 /**
  * Validate the dependency, reference, and documentation list flags shared by task create and task edit.
- * `supportsClearFlags` is false for task create, which has no --clear-deps/--clear-refs/--clear-docs flags.
+ * `supportsClearFlags` is false for task create, which has no --clear-deps/--clear-refs/--clear-docs flags
+ * and where an empty value therefore stays an error rather than clearing a list that does not exist yet.
  */
 function validateTaskListFlags(
 	options: Record<string, unknown>,
@@ -598,6 +606,7 @@ function validateTaskListFlags(
 			setterFlags: "--depends-on or --dep",
 			clearFlag: clearFlag("--clear-deps"),
 			subject: "task dependencies",
+			emptyClears: supportsClearFlags,
 		}) ??
 		validateClearableListInput({
 			rawValues: toStringArray(options.ref),
@@ -606,6 +615,7 @@ function validateTaskListFlags(
 			setterFlags: "--ref",
 			clearFlag: clearFlag("--clear-refs"),
 			subject: "references",
+			emptyClears: supportsClearFlags,
 		}) ??
 		validateClearableListInput({
 			rawValues: toStringArray(options.addRef),
@@ -630,6 +640,7 @@ function validateTaskListFlags(
 			setterFlags: "--doc",
 			clearFlag: clearFlag("--clear-docs"),
 			subject: "documentation",
+			emptyClears: supportsClearFlags,
 		})
 	);
 }
@@ -2892,7 +2903,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 	.option("--clear-deps", "remove all task dependencies (cannot combine with --depends-on or --dep)")
 	.option(
 		"--depends-on <taskIds>",
-		"set task dependencies (comma-separated or use multiple times)",
+		'set task dependencies (comma-separated or use multiple times); pass "" to clear them',
 		(value, previous) => {
 			const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
 			return [...soFar, value];
@@ -2904,7 +2915,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 	})
 	.option(
 		"--ref <reference>",
-		"replace all references (comma-separated or repeatable; cannot combine with --add-ref/--remove-ref)",
+		'replace all references (comma-separated or repeatable; cannot combine with --add-ref/--remove-ref); pass "" to clear them',
 		createMultiValueAccumulator(),
 	)
 	.option(
@@ -2926,10 +2937,14 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			return [...soFar, value];
 		},
 	)
-	.option("--doc <documentation>", "set documentation (can be used multiple times)", (value, previous) => {
-		const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
-		return [...soFar, value];
-	})
+	.option(
+		"--doc <documentation>",
+		'set documentation (can be used multiple times); pass "" to clear it',
+		(value, previous) => {
+			const soFar = Array.isArray(previous) ? previous : previous ? [previous] : [];
+			return [...soFar, value];
+		},
+	)
 	.option("--clear-docs", "remove all documentation (cannot combine with --doc)")
 	.action(async (taskId: string | undefined, options) => {
 		const shouldUseWizard = hasInteractiveTTY && !hasEditFieldFlags(options);
@@ -3148,15 +3163,17 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			process.exitCode = 1;
 			return;
 		}
-		const dependencyValues = parseDelimitedStringList([
+		// These three read as clearable lists: an absent flag keeps the current list, and an explicit
+		// empty value produces [], which the assignments below apply as the same clear as --clear-deps.
+		const dependencyValues = parseClearableStringList([
 			...toStringArray(options.dependsOn),
 			...toStringArray(options.dep),
 		]);
 
-		const normalizedReferences = parseDelimitedStringList(options.ref);
+		const normalizedReferences = parseClearableStringList(options.ref);
 		const addReferenceValues = parseDelimitedStringList(options.addRef) ?? [];
 		const removeReferenceValues = parseDelimitedStringList(options.removeRef) ?? [];
-		const normalizedDocumentation = parseDelimitedStringList(options.doc);
+		const normalizedDocumentation = parseClearableStringList(options.doc);
 		const normalizedModifiedFiles = parseDelimitedStringList(options.modifiedFile);
 
 		const planAppendValues = toStringArray(options.appendPlan);

--- a/src/test/cli-dependency.test.ts
+++ b/src/test/cli-dependency.test.ts
@@ -79,7 +79,10 @@ describe("CLI dependency options", () => {
 			.quiet()
 			.nothrow();
 		expect(emptyDependsOn.exitCode).toBe(1);
-		expect(emptyDependsOn.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+		// Create has nothing to clear, so the empty value stays an error here even though task edit clears.
+		expect(emptyDependsOn.stderr.toString()).toContain(
+			"Cannot use an empty value with --depends-on or --dep. Omit the flag to leave task dependencies unset.",
+		);
 
 		const emptyDep = await $`bun ${CLI_PATH} task create "Empty dep" --dep ""`.cwd(testDir).quiet().nothrow();
 		expect(emptyDep.exitCode).toBe(1);
@@ -125,24 +128,46 @@ describe("CLI dependency options", () => {
 		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual([]);
 	});
 
-	it("rejects empty and conflicting dependency edits without changing dependencies", async () => {
+	// On edit an explicit empty value is the second spelling of --clear-deps, matching `-a ""`.
+	it("clears dependencies with an explicit empty value", async () => {
 		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
 		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1`.cwd(testDir).quiet();
 
-		const emptyDependsOn = await $`bun ${CLI_PATH} task edit 2 --depends-on ""`.cwd(testDir).quiet().nothrow();
-		expect(emptyDependsOn.exitCode).toBe(1);
-		expect(emptyDependsOn.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+		const emptyDependsOn = await $`bun ${CLI_PATH} task edit 2 --depends-on ${""} --plain`.cwd(testDir).quiet();
+		expect(emptyDependsOn.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual([]);
 
-		const emptyDep = await $`bun ${CLI_PATH} task edit 2 --dep ""`.cwd(testDir).quiet().nothrow();
-		expect(emptyDep.exitCode).toBe(1);
-		expect(emptyDep.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+		await $`bun ${CLI_PATH} task edit 2 --depends-on TASK-1`.cwd(testDir).quiet();
+		const emptyDep = await $`bun ${CLI_PATH} task edit 2 --dep ${""} --plain`.cwd(testDir).quiet();
+		expect(emptyDep.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual([]);
+	});
 
-		const emptyAlongsideValue = await $`bun ${CLI_PATH} task edit 2 --depends-on "" --dep TASK-1`
-			.cwd(testDir)
-			.quiet()
-			.nothrow();
-		expect(emptyAlongsideValue.exitCode).toBe(1);
-		expect(emptyAlongsideValue.stderr.toString()).toContain("Cannot use an empty value with --depends-on or --dep");
+	it("accepts an explicit empty value together with --clear-deps", async () => {
+		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
+		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1`.cwd(testDir).quiet();
+
+		const result = await $`bun ${CLI_PATH} task edit 2 --clear-deps --dep ${""} --plain`.cwd(testDir).quiet().nothrow();
+
+		expect(result.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual([]);
+	});
+
+	// Blank values normalize away exactly as they do inside one value (`--dep "TASK-1,"`) and for `-a ""`,
+	// so a real dependency alongside a blank one still sets that dependency.
+	it("ignores an empty value when a dependency value is also given", async () => {
+		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
+		await $`bun ${CLI_PATH} task create "Dependent task"`.cwd(testDir).quiet();
+
+		const result = await $`bun ${CLI_PATH} task edit 2 --depends-on ${""} --dep TASK-1 --plain`.cwd(testDir).quiet();
+
+		expect(result.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual(["TASK-1"]);
+	});
+
+	it("rejects conflicting dependency edits without changing dependencies", async () => {
+		await $`bun ${CLI_PATH} task create "Base task"`.cwd(testDir).quiet();
+		await $`bun ${CLI_PATH} task create "Dependent task" --depends-on TASK-1`.cwd(testDir).quiet();
 
 		const conflicting = await $`bun ${CLI_PATH} task edit 2 --clear-deps --depends-on TASK-1`
 			.cwd(testDir)

--- a/src/test/cli-refs-docs.test.ts
+++ b/src/test/cli-refs-docs.test.ts
@@ -135,7 +135,10 @@ await import(${JSON.stringify(pathToFileURL(cliPath).href)});
 			const result = await $`bun ${cliPath} task create "Feature" --ref ""`.cwd(TEST_DIR).quiet().nothrow();
 
 			expect(result.exitCode).toBe(1);
-			expect(result.stderr.toString()).toContain("Cannot use an empty value with --ref");
+			// Create has nothing to clear, so the empty value stays an error here even though task edit clears.
+			expect(result.stderr.toString()).toContain(
+				"Cannot use an empty value with --ref. Omit the flag to leave references unset.",
+			);
 			expect(await new Core(TEST_DIR).filesystem.loadTask("TASK-1")).toBeNull();
 		});
 
@@ -153,7 +156,9 @@ await import(${JSON.stringify(pathToFileURL(cliPath).href)});
 			const result = await $`bun ${cliPath} task create "Feature" --doc ""`.cwd(TEST_DIR).quiet().nothrow();
 
 			expect(result.exitCode).toBe(1);
-			expect(result.stderr.toString()).toContain("Cannot use an empty value with --doc");
+			expect(result.stderr.toString()).toContain(
+				"Cannot use an empty value with --doc. Omit the flag to leave documentation unset.",
+			);
 			expect(await new Core(TEST_DIR).filesystem.loadTask("TASK-1")).toBeNull();
 		});
 
@@ -275,45 +280,72 @@ await import(${JSON.stringify(pathToFileURL(cliPath).href)});
 			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.documentation).toEqual([]);
 		});
 
-		it("rejects empty and conflicting reference edits without changing references", async () => {
+		// On edit an explicit empty value is the second spelling of --clear-refs/--clear-docs, matching `-a ""`.
+		it("clears references with an explicit empty --ref value", async () => {
 			await createTaskWithRefsAndDocs();
 
-			const empty = await $`bun ${cliPath} task edit 1 --ref ""`.cwd(TEST_DIR).quiet().nothrow();
-			expect(empty.exitCode).toBe(1);
-			expect(empty.stderr.toString()).toContain("Cannot use an empty value with --ref");
-			expect(empty.stdout.toString()).not.toContain("Updated task");
+			const result = await $`bun ${cliPath} task edit 1 --ref ${""} --plain`.cwd(TEST_DIR).quiet();
 
-			const emptyAlongsideValue = await $`bun ${cliPath} task edit 1 --ref "" --ref c`.cwd(TEST_DIR).quiet().nothrow();
-			expect(emptyAlongsideValue.exitCode).toBe(1);
-			expect(emptyAlongsideValue.stderr.toString()).toContain("Cannot use an empty value with --ref");
-
-			const conflicting = await $`bun ${cliPath} task edit 1 --clear-refs --ref c`.cwd(TEST_DIR).quiet().nothrow();
-			expect(conflicting.exitCode).toBe(1);
-			expect(conflicting.stderr.toString()).toContain("Cannot combine --clear-refs with --ref");
-
-			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.references).toEqual(["a", "b"]);
+			expect(result.exitCode).toBe(0);
+			const task = await new Core(TEST_DIR).filesystem.loadTask("TASK-1");
+			expect(task?.references).toEqual([]);
+			expect(task?.documentation).toEqual(["doc-a", "doc-b"]);
 		});
 
-		it("rejects empty and conflicting documentation edits without changing documentation", async () => {
+		it("clears documentation with an explicit empty --doc value", async () => {
 			await createTaskWithRefsAndDocs();
 
-			const empty = await $`bun ${cliPath} task edit 1 --doc ""`.cwd(TEST_DIR).quiet().nothrow();
-			expect(empty.exitCode).toBe(1);
-			expect(empty.stderr.toString()).toContain("Cannot use an empty value with --doc");
-			expect(empty.stdout.toString()).not.toContain("Updated task");
+			const result = await $`bun ${cliPath} task edit 1 --doc ${""} --plain`.cwd(TEST_DIR).quiet();
 
-			const emptyAlongsideValue = await $`bun ${cliPath} task edit 1 --doc "" --doc doc-c`
+			expect(result.exitCode).toBe(0);
+			const task = await new Core(TEST_DIR).filesystem.loadTask("TASK-1");
+			expect(task?.documentation).toEqual([]);
+			expect(task?.references).toEqual(["a", "b"]);
+		});
+
+		it("accepts an explicit empty value together with the matching clear flag", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const refs = await $`bun ${cliPath} task edit 1 --clear-refs --ref ${""} --plain`.cwd(TEST_DIR).quiet().nothrow();
+			expect(refs.exitCode).toBe(0);
+			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.references).toEqual([]);
+
+			const docs = await $`bun ${cliPath} task edit 1 --clear-docs --doc ${""} --plain`.cwd(TEST_DIR).quiet().nothrow();
+			expect(docs.exitCode).toBe(0);
+			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.documentation).toEqual([]);
+		});
+
+		// Blank values normalize away exactly as they do inside one value (`--ref "a,"`) and for `-a ""`,
+		// so a real value alongside a blank one still sets that value.
+		it("ignores an empty value when a real value is also given", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const refs = await $`bun ${cliPath} task edit 1 --ref ${""} --ref c --plain`.cwd(TEST_DIR).quiet();
+			expect(refs.exitCode).toBe(0);
+			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.references).toEqual(["c"]);
+
+			const docs = await $`bun ${cliPath} task edit 1 --doc ${""} --doc doc-c --plain`.cwd(TEST_DIR).quiet();
+			expect(docs.exitCode).toBe(0);
+			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.documentation).toEqual(["doc-c"]);
+		});
+
+		it("rejects conflicting reference and documentation edits without changing them", async () => {
+			await createTaskWithRefsAndDocs();
+
+			const conflictingRefs = await $`bun ${cliPath} task edit 1 --clear-refs --ref c`.cwd(TEST_DIR).quiet().nothrow();
+			expect(conflictingRefs.exitCode).toBe(1);
+			expect(conflictingRefs.stderr.toString()).toContain("Cannot combine --clear-refs with --ref");
+
+			const conflictingDocs = await $`bun ${cliPath} task edit 1 --clear-docs --doc doc-c`
 				.cwd(TEST_DIR)
 				.quiet()
 				.nothrow();
-			expect(emptyAlongsideValue.exitCode).toBe(1);
-			expect(emptyAlongsideValue.stderr.toString()).toContain("Cannot use an empty value with --doc");
+			expect(conflictingDocs.exitCode).toBe(1);
+			expect(conflictingDocs.stderr.toString()).toContain("Cannot combine --clear-docs with --doc");
 
-			const conflicting = await $`bun ${cliPath} task edit 1 --clear-docs --doc doc-c`.cwd(TEST_DIR).quiet().nothrow();
-			expect(conflicting.exitCode).toBe(1);
-			expect(conflicting.stderr.toString()).toContain("Cannot combine --clear-docs with --doc");
-
-			expect((await new Core(TEST_DIR).filesystem.loadTask("TASK-1"))?.documentation).toEqual(["doc-a", "doc-b"]);
+			const task = await new Core(TEST_DIR).filesystem.loadTask("TASK-1");
+			expect(task?.references).toEqual(["a", "b"]);
+			expect(task?.documentation).toEqual(["doc-a", "doc-b"]);
 		});
 
 		it("documents --clear-refs and --clear-docs in task edit help", async () => {

--- a/src/utils/task-builders.ts
+++ b/src/utils/task-builders.ts
@@ -143,9 +143,12 @@ export function parseDelimitedStringList(value: unknown): string[] | undefined {
  * Parse a CLI list option that supports an explicit empty value.
  * Returns `undefined` when the option was absent (no opinion) and `[]` when it was supplied
  * with only blank values (explicitly empty), so callers can tell the two cases apart.
+ * An empty array counts as absent, so callers merging several flags into one list can pass the
+ * merged values straight through.
  */
 export function parseClearableStringList(value: unknown): string[] | undefined {
 	if (value === undefined || value === null) return undefined;
+	if (Array.isArray(value) && value.length === 0) return undefined;
 	return parseDelimitedStringList(value) ?? [];
 }
 


### PR DESCRIPTION
Implements BACK-618.

## What changed

On `task edit`, an explicit empty value for the three replacement list families is now a second spelling of clear:

- `--depends-on ""` / `--dep ""` clears dependencies, exactly like `--clear-deps`
- `--ref ""` clears references, exactly like `--clear-refs`
- `--doc ""` clears documentation, exactly like `--clear-docs`

This aligns them with `-a ""`, which has meant "clear" for assignees since BACK-604. The `--clear-*` flags remain and are unchanged.

On `task create` an empty value stays an error with the BACK-603 message ("Omit the flag to leave ... unset.") — a new task has no list to clear and, unlike assignee, no default to override.

## How

Both changes live in the shared helpers from BACK-603.

`validateClearableListInput` gained an `emptyClears` input. When it is on, a blank raw value stops being a setter value: it is filtered out before the `--clear-*` conflict check and no longer produces the empty-value error. `validateTaskListFlags` passes `emptyClears: supportsClearFlags`, so it is on only for the three replacement families on edit. Task create and the incremental `--add-ref`/`--remove-ref` flags keep their current messages byte for byte.

The edit path then reads those three through `parseClearableStringList` instead of `parseDelimitedStringList`, so an explicit empty value yields `[]` while an absent flag still yields `undefined`. The existing `if (values) editArgs.X = values` branches already treat `[]` as a clear, which is the same assignment the `--clear-*` flags make, so both spellings produce identical output.

`parseClearableStringList` now treats an empty array as absent, which lets the merged `--depends-on`/`--dep` input pass straight through and makes the three families read identically at the call site. No current caller passes `[]` (Commander accumulators give `undefined` for an absent flag), so assignee behavior is unchanged.

No new error strings. The only new copy is CLI help, where `--depends-on`, `--ref`, and `--doc` on `task edit` now carry the same `pass "" to clear` note `-a` already had.

## Mixed input

`--dep "" --dep TASK-1` sets `TASK-1`; the blank is dropped and no error is raised.

This mirrors BACK-604 — `task edit -a "" -a @bob` sets `@bob` on main today, verified before implementing — and matches how blanks already normalize away inside a single value: `--dep "TASK-1,"` is accepted today and yields `[TASK-1]`. Blank handling no longer depends on whether the blank landed in the same argv token.

The alternative, treating a blank as a clear operation and erroring the way `--clear-deps --dep TASK-1` does, was rejected: the flag and the empty value are not the same kind of thing. `--clear-deps` is a standalone operation, whereas an empty `--dep` is an option supplied with no values — exactly the `parseClearableStringList` contract BACK-604 established. The `--clear-*` conflict checks are unchanged for value-bearing setters.

Combining an empty value with the matching `--clear-*` flag is now accepted, since both say the same thing.

## Unchanged

- `task create` (and `task create --draft`) behavior and messages
- `task edit` with non-empty values
- `--add-ref ""` / `--remove-ref ""`, which still error, and `--clear-refs --add-ref ""`, which still reports the conflict
- MCP and web, which already have explicit empty-list semantics
- Bare numeric and prefix dependency resolution from BACK-607

## Verification

- New CLI tests for clear-via-empty across all three families, empty plus the matching `--clear-*` flag, and the mixed-input rule; written red first against main behavior.
- Create-path error tests strengthened to pin the full BACK-603 message rather than its prefix.
- `bunx tsc --noEmit` clean, `bun run check .` clean.
- Full `bun run test`: 2181 pass, 6 skip, 0 fail across 226 files.
- Exercised by hand in a scratch project: `task edit --dep "" --ref "" --doc ""` leaves `dependencies: []` and drops references/documentation, matching what `--clear-*` writes.
