### PR TITLE
BACK-617 - Fix web board drag-and-drop when hideEmptyColumns is enabled

### DIFF
--- a/backlog/tasks/back-617 - Fix-web-board-drag-and-drop-when-hideEmptyColumns-is-enabled.md
+++ b/backlog/tasks/back-617 - Fix-web-board-drag-and-drop-when-hideEmptyColumns-is-enabled.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-617
 title: Fix web board drag-and-drop when hideEmptyColumns is enabled
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-09 16:05'
+updated_date: '2026-08-09 16:38'
 labels: []
 dependencies: []
 ordinal: 256000
@@ -17,15 +19,45 @@ Approved by Alex 2026-08-09. Shipped defect in the BACK-522 web board code, repo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With hideEmptyColumns enabled, cards can be dragged and dropped on the web board in Chromium
-- [ ] #2 Hidden empty columns become available as drop targets during a drag, consistent with the TUI move-mode behavior
-- [ ] #3 Contributor credit is preserved where his changes are used
-- [ ] #4 Tests cover dragging with hidden columns on and off
+- [x] #1 With hideEmptyColumns enabled, cards can be dragged and dropped on the web board in Chromium
+- [x] #2 Hidden empty columns become available as drop targets during a drag, consistent with the TUI move-mode behavior
+- [x] #3 Contributor credit is preserved where his changes are used
+- [x] #4 Tests cover dragging with hidden columns on and off
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce in Chromium against current main: serve the web UI over a scratch project with hideEmptyColumns on and drive a real native drag; record the event trace and the DOM state before/after React's dragstart handler.
+2. Fix Board.tsx: keep dragSourceStatus/dragSourceLane synchronous (they do not break the drag) but move the hidden-column reveal behind a deferred flag set in a setTimeout(0) task, so the board layout is not mutated inside the dragstart dispatch. Only arm the timer when hideEmptyColumns is on so the toggle-off path is unchanged. Clear the timer on dragend and on unmount.
+3. Adapt the deferred-expansion idea from janosmiko's PR #808 with credit (Co-authored-by + PR attribution); leave his scroll-preservation and edge auto-scroll out unless required by the core fix.
+4. Add src/test/web-board-drag-hidden-columns.test.tsx: jsdom coverage for hidden columns on (no synchronous reveal on dragstart, reveal after the next task, drop onto a revealed column reorders, re-hide on dragend) and off (all columns present throughout).
+5. Re-verify the fixed build in Chromium (drag survives, hidden columns appear mid-drag, drop onto a revealed column moves the task); run bunx tsc --noEmit, bun run check ., and the full bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced first on current main in Chromium (chrome-devtools native drag against a scratch project: statuses To Do/In Progress/Done/Blocked, one task in In Progress, hideEmptyColumns on). Event trace was dragstart -> dragend with nothing in between: no drag, dragenter, dragover or drop, so the browser aborted the drag immediately. Instrumenting around React's handler showed why: before React ran, 1 column was rendered; still inside the same dragstart dispatch, after React's handler, 4 columns were rendered. The dragged card node itself stayed connected and identical, so this is the board layout mutating during dragstart, not the source node being replaced. Same drag with hideEmptyColumns off gave the full dragstart/drag/dragenter/dragover/drop/dragend sequence and moved the task, confirming the harness performs a real native drag.
+
+Fix keeps dragSourceStatus/dragSourceLane synchronous (they re-render columns without breaking the drag, as the toggle-off control proves) and moves only the hidden-column reveal behind hiddenColumnsRevealed, set from a setTimeout(0) armed in handleColumnDragStart. The timer is only armed when hideEmptyColumns is on, so the toggle-off path arms nothing and changes no state. handleColumnDragEnd cancels the timer and resets all three values in one batch; the same cancel runs on unmount.
+
+Credit: the diagnosis and the deferred-expansion remedy come from janosmiko's unmerged PR #808 (commit 63e36249). Cherry-picking was not practical because his commit also carries the web toggle button, the TUI work already landed in BACK-615, and README changes, so it is carried as a Co-authored-by trailer plus PR-body attribution. His scroll-preservation and edge auto-scroll commit (9b875573) is deliberately out of scope: neither is needed to make the drag work, and the underlying no-auto-scroll limitation affects wide boards identically when hideEmptyColumns is off.
+
+Post-fix verification in Chromium, hideEmptyColumns on: dragging TASK-2 from To Do onto the Blocked column completed the whole native sequence (dragstart, drag, dragenter, dragover, drop, dragend) and moved the task on disk. The trace shows the reveal landing mid-drag: the first dragover saw 'To Do|Blocked', the next saw 'To Do|In Progress|Done|Blocked'. A separate probe run read the DOM during a live drag and found the previously hidden Done column laid out at x 924-1202 (width 278), hit-testable via elementFromPoint at its centre, and rendering its 'Drop to move' affordance. With hideEmptyColumns off the trace and the resulting move are unchanged from the pre-fix control run.
+
+jsdom limits, stated plainly: jsdom has no drag controller, so the test suite cannot show the Chromium cancellation itself or anything about layout, scrolling or hit testing. What src/test/web-board-drag-hidden-columns.test.tsx does prove is the invariant that avoids the cancellation (dragstart leaves the rendered column set untouched), that the hidden columns arrive on the next task, that dropping on one of those revealed columns reorders into it, that dragend re-hides them and cancels a reveal that has not run yet, and that the column set never changes at any point when hideEmptyColumns is off. The first of those assertions fails against unfixed Board.tsx (verified by stashing the fix).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Web board cards were undraggable whenever hideEmptyColumns was on: Board.tsx re-showed the hidden empty columns from inside the dragstart handler, and Chromium aborts a native drag whose dragstart mutates the board layout. Confirmed on main in Chromium before changing anything (dragstart followed straight by dragend, no drag/dragover/drop; 1 column before React's handler, 4 columns after it, still inside the same dispatch), with the toggle-off case completing a real drop as a control. The reveal now sits behind a hiddenColumnsRevealed flag set from a setTimeout(0) armed in a shared handleColumnDragStart, so the columns arrive on the next task once the browser has committed the drag; the timer is only armed when hideEmptyColumns is on, and handleColumnDragEnd cancels it and clears the drag state in one batch. Verified in Chromium after the fix: the drag completes and moves the task with hideEmptyColumns on, the hidden columns appear mid-drag and are laid out, hit-testable and showing their drop affordance, and the toggle-off behaviour is unchanged. src/test/web-board-drag-hidden-columns.test.tsx covers the jsdom-provable parts for both toggle states and fails against the unfixed component. bunx tsc --noEmit, bun run check . and bun run test (2179 pass, 6 skip, 0 fail) are clean. Diagnosis and the deferred-reveal remedy are janosmiko's from unmerged PR #808, credited with a Co-authored-by trailer; his scroll-preservation and edge auto-scroll extras are out of scope.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/web-board-drag-hidden-columns.test.tsx
+++ b/src/test/web-board-drag-hidden-columns.test.tsx
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Task } from "../types/index.ts";
+import { apiClient } from "../web/lib/api.ts";
+import Board from "../web/components/Board.tsx";
+
+// jsdom has no drag controller, so it cannot show the browser bug this guards: Chromium aborts a
+// native drag whose dragstart handler mutates the board layout, which is what re-showing the
+// hidden columns inside the event used to do. What jsdom can prove is the invariant that avoids
+// it - dragstart leaves the rendered columns untouched, and the hidden ones only arrive on a later
+// task - plus that they really do become drop targets once they arrive. The drag surviving in a
+// real browser was verified by hand in Chromium (see the task record).
+
+const STATUSES = ["To Do", "In Progress", "Done", "Blocked"];
+
+const draggedTask: Task = {
+	id: "task-1",
+	title: "Draggable card",
+	status: "In Progress",
+	assignee: [],
+	labels: [],
+	dependencies: [],
+	createdDate: "2026-01-01",
+};
+
+let activeRoot: Root | null = null;
+
+const setupDom = () => {
+	const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: "http://localhost/board",
+	});
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = dom.window as unknown as Window & typeof globalThis;
+	globalThis.document = dom.window.document as unknown as Document;
+	globalThis.navigator = dom.window.navigator as unknown as Navigator;
+};
+
+const renderBoard = (options: {
+	hideEmptyColumns: boolean;
+	onTasksUpdated?: (tasks: Task[], requestTask: Task) => void;
+}): HTMLElement => {
+	setupDom();
+	const container = document.getElementById("root");
+	expect(container).toBeTruthy();
+	activeRoot = createRoot(container as HTMLElement);
+	act(() => {
+		activeRoot?.render(
+			<Board
+				onEditTask={() => {}}
+				onNewTask={() => {}}
+				tasks={[draggedTask]}
+				statuses={STATUSES}
+				isLoading={false}
+				milestones={[]}
+				availableLabels={[]}
+				milestoneEntities={[]}
+				archivedMilestones={[]}
+				laneMode="none"
+				onLaneChange={() => {}}
+				hideEmptyColumns={options.hideEmptyColumns}
+				onTasksUpdated={options.onTasksUpdated}
+			/>,
+		);
+	});
+	return container as HTMLElement;
+};
+
+const renderedColumns = (container: HTMLElement): string[] =>
+	Array.from(container.querySelectorAll("h3")).map((heading) => heading.textContent ?? "");
+
+const getCard = (container: HTMLElement): HTMLElement => {
+	const card = container.querySelector('[draggable="true"]');
+	expect(card).toBeTruthy();
+	return card as HTMLElement;
+};
+
+const getColumn = (container: HTMLElement, status: string): HTMLElement => {
+	const heading = Array.from(container.querySelectorAll("h3")).find((element) => element.textContent === status);
+	const column = heading?.closest(".rounded-lg");
+	expect(column).toBeTruthy();
+	return column as HTMLElement;
+};
+
+const dispatchDragEvent = (target: HTMLElement, type: string, data: Record<string, string> = {}) => {
+	const event = new window.Event(type, { bubbles: true, cancelable: true });
+	Object.defineProperty(event, "dataTransfer", {
+		value: {
+			setData: (key: string, value: string) => {
+				data[key] = value;
+			},
+			getData: (key: string) => data[key] ?? "",
+			effectAllowed: "",
+		},
+	});
+	target.dispatchEvent(event);
+};
+
+// The reveal is deferred by exactly one task, so a single macrotask hop is enough to observe it.
+const flushTasks = async () => {
+	await act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	});
+};
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => {
+			activeRoot?.unmount();
+		});
+		activeRoot = null;
+	}
+});
+
+describe("Web board drag and drop with hidden empty columns", () => {
+	it("leaves the rendered columns untouched during dragstart and reveals them on the next task", async () => {
+		const container = renderBoard({ hideEmptyColumns: true });
+		expect(renderedColumns(container)).toEqual(["In Progress"]);
+
+		act(() => {
+			dispatchDragEvent(getCard(container), "dragstart");
+		});
+		// Mutating the board here is what cancels the native drag in Chromium.
+		expect(renderedColumns(container)).toEqual(["In Progress"]);
+
+		await flushTasks();
+		expect(renderedColumns(container)).toEqual(STATUSES);
+	});
+
+	it("drops onto a column that was hidden before the drag", async () => {
+		const originalReorderTask = apiClient.reorderTask.bind(apiClient);
+		const movedTask: Task = { ...draggedTask, status: "Done", ordinal: 1000 };
+		const reorderCalls: Array<{ taskId: string; targetStatus: string }> = [];
+		const publishedTasks: Task[] = [];
+		apiClient.reorderTask = async (payload) => {
+			reorderCalls.push({ taskId: payload.taskId, targetStatus: payload.targetStatus });
+			return { success: true, task: movedTask, changedTasks: [movedTask] };
+		};
+
+		try {
+			const container = renderBoard({
+				hideEmptyColumns: true,
+				onTasksUpdated: (changedTasks) => publishedTasks.push(...changedTasks),
+			});
+			const card = getCard(container);
+			const transfer: Record<string, string> = {};
+
+			act(() => {
+				dispatchDragEvent(card, "dragstart", transfer);
+			});
+			await flushTasks();
+
+			const doneColumn = getColumn(container, "Done");
+			expect(doneColumn.textContent).toContain("Drop to move");
+
+			await act(async () => {
+				dispatchDragEvent(doneColumn, "dragover", transfer);
+				dispatchDragEvent(doneColumn, "drop", transfer);
+				await Promise.resolve();
+			});
+
+			expect(reorderCalls).toEqual([{ taskId: draggedTask.id, targetStatus: "Done" }]);
+			expect(publishedTasks).toEqual([movedTask]);
+		} finally {
+			apiClient.reorderTask = originalReorderTask;
+		}
+	});
+
+	it("hides the empty columns again once the drag ends", async () => {
+		const container = renderBoard({ hideEmptyColumns: true });
+		const card = getCard(container);
+
+		act(() => {
+			dispatchDragEvent(card, "dragstart");
+		});
+		await flushTasks();
+		expect(renderedColumns(container)).toEqual(STATUSES);
+
+		act(() => {
+			dispatchDragEvent(card, "dragend");
+		});
+		expect(renderedColumns(container)).toEqual(["In Progress"]);
+
+		// A drag that ends before the deferred reveal runs must not reveal anything afterwards.
+		act(() => {
+			dispatchDragEvent(card, "dragstart");
+			dispatchDragEvent(card, "dragend");
+		});
+		await flushTasks();
+		expect(renderedColumns(container)).toEqual(["In Progress"]);
+	});
+
+	it("keeps every column rendered throughout a drag when hideEmptyColumns is off", async () => {
+		const container = renderBoard({ hideEmptyColumns: false });
+		expect(renderedColumns(container)).toEqual(STATUSES);
+
+		const card = getCard(container);
+		act(() => {
+			dispatchDragEvent(card, "dragstart");
+		});
+		expect(renderedColumns(container)).toEqual(STATUSES);
+
+		await flushTasks();
+		expect(renderedColumns(container)).toEqual(STATUSES);
+		expect(getColumn(container, "Done").textContent).toContain("Drop to move");
+
+		act(() => {
+			dispatchDragEvent(card, "dragend");
+		});
+		expect(renderedColumns(container)).toEqual(STATUSES);
+	});
+});

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { type Milestone, type Task } from '../../types';
 import { apiClient, type ReorderTaskPayload } from '../lib/api';
 import { buildLanes, DEFAULT_LANE_KEY, groupTasksByLaneAndStatus, type LaneMode } from '../lib/lanes';
@@ -78,6 +78,9 @@ const Board: React.FC<BoardProps> = ({
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [dragSourceStatus, setDragSourceStatus] = useState<string | null>(null);
   const [dragSourceLane, setDragSourceLane] = useState<string | null>(null);
+  // Set one task after dragstart, never inside it: see handleColumnDragStart.
+  const [hiddenColumnsRevealed, setHiddenColumnsRevealed] = useState(false);
+  const revealHiddenColumnsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [showCleanupModal, setShowCleanupModal] = useState(false);
   const [cleanupSuccessMessage, setCleanupSuccessMessage] = useState<string | null>(null);
   const [collapsedLanes, setCollapsedLanes] = useState<Record<string, boolean>>({});
@@ -417,16 +420,44 @@ const Board: React.FC<BoardProps> = ({
 
   // When hideEmptyColumns is on, filter out status columns with no tasks across all visible lanes.
   // While a task is being dragged we keep every column visible so empty statuses remain drop targets.
-  const isDragging = dragSourceStatus !== null;
   const visibleStatuses = useMemo(() => {
-    if (!hideEmptyColumns || isDragging) return statuses;
+    if (!hideEmptyColumns || hiddenColumnsRevealed) return statuses;
     return statuses.filter(status => {
       for (const statusMap of displayTasksByLane.values()) {
         if ((statusMap.get(status) ?? []).length > 0) return true;
       }
       return false;
     });
-  }, [hideEmptyColumns, isDragging, statuses, displayTasksByLane]);
+  }, [hideEmptyColumns, hiddenColumnsRevealed, statuses, displayTasksByLane]);
+
+  const cancelHiddenColumnsReveal = () => {
+    if (revealHiddenColumnsTimer.current !== null) clearTimeout(revealHiddenColumnsTimer.current);
+    revealHiddenColumnsTimer.current = null;
+  };
+
+  const handleColumnDragStart = ({ status, laneId }: { status: string; laneId?: string | null }) => {
+    setDragSourceStatus(status);
+    setDragSourceLane(laneId ?? null);
+    if (!hideEmptyColumns) return;
+    // Adding the hidden columns changes the board layout, and Chromium aborts a native drag whose
+    // dragstart handler does that: the card never becomes draggable. React commits this state
+    // update synchronously inside the event, so the reveal has to wait for the next task, by which
+    // time the browser has committed the drag.
+    cancelHiddenColumnsReveal();
+    revealHiddenColumnsTimer.current = setTimeout(() => {
+      revealHiddenColumnsTimer.current = null;
+      setHiddenColumnsRevealed(true);
+    }, 0);
+  };
+
+  const handleColumnDragEnd = () => {
+    cancelHiddenColumnsReveal();
+    setDragSourceStatus(null);
+    setDragSourceLane(null);
+    setHiddenColumnsRevealed(false);
+  };
+
+  useEffect(() => cancelHiddenColumnsReveal, []);
 
   // Only show lane headers when multiple lanes exist
   const shouldShowLaneHeaders = useMemo(() => {
@@ -664,14 +695,8 @@ const Board: React.FC<BoardProps> = ({
                             targetMilestone={lane.milestone ?? null}
                             priorityOrder={availablePriorities}
                             availableTypes={typeOptions}
-                            onDragStart={({ status: draggedStatus, laneId }) => {
-                              setDragSourceStatus(draggedStatus);
-                              setDragSourceLane(laneId ?? null);
-                            }}
-                            onDragEnd={() => {
-                              setDragSourceStatus(null);
-                              setDragSourceLane(null);
-                            }}
+                            onDragStart={handleColumnDragStart}
+                            onDragEnd={handleColumnDragEnd}
                             onCleanup={status === terminalStatus ? () => setShowCleanupModal(true) : undefined}
                           />
                         </div>
@@ -699,14 +724,8 @@ const Board: React.FC<BoardProps> = ({
                   laneId={DEFAULT_LANE_KEY}
                   priorityOrder={availablePriorities}
                   availableTypes={typeOptions}
-                  onDragStart={({ status: draggedStatus, laneId }) => {
-                    setDragSourceStatus(draggedStatus);
-                    setDragSourceLane(laneId ?? null);
-                  }}
-                  onDragEnd={() => {
-                    setDragSourceStatus(null);
-                    setDragSourceLane(null);
-                  }}
+                  onDragStart={handleColumnDragStart}
+                  onDragEnd={handleColumnDragEnd}
                   onCleanup={status === terminalStatus ? () => setShowCleanupModal(true) : undefined}
                 />
               </div>


### PR DESCRIPTION
Closes BACK-617.

## The defect

With `hideEmptyColumns` enabled, cards on the browser board could not be dragged at all.

`Board.tsx` computed the visible columns from `!hideEmptyColumns || isDragging`, and `isDragging` was derived from `dragSourceStatus`, which the `dragstart` handler set synchronously. React commits that update inside the event dispatch, so the hidden columns were re-inserted while the browser was still starting the drag — and Chromium aborts a native drag whose `dragstart` handler mutates the layout.

## Reproduction on current main

Driven in Chromium against a scratch project (statuses To Do / In Progress / Done / Blocked, one task in In Progress) with `hideEmptyColumns` on:

| | event trace | result |
|---|---|---|
| toggle **on** (before fix) | `dragstart` → `dragend` | drag aborted, card undraggable |
| toggle **off** (control) | `dragstart` → `drag` → `dragenter` → `dragover` → `drop` → `dragend` | task moved |

Instrumenting either side of React's handler pinned the mechanism: 1 column rendered before it ran, 4 columns rendered after it, both inside the same `dragstart` dispatch. The dragged card node itself stayed connected and identical, so this is the surrounding layout changing, not the source node being replaced.

## The fix

The reveal moves behind `hiddenColumnsRevealed`, set from a `setTimeout(0)` armed in a shared `handleColumnDragStart`, so the hidden columns arrive on the next task, by which point the drag is committed. `handleColumnDragEnd` cancels the timer and clears the drag state in one batch, and the same cancel runs on unmount.

The timer is only armed when `hideEmptyColumns` is on, so the toggle-off path arms nothing and changes no state. The `!hideEmptyColumns || <dragging>` reveal semantics are unchanged: hidden empty columns still become drop targets during a drag, matching TUI move mode.

## Verification after the fix

In Chromium with `hideEmptyColumns` on, dragging a card from To Do onto Blocked completes the full native sequence and moves the task, with the reveal visible mid-drag (first `dragover` sees `To Do|Blocked`, the next sees `To Do|In Progress|Done|Blocked`). Reading the DOM during a live drag found the previously hidden Done column laid out at x 924–1202, hit-testable at its centre via `elementFromPoint`, and rendering its "Drop to move" affordance. With the toggle off, trace and outcome are unchanged from the pre-fix control.

`src/test/web-board-drag-hidden-columns.test.tsx` covers what jsdom can prove for both toggle states: that `dragstart` leaves the rendered column set untouched, that the hidden columns arrive on the next task, that dropping on a revealed column reorders into it, that `dragend` re-hides them and cancels a reveal that has not run yet, and that the column set never changes at any point when the toggle is off. The first assertion fails against the unfixed component. jsdom has no drag controller, so it cannot show the Chromium cancellation itself or anything about layout, scrolling or hit testing — hence the browser runs above.

## Credit

The diagnosis and the deferred-reveal remedy are @janosmiko's, from his unmerged PR #808 (commit 63e36249). Cherry-picking was not practical: that commit also carries the web toggle button, and the TUI half of #808 already landed in BACK-615, so it is carried here as a `Co-authored-by` trailer.

Out of scope, from his follow-up commit 9b875573: scroll preservation for the dragged column and edge auto-scroll. Neither is needed to make the drag work, and the underlying "native DnD does not auto-scroll" limitation affects wide boards identically when `hideEmptyColumns` is off.

## Checks

- `bunx tsc --noEmit` — clean
- `bun run check .` — clean
- `bun run test` — 2179 pass, 6 skip, 0 fail
