### PR TITLE
BACK-620 - Restore uppercase key indicators in filter footer hints

### DIFF
--- a/backlog/tasks/back-620 - Align-the-filter-footer-hint-between-TUI-kanban-and-task-list.md
+++ b/backlog/tasks/back-620 - Align-the-filter-footer-hint-between-TUI-kanban-and-task-list.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-09 18:59'
-updated_date: '2026-08-09 19:25'
+updated_date: '2026-08-09 19:47'
 labels: []
 dependencies: []
 ordinal: 258000
@@ -57,16 +57,26 @@ Convention chosen: lowercase letters, slash separated, no spaces, ordered the wa
 Changes: both footer strings moved to src/ui/footer-content.ts as BOARD_FOOTER_CONTENT and TASK_LIST_FOOTER_CONTENT (that module already owns footer wrapping and was already imported by both views), so one test covers both. Board help popup filter rows corrected to lowercase and reordered to match; task-list help popup rows reordered to milestone-before-labels so the popup and its own footer agree. No keybindings changed.
 
 Out of scope observation: the same S- parsing gotcha makes parts of other footer hints wrong. E and M are safe because they also bind S-e/S-m, and H binds S-h, but c, a and y have no S- variants, so [E/M/C/A] and [Y] advertise dead uppercase C, A and Y. Verified in the PTY: lowercase c opened the complete-task confirm dialog, Shift+C did nothing. Not touched here; needs a product decision (fix the hints or add the S- bindings).
+
+Reopened after owner review of PR #892. Owner ruling, verbatim: "uppercase footer instructions don't mean shift + key... They are clearly key indicators. nobody is expecting to press the upper key version."
+
+So uppercase letters in footer and help hints are this TUI's display convention for "this key", not a claim that Shift is required. My lowercasing in #892 misread the design language and broke the footer's own visual grammar, where [Tab], [N], [E/M/C/A] and [Y] are all uppercase indicators. Restoring uppercase display for the filter hints.
+
+The two substantive fixes from #892 stay, because they were about content rather than styling: the corrected letter sets (board has no status filter and uses F for labels since L is column navigation) and the filter-bar ordering (status, type, priority, milestone, labels, matching ALL_FILTER_ITEMS in src/ui/components/filter-header.ts). Shipping [T/P/I/F] on the board and [S/T/P/I/L] in the task list, with the help-popup filter rows uppercased to match the untouched C/A/Y rows. No keybinding changes; the bound keys remain the lowercase letters plus the existing S- variants for e, m, n and h.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Aligned the TUI filter footer hint across the kanban board and the task list, and fixed the board hint's dead keys.
+Aligned the TUI filter footer hint across the kanban board and the task list.
 
-Research in a real PTY showed the board footer's [T/P/F/I] advertised four keys that do nothing: both views bind their filter pickers as screen.key(["t", "T"]), but Shift+letter arrives as S-t, so only the lowercase letter fires. The board footer is now [t/p/i/f] and the task list stays [s/t/p/i/l] - both lowercase, slash separated, ordered the way the shared filter header renders its controls (status, type, priority, milestone, labels). The board keeps f for labels because l is column navigation there; that is the only remaining per-view letter difference and it reflects a real binding difference, not styling. The board help popup's filter rows were corrected the same way, and the task-list help popup rows reordered so each view's popup and footer agree. No keybindings changed and the hint is the same width as before, so the footer does not grow.
+Both footers now use the same uppercase slash-separated key indicators, in the order the shared filter header renders its controls (status, type, priority, milestone, labels): board [T/P/I/F], task list [S/T/P/I/L]. Uppercase is this TUI's display convention for a key indicator, consistent with [Tab], [N], [E/M/C/A] and [Y]; it does not mean Shift. The bound keys are the lowercase letters (plus the existing S- variants for e, m, n and h) and no binding changed.
 
-Both footer strings now live in src/ui/footer-content.ts as BOARD_FOOTER_CONTENT and TASK_LIST_FOOTER_CONTENT, next to the wrapping helper both views already imported.
+Two content fixes beyond styling: the board omits a status filter because its columns are the statuses, and it uses F for labels because L navigates columns there, so the letter sets legitimately differ per view; and the board hint previously listed labels before milestone, which contradicted its own filter bar. The board and task-list help popup filter rows were brought in line with the same letters and order, so each view's footer and its ? popup agree. The hints are the same visible width as before, so the footer does not grow.
 
-Verified: new tests in src/test/footer-content.test.ts assert both footer strings' filter letters, the shared lowercase slash-separated convention, and that the help popup filter rows match each footer; src/test/help-popup.test.ts updated. bunx tsc --noEmit clean, bun run check . clean, bun run test 2188 pass / 6 skip / 0 fail. Behavior confirmed by tmux PTY captures of both footers before and after, plus per-key probes showing lowercase keys open the expected picker and uppercase keys open nothing.
+Both footer strings live in src/ui/footer-content.ts as BOARD_FOOTER_CONTENT and TASK_LIST_FOOTER_CONTENT, next to the wrapping helper both views already imported.
+
+Verified: src/test/footer-content.test.ts asserts the uppercase indicator convention in both views, that each hint maps to the lowercase keys the view actually binds, and that the help-popup filter rows match each footer; src/test/help-popup.test.ts covers the per-view letter sets. bunx tsc --noEmit clean, bun run check . clean, bun run test 2188 pass / 6 skip / 0 fail. Rendered footers and both help popups confirmed with tmux PTY captures at 130x30, and a PTY key probe confirmed T/P/I/F and S/T/P/I/L still open the expected pickers after the change.
+
+History: PR #892 shipped this with lowercase hints; the owner ruled that uppercase footer letters are key indicators rather than Shift chords, and PR for branch tasks/back-620-uppercase-hints restores uppercase while keeping the corrected letters and order.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/footer-content.test.ts
+++ b/src/test/footer-content.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from "bun:test";
 import { getHelpShortcuts } from "../ui/components/help-popup.ts";
 import { BOARD_FOOTER_CONTENT, formatFooterContent, TASK_LIST_FOOTER_CONTENT } from "../ui/footer-content.ts";
 
-/** Filter letters advertised by a footer, e.g. "t/p/i/f" -> ["t", "p", "i", "f"]. */
+/** Filter letters advertised by a footer, e.g. "T/P/I/F" -> ["T", "P", "I", "F"]. */
 function filterHintKeys(footer: string): string[] {
 	const hint = footer.match(/\[([^\]]+)\]\{\/\} Filter\b/)?.[1];
 	if (!hint) throw new Error(`footer has no filter hint: ${footer}`);
 	return hint.split("/");
+}
+
+/** The keys a hint maps to: uppercase letters are indicators, the bound key is lowercase. */
+function boundKeys(footer: string): string[] {
+	return filterHintKeys(footer).map((key) => key.toLowerCase());
 }
 
 function helpFilterKeys(context: "board" | "task-list"): string[] {
@@ -16,16 +21,17 @@ function helpFilterKeys(context: "board" | "task-list"): string[] {
 }
 
 describe("TUI footer filter hint", () => {
-	// Shift+letter is delivered as `S-t`, so bindings registered as ["t", "T"] only fire
-	// for the lowercase letter. Hints must therefore stay lowercase.
-	it("advertises the filter keys each view actually binds", () => {
-		expect(filterHintKeys(BOARD_FOOTER_CONTENT)).toEqual(["t", "p", "i", "f"]);
-		expect(filterHintKeys(TASK_LIST_FOOTER_CONTENT)).toEqual(["s", "t", "p", "i", "l"]);
+	// The board has no status filter (its columns are the statuses) and uses F for labels
+	// because L navigates columns there. Both views list the letters in filter-header order:
+	// status, type, priority, milestone, labels.
+	it("maps to the filter keys each view actually binds", () => {
+		expect(boundKeys(BOARD_FOOTER_CONTENT)).toEqual(["t", "p", "i", "f"]);
+		expect(boundKeys(TASK_LIST_FOOTER_CONTENT)).toEqual(["s", "t", "p", "i", "l"]);
 	});
 
-	it("uses the same lowercase slash-separated convention in both views", () => {
+	it("uses the same uppercase slash-separated indicator convention in both views", () => {
 		for (const footer of [BOARD_FOOTER_CONTENT, TASK_LIST_FOOTER_CONTENT]) {
-			expect(footer).toMatch(/\{cyan-fg\}\[[a-z](?:\/[a-z])+\]\{\/\} Filter \|/);
+			expect(footer).toMatch(/\{cyan-fg\}\[[A-Z](?:\/[A-Z])+\]\{\/\} Filter \|/);
 		}
 	});
 

--- a/src/test/help-popup.test.ts
+++ b/src/test/help-popup.test.ts
@@ -7,8 +7,8 @@ describe("help popup shortcuts", () => {
 	it("keeps board-specific shortcuts in the board help menu", () => {
 		const keys = keysFor("board");
 
-		expect(keys).toContain("f");
-		expect(keys).toContain("t");
+		expect(keys).toContain("F");
+		expect(keys).toContain("T");
 		expect(keys).toContain("M");
 		expect(keys).toContain("N");
 		expect(keys).toContain("←→");
@@ -17,10 +17,10 @@ describe("help popup shortcuts", () => {
 	it("uses task-list shortcuts in the task viewer help menu", () => {
 		const keys = keysFor("task-list");
 
-		expect(keys).toContain("s");
-		expect(keys).toContain("t");
-		expect(keys).toContain("l");
-		expect(keys).not.toContain("f");
+		expect(keys).toContain("S");
+		expect(keys).toContain("T");
+		expect(keys).toContain("L");
+		expect(keys).not.toContain("F");
 		expect(keys).not.toContain("M");
 	});
 

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -8,16 +8,16 @@ type Shortcut = {
 	desc: string;
 };
 
-// Keys are listed exactly as they must be typed: Shift+letter arrives as `S-t`, so a
-// binding registered as `["t", "T"]` only ever fires for the lowercase letter.
+// Letters are uppercase key indicators, matching the footer: `T` means "press the T key",
+// not Shift+T. The bound key is the lowercase letter.
 const BOARD_SHORTCUTS: Shortcut[] = [
 	{ key: "Tab", desc: "Switch View (Kanban/List)" },
 	{ key: "N", desc: "Create a task" },
 	{ key: "/", desc: "Search tasks" },
-	{ key: "t", desc: "Filter by Type" },
-	{ key: "p", desc: "Filter by Priority" },
-	{ key: "i", desc: "Filter by Milestone" },
-	{ key: "f", desc: "Filter by Labels" },
+	{ key: "T", desc: "Filter by Type" },
+	{ key: "P", desc: "Filter by Priority" },
+	{ key: "I", desc: "Filter by Milestone" },
+	{ key: "F", desc: "Filter by Labels" },
 	{ key: "←→", desc: "Navigate columns" },
 	{ key: "↑↓", desc: "Navigate tasks" },
 	{ key: "Enter", desc: "View task details" },
@@ -34,11 +34,11 @@ const BOARD_SHORTCUTS: Shortcut[] = [
 const TASK_LIST_SHORTCUTS: Shortcut[] = [
 	{ key: "Tab", desc: "Switch View (Kanban/List)" },
 	{ key: "/", desc: "Search tasks" },
-	{ key: "s", desc: "Filter by Status" },
-	{ key: "t", desc: "Filter by Type" },
-	{ key: "p", desc: "Filter by Priority" },
-	{ key: "i", desc: "Filter by Milestone" },
-	{ key: "l", desc: "Filter by Labels" },
+	{ key: "S", desc: "Filter by Status" },
+	{ key: "T", desc: "Filter by Type" },
+	{ key: "P", desc: "Filter by Priority" },
+	{ key: "I", desc: "Filter by Milestone" },
+	{ key: "L", desc: "Filter by Labels" },
 	{ key: "↑↓", desc: "Navigate tasks" },
 	{ key: "←→", desc: "Switch between list and details" },
 	{ key: "Enter", desc: "Focus task details" },

--- a/src/ui/footer-content.ts
+++ b/src/ui/footer-content.ts
@@ -1,17 +1,16 @@
 /**
  * Footer shortcut hints for the two task views.
  *
- * Letters are shown exactly as they must be typed. A bare uppercase binding such as
- * `screen.key(["t", "T"])` never fires, because Shift+T is delivered as `S-t`, so an
- * uppercase filter hint would advertise a key that does nothing. Filter letters are
- * listed in the same order the filter header renders its controls
- * (status, type, priority, milestone, labels).
+ * Letters are uppercase key indicators, not Shift chords: `[T]` means "press the T key".
+ * The bound key is the lowercase letter (some actions also bind an explicit `S-` variant,
+ * which is how Shift+letter is delivered). Filter letters are listed in the same order the
+ * filter header renders its controls (status, type, priority, milestone, labels).
  */
 export const BOARD_FOOTER_CONTENT =
-	" {cyan-fg}[Tab]{/} View | {cyan-fg}[N]{/} New | {cyan-fg}[/]{/} Search | {cyan-fg}[t/p/i/f]{/} Filter | {cyan-fg}[←→/↑↓]{/} Nav | {cyan-fg}[Enter]{/} Details | {cyan-fg}[E/M/C/A]{/} Edit/Move/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
+	" {cyan-fg}[Tab]{/} View | {cyan-fg}[N]{/} New | {cyan-fg}[/]{/} Search | {cyan-fg}[T/P/I/F]{/} Filter | {cyan-fg}[←→/↑↓]{/} Nav | {cyan-fg}[Enter]{/} Details | {cyan-fg}[E/M/C/A]{/} Edit/Move/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 
 export const TASK_LIST_FOOTER_CONTENT =
-	" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[s/t/p/i/l]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
+	" {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[S/T/P/I/L]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit";
 
 function visibleLength(value: string): number {
 	return value.replace(/\{[^{}]+\}/g, "").length;


### PR DESCRIPTION
Follow-up to #892.

## Correction

#892 lowercased the filter hints on the theory that uppercase implied Shift. That misread the design language. Uppercase letters in this TUI's footer are **key indicators** — `[T]` means "press the T key" — which is why `[Tab]`, `[N]`, `[E/M/C/A]` and `[Y]` are already uppercase. Nobody is expected to press the shifted version. This PR restores uppercase display.

## What stays from #892

The two fixes that were about content rather than styling:

- **Correct letter sets per view.** The board has no status filter (its columns *are* the statuses) and uses `F` for labels because `L` navigates columns there. The task list has all five.
- **Filter-bar order.** Both hints now read in the order the shared filter header renders its controls (`ALL_FILTER_ITEMS` in `src/ui/components/filter-header.ts`: status, type, priority, milestone, labels) — which is also what the user reads left-to-right in the filter bar directly above the footer. The board hint previously listed labels before milestone, contradicting its own filter bar.

## Shipped strings

Captured from a real PTY (tmux, 130x30):

```
board     [Tab] View | [N] New | [/] Search | [T/P/I/F] Filter | [←→/↑↓] Nav | [Enter] Details | [E/M/C/A] Edit/Move/Comp/Arch | [Y] Yank …
tasklist  [Tab] View | [/] Search | [S/T/P/I/L] Filter | [↑↓] Nav | [E/C/A] Edit/Comp/Arch | [Y] Yank | [?] Help | [q] Quit
```

Same visible width as before the whole exercise (`[T/P/F/I]` → `[T/P/I/F]`, 9 chars; task list 11 chars either way), so the footer does not grow.

The `?` help popups were brought in line so each view's popup and its own footer agree, and the filter rows now match the style of the untouched `C`/`A`/`Y` rows:

```
board                                task list
[    T] Filter by Type               [    S] Filter by Status
[    P] Filter by Priority           [    T] Filter by Type
[    I] Filter by Milestone          [    P] Filter by Priority
[    F] Filter by Labels             [    I] Filter by Milestone
                                     [    L] Filter by Labels
```

## No behavior change

No keybindings touched. The bound keys are the lowercase letters (plus the existing `S-` variants for `e`, `m`, `n`, `h`). PTY key probe after this change:

```
board  t -> Task Type Filter    list  s -> Status Filter
board  f -> Label Filter        list  l -> Label Filter
```

The doc comments in `src/ui/footer-content.ts` and `src/ui/components/help-popup.ts` now record that relationship — uppercase display, lowercase binding — so the next reader does not "fix" it in either direction.

## Verification

- `src/test/footer-content.test.ts`: asserts the shared uppercase slash-separated indicator convention in both views, that each hint maps to the lowercase keys the view actually binds, and that the help-popup filter rows match each footer.
- `src/test/help-popup.test.ts`: per-view letter sets.
- `bunx tsc --noEmit` clean, `bun run check .` clean, `bun run test` 2188 pass / 6 skip / 0 fail.
- tmux PTY captures of both footers and both help popups, plus the key probe above.

Task: BACK-620
