### PR TITLE
BACK-648 - Fall back to a placeholder filename for punctuation-only titles

### DIFF
--- a/backlog/tasks/back-648 - Fall-back-to-a-placeholder-filename-for-punctuation-only-titles.md
+++ b/backlog/tasks/back-648 - Fall-back-to-a-placeholder-filename-for-punctuation-only-titles.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-648
 title: Fall back to a placeholder filename for punctuation-only titles
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-29 21:04'
+updated_date: '2026-08-29 21:19'
 labels:
   - cli
 dependencies: []
@@ -20,14 +22,48 @@ backlog task create '!!!' produces a file named 'task-42 - .md' because sanitize
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A punctuation-only title produces a filename with a non-empty title segment (e.g. 'task-42 - untitled.md')
-- [ ] #2 Filenames keep the 'id - title.md' shape; no id-only filenames are introduced
-- [ ] #3 Tests cover punctuation-only titles for tasks, docs, and decisions
+- [x] #1 A punctuation-only title produces a filename with a non-empty title segment (e.g. 'task-42 - untitled.md')
+- [x] #2 Filenames keep the 'id - title.md' shape; no id-only filenames are introduced
+- [x] #3 Tests cover punctuation-only titles for tasks, docs, and decisions
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Revert the contributor's three call-site branches in src/file-system/operations.ts (resolveTaskWriteTarget, saveDecision, saveDocument) that drop the ' - ' separator and emit an id-only filename.
+2. Add the placeholder inside sanitizeFilename itself: when the sanitized result is empty, return 'untitled' so every generated filename keeps the '<id> - <title>.md' shape from one owner.
+3. Add tests for punctuation-only titles covering tasks, drafts, documents, and decisions, asserting the filename shape and that the id-parsing readers still work.
+4. Verify with bunx tsc --noEmit, bun run check ., and the scoped test files.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Took over contributor PR #897 (pxmpsdev) in place and replaced its approach.
+
+The contributor fixed the dangling separator by dropping it: when the sanitized title was empty, each of the three call sites emitted an id-only filename ('back-42.md' instead of 'back-42 - .md'). That special-cased the same condition in three places and broke the '<id> - <title>.md' shape that three readers depend on:
+- src/core/content-store.ts createTaskWatcher recovers the task id with file.split(' ')[0], which yields 'back-42.md' for an id-only filename;
+- src/file-system/operations.ts saveDocument dedup matches an existing document by base.split(' - ')[0], which never matches an id-only filename, so a resave leaves a duplicate behind;
+- src/core/duplicate-task-repair.ts buildTargetPath returns null when the filename has no ' - ' separator, so an id-only task file can never be repaired.
+
+Reverted all three call sites to their original single-expression form and put the fallback in sanitizeFilename instead: a title that sanitizes to nothing now yields 'untitled'. Every generated filename keeps the '<id> - <title>.md' shape and the fix has one owner. The title itself is untouched in frontmatter; only the filename uses the placeholder. Net source diff is one function.
+
+Confirmed the new tests are not vacuous: stashing the fix and running them against the contributor's version fails 5/5, observing 'decision-punct.md' and 'doc-punct.md' instead of the placeholder form.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made sanitizeFilename fall back to 'untitled' when a title sanitizes to an empty string, so a punctuation-only title such as '!!!' yields 'task-1 - untitled.md' instead of 'task-1 - .md'. The fallback lives in the one function that owns filename sanitization, so tasks, drafts, documents, and decisions are all fixed without any call site special-casing the empty-title condition.
+
+This replaces contributor PR #897's approach, which dropped the ' - ' separator and emitted id-only filenames. That would have broken three readers that require the '<id> - <title>.md' shape: the content-store task watcher (file.split(' ')[0]), document save dedup (base.split(' - ')[0]), and duplicate-task repair's buildTargetPath, which returns null without the separator. Net source change is one function; the contributor's call-site edits were reverted.
+
+Verified: 5 new tests in src/test/filesystem.test.ts cover punctuation-only titles for tasks, drafts, documents, and decisions, assert the id stays recoverable by both the space-split and ' - '-split readers, and assert a document resave still dedupes to a single file. Reverting the fix fails all 5 (observing 'decision-punct.md' and 'doc-punct.md'), so they are not vacuous. End-to-end CLI check in a scratch project produced 'task-1 - untitled.md', 'doc-1 - untitled.md', and 'decision-1 - untitled.md' with the '!!!' title preserved in frontmatter and rendered by task list. bunx tsc --noEmit clean, bun run check . clean (389 files), full bun run test 2467 pass / 0 fail / 7 skip across 248 files.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -763,8 +763,7 @@ export class FileSystem {
 		let prefix = isDraft ? "draft" : extractAnyPrefix(task.id);
 		if (!prefix) prefix = (await this.loadConfig())?.prefixes?.task ?? "task";
 		const id = normalizeId(task.id, prefix);
-		const sanitizedTitle = this.sanitizeFilename(task.title);
-		const filename = sanitizedTitle ? `${idForFilename(id)} - ${sanitizedTitle}.md` : `${idForFilename(id)}.md`;
+		const filename = `${idForFilename(id)} - ${this.sanitizeFilename(task.title)}.md`;
 		const directory = isDraft ? await this.getDraftsDir() : await this.getTasksDir();
 		const preservesPath = !isDraft && typeof task.filePath === "string" && task.filePath.trim().length > 0;
 		return { id, filename, filePath: preservesPath ? (task.filePath as string) : join(directory, filename) };
@@ -1470,8 +1469,7 @@ export class FileSystem {
 	async saveDecision(decision: Decision): Promise<{ filepath: string; removedFilepaths: string[] }> {
 		// Normalize ID - remove "decision-" prefix if present
 		const normalizedId = decision.id.replace(/^decision-/, "");
-		const sanitizedTitle = this.sanitizeFilename(decision.title);
-		const filename = sanitizedTitle ? `decision-${normalizedId} - ${sanitizedTitle}.md` : `decision-${normalizedId}.md`;
+		const filename = `decision-${normalizedId} - ${this.sanitizeFilename(decision.title)}.md`;
 		const decisionsDir = await this.getDecisionsDir();
 		const filepath = join(decisionsDir, filename);
 		const content = serializeDecision(decision);
@@ -1507,8 +1505,7 @@ export class FileSystem {
 		const docsDir = await this.getDocsDir();
 		const canonicalId = normalizeDocumentId(document.id);
 		document.id = canonicalId;
-		const sanitizedTitle = this.sanitizeFilename(document.title);
-		const filename = sanitizedTitle ? `${canonicalId} - ${sanitizedTitle}.md` : `${canonicalId}.md`;
+		const filename = `${canonicalId} - ${this.sanitizeFilename(document.title)}.md`;
 		const normalizedSubPath = normalizeDocumentSubPath(subPath);
 		const relativePath = normalizedSubPath ? `${normalizedSubPath}/${filename}` : filename;
 		const filepath = join(docsDir, ...relativePath.split("/"));
@@ -2057,15 +2054,15 @@ ${description || `Milestone: ${title}`}`,
 	// Utility methods
 	private sanitizeFilename(filename: string): string {
 		// Remove path-unsafe characters, then strip noisy punctuation before normalizing whitespace
-		return (
-			filename
-				.replace(/[<>:"/\\|?*]/g, "-")
-				// biome-ignore lint/complexity/noUselessEscapeInRegex: we need explicit escapes inside the character class
-				.replace(/['(),!@#$%^&+=\[\]{};]/g, "")
-				.replace(/\s+/g, "-")
-				.replace(/-+/g, "-")
-				.replace(/^-|-$/g, "")
-		);
+		const sanitized = filename
+			.replace(/[<>:"/\\|?*]/g, "-")
+			// biome-ignore lint/complexity/noUselessEscapeInRegex: we need explicit escapes inside the character class
+			.replace(/['(),!@#$%^&+=\[\]{};]/g, "")
+			.replace(/\s+/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^-|-$/g, "");
+		// A punctuation-only title sanitizes to nothing; fall back so filenames keep the "<id> - <title>.md" shape
+		return sanitized || "untitled";
 	}
 
 	private async ensureDirectoryExists(dirPath: string): Promise<void> {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -763,7 +763,8 @@ export class FileSystem {
 		let prefix = isDraft ? "draft" : extractAnyPrefix(task.id);
 		if (!prefix) prefix = (await this.loadConfig())?.prefixes?.task ?? "task";
 		const id = normalizeId(task.id, prefix);
-		const filename = `${idForFilename(id)} - ${this.sanitizeFilename(task.title)}.md`;
+		const sanitizedTitle = this.sanitizeFilename(task.title);
+		const filename = sanitizedTitle ? `${idForFilename(id)} - ${sanitizedTitle}.md` : `${idForFilename(id)}.md`;
 		const directory = isDraft ? await this.getDraftsDir() : await this.getTasksDir();
 		const preservesPath = !isDraft && typeof task.filePath === "string" && task.filePath.trim().length > 0;
 		return { id, filename, filePath: preservesPath ? (task.filePath as string) : join(directory, filename) };
@@ -1469,7 +1470,8 @@ export class FileSystem {
 	async saveDecision(decision: Decision): Promise<{ filepath: string; removedFilepaths: string[] }> {
 		// Normalize ID - remove "decision-" prefix if present
 		const normalizedId = decision.id.replace(/^decision-/, "");
-		const filename = `decision-${normalizedId} - ${this.sanitizeFilename(decision.title)}.md`;
+		const sanitizedTitle = this.sanitizeFilename(decision.title);
+		const filename = sanitizedTitle ? `decision-${normalizedId} - ${sanitizedTitle}.md` : `decision-${normalizedId}.md`;
 		const decisionsDir = await this.getDecisionsDir();
 		const filepath = join(decisionsDir, filename);
 		const content = serializeDecision(decision);
@@ -1505,7 +1507,8 @@ export class FileSystem {
 		const docsDir = await this.getDocsDir();
 		const canonicalId = normalizeDocumentId(document.id);
 		document.id = canonicalId;
-		const filename = `${canonicalId} - ${this.sanitizeFilename(document.title)}.md`;
+		const sanitizedTitle = this.sanitizeFilename(document.title);
+		const filename = sanitizedTitle ? `${canonicalId} - ${sanitizedTitle}.md` : `${canonicalId}.md`;
 		const normalizedSubPath = normalizeDocumentSubPath(subPath);
 		const relativePath = normalizedSubPath ? `${normalizedSubPath}/${filename}` : filename;
 		const filepath = join(docsDir, ...relativePath.split("/"));

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -658,7 +658,8 @@ export class FileSystem {
 		let prefix = isDraft ? "draft" : extractAnyPrefix(task.id);
 		if (!prefix) prefix = (await this.loadConfig())?.prefixes?.task ?? "task";
 		const id = normalizeId(task.id, prefix);
-		const filename = `${idForFilename(id)} - ${this.sanitizeFilename(task.title)}.md`;
+		const sanitizedTitle = this.sanitizeFilename(task.title);
+		const filename = sanitizedTitle ? `${idForFilename(id)} - ${sanitizedTitle}.md` : `${idForFilename(id)}.md`;
 		const directory = isDraft ? await this.getDraftsDir() : await this.getTasksDir();
 		const preservesPath = !isDraft && typeof task.filePath === "string" && task.filePath.trim().length > 0;
 		return { id, filename, filePath: preservesPath ? (task.filePath as string) : join(directory, filename) };
@@ -1123,7 +1124,8 @@ export class FileSystem {
 	async saveDecision(decision: Decision): Promise<{ filepath: string; removedFilepaths: string[] }> {
 		// Normalize ID - remove "decision-" prefix if present
 		const normalizedId = decision.id.replace(/^decision-/, "");
-		const filename = `decision-${normalizedId} - ${this.sanitizeFilename(decision.title)}.md`;
+		const sanitizedTitle = this.sanitizeFilename(decision.title);
+		const filename = sanitizedTitle ? `decision-${normalizedId} - ${sanitizedTitle}.md` : `decision-${normalizedId}.md`;
 		const decisionsDir = await this.getDecisionsDir();
 		const filepath = join(decisionsDir, filename);
 		const content = serializeDecision(decision);
@@ -1159,7 +1161,8 @@ export class FileSystem {
 		const docsDir = await this.getDocsDir();
 		const canonicalId = normalizeDocumentId(document.id);
 		document.id = canonicalId;
-		const filename = `${canonicalId} - ${this.sanitizeFilename(document.title)}.md`;
+		const sanitizedTitle = this.sanitizeFilename(document.title);
+		const filename = sanitizedTitle ? `${canonicalId} - ${sanitizedTitle}.md` : `${canonicalId}.md`;
 		const normalizedSubPath = normalizeDocumentSubPath(subPath);
 		const relativePath = normalizedSubPath ? `${normalizedSubPath}/${filename}` : filename;
 		const filepath = join(docsDir, ...relativePath.split("/"));

--- a/src/test/filesystem.test.ts
+++ b/src/test/filesystem.test.ts
@@ -1044,4 +1044,105 @@ Invalid content`,
 			expect(filename?.includes("--")).toBe(false);
 		});
 	});
+
+	describe("punctuation-only titles", () => {
+		const punctuationOnlyTitle = "!!!";
+
+		it("names a task file with a placeholder title instead of an empty segment", async () => {
+			const task: Task = {
+				id: "task-punct-only",
+				title: punctuationOnlyTitle,
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-07",
+				labels: [],
+				dependencies: [],
+				description: "Punctuation-only title",
+			};
+
+			await filesystem.saveTask(task);
+
+			const files = await readdir(filesystem.tasksDir);
+			expect(files).toContain("task-punct-only - untitled.md");
+			expect(await filesystem.getTaskWritePath(task)).toBe(join(filesystem.tasksDir, "task-punct-only - untitled.md"));
+			// The title itself is preserved in the file; only the filename uses the placeholder
+			expect((await filesystem.loadTask("task-punct-only"))?.title).toBe(punctuationOnlyTitle);
+		});
+
+		it("keeps the id parseable by the readers that split the task filename", async () => {
+			await filesystem.saveTask({
+				id: "task-punct-reader",
+				title: punctuationOnlyTitle,
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-06-07",
+				labels: [],
+				dependencies: [],
+				description: "Punctuation-only title",
+			});
+
+			const files = await readdir(filesystem.tasksDir);
+			const filename = files.find((f) => f.startsWith("task-punct-reader"));
+			expect(filename).toBeDefined();
+			// The content-store task watcher recovers the id by splitting on the first space
+			expect(filename?.split(" ")[0]).toBe("task-punct-reader");
+			// Duplicate-task repair refuses to rebuild a path whose filename has no " - " separator
+			expect(filename?.indexOf(" - ")).toBeGreaterThan(0);
+		});
+
+		it("names a draft file with a placeholder title", async () => {
+			await filesystem.saveDraft({
+				id: "draft-punct",
+				title: punctuationOnlyTitle,
+				status: "Draft",
+				assignee: [],
+				createdDate: "2025-06-07",
+				labels: [],
+				dependencies: [],
+				description: "Punctuation-only title",
+			});
+
+			const draftFiles = await readdir(await filesystem.getDraftsDir());
+			expect(draftFiles).toContain("draft-punct - untitled.md");
+		});
+
+		it("names a decision file with a placeholder title", async () => {
+			await filesystem.saveDecision({
+				id: "decision-punct",
+				title: punctuationOnlyTitle,
+				date: "2025-06-07",
+				status: "accepted",
+				context: "Punctuation-only title",
+				decision: "Use a placeholder",
+				consequences: "Filenames stay parseable",
+				rawContent: "",
+			});
+
+			const decisionFiles = await readdir(filesystem.decisionsDir);
+			expect(decisionFiles).toContain("decision-punct - untitled.md");
+		});
+
+		it("names a document file with a placeholder title and still dedupes it on resave", async () => {
+			const document: Document = {
+				id: "doc-punct",
+				title: punctuationOnlyTitle,
+				type: "guide",
+				createdDate: "2025-06-07",
+				updatedDate: "2025-06-08",
+				rawContent: "Original content",
+				tags: [],
+			};
+
+			await filesystem.saveDocument(document);
+			expect(await readdir(filesystem.docsDir)).toContain("doc-punct - untitled.md");
+
+			// Document save dedup matches an existing file by splitting the basename on " - "
+			await filesystem.saveDocument({ ...document, rawContent: "Updated content" });
+
+			const docFiles = await Array.fromAsync(
+				new Bun.Glob("doc-*.md").scan({ cwd: filesystem.docsDir, followSymlinks: true }),
+			);
+			expect(docFiles).toEqual(["doc-punct - untitled.md"]);
+		});
+	});
 });


### PR DESCRIPTION
Previously `sanitizeFilename('!!!')` → `''` gave filenames like `task-42 - .md`. Fallback to id-only (`task-42.md`, `decision-1.md`, `doc-1.md`) when sanitized title is empty. Covers tasks, decisions, documents in `src/file-system/operations.ts:661,1126,1162`.\n\nVerified: `bunx tsc --noEmit` ok, `bun run check` 369 files ok.