### PR TITLE
BACK-620 - Align the filter footer hint between TUI kanban and task list

### DIFF
--- a/backlog/tasks/back-620 - Align-the-filter-footer-hint-between-TUI-kanban-and-task-list.md
+++ b/backlog/tasks/back-620 - Align-the-filter-footer-hint-between-TUI-kanban-and-task-list.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-620
 title: Align the filter footer hint between TUI kanban and task list
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-09 18:59'
+updated_date: '2026-08-09 19:25'
 labels: []
 dependencies: []
 ordinal: 258000
@@ -17,14 +19,54 @@ Reported by Alex 2026-08-09 with screenshots: the TUI kanban board footer shows 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Both footers use the same casing and separator convention for the filter hint
-- [ ] #2 Each footer lists exactly the filter keys that actually work in that view
-- [ ] #3 A test or recorded verification covers both footer strings
+- [x] #1 Both footers use the same casing and separator convention for the filter hint
+- [x] #2 Each footer lists exactly the filter keys that actually work in that view
+- [x] #3 A test or recorded verification covers both footer strings
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Map the real filter keybindings per view: board (src/ui/board.ts) binds t/T type, p/P priority, f/F labels, i/I milestone (no status filter; l is column nav). Task list (src/ui/task-viewer-with-search.ts) binds s/S status, t/T type, p/P priority, l/L labels, i/I milestone.
+2. Confirm no footer hint advertises a dead key: board [T/P/F/I] is accurate; task list [s/t/p/i/l] has the right letters but lowercase and milestone/labels swapped relative to the board and to the task-list help popup order.
+3. Unify presentation on the convention already used by the neighbouring footer groups ([E/M/C/A], [E/C/A], [N], [Y], [Tab]) and by the board help popup: uppercase letters, slash separated, no spaces, ordered status/type/priority/labels/milestone. Board keeps [T/P/F/I]; task list becomes [S/T/P/L/I]. No new keys, no extra footer segments.
+4. Move both footer strings into src/ui/footer-content.ts as exported constants (module already owns footer formatting and is already imported by both views) so a single test can cover both strings.
+5. Align the task-list help popup filter rows to the same uppercase letters so the view does not contradict its own footer.
+6. Extend src/test/footer-content.test.ts to assert both footer strings share the filter-hint convention and list exactly the live keys; verify with bunx tsc --noEmit, bun run check ., bun run test, plus a PTY capture of both footers.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Keybinding research (verified in a real PTY with tmux capture-pane, 130x30, against src/cli.ts):
+
+Board (src/ui/board.ts): t Type, p Priority, f Labels, i Milestone. No status filter (columns are the statuses). l is column navigation, which is why labels uses f.
+Task list (src/ui/task-viewer-with-search.ts): s Status, t Type, p Priority, l Labels, i Milestone.
+
+Root-cause finding: uppercase filter keys do not work in either view. Both views register the pickers as screen.key(["t", "T"]), but neo-neo-bblessed builds key.full as (shift ? "S-" : "") + name (lib/program.ts:480), so Shift+T is delivered as S-t and the "T" listener never fires. PTY probe: board t/p/f/i each opened the expected popup; board T/P/F/I, S and L opened nothing; task list s/t/p/l/i each opened the expected popup; S/T/P/L/I opened nothing. The board footer's [T/P/F/I] and the board help popup's T/P/F/I therefore advertised four keys that do nothing.
+
+Convention chosen: lowercase letters, slash separated, no spaces, ordered the way the shared filter header renders its controls (ALL_FILTER_ITEMS in src/ui/components/filter-header.ts: status, type, priority, milestone, labels). Board becomes [t/p/i/f] (same 9 visible characters as [T/P/F/I], so no footer widening); the task list keeps [s/t/p/i/l] unchanged because it already matched both the real keys and the filter-header order.
+
+Changes: both footer strings moved to src/ui/footer-content.ts as BOARD_FOOTER_CONTENT and TASK_LIST_FOOTER_CONTENT (that module already owns footer wrapping and was already imported by both views), so one test covers both. Board help popup filter rows corrected to lowercase and reordered to match; task-list help popup rows reordered to milestone-before-labels so the popup and its own footer agree. No keybindings changed.
+
+Out of scope observation: the same S- parsing gotcha makes parts of other footer hints wrong. E and M are safe because they also bind S-e/S-m, and H binds S-h, but c, a and y have no S- variants, so [E/M/C/A] and [Y] advertise dead uppercase C, A and Y. Verified in the PTY: lowercase c opened the complete-task confirm dialog, Shift+C did nothing. Not touched here; needs a product decision (fix the hints or add the S- bindings).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Aligned the TUI filter footer hint across the kanban board and the task list, and fixed the board hint's dead keys.
+
+Research in a real PTY showed the board footer's [T/P/F/I] advertised four keys that do nothing: both views bind their filter pickers as screen.key(["t", "T"]), but Shift+letter arrives as S-t, so only the lowercase letter fires. The board footer is now [t/p/i/f] and the task list stays [s/t/p/i/l] - both lowercase, slash separated, ordered the way the shared filter header renders its controls (status, type, priority, milestone, labels). The board keeps f for labels because l is column navigation there; that is the only remaining per-view letter difference and it reflects a real binding difference, not styling. The board help popup's filter rows were corrected the same way, and the task-list help popup rows reordered so each view's popup and footer agree. No keybindings changed and the hint is the same width as before, so the footer does not grow.
+
+Both footer strings now live in src/ui/footer-content.ts as BOARD_FOOTER_CONTENT and TASK_LIST_FOOTER_CONTENT, next to the wrapping helper both views already imported.
+
+Verified: new tests in src/test/footer-content.test.ts assert both footer strings' filter letters, the shared lowercase slash-separated convention, and that the help popup filter rows match each footer; src/test/help-popup.test.ts updated. bunx tsc --noEmit clean, bun run check . clean, bun run test 2188 pass / 6 skip / 0 fail. Behavior confirmed by tmux PTY captures of both footers before and after, plus per-key probes showing lowercase keys open the expected picker and uppercase keys open nothing.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/footer-content.test.ts
+++ b/src/test/footer-content.test.ts
@@ -1,5 +1,39 @@
 import { describe, expect, it } from "bun:test";
-import { formatFooterContent } from "../ui/footer-content.ts";
+import { getHelpShortcuts } from "../ui/components/help-popup.ts";
+import { BOARD_FOOTER_CONTENT, formatFooterContent, TASK_LIST_FOOTER_CONTENT } from "../ui/footer-content.ts";
+
+/** Filter letters advertised by a footer, e.g. "t/p/i/f" -> ["t", "p", "i", "f"]. */
+function filterHintKeys(footer: string): string[] {
+	const hint = footer.match(/\[([^\]]+)\]\{\/\} Filter\b/)?.[1];
+	if (!hint) throw new Error(`footer has no filter hint: ${footer}`);
+	return hint.split("/");
+}
+
+function helpFilterKeys(context: "board" | "task-list"): string[] {
+	return getHelpShortcuts(context)
+		.filter((shortcut) => shortcut.desc.startsWith("Filter by "))
+		.map((shortcut) => shortcut.key);
+}
+
+describe("TUI footer filter hint", () => {
+	// Shift+letter is delivered as `S-t`, so bindings registered as ["t", "T"] only fire
+	// for the lowercase letter. Hints must therefore stay lowercase.
+	it("advertises the filter keys each view actually binds", () => {
+		expect(filterHintKeys(BOARD_FOOTER_CONTENT)).toEqual(["t", "p", "i", "f"]);
+		expect(filterHintKeys(TASK_LIST_FOOTER_CONTENT)).toEqual(["s", "t", "p", "i", "l"]);
+	});
+
+	it("uses the same lowercase slash-separated convention in both views", () => {
+		for (const footer of [BOARD_FOOTER_CONTENT, TASK_LIST_FOOTER_CONTENT]) {
+			expect(footer).toMatch(/\{cyan-fg\}\[[a-z](?:\/[a-z])+\]\{\/\} Filter \|/);
+		}
+	});
+
+	it("keeps the help popup filter rows in step with the footer hint", () => {
+		expect(helpFilterKeys("board")).toEqual(filterHintKeys(BOARD_FOOTER_CONTENT));
+		expect(helpFilterKeys("task-list")).toEqual(filterHintKeys(TASK_LIST_FOOTER_CONTENT));
+	});
+});
 
 describe("formatFooterContent", () => {
 	it("keeps footer on one line when terminal width is sufficient", () => {

--- a/src/test/help-popup.test.ts
+++ b/src/test/help-popup.test.ts
@@ -7,8 +7,8 @@ describe("help popup shortcuts", () => {
 	it("keeps board-specific shortcuts in the board help menu", () => {
 		const keys = keysFor("board");
 
-		expect(keys).toContain("F");
-		expect(keys).toContain("T");
+		expect(keys).toContain("f");
+		expect(keys).toContain("t");
 		expect(keys).toContain("M");
 		expect(keys).toContain("N");
 		expect(keys).toContain("←→");
@@ -20,7 +20,7 @@ describe("help popup shortcuts", () => {
 		expect(keys).toContain("s");
 		expect(keys).toContain("t");
 		expect(keys).toContain("l");
-		expect(keys).not.toContain("F");
+		expect(keys).not.toContain("f");
 		expect(keys).not.toContain("M");
 	});
 

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -25,7 +25,7 @@ import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./compo
 import type { BoundaryNavigationKey } from "./components/generic-list.ts";
 import { openHelpPopup } from "./components/help-popup.ts";
 import { openTaskComposer, type TaskComposerOptions } from "./components/task-composer.ts";
-import { formatFooterContent } from "./footer-content.ts";
+import { BOARD_FOOTER_CONTENT, formatFooterContent } from "./footer-content.ts";
 import { getStatusIcon } from "./status-icon.ts";
 import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-lifecycle.ts";
 import { formatTaskTypeBadge } from "./task-type.ts";
@@ -175,9 +175,6 @@ function buildRenderedTaskListItems(tasks: Task[], movingTaskId?: string): { ric
 function formatColumnLabel(status: string, count: number): string {
 	return `\u00A0${getStatusIcon(status)} ${status || "No Status"} (${count})\u00A0`;
 }
-
-const DEFAULT_FOOTER_CONTENT =
-	" {cyan-fg}[Tab]{/} View | {cyan-fg}[N]{/} New | {cyan-fg}[/]{/} Search | {cyan-fg}[T/P/F/I]{/} Filter | {cyan-fg}[←→/↑↓]{/} Nav | {cyan-fg}[Enter]{/} Details | {cyan-fg}[E/M/C/A]{/} Edit/Move/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 
 /**
  * Board columns to render: with `hideEmptyColumns` enabled, columns without tasks are
@@ -920,7 +917,7 @@ export async function renderBoardTui(
 					" {green-fg}MOVE MODE{/} | {cyan-fg}[←→]{/} Change Column | {cyan-fg}[↑↓]{/} Reorder | {cyan-fg}[Enter/M]{/} Confirm | {cyan-fg}[Esc]{/} Cancel",
 				);
 			} else {
-				const base = DEFAULT_FOOTER_CONTENT;
+				const base = BOARD_FOOTER_CONTENT;
 				setFooterContent(hasActiveSharedFilters() ? `${base} | {yellow-fg}Filtered{/}` : base);
 			}
 			syncBoardAreaLayout();

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -8,14 +8,16 @@ type Shortcut = {
 	desc: string;
 };
 
+// Keys are listed exactly as they must be typed: Shift+letter arrives as `S-t`, so a
+// binding registered as `["t", "T"]` only ever fires for the lowercase letter.
 const BOARD_SHORTCUTS: Shortcut[] = [
 	{ key: "Tab", desc: "Switch View (Kanban/List)" },
 	{ key: "N", desc: "Create a task" },
 	{ key: "/", desc: "Search tasks" },
-	{ key: "T", desc: "Filter by Type" },
-	{ key: "P", desc: "Filter by Priority" },
-	{ key: "F", desc: "Filter by Labels" },
-	{ key: "I", desc: "Filter by Milestone" },
+	{ key: "t", desc: "Filter by Type" },
+	{ key: "p", desc: "Filter by Priority" },
+	{ key: "i", desc: "Filter by Milestone" },
+	{ key: "f", desc: "Filter by Labels" },
 	{ key: "←→", desc: "Navigate columns" },
 	{ key: "↑↓", desc: "Navigate tasks" },
 	{ key: "Enter", desc: "View task details" },
@@ -35,8 +37,8 @@ const TASK_LIST_SHORTCUTS: Shortcut[] = [
 	{ key: "s", desc: "Filter by Status" },
 	{ key: "t", desc: "Filter by Type" },
 	{ key: "p", desc: "Filter by Priority" },
-	{ key: "l", desc: "Filter by Labels" },
 	{ key: "i", desc: "Filter by Milestone" },
+	{ key: "l", desc: "Filter by Labels" },
 	{ key: "↑↓", desc: "Navigate tasks" },
 	{ key: "←→", desc: "Switch between list and details" },
 	{ key: "Enter", desc: "Focus task details" },

--- a/src/ui/footer-content.ts
+++ b/src/ui/footer-content.ts
@@ -1,3 +1,18 @@
+/**
+ * Footer shortcut hints for the two task views.
+ *
+ * Letters are shown exactly as they must be typed. A bare uppercase binding such as
+ * `screen.key(["t", "T"])` never fires, because Shift+T is delivered as `S-t`, so an
+ * uppercase filter hint would advertise a key that does nothing. Filter letters are
+ * listed in the same order the filter header renders its controls
+ * (status, type, priority, milestone, labels).
+ */
+export const BOARD_FOOTER_CONTENT =
+	" {cyan-fg}[Tab]{/} View | {cyan-fg}[N]{/} New | {cyan-fg}[/]{/} Search | {cyan-fg}[t/p/i/f]{/} Filter | {cyan-fg}[←→/↑↓]{/} Nav | {cyan-fg}[Enter]{/} Details | {cyan-fg}[E/M/C/A]{/} Edit/Move/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
+
+export const TASK_LIST_FOOTER_CONTENT =
+	" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[s/t/p/i/l]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
+
 function visibleLength(value: string): number {
 	return value.replace(/\{[^{}]+\}/g, "").length;
 }

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -43,7 +43,7 @@ import {
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
 import { type BoundaryNavigationKey, createGenericList, type GenericList } from "./components/generic-list.ts";
 import { openHelpPopup } from "./components/help-popup.ts";
-import { formatFooterContent } from "./footer-content.ts";
+import { formatFooterContent, TASK_LIST_FOOTER_CONTENT } from "./footer-content.ts";
 import { formatHeading } from "./heading.ts";
 import { createLoadingScreen } from "./loading.ts";
 import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-icon.ts";
@@ -1185,8 +1185,7 @@ export async function viewTaskEnhanced(
 				" {cyan-fg}[Tab]{/} View | {cyan-fg}[←]{/} List | {cyan-fg}[↑↓]{/} Scroll | {cyan-fg}[E]{/} Edit | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 		} else {
 			// Task list help
-			content =
-				" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[s/t/p/i/l]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
+			content = TASK_LIST_FOOTER_CONTENT;
 		}
 
 		setHelpBarContent(content);


### PR DESCRIPTION
## Problem

The two TUI views advertised their filter shortcuts differently, and one of them advertised keys that do nothing.

Captured from a real PTY (tmux, 130x30, `bun src/cli.ts board` / `task list`) on `main`:

```
board     [Tab] View | [N] New | [/] Search | [T/P/F/I] Filter | [←→/↑↓] Nav | [Enter] Details | [E/M/C/A] Edit/Move/Comp/Arch | [Y] Yank …
tasklist  [Tab] View | [/] Search | [s/t/p/i/l] Filter | [↑↓] Nav | [E/C/A] Edit/Comp/Arch | [Y] Yank | [?] Help | [q] Quit
```

## What the keys actually are

| View | Status | Type | Priority | Milestone | Labels |
| --- | --- | --- | --- | --- | --- |
| Kanban board | – (columns are the statuses) | `t` | `p` | `i` | `f` |
| Task list | `s` | `t` | `p` | `i` | `l` |

The board uses `f` for labels because `l` is column navigation there. That is the only per-view letter difference and it reflects a real binding difference, not styling.

**The uppercase letters in the board hint were dead.** Both views register the pickers as `screen.key(["t", "T"])`, but `neo-neo-bblessed` builds `key.full` as `(shift ? "S-" : "") + name` ([`lib/program.ts:480`](https://github.com/MrLesk/Backlog.md/blob/main/node_modules/neo-neo-bblessed/lib/program.ts)), so Shift+T is delivered as `S-t` and the `"T"` listener never fires. Per-key PTY probe:

```
board  t -> Task Type Filter      board  T -> <no popup>
board  p -> Priority Filter       board  P -> <no popup>
board  f -> Label Filter          board  F -> <no popup>
board  i -> Milestone Filter      board  I -> <no popup>
list   s -> Status Filter         list   S -> <no popup>
list   t -> Task Type Filter      list   T -> <no popup>
list   p -> Priority Filter       list   P -> <no popup>
list   l -> Label Filter          list   L -> <no popup>
list   i -> Milestone Filter      list   I -> <no popup>
```

So `[T/P/F/I]` named four keys that do nothing, and the `?` help popup on the board repeated the same four.

## Change

One convention for both views: **lowercase letters, slash separated, ordered the way the shared filter header renders its controls** (`ALL_FILTER_ITEMS` in `src/ui/components/filter-header.ts`: status, type, priority, milestone, labels). That order is also what the user reads left-to-right in the filter bar at the top of both views.

```
board     [Tab] View | [N] New | [/] Search | [t/p/i/f] Filter | [←→/↑↓] Nav | [Enter] Details | [E/M/C/A] Edit/Move/Comp/Arch | [Y] Yank …
tasklist  [Tab] View | [/] Search | [s/t/p/i/l] Filter | [↑↓] Nav | [E/C/A] Edit/Comp/Arch | [Y] Yank | [?] Help | [q] Quit
```

- The task list hint is unchanged — it already matched both the real keys and the filter-header order.
- `[t/p/i/f]` is the same 9 visible characters as `[T/P/F/I]`, so the footer does not grow.
- The board `?` help popup's filter rows were corrected the same way, and the task-list popup rows reordered so each view's popup and its own footer agree:

```
[    t] Filter by Type
[    p] Filter by Priority
[    i] Filter by Milestone
[    f] Filter by Labels
```

- Both footer strings now live in `src/ui/footer-content.ts` (`BOARD_FOOTER_CONTENT`, `TASK_LIST_FOOTER_CONTENT`) next to the wrapping helper both views already imported, so one test covers both.
- **No keybindings changed.** Hints and help rows only.

## Verification

- `src/test/footer-content.test.ts`: asserts each footer's filter letters, the shared lowercase slash-separated convention, and that the help-popup filter rows match each footer.
- `src/test/help-popup.test.ts` updated for the corrected board letters.
- `bunx tsc --noEmit` clean, `bun run check .` clean, `bun run test` 2188 pass / 6 skip / 0 fail.
- PTY captures and per-key probes above.

## Observation, not fixed here

The same `S-` parsing gotcha affects other footer hints. `E` and `M` are safe because they also bind `S-e`/`S-m`, and `H` binds `S-h`, but `c`, `a` and `y` have no `S-` variant — so `[E/M/C/A]` and `[Y]` advertise dead uppercase `C`, `A` and `Y`. Confirmed in the PTY: lowercase `c` opened the complete-task confirm dialog, Shift+C did nothing. Out of scope for BACK-620; it needs a product decision (lowercase the hints, or add the missing `S-` bindings).

Task: BACK-620
