### PR TITLE
fix: avoid mutating subtask array when sorting in board generation

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -129,12 +129,12 @@ Project: ${projectName}
 		for (const t of top) {
 			result.push(t);
 			const subs = children.get(t.id) || [];
-			subs.sort((a, b) => {
+			const sortedSubs = [...subs].sort((a, b) => {
 				const idA = Number.parseInt(a.id.replace("task-", ""), 10);
 				const idB = Number.parseInt(b.id.replace("task-", ""), 10);
 				return idA - idB; // Subtasks in ascending order
 			});
-			result.push(...subs);
+			result.push(...sortedSubs);
 		}
 
 		return result;


### PR DESCRIPTION
Consistent with prior `items` fix: `src/board.ts:131` mutates `children` map via `subs.sort()`. Use `[...subs].sort()` with `sortedSubs` to keep render pure.\n\nVerified: `bunx tsc --noEmit` ok, `bun run check` 369 files ok, board tests 8 pass. Small focused fix.