### PR TITLE
BACK-623 - Make common task commands avoid unnecessary cross-branch work

### DIFF
--- a/backlog/tasks/back-623 - Make-common-task-commands-avoid-unnecessary-cross-branch-work.md
+++ b/backlog/tasks/back-623 - Make-common-task-commands-avoid-unnecessary-cross-branch-work.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-09 22:02'
-updated_date: '2026-08-09 22:24'
+updated_date: '2026-08-10 06:43'
 labels: []
 dependencies: []
 priority: high
@@ -56,6 +56,8 @@ Implemented a working-copy active/completed identity resolver for local reads an
 Validation passed: TypeScript, Biome over 371 files, build, and 178 focused/control tests covering local Git tripwires, CLI branch-only behavior, list/search, custom IDs, task views, Core identity behavior, atomic locks, board/worktree refresh, and cross-branch ContentStore preservation. A broad ContentStore batch also exposed unrelated temporary-worktree watcher timeouts; the relevant cross-branch invariant passed alone.
 
 Same-checkout benchmark, v1.50 to fixed binary: task view 4.42s to 0.85s; task list 4.15s to 0.21s; no-op task edit 12.19s to 0.42s. The old commands attempted remote fetches; the fixed commands did not.
+
+Review fix round: reconciled parent-ID resolution so task create --parent uses the same local active/completed fail-closed resolution as task list --parent and task view, and moved dependency validation onto the same working-copy lookup so it no longer runs a cross-branch load and remote fetch inside the task lock; a parent or dependency that exists only on another branch is now refused on every surface. Local not-found messages (view, shorthand, edit, --parent on list and create, missing dependencies) now name the working copy as the corpus searched and point at the browser view, using a fixed sentence with no branch scanning. Restored the browser default: /api/tasks serves the cross-branch ContentStore again instead of re-globbing the working copy per request, with crossBranch=false still serving the local view. Removed the unused TaskReadOptions parameters from archiveTask, completeTask, demoteTask, and editTaskOrDraft; archive/complete/demote keep their existing cross-branch reads. New pins cover create-parent and dependency locality under the fetch tripwire, fail-closed ambiguity for both, the hint wording across CLI surfaces, and the store-served /api/tasks default; the two tests that pinned cross-branch parent and dependency acceptance were inverted. Gates: tsc, biome (371 files), build, and the full suite at 2201 pass / 6 skip / 0 fail.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-623 - Make-common-task-commands-avoid-unnecessary-cross-branch-work.md
+++ b/backlog/tasks/back-623 - Make-common-task-commands-avoid-unnecessary-cross-branch-work.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-09 22:02'
-updated_date: '2026-08-10 06:43'
+updated_date: '2026-08-10 06:56'
 labels: []
 dependencies: []
 priority: high
@@ -58,6 +58,8 @@ Validation passed: TypeScript, Biome over 371 files, build, and 178 focused/cont
 Same-checkout benchmark, v1.50 to fixed binary: task view 4.42s to 0.85s; task list 4.15s to 0.21s; no-op task edit 12.19s to 0.42s. The old commands attempted remote fetches; the fixed commands did not.
 
 Review fix round: reconciled parent-ID resolution so task create --parent uses the same local active/completed fail-closed resolution as task list --parent and task view, and moved dependency validation onto the same working-copy lookup so it no longer runs a cross-branch load and remote fetch inside the task lock; a parent or dependency that exists only on another branch is now refused on every surface. Local not-found messages (view, shorthand, edit, --parent on list and create, missing dependencies) now name the working copy as the corpus searched and point at the browser view, using a fixed sentence with no branch scanning. Restored the browser default: /api/tasks serves the cross-branch ContentStore again instead of re-globbing the working copy per request, with crossBranch=false still serving the local view. Removed the unused TaskReadOptions parameters from archiveTask, completeTask, demoteTask, and editTaskOrDraft; archive/complete/demote keep their existing cross-branch reads. New pins cover create-parent and dependency locality under the fetch tripwire, fail-closed ambiguity for both, the hint wording across CLI surfaces, and the store-served /api/tasks default; the two tests that pinned cross-branch parent and dependency acceptance were inverted. Gates: tsc, biome (371 files), build, and the full suite at 2201 pass / 6 skip / 0 fail.
+
+Reconciliation went both ways: task list --parent now resolves through the same working-copy lookup as task view and task create --parent, so a completed parent is no longer missing for the filter alone, the filter reads the corpus once instead of twice, and the ambiguity message still names the configured prefix. Full suite after that change: 2203 pass / 6 skip / 0 fail.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-623 - Make-common-task-commands-avoid-unnecessary-cross-branch-work.md
+++ b/backlog/tasks/back-623 - Make-common-task-commands-avoid-unnecessary-cross-branch-work.md
@@ -1,0 +1,65 @@
+---
+id: BACK-623
+title: Make common task commands avoid unnecessary cross-branch work
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-09 22:02'
+updated_date: '2026-08-09 22:24'
+labels: []
+dependencies: []
+priority: high
+type: bug
+ordinal: 261000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Common single-task commands currently load the cross-branch corpus and may fetch origin before resolving a local task. On this repository that makes task view and task edit take tens of seconds or hang. Task list is also slower than expected. Preserve fail-closed identity semantics while making local single-task operations bypass cross-branch work and removing avoidable work from task listing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 backlog task view and the task shorthand resolve and render a unique local task without fetching remotes or enumerating active branches
+- [x] #2 backlog task edit resolves and updates a unique local task without fetching remotes or enumerating active branches
+- [x] #3 Single-task commands still fail closed for ambiguous local task identities and report missing tasks correctly
+- [x] #4 backlog task list performs only the remote and cross-branch work required by configuration without duplicate refreshes or redundant corpus loads
+- [x] #5 Focused automated tests assert the Git-operation boundaries for task view, shorthand, edit, and list
+- [x] #6 Before-and-after timings on a representative repository demonstrate faster task view, task edit, and task list behavior
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add working-copy active/completed identity resolution that preserves canonical ambiguity without branch loading.
+2. Make includeCrossBranch:false load and search local tasks directly, and route CLI view, shorthand, and edit through that path.
+3. Preserve the atomic in-lock reread but make it local, and remove the redundant interactive-list corpus load.
+4. Add regression tests proving fetch and branch readers are not called while existing cross-branch Core behavior remains.
+5. Run focused tests, typecheck, lint, build, and before/after command timings.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Diagnosis: v1.49.0 routed local view/edit through the cross-branch ContentStore; v1.50.0 added a necessary in-lock reread that currently repeats that full scan. includeCrossBranch:false has only filtered results after loading. Backlog lock directories were empty and task locks fail fast; unbounded fetch plus repeated branch indexing is the dominant delay.
+
+Implemented a working-copy active/completed identity resolver for local reads and mutations; includeCrossBranch:false now loads and searches local tasks before ContentStore initialization. CLI view, shorthand, edit, and parent filtering use the local scope; the atomic in-lock reread remains. Removed the interactive list's redundant full load. Consolidated padded/dotted task search variants into one shared helper so local and global search remain aligned.
+
+Validation passed: TypeScript, Biome over 371 files, build, and 178 focused/control tests covering local Git tripwires, CLI branch-only behavior, list/search, custom IDs, task views, Core identity behavior, atomic locks, board/worktree refresh, and cross-branch ContentStore preservation. A broad ContentStore batch also exposed unrelated temporary-worktree watcher timeouts; the relevant cross-branch invariant passed alone.
+
+Same-checkout benchmark, v1.50 to fixed binary: task view 4.42s to 0.85s; task list 4.15s to 0.21s; no-op task edit 12.19s to 0.42s. The old commands attempted remote fetches; the fixed commands did not.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made local task list, view, shorthand, and edit bypass cross-branch fetching and branch enumeration while preserving local ambiguity checks and atomic edit locking. Global cross-branch Core behavior remains available for browser/MCP surfaces. Verified with structural Git-boundary tests, CLI branch-only tests, 178 focused/control tests, typecheck, lint, build, and same-checkout timings.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,7 +95,7 @@ import {
 	toStringArray,
 } from "./utils/task-builders.ts";
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
-import { AmbiguousTaskIdError, canonicalTaskId, taskIdsEqual } from "./utils/task-path.ts";
+import { AmbiguousTaskIdError, canonicalTaskId, LOCAL_TASK_LOOKUP_HINT, taskIdsEqual } from "./utils/task-path.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
 import { formatValidTaskTypeValues, getTaskTypeValues, resolveTaskTypeValues } from "./utils/task-type-config.ts";
 import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
@@ -579,7 +579,7 @@ async function resolveParentFilterId(core: Core, parentId: string, parentDisplay
 	}
 	const parent = matches[0];
 	if (!parent) {
-		throw new Error(`Parent task ${parentDisplayId} not found.`);
+		throw new Error(`Parent task ${parentDisplayId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 	}
 	// Include completed working-copy files in the ambiguity check without scanning branches.
 	await core.loadTaskById(parent.id, { includeCrossBranch: false });
@@ -2969,7 +2969,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 
 			const existingTaskForWizard = await core.loadTaskById(selectedTaskId, { includeCrossBranch: false });
 			if (!existingTaskForWizard) {
-				console.error(`Task ${selectedTaskId} not found.`);
+				console.error(`Task ${selectedTaskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 				process.exitCode = 1;
 				return;
 			}
@@ -3002,7 +3002,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		const existingTask = await core.loadTaskById(taskId ?? "", { includeCrossBranch: false });
 
 		if (!existingTask) {
-			console.error(`Task ${taskId} not found.`);
+			console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 			process.exitCode = 1;
 			return;
 		}
@@ -3335,7 +3335,7 @@ addHelpSchema(taskCmd.command("view <taskId>"), {
 		const localTasks = await core.fs.listTasks();
 		const task = await core.getTaskWithSubtasks(taskId, localTasks, { includeCrossBranch: false });
 		if (!task) {
-			console.error(`Task ${taskId} not found.`);
+			console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 			process.exitCode = 1;
 			return;
 		}
@@ -3511,7 +3511,7 @@ taskCmd
 		const localTasks = await core.fs.listTasks();
 		const task = await core.getTaskWithSubtasks(taskId, localTasks, { includeCrossBranch: false });
 		if (!task) {
-			console.error(`Task ${taskId} not found.`);
+			console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 			process.exitCode = 1;
 			return;
 		}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2988,7 +2988,9 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			}
 
 			try {
-				const updatedTask = await core.editTask(existingTaskForWizard.id, wizardInput);
+				const updatedTask = await core.editTask(existingTaskForWizard.id, wizardInput, undefined, {
+					includeCrossBranch: false,
+				});
 				console.log(`Updated task ${updatedTask.id}`);
 			} catch (error) {
 				console.error(formatTaskEditError(error, existingTaskForWizard.id));
@@ -3294,7 +3296,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		let updatedTask: Task;
 		try {
 			const updateInput = buildTaskUpdateInput(editArgs);
-			updatedTask = await core.editTask(existingTask.id, updateInput);
+			updatedTask = await core.editTask(existingTask.id, updateInput, undefined, { includeCrossBranch: false });
 		} catch (error) {
 			console.error(formatTaskEditError(error, existingTask.id));
 			process.exitCode = 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,7 +95,13 @@ import {
 	toStringArray,
 } from "./utils/task-builders.ts";
 import { buildTaskUpdateInput } from "./utils/task-edit-builder.ts";
-import { AmbiguousTaskIdError, canonicalTaskId, LOCAL_TASK_LOOKUP_HINT, taskIdsEqual } from "./utils/task-path.ts";
+import {
+	AmbiguousTaskIdError,
+	canonicalTaskId,
+	isAmbiguousTaskIdError,
+	LOCAL_TASK_LOOKUP_HINT,
+	taskIdsEqual,
+} from "./utils/task-path.ts";
 import { sortTasks } from "./utils/task-sorting.ts";
 import { formatValidTaskTypeValues, getTaskTypeValues, resolveTaskTypeValues } from "./utils/task-type-config.ts";
 import { getTerminalStatus, isTerminalStatus } from "./utils/terminal-status.ts";
@@ -561,28 +567,24 @@ function validateClearableListInput(input: {
 /**
  * Resolve a --parent argument to the single task it names, before any child task is read.
  *
- * Identity fails closed here exactly as it does for a targeted task ID: a value matching several
- * files must not silently filter on whichever one came first. Returns the resolved canonical ID so
- * filtering never runs on the raw input.
- *
- * The corpus is loaded here rather than passed in, so every output mode resolves the parent from the
- * same local task list that produces the displayed children and cannot drift apart.
+ * This is the same working-copy lookup that `task view` and `task create --parent` use, so one ID
+ * cannot name a filterable parent for one command and a missing task for another. Identity fails
+ * closed exactly as it does for a targeted task ID: a value matching several files must not silently
+ * filter on whichever one came first. Returns the resolved canonical ID so filtering never runs on
+ * the raw input.
  */
 async function resolveParentFilterId(core: Core, parentId: string, parentDisplayId: string): Promise<string> {
-	const tasks = await core.queryTasks({ includeCrossBranch: false });
-	const matches = tasks.filter((task) => taskIdsEqual(parentId, task.id));
-	if (matches.length > 1) {
-		throw new AmbiguousTaskIdError(
-			parentDisplayId,
-			matches.map((task) => task.filePath ?? task.id),
-		);
+	let parent: Task | null;
+	try {
+		parent = await core.loadTaskById(parentId, { includeCrossBranch: false });
+	} catch (error) {
+		// Report the collision under the configured prefix, which a bare numeric argument lacks.
+		if (isAmbiguousTaskIdError(error)) throw new AmbiguousTaskIdError(parentDisplayId, error.candidates);
+		throw error;
 	}
-	const parent = matches[0];
 	if (!parent) {
 		throw new Error(`Parent task ${parentDisplayId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 	}
-	// Include completed working-copy files in the ambiguity check without scanning branches.
-	await core.loadTaskById(parent.id, { includeCrossBranch: false });
 	return parent.id;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -581,9 +581,8 @@ async function resolveParentFilterId(core: Core, parentId: string, parentDisplay
 	if (!parent) {
 		throw new Error(`Parent task ${parentDisplayId} not found.`);
 	}
-	// Called for its ambiguity check: it raises AmbiguousTaskIdError when several files claim this
-	// ID, which the corpus cannot report because it keeps one entry per ID.
-	await core.getTask(parent.id);
+	// Include completed working-copy files in the ambiguity check without scanning branches.
+	await core.loadTaskById(parent.id, { includeCrossBranch: false });
 	return parent.id;
 }
 
@@ -2678,14 +2677,7 @@ addHelpSchema(taskCmd.command("list"), {
 				updateProgress("Loading configuration...");
 				const config = await core.filesystem.loadConfig();
 
-				// Use loadTasks with progress callback for consistent loading experience
-				// This populates the ContentStore, so subsequent queryTasks calls are fast
-				await core.loadTasks((msg) => {
-					updateProgress(msg);
-				});
-
-				// Now query with filters - this will use the already-populated ContentStore
-				updateProgress("Applying filters...");
+				updateProgress("Loading local tasks...");
 				const tasks = await core.queryTasks({
 					filters: Object.keys(interactiveLoaderFilters).length > 0 ? interactiveLoaderFilters : undefined,
 					includeCrossBranch: false,
@@ -2975,7 +2967,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 				}
 			}
 
-			const existingTaskForWizard = await core.loadTaskById(selectedTaskId);
+			const existingTaskForWizard = await core.loadTaskById(selectedTaskId, { includeCrossBranch: false });
 			if (!existingTaskForWizard) {
 				console.error(`Task ${selectedTaskId} not found.`);
 				process.exitCode = 1;
@@ -3005,7 +2997,7 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			return;
 		}
 
-		const existingTask = await core.loadTaskById(taskId ?? "");
+		const existingTask = await core.loadTaskById(taskId ?? "", { includeCrossBranch: false });
 
 		if (!existingTask) {
 			console.error(`Task ${taskId} not found.`);
@@ -3339,7 +3331,7 @@ addHelpSchema(taskCmd.command("view <taskId>"), {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		const localTasks = await core.fs.listTasks();
-		const task = await core.getTaskWithSubtasks(taskId, localTasks);
+		const task = await core.getTaskWithSubtasks(taskId, localTasks, { includeCrossBranch: false });
 		if (!task) {
 			console.error(`Task ${taskId} not found.`);
 			process.exitCode = 1;
@@ -3515,7 +3507,7 @@ taskCmd
 		}
 
 		const localTasks = await core.fs.listTasks();
-		const task = await core.getTaskWithSubtasks(taskId, localTasks);
+		const task = await core.getTaskWithSubtasks(taskId, localTasks, { includeCrossBranch: false });
 		if (!task) {
 			console.error(`Task ${taskId} not found.`);
 			process.exitCode = 1;

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -748,8 +748,15 @@ export class Core {
 		return resolution.status === "found" ? { ...resolution.task } : null;
 	}
 
-	private async loadLocalTaskForMutation(taskId: string): Promise<Task | null> {
-		return await this.loadWorkingCopyTask(taskId, true);
+	private async loadTaskForMutation(taskId: string, options: TaskReadOptions = {}): Promise<Task | null> {
+		if (options.includeCrossBranch === false) {
+			return await this.loadWorkingCopyTask(taskId, true);
+		}
+		const store = await this.getContentStore();
+		await store.refreshTasks();
+		const resolution = store.resolveTaskForMutation(taskId);
+		if (resolution.status === "ambiguous") throw new AmbiguousTaskIdError(taskId, resolution.candidates);
+		return resolution.status === "found" ? { ...resolution.task } : null;
 	}
 
 	async getTaskContent(taskId: string): Promise<string | null> {
@@ -2102,8 +2109,13 @@ export class Core {
 		return { task, mutated };
 	}
 
-	async updateTaskFromInput(taskId: string, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
-		const task = await this.loadLocalTaskForMutation(taskId);
+	async updateTaskFromInput(
+		taskId: string,
+		input: TaskUpdateInput,
+		autoCommit?: boolean,
+		options: TaskReadOptions = {},
+	): Promise<Task> {
+		const task = await this.loadTaskForMutation(taskId, options);
 		if (!task) {
 			throw new Error(`Task not found: ${taskId}`);
 		}
@@ -2111,7 +2123,7 @@ export class Core {
 		const requestedStatus = input.status?.trim().toLowerCase();
 		if (requestedStatus === "draft") {
 			// demoteTaskWithUpdates takes the task lock itself, so it must not be nested here.
-			return await this.demoteTaskWithUpdates(task, input, autoCommit);
+			return await this.demoteTaskWithUpdates(task, input, autoCommit, options);
 		}
 
 		// Fail fast when another process is mid-edit, and re-read inside the lock so the whole
@@ -2119,7 +2131,7 @@ export class Core {
 		// whenever one writer releases before the next acquires: the second would then apply
 		// its changes to a snapshot taken before the first wrote.
 		return await this.fs.withTaskLock(task, async () => {
-			const current = await this.loadLocalTaskForMutation(taskId);
+			const current = await this.loadTaskForMutation(taskId, options);
 			if (!current) {
 				throw new Error(`Task not found: ${taskId}`);
 			}
@@ -2173,7 +2185,12 @@ export class Core {
 		return refreshed ?? draft;
 	}
 
-	async editTaskOrDraft(taskId: string, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
+	async editTaskOrDraft(
+		taskId: string,
+		input: TaskUpdateInput,
+		autoCommit?: boolean,
+		options: TaskReadOptions = {},
+	): Promise<Task> {
 		const draft = await this.fs.loadDraft(taskId);
 		if (draft) {
 			const requestedStatus = input.status?.trim();
@@ -2192,10 +2209,10 @@ export class Core {
 		const requestedStatus = input.status?.trim();
 		const wantsDraft = requestedStatus?.toLowerCase() === "draft";
 		if (wantsDraft) {
-			return await this.demoteTaskWithUpdates(task, input, autoCommit);
+			return await this.demoteTaskWithUpdates(task, input, autoCommit, options);
 		}
 
-		return await this.updateTaskFromInput(task.id, input, autoCommit);
+		return await this.updateTaskFromInput(task.id, input, autoCommit, options);
 	}
 
 	private async promoteDraftWithUpdates(draft: Task, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
@@ -2258,9 +2275,14 @@ export class Core {
 	// and editTaskOrDraft, so it takes the task lock here rather than at each caller. Waiting on
 	// the create lock below happens while the task lock is held; the order is always task lock
 	// then create lock, never the reverse, so the two cannot deadlock.
-	private async demoteTaskWithUpdates(task: Task, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
+	private async demoteTaskWithUpdates(
+		task: Task,
+		input: TaskUpdateInput,
+		autoCommit?: boolean,
+		options: TaskReadOptions = {},
+	): Promise<Task> {
 		return await this.fs.withTaskLock(task, async () => {
-			const current = await this.loadLocalTaskForMutation(task.id);
+			const current = await this.loadTaskForMutation(task.id, options);
 			if (!current) {
 				throw new Error(`Task not found: ${task.id}`);
 			}
@@ -2342,8 +2364,13 @@ export class Core {
 		}
 	}
 
-	async editTask(taskId: string, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
-		return await this.updateTaskFromInput(taskId, input, autoCommit);
+	async editTask(
+		taskId: string,
+		input: TaskUpdateInput,
+		autoCommit?: boolean,
+		options: TaskReadOptions = {},
+	): Promise<Task> {
+		return await this.updateTaskFromInput(taskId, input, autoCommit, options);
 	}
 
 	async updateTasksBulk(tasks: Task[], commitMessage?: string, autoCommit?: boolean): Promise<void> {
@@ -2486,8 +2513,8 @@ export class Core {
 		return { updatedTask, changedTasks };
 	}
 
-	async archiveTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const taskToArchive = await this.loadLocalTaskForMutation(taskId);
+	async archiveTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
+		const taskToArchive = await this.loadTaskForMutation(taskId, options);
 		if (!taskToArchive) {
 			return false;
 		}
@@ -2602,8 +2629,8 @@ export class Core {
 		return result;
 	}
 
-	async completeTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const task = await this.loadLocalTaskForMutation(taskId);
+	async completeTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
+		const task = await this.loadTaskForMutation(taskId, options);
 		if (!task) return false;
 		// Get paths before moving the file
 		const completedDir = this.fs.completedDir;
@@ -2720,8 +2747,8 @@ export class Core {
 		return moved !== null;
 	}
 
-	async demoteTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const task = await this.loadLocalTaskForMutation(taskId);
+	async demoteTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
+		const task = await this.loadTaskForMutation(taskId, options);
 		if (!task) return false;
 		const movedPaths: Array<{ previousPath: string; savedPath: string }> = [];
 		const success = await this.fs.demoteTask(task.id, (previousPath, savedPath) => {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -68,6 +68,7 @@ import {
 	canonicalTaskId,
 	getDraftPath,
 	getTaskPath,
+	LOCAL_TASK_LOOKUP_HINT,
 	normalizeTaskId,
 	taskIdsEqual,
 } from "../utils/task-path.ts";
@@ -213,6 +214,13 @@ function formatAvailableIndexHint(items: AcceptanceCriterion[], emptyMessage: st
 	const last = indexes[indexes.length - 1] ?? first;
 	const range = first === last ? `#${first}` : `#${first}-#${last}`;
 	return `Available indexes: ${range}.`;
+}
+
+/** Dependencies are validated against the working copy on both the create and the edit path. */
+function formatMissingDependenciesError(invalid: string[]): Error {
+	return new Error(
+		`The following dependencies do not exist: ${invalid.join(", ")}. Please create these tasks first or verify the IDs. ${LOCAL_TASK_LOOKUP_HINT}`,
+	);
 }
 
 export class Core {
@@ -1351,9 +1359,7 @@ export class Core {
 			this,
 		);
 		if (invalidDependencies.length > 0) {
-			throw new Error(
-				`The following dependencies do not exist: ${invalidDependencies.join(", ")}. Please create these tasks first or verify the IDs.`,
-			);
+			throw formatMissingDependenciesError(invalidDependencies);
 		}
 
 		let status = "";
@@ -1479,13 +1485,17 @@ export class Core {
 		}
 	}
 
+	/**
+	 * Resolve `--parent` against the working copy, the same corpus the parent filter and task reads
+	 * use, so one ID cannot be an acceptable parent for a child that no task command can then show.
+	 */
 	private async resolveParentTaskIdForCreate(parentTaskId: string): Promise<string> {
-		const parentTask = await this.loadTaskById(parentTaskId);
+		const parentTask = await this.loadTaskById(parentTaskId, { includeCrossBranch: false });
 		if (!parentTask) {
 			const config = await this.fs.loadConfig();
 			const canonicalParent = canonicalTaskId(parentTaskId, config?.prefixes?.task ?? "task");
 			throw new Error(
-				`Parent task ${canonicalParent} not found. Use an existing task ID with --parent; use --milestone to assign a task to a milestone.`,
+				`Parent task ${canonicalParent} not found. ${LOCAL_TASK_LOOKUP_HINT} Use an existing task ID with --parent; use --milestone to assign a task to a milestone.`,
 			);
 		}
 		return parentTask.id;
@@ -1674,9 +1684,7 @@ export class Core {
 				const normalized = parseDelimitedStringList(input.dependencies) ?? [];
 				const { valid, invalid } = await validateDependencies(normalized, this);
 				if (invalid.length > 0) {
-					throw new Error(
-						`The following dependencies do not exist: ${invalid.join(", ")}. Please create these tasks first or verify the IDs.`,
-					);
+					throw formatMissingDependenciesError(invalid);
 				}
 				if (!stringArraysEqual(valid, currentDependencies)) {
 					currentDependencies = valid;
@@ -1688,9 +1696,7 @@ export class Core {
 				const additions = parseDelimitedStringList(input.addDependencies) ?? [];
 				const { valid, invalid } = await validateDependencies(additions, this);
 				if (invalid.length > 0) {
-					throw new Error(
-						`The following dependencies do not exist: ${invalid.join(", ")}. Please create these tasks first or verify the IDs.`,
-					);
+					throw formatMissingDependenciesError(invalid);
 				}
 				const depSet = new Set(currentDependencies);
 				for (const dep of valid) {
@@ -2185,12 +2191,7 @@ export class Core {
 		return refreshed ?? draft;
 	}
 
-	async editTaskOrDraft(
-		taskId: string,
-		input: TaskUpdateInput,
-		autoCommit?: boolean,
-		options: TaskReadOptions = {},
-	): Promise<Task> {
+	async editTaskOrDraft(taskId: string, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
 		const draft = await this.fs.loadDraft(taskId);
 		if (draft) {
 			const requestedStatus = input.status?.trim();
@@ -2209,10 +2210,10 @@ export class Core {
 		const requestedStatus = input.status?.trim();
 		const wantsDraft = requestedStatus?.toLowerCase() === "draft";
 		if (wantsDraft) {
-			return await this.demoteTaskWithUpdates(task, input, autoCommit, options);
+			return await this.demoteTaskWithUpdates(task, input, autoCommit);
 		}
 
-		return await this.updateTaskFromInput(task.id, input, autoCommit, options);
+		return await this.updateTaskFromInput(task.id, input, autoCommit);
 	}
 
 	private async promoteDraftWithUpdates(draft: Task, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
@@ -2513,8 +2514,8 @@ export class Core {
 		return { updatedTask, changedTasks };
 	}
 
-	async archiveTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
-		const taskToArchive = await this.loadTaskForMutation(taskId, options);
+	async archiveTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
+		const taskToArchive = await this.loadTaskForMutation(taskId);
 		if (!taskToArchive) {
 			return false;
 		}
@@ -2629,8 +2630,8 @@ export class Core {
 		return result;
 	}
 
-	async completeTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
-		const task = await this.loadTaskForMutation(taskId, options);
+	async completeTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
+		const task = await this.loadTaskForMutation(taskId);
 		if (!task) return false;
 		// Get paths before moving the file
 		const completedDir = this.fs.completedDir;
@@ -2747,8 +2748,8 @@ export class Core {
 		return moved !== null;
 	}
 
-	async demoteTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
-		const task = await this.loadTaskForMutation(taskId, options);
+	async demoteTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
+		const task = await this.loadTaskForMutation(taskId);
 		if (!task) return false;
 		const movedPaths: Array<{ previousPath: string; savedPath: string }> = [];
 		const success = await this.fs.demoteTask(task.id, (previousPath, savedPath) => {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -71,6 +71,7 @@ import {
 	normalizeTaskId,
 	taskIdsEqual,
 } from "../utils/task-path.ts";
+import { createTaskSearchIndex } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { formatValidTaskTypeValues, matchesTaskTypeFilter, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
@@ -137,6 +138,10 @@ interface TaskQueryOptions {
 	filters?: TaskListFilter;
 	query?: string;
 	limit?: number;
+	includeCrossBranch?: boolean;
+}
+
+interface TaskReadOptions {
 	includeCrossBranch?: boolean;
 }
 
@@ -237,6 +242,7 @@ export class Core {
 		branchRecords: BranchTaskStateEntry[],
 		statuses: string[],
 		resolutionStrategy: "most_recent" | "most_progressed",
+		repositoryRoot?: string | null,
 	): Promise<TaskIdentityIndex> {
 		const records: TaskIdentityRecord[] = [];
 		for (const task of localTasks) {
@@ -266,7 +272,7 @@ export class Core {
 		return new TaskIdentityIndex(
 			records,
 			{
-				repositoryRoot: await this.git.getRepositoryRoot(),
+				repositoryRoot: repositoryRoot === undefined ? await this.git.getRepositoryRoot() : repositoryRoot,
 				projectRoot: this.fs.rootDir,
 				backlogDirectory: this.fs.backlogDirName,
 			},
@@ -637,6 +643,12 @@ export class Core {
 			return filtered;
 		};
 
+		if (!includeCrossBranch) {
+			const localTasks = await this.fs.listTasks();
+			const tasks = trimmedQuery ? createTaskSearchIndex(localTasks).search({ query: trimmedQuery }) : localTasks;
+			return await applyFiltersAndLimit(tasks);
+		}
+
 		if (!trimmedQuery) {
 			const store = await this.getContentStore();
 			await this.refreshCachedTasksForCrossBranchRead(includeCrossBranch);
@@ -698,8 +710,11 @@ export class Core {
 		return identityResolution.status === "found" ? identityResolution.task : null;
 	}
 
-	async getTaskWithSubtasks(taskId: string, localTasks?: Task[]): Promise<Task | null> {
-		const task = await this.getTask(taskId);
+	async getTaskWithSubtasks(taskId: string, localTasks?: Task[], options: TaskReadOptions = {}): Promise<Task | null> {
+		const task =
+			options.includeCrossBranch === false
+				? await this.loadWorkingCopyTask(taskId, false, localTasks)
+				: await this.getTask(taskId);
 		if (!task) {
 			return null;
 		}
@@ -708,16 +723,33 @@ export class Core {
 		return attachSubtaskSummaries(task, tasks);
 	}
 
-	async loadTaskById(taskId: string): Promise<Task | null> {
-		return await this.getTask(taskId);
+	async loadTaskById(taskId: string, options: TaskReadOptions = {}): Promise<Task | null> {
+		return options.includeCrossBranch === false
+			? await this.loadWorkingCopyTask(taskId, false)
+			: await this.getTask(taskId);
+	}
+
+	private async loadWorkingCopyTask(taskId: string, forMutation: boolean, activeTasks?: Task[]): Promise<Task | null> {
+		const [localTasks, completedTasks, config] = await Promise.all([
+			activeTasks ? Promise.resolve(activeTasks) : this.fs.listTasks(),
+			this.fs.listCompletedTasks(),
+			this.fs.loadConfig(),
+		]);
+		const index = await this.buildTaskIdentityIndex(
+			localTasks,
+			completedTasks,
+			[],
+			config?.statuses ?? [...DEFAULT_STATUSES],
+			config?.taskResolutionStrategy ?? "most_progressed",
+			null,
+		);
+		const resolution = forMutation ? index.resolveForMutation(taskId) : index.resolveForRead(taskId);
+		if (resolution.status === "ambiguous") throw new AmbiguousTaskIdError(taskId, resolution.candidates);
+		return resolution.status === "found" ? { ...resolution.task } : null;
 	}
 
 	private async loadLocalTaskForMutation(taskId: string): Promise<Task | null> {
-		const store = await this.getContentStore();
-		await store.refreshTasks();
-		const resolution = store.resolveTaskForMutation(taskId);
-		if (resolution.status === "ambiguous") throw new AmbiguousTaskIdError(taskId, resolution.candidates);
-		return resolution.status === "found" ? { ...resolution.task } : null;
+		return await this.loadWorkingCopyTask(taskId, true);
 	}
 
 	async getTaskContent(taskId: string): Promise<string | null> {

--- a/src/core/search-service.ts
+++ b/src/core/search-service.ts
@@ -12,6 +12,7 @@ import type {
 } from "../types/index.ts";
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "../utils/modified-files.ts";
 import { normalizePriorityValue } from "../utils/priority-config.ts";
+import { createTaskIdSearchVariants } from "../utils/task-id-search.ts";
 import { matchesTaskTypeFilter } from "../utils/task-type-config.ts";
 import type { ContentStore, ContentStoreEvent } from "./content-store.ts";
 
@@ -55,64 +56,6 @@ type NormalizedFilters = {
 	labels?: string[];
 	modifiedFiles?: string[];
 };
-
-// Regex pattern to match any prefix (letters followed by dash)
-const PREFIX_PATTERN = /^[a-zA-Z]+-/i;
-
-/**
- * Extract prefix from an ID if present (e.g., "task-" from "task-123")
- */
-function extractPrefix(id: string): string | null {
-	const match = id.match(PREFIX_PATTERN);
-	return match ? match[0] : null;
-}
-
-/**
- * Strip any prefix from an ID (e.g., "task-123" -> "123", "JIRA-456" -> "456")
- */
-function stripPrefix(id: string): string {
-	return id.replace(PREFIX_PATTERN, "");
-}
-
-function parseTaskIdSegments(value: string): number[] | null {
-	const withoutPrefix = stripPrefix(value.toLowerCase());
-	if (!/^[0-9]+(?:\.[0-9]+)*$/.test(withoutPrefix)) {
-		return null;
-	}
-	return withoutPrefix.split(".").map((segment) => Number.parseInt(segment, 10));
-}
-
-function createTaskIdVariants(id: string): string[] {
-	const lowerId = id.toLowerCase();
-	const segments = parseTaskIdSegments(id);
-	const prefix = extractPrefix(id) ?? "task-"; // Default to task- if no prefix
-
-	if (!segments) {
-		// Non-numeric ID - just return the ID and its lowercase variant
-		return id === lowerId ? [id] : [id, lowerId];
-	}
-
-	const canonicalSuffix = segments.join(".");
-	const variants = new Set<string>();
-
-	// Add original ID and lowercase variant
-	variants.add(id);
-	variants.add(lowerId);
-
-	// Add with extracted/default prefix
-	variants.add(`${prefix}${canonicalSuffix}`);
-	variants.add(`${prefix.toLowerCase()}${canonicalSuffix}`);
-
-	// Add just the numeric part
-	variants.add(canonicalSuffix);
-
-	// Also add individual numeric segments for short-query matching (e.g., "7" matching "TASK-0007")
-	for (const segment of segments) {
-		variants.add(String(segment));
-	}
-
-	return Array.from(variants);
-}
 
 export class SearchService {
 	private initialized = false;
@@ -233,8 +176,8 @@ export class SearchService {
 			priorityLower: normalizePriorityValue(task.priority),
 			assigneesLower: (task.assignee ?? []).map((assignee) => assignee.toLowerCase()),
 			labelsLower: (task.labels || []).map((label) => label.toLowerCase()),
-			idVariants: createTaskIdVariants(task.id),
-			dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdVariants(dependency)),
+			idVariants: createTaskIdSearchVariants(task.id),
+			dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdSearchVariants(dependency)),
 			modifiedFiles: task.modifiedFiles ?? [],
 		}));
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -648,7 +648,9 @@ export class BacklogServer {
 		const assignee = url.searchParams.get("assignee") || undefined;
 		const parent = url.searchParams.get("parent") || undefined;
 		const priorityParam = url.searchParams.get("priority") || undefined;
-		const crossBranch = url.searchParams.get("crossBranch") === "true";
+		// The browser reads the cross-branch corpus the server already keeps in the content store, so
+		// the default must not fall back to re-reading the working copy on every list request.
+		const crossBranch = url.searchParams.get("crossBranch") !== "false";
 		const excludeStatusParams = collectDelimitedSearchParams(url, [
 			"excludeStatus",
 			"exclude-status",

--- a/src/test/cli-custom-prefix-id-resolution.test.ts
+++ b/src/test/cli-custom-prefix-id-resolution.test.ts
@@ -3,6 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
+import { LOCAL_TASK_LOOKUP_HINT } from "../utils/task-path.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import {
 	commitSamePathBranchTaskVariant,
@@ -469,10 +470,12 @@ describe("CLI task ID resolution with a custom ID prefix", () => {
 		const parentFilter = await $`bun ${CLI_PATH} task list --parent 999 --plain`.cwd(TEST_DIR).nothrow().quiet();
 		expect(parentFilter.exitCode).toBe(1);
 		expect(parentFilter.stderr.toString()).toContain("Parent task BACK-999 not found.");
+		expect(parentFilter.stderr.toString()).toContain(LOCAL_TASK_LOOKUP_HINT);
 
 		const parentCreate = await $`bun ${CLI_PATH} task create Child --parent 999`.cwd(TEST_DIR).nothrow().quiet();
 		expect(parentCreate.exitCode).toBe(1);
 		expect(parentCreate.stderr.toString()).toContain("Parent task BACK-999 not found.");
+		expect(parentCreate.stderr.toString()).toContain(LOCAL_TASK_LOOKUP_HINT);
 	});
 
 	it("fails closed on every ID-accepting command when the ID is ambiguous", async () => {

--- a/src/test/cli-custom-prefix-id-resolution.test.ts
+++ b/src/test/cli-custom-prefix-id-resolution.test.ts
@@ -330,7 +330,7 @@ describe("CLI task ID resolution with a custom ID prefix", () => {
 		});
 	}
 
-	it("resolves the parent filter from the local corpus in every output mode", async () => {
+	it("keeps the parent filter local when another branch has a canonical ID variant", async () => {
 		// A branch variant spelling BACK-1 as BACK-001 sits at its own path. The cross-branch corpus
 		// therefore holds two entries for identity BACK-1 while the local corpus holds one, so the
 		// parent filter must not resolve from a cross-branch list: whichever corpus a mode used would
@@ -382,14 +382,14 @@ describe("CLI task ID resolution with a custom ID prefix", () => {
 		expect(localMatches).toHaveLength(1);
 		expect(crossBranchMatches.length).toBeGreaterThan(1);
 
-		// Selecting the parent from the local corpus finds exactly one candidate, and the shared
-		// identity check then fails closed because the branch variant claims the same identity.
+		// Parent filtering is a local task-list operation, so the branch variant must neither block
+		// the command nor change which local children are displayed.
 		const result = await $`bun ${CLI_PATH} task list --parent 1 --plain`.cwd(TEST_DIR).nothrow().quiet();
 		const output = `${result.stdout.toString()}${result.stderr.toString()}`;
-		expect(result.exitCode).not.toBe(0);
-		expect(output).toContain("Task ID BACK-1 is ambiguous");
+		expect(result.exitCode).toBe(0);
+		expect(output).not.toContain("Task ID BACK-1 is ambiguous");
 		expect(output).not.toContain("Parent task BACK-1 not found.");
-		expect(result.stdout.toString()).not.toContain("BACK-1.1 - Child task");
+		expect(result.stdout.toString()).toContain("BACK-1.1 - Child task");
 	});
 
 	it("archives and promotes the draft file named by the argument, not by its frontmatter ID", async () => {

--- a/src/test/cli-init-create.test.ts
+++ b/src/test/cli-init-create.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { $ } from "bun";
 import { CLI_AGENT_NUDGE, Core, isGitRepository } from "../index.ts";
 import { BACKLOG_CWD_ENV } from "../utils/runtime-cwd.ts";
+import { LOCAL_TASK_LOOKUP_HINT } from "../utils/task-path.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
 
@@ -585,7 +586,9 @@ describe("CLI Integration", () => {
 			expect(task?.assignee).toEqual([]);
 		});
 
-		it("should accept dependencies from other active branches", async () => {
+		// Dependency validation shares the working-copy corpus with every other task lookup, so a
+		// dependency the CLI could never resolve afterwards is refused up front.
+		it("should reject dependencies that exist only on another active branch", async () => {
 			const core = new Core(TEST_DIR);
 
 			const remoteDir = join(TEST_DIR, "remote.git");
@@ -614,14 +617,18 @@ describe("CLI Integration", () => {
 
 			const visibleTasks = await core.queryTasks();
 			expect(visibleTasks.some((task) => task.id === "TASK-1")).toBe(true);
+			expect((await core.filesystem.listTasks()).some((task) => task.id === "TASK-1")).toBe(false);
 
-			const output = await $`bun ${CLI_PATH} task create "Depends on feature task" --depends-on task-1`
+			const result = await $`bun ${CLI_PATH} task create "Depends on feature task" --depends-on task-1`
 				.cwd(TEST_DIR)
-				.text();
-			const createdTask = await core.filesystem.loadTask("task-2");
+				.nothrow()
+				.quiet();
+			const output = `${result.stdout.toString()}${result.stderr.toString()}`;
 
-			expect(output).toContain("Created task TASK-2");
-			expect(createdTask?.dependencies).toEqual(["TASK-1"]);
+			expect(result.exitCode).toBe(1);
+			expect(output).toContain("The following dependencies do not exist: task-1");
+			expect(output).toContain(LOCAL_TASK_LOOKUP_HINT);
+			expect(await core.filesystem.loadTask("task-2")).toBeNull();
 		});
 	});
 });

--- a/src/test/cli-parent-filter.test.ts
+++ b/src/test/cli-parent-filter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir } from "node:fs/promises";
 import { $ } from "bun";
 import { Core } from "../index.ts";
+import { LOCAL_TASK_LOOKUP_HINT } from "../utils/task-path.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
 
@@ -131,6 +132,7 @@ describe("CLI parent task filtering", () => {
 
 		expect(exitCode).toBe(1); // CLI exits with error for non-existent parent
 		expect(result.stderr.toString()).toContain("Parent task TASK-999 not found.");
+		expect(result.stderr.toString()).toContain(LOCAL_TASK_LOOKUP_HINT);
 	});
 
 	it("should show message when parent has no children", async () => {

--- a/src/test/cli-parent-filter.test.ts
+++ b/src/test/cli-parent-filter.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
 import { LOCAL_TASK_LOOKUP_HINT } from "../utils/task-path.ts";
@@ -123,6 +124,45 @@ describe("CLI parent task filtering", () => {
 		// Should not contain parent or standalone tasks
 		expect(result.stdout.toString()).not.toContain("TASK-1 - Parent task");
 		expect(result.stdout.toString()).not.toContain("TASK-2 - Standalone task");
+	});
+
+	// One ID must not be a filterable parent for one command and a missing task for another, so the
+	// filter resolves the parent through the same working-copy lookup as task view and task create.
+	it("keeps the parent filter, task view, and create --parent in agreement about a completed parent", async () => {
+		const core = new Core(TEST_DIR);
+		await core.editTask("task-1", { status: "Done" }, false);
+		expect(await core.completeTask("task-1", false)).toBe(true);
+
+		const view = await $`bun ${cliPath} task view 1 --plain`.cwd(TEST_DIR).nothrow().quiet();
+		expect(view.exitCode).toBe(0);
+		expect(view.stdout.toString()).toContain("Parent task");
+
+		const filtered = await $`bun ${cliPath} task list --parent 1 --plain`.cwd(TEST_DIR).nothrow().quiet();
+		expect(filtered.exitCode).toBe(0);
+		expect(filtered.stdout.toString()).toContain("TASK-1.1 - Child task 1");
+		expect(filtered.stdout.toString()).toContain("TASK-1.2 - Child task 2");
+		expect(filtered.stdout.toString()).not.toContain("TASK-2 - Standalone task");
+
+		const created = await $`bun ${cliPath} task create ${"Late child"} --parent 1`.cwd(TEST_DIR).nothrow().quiet();
+		expect(created.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("task-1.3"))?.parentTaskId).toBe("TASK-1");
+	});
+
+	it("fails closed when the parent filter names more than one working-copy file", async () => {
+		const core = new Core(TEST_DIR);
+		const tasksDir = core.filesystem.tasksDir;
+		await Bun.write(
+			join(tasksDir, "task-01 - Duplicate-parent.md"),
+			await Bun.file(join(tasksDir, "task-1 - Parent-task.md")).text(),
+		);
+
+		const result = await $`bun ${cliPath} task list --parent 1 --plain`.cwd(TEST_DIR).nothrow().quiet();
+
+		expect(result.exitCode).not.toBe(0);
+		const output = `${result.stdout.toString()}${result.stderr.toString()}`;
+		expect(output).toContain("is ambiguous");
+		expect(output).toContain("task-01 - Duplicate-parent.md");
+		expect(result.stdout.toString()).not.toContain("TASK-1.1 - Child task 1");
 	});
 
 	it("should show error for non-existent parent task", async () => {

--- a/src/test/local-task-command-performance.test.ts
+++ b/src/test/local-task-command-performance.test.ts
@@ -5,7 +5,7 @@ import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
 import { serializeTask } from "../markdown/serializer.ts";
 import type { Task } from "../types/index.ts";
-import { AmbiguousTaskIdError } from "../utils/task-path.ts";
+import { AmbiguousTaskIdError, LOCAL_TASK_LOOKUP_HINT } from "../utils/task-path.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
 
@@ -132,7 +132,7 @@ describe("local task command performance boundaries", () => {
 		}
 	});
 
-	it("keeps CLI view, shorthand, and edit scoped to the working copy", async () => {
+	it("keeps CLI reads, parent resolution, and dependency validation scoped to the working copy", async () => {
 		await $`git add .`.cwd(testDir).quiet();
 		await $`git commit -m ${"Commit working copy"}`.cwd(testDir).quiet();
 		await $`git switch -c branch-only`.cwd(testDir).quiet();
@@ -151,12 +151,99 @@ describe("local task command performance boundaries", () => {
 			.cwd(testDir)
 			.nothrow()
 			.quiet();
+		const parentFilter = await $`bun ${CLI_PATH} task list --parent TASK-99 --plain`.cwd(testDir).nothrow().quiet();
+		const parentCreate = await $`bun ${CLI_PATH} task create ${"Child of a branch task"} --parent TASK-99`
+			.cwd(testDir)
+			.nothrow()
+			.quiet();
+		const dependencyEdit = await $`bun ${CLI_PATH} task edit TASK-1 --dep TASK-99 --plain`
+			.cwd(testDir)
+			.nothrow()
+			.quiet();
 
-		for (const result of [view, shorthand, edit]) {
+		const outputOf = (result: { stdout: Buffer; stderr: Buffer }) =>
+			`${result.stdout.toString()}${result.stderr.toString()}`;
+		// Every local miss names the working copy as the corpus it searched, so a task parked on
+		// another branch reads as scope rather than as a missing task.
+		for (const result of [view, shorthand, edit, parentFilter, parentCreate, dependencyEdit]) {
 			expect(result.exitCode).not.toBe(0);
-			expect(`${result.stdout.toString()}${result.stderr.toString()}`).toContain("Task TASK-99 not found.");
+			expect(outputOf(result)).toContain(LOCAL_TASK_LOOKUP_HINT);
 		}
+		for (const result of [view, shorthand, edit]) {
+			expect(outputOf(result)).toContain("Task TASK-99 not found.");
+		}
+		for (const result of [parentFilter, parentCreate]) {
+			expect(outputOf(result)).toContain("Parent task TASK-99 not found.");
+		}
+		expect(outputOf(dependencyEdit)).toContain("The following dependencies do not exist: TASK-99");
+
 		expect(await core.filesystem.loadTask("TASK-99")).toBeNull();
+		expect(await core.filesystem.loadTask("TASK-99.1")).toBeNull();
+		expect((await core.filesystem.loadTask("TASK-1"))?.dependencies ?? []).toEqual([]);
+	});
+
+	it("resolves a create parent from the working copy without loading branches", async () => {
+		const tripwires = installCrossBranchTripwires(core);
+		try {
+			await expect(
+				core.createTaskFromInput({ title: "Child of a missing parent", parentTaskId: "TASK-99" }, false),
+			).rejects.toThrow("Parent task TASK-99 not found.");
+			// The parent is rejected before an ID is allocated, which is the only step that may
+			// legitimately look beyond the working copy.
+			tripwires.expectUntouched();
+		} finally {
+			tripwires.restore();
+		}
+
+		const child = await core.createTaskFromInput({ title: "Child of a local parent", parentTaskId: "1" }, false);
+		expect(child.task.id).toBe("TASK-1.2");
+		expect(child.task.parentTaskId).toBe("TASK-1");
+	});
+
+	it("validates dependencies against the working copy without loading branches", async () => {
+		const tripwires = installCrossBranchTripwires(core);
+		try {
+			const updated = await core.updateTaskFromInput("TASK-1", { addDependencies: ["2"] }, false, {
+				includeCrossBranch: false,
+			});
+			expect(updated.dependencies).toEqual(["TASK-2"]);
+
+			await expect(
+				core.updateTaskFromInput("TASK-1", { dependencies: ["TASK-99"] }, false, { includeCrossBranch: false }),
+			).rejects.toThrow("The following dependencies do not exist: TASK-99");
+			tripwires.expectUntouched();
+		} finally {
+			tripwires.restore();
+		}
+
+		expect((await core.filesystem.loadTask("TASK-1"))?.dependencies).toEqual(["TASK-2"]);
+	});
+
+	it("fails closed on ambiguous parent and dependency identities without loading branches", async () => {
+		await Bun.write(
+			join(core.filesystem.completedDir, "task-02 - Completed-collision.md"),
+			serializeTask({
+				...parentTask,
+				id: "TASK-02",
+				title: "Completed collision",
+				status: "Done",
+			}),
+		);
+		const tripwires = installCrossBranchTripwires(core);
+		try {
+			await expect(
+				core.createTaskFromInput({ title: "Child of an ambiguous parent", parentTaskId: "2" }, false),
+			).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+			await expect(
+				core.updateTaskFromInput("TASK-1", { addDependencies: ["2"] }, false, { includeCrossBranch: false }),
+			).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+			tripwires.expectUntouched();
+		} finally {
+			tripwires.restore();
+		}
+
+		expect((await core.filesystem.loadTask("TASK-1"))?.dependencies ?? []).toEqual([]);
+		expect(await core.filesystem.loadTask("TASK-2.1")).toBeNull();
 	});
 
 	it("edits a working-copy task without loading branches", async () => {

--- a/src/test/local-task-command-performance.test.ts
+++ b/src/test/local-task-command-performance.test.ts
@@ -162,7 +162,9 @@ describe("local task command performance boundaries", () => {
 	it("edits a working-copy task without loading branches", async () => {
 		const tripwires = installCrossBranchTripwires(core);
 		try {
-			const updated = await core.updateTaskFromInput(parentTask.id, { title: "Renamed locally" }, false);
+			const updated = await core.updateTaskFromInput(parentTask.id, { title: "Renamed locally" }, false, {
+				includeCrossBranch: false,
+			});
 
 			expect(updated.title).toBe("Renamed locally");
 			expect((await core.filesystem.listTasks()).find((task) => task.id === parentTask.id)?.title).toBe(
@@ -192,9 +194,11 @@ describe("local task command performance boundaries", () => {
 			await expect(
 				core.getTaskWithSubtasks(parentTask.id, undefined, { includeCrossBranch: false }),
 			).rejects.toBeInstanceOf(AmbiguousTaskIdError);
-			await expect(core.updateTaskFromInput(parentTask.id, { title: "Must not change" }, false)).rejects.toBeInstanceOf(
-				AmbiguousTaskIdError,
-			);
+			await expect(
+				core.updateTaskFromInput(parentTask.id, { title: "Must not change" }, false, {
+					includeCrossBranch: false,
+				}),
+			).rejects.toBeInstanceOf(AmbiguousTaskIdError);
 			tripwires.expectUntouched();
 		} finally {
 			tripwires.restore();

--- a/src/test/local-task-command-performance.test.ts
+++ b/src/test/local-task-command-performance.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { serializeTask } from "../markdown/serializer.ts";
+import type { Task } from "../types/index.ts";
+import { AmbiguousTaskIdError } from "../utils/task-path.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+let testDir: string;
+let core: Core;
+const CLI_PATH = getTestCliPath();
+
+const parentTask: Task = {
+	id: "TASK-1",
+	title: "Fast local task",
+	status: "To Do",
+	assignee: [],
+	createdDate: "2026-08-10",
+	labels: ["local"],
+	dependencies: [],
+	description: "Contains the distinctive local-search-token.",
+};
+
+function installCrossBranchTripwires(coreUnderTest: Core) {
+	const error = new Error("Local task command crossed the branch-loading boundary");
+	const loadTasks = spyOn(coreUnderTest, "loadTasks").mockRejectedValue(error);
+	const fetch = spyOn(coreUnderTest.gitOps, "fetch").mockRejectedValue(error);
+	const listRecentBranchTips = spyOn(coreUnderTest.gitOps, "listRecentBranchTips").mockRejectedValue(error);
+	const listRecentBranches = spyOn(coreUnderTest.gitOps, "listRecentBranches").mockRejectedValue(error);
+	const getRepositoryRoot = spyOn(coreUnderTest.gitOps, "getRepositoryRoot").mockRejectedValue(error);
+
+	return {
+		expectUntouched() {
+			expect(loadTasks).toHaveBeenCalledTimes(0);
+			expect(fetch).toHaveBeenCalledTimes(0);
+			expect(listRecentBranchTips).toHaveBeenCalledTimes(0);
+			expect(listRecentBranches).toHaveBeenCalledTimes(0);
+			expect(getRepositoryRoot).toHaveBeenCalledTimes(0);
+		},
+		restore() {
+			loadTasks.mockRestore();
+			fetch.mockRestore();
+			listRecentBranchTips.mockRestore();
+			listRecentBranches.mockRestore();
+			getRepositoryRoot.mockRestore();
+		},
+	};
+}
+
+describe("local task command performance boundaries", () => {
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("local-task-command-performance");
+		await mkdir(testDir, { recursive: true });
+		await $`git init -b main`.cwd(testDir).quiet();
+		core = new Core(testDir);
+		await initializeTestProject(core, "Local task command performance");
+
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Expected initialized config");
+		await core.filesystem.saveConfig({
+			...config,
+			checkActiveBranches: true,
+			remoteOperations: true,
+		});
+
+		await core.filesystem.saveTask(parentTask);
+		await core.filesystem.saveTask({
+			...parentTask,
+			id: "TASK-1.1",
+			title: "Local child",
+			parentTaskId: parentTask.id,
+			description: "Child content",
+		});
+		await core.filesystem.saveTask({
+			...parentTask,
+			id: "TASK-2",
+			title: "Unrelated local task",
+			description: "No matching search content",
+		});
+	});
+
+	afterEach(async () => {
+		core.disposeSearchService();
+		core.disposeContentStore();
+		await safeCleanup(testDir);
+	});
+
+	it("lists and searches working-copy tasks without loading branches", async () => {
+		await core.filesystem.saveTask({
+			...parentTask,
+			id: "TASK-0007.0024",
+			title: "Padded task identity",
+			description: "No matching search content",
+		});
+		const tripwires = installCrossBranchTripwires(core);
+		try {
+			const listed = await core.queryTasks({ includeCrossBranch: false });
+			const searched = await core.queryTasks({
+				query: "local-search-token",
+				includeCrossBranch: false,
+			});
+			const searchedByPaddedSegment = await core.queryTasks({
+				query: "7",
+				includeCrossBranch: false,
+			});
+
+			expect(listed.map((task) => task.id).sort()).toEqual(["TASK-0007.0024", "TASK-1", "TASK-1.1", "TASK-2"]);
+			expect(searched.map((task) => task.id)).toEqual(["TASK-1"]);
+			expect(searchedByPaddedSegment.map((task) => task.id)).toContain("TASK-0007.0024");
+			tripwires.expectUntouched();
+		} finally {
+			tripwires.restore();
+		}
+	});
+
+	it("loads one working-copy task and its subtasks without loading branches", async () => {
+		const tripwires = installCrossBranchTripwires(core);
+		try {
+			const loaded = await core.loadTaskById(parentTask.id, { includeCrossBranch: false });
+			const withSubtasks = await core.getTaskWithSubtasks(parentTask.id, undefined, {
+				includeCrossBranch: false,
+			});
+
+			expect(loaded?.title).toBe(parentTask.title);
+			expect(withSubtasks?.subtaskSummaries).toEqual([{ id: "TASK-1.1", title: "Local child" }]);
+			tripwires.expectUntouched();
+		} finally {
+			tripwires.restore();
+		}
+	});
+
+	it("keeps CLI view, shorthand, and edit scoped to the working copy", async () => {
+		await $`git add .`.cwd(testDir).quiet();
+		await $`git commit -m ${"Commit working copy"}`.cwd(testDir).quiet();
+		await $`git switch -c branch-only`.cwd(testDir).quiet();
+		await core.filesystem.saveTask({
+			...parentTask,
+			id: "TASK-99",
+			title: "Branch-only task",
+		});
+		await $`git add .`.cwd(testDir).quiet();
+		await $`git commit -m ${"Commit branch-only task"}`.cwd(testDir).quiet();
+		await $`git switch main`.cwd(testDir).quiet();
+
+		const view = await $`bun ${CLI_PATH} task view TASK-99 --plain`.cwd(testDir).nothrow().quiet();
+		const shorthand = await $`bun ${CLI_PATH} task TASK-99 --plain`.cwd(testDir).nothrow().quiet();
+		const edit = await $`bun ${CLI_PATH} task edit TASK-99 --title ${"Must remain absent"} --plain`
+			.cwd(testDir)
+			.nothrow()
+			.quiet();
+
+		for (const result of [view, shorthand, edit]) {
+			expect(result.exitCode).not.toBe(0);
+			expect(`${result.stdout.toString()}${result.stderr.toString()}`).toContain("Task TASK-99 not found.");
+		}
+		expect(await core.filesystem.loadTask("TASK-99")).toBeNull();
+	});
+
+	it("edits a working-copy task without loading branches", async () => {
+		const tripwires = installCrossBranchTripwires(core);
+		try {
+			const updated = await core.updateTaskFromInput(parentTask.id, { title: "Renamed locally" }, false);
+
+			expect(updated.title).toBe("Renamed locally");
+			expect((await core.filesystem.listTasks()).find((task) => task.id === parentTask.id)?.title).toBe(
+				"Renamed locally",
+			);
+			tripwires.expectUntouched();
+		} finally {
+			tripwires.restore();
+		}
+	});
+
+	it("fails closed on a working-copy active/completed identity collision without loading branches", async () => {
+		await Bun.write(
+			join(core.filesystem.completedDir, "task-01 - Completed-collision.md"),
+			serializeTask({
+				...parentTask,
+				id: "TASK-01",
+				title: "Completed collision",
+				status: "Done",
+			}),
+		);
+		const tripwires = installCrossBranchTripwires(core);
+		try {
+			await expect(core.loadTaskById(parentTask.id, { includeCrossBranch: false })).rejects.toBeInstanceOf(
+				AmbiguousTaskIdError,
+			);
+			await expect(
+				core.getTaskWithSubtasks(parentTask.id, undefined, { includeCrossBranch: false }),
+			).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+			await expect(core.updateTaskFromInput(parentTask.id, { title: "Must not change" }, false)).rejects.toBeInstanceOf(
+				AmbiguousTaskIdError,
+			);
+			tripwires.expectUntouched();
+		} finally {
+			tripwires.restore();
+		}
+
+		expect((await core.filesystem.listTasks()).find((task) => task.id === parentTask.id)?.title).toBe(parentTask.title);
+	});
+});

--- a/src/test/parent-id-normalization.test.ts
+++ b/src/test/parent-id-normalization.test.ts
@@ -74,9 +74,6 @@ describe("CLI parent task id normalization", () => {
 		await $`git checkout main`.cwd(TEST_DIR).quiet();
 		await core.gitOps.fetch();
 
-		const viewResult = await $`bun run ${CLI_PATH} task view task-1 --plain`.cwd(TEST_DIR).quiet();
-		expect(viewResult.stdout.toString()).toContain("Cross-branch parent");
-
 		const createResult = await $`bun run ${CLI_PATH} task create Child --parent task-1`.cwd(TEST_DIR).quiet();
 
 		expect(createResult.stdout.toString()).toContain("Created task TASK-1.1");

--- a/src/test/parent-id-normalization.test.ts
+++ b/src/test/parent-id-normalization.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../index.ts";
 import type { Task } from "../types/index.ts";
+import { LOCAL_TASK_LOOKUP_HINT } from "../utils/task-path.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
 
@@ -46,7 +47,9 @@ describe("CLI parent task id normalization", () => {
 		expect(child?.parentTaskId).toBe("TASK-4");
 	});
 
-	it("accepts parent task IDs from other active branches", async () => {
+	// A parent that only exists on another branch cannot be shown by any task command, so accepting
+	// it would create a child whose parent the CLI reports as missing.
+	it("rejects parent task IDs that exist only on another branch", async () => {
 		const core = new Core(TEST_DIR);
 		await initializeTestProject(core, "Cross Branch Parent Test", true);
 
@@ -74,11 +77,13 @@ describe("CLI parent task id normalization", () => {
 		await $`git checkout main`.cwd(TEST_DIR).quiet();
 		await core.gitOps.fetch();
 
-		const createResult = await $`bun run ${CLI_PATH} task create Child --parent task-1`.cwd(TEST_DIR).quiet();
+		const createResult = await $`bun run ${CLI_PATH} task create Child --parent task-1`.cwd(TEST_DIR).nothrow().quiet();
 
-		expect(createResult.stdout.toString()).toContain("Created task TASK-1.1");
-		const child = await core.filesystem.loadTask("task-1.1");
-		expect(child?.parentTaskId).toBe("TASK-1");
+		expect(createResult.exitCode).toBe(1);
+		expect(createResult.stderr.toString()).toContain("Parent task TASK-1 not found.");
+		expect(createResult.stderr.toString()).toContain(LOCAL_TASK_LOOKUP_HINT);
+		expect(await core.filesystem.loadTask("task-1.1")).toBeNull();
+		expect(await core.filesystem.listTasks()).toHaveLength(0);
 	});
 
 	it("rejects milestone IDs as parent task IDs when creating subtasks", async () => {

--- a/src/test/server-tasks-spa-fallback.test.ts
+++ b/src/test/server-tasks-spa-fallback.test.ts
@@ -660,6 +660,35 @@ describe("BacklogServer task SPA fallback", () => {
 		expect(((await response.json()) as Task).title).toBe("Local legacy task");
 	});
 
+	it("serves the default task list from the content store instead of re-reading the working copy", async () => {
+		await restartWithActiveBranchCollision("BACK-001", true);
+		// Warm the store so the counted requests measure steady-state list serving.
+		expect((await request("/api/tasks")).status).toBe(200);
+
+		const serverFilesystem = (server as unknown as { core: { filesystem: FileSystem } }).core.filesystem;
+		const originalListTasks = serverFilesystem.listTasks.bind(serverFilesystem);
+		let workingCopyScans = 0;
+		serverFilesystem.listTasks = async (...args) => {
+			workingCopyScans += 1;
+			return await originalListTasks(...args);
+		};
+
+		try {
+			const defaultList = await request("/api/tasks");
+			expect(defaultList.status).toBe(200);
+			expect(((await defaultList.json()) as Task[]).map((task) => task.id)).toContain("BACK-099");
+			expect(workingCopyScans).toBe(0);
+
+			// The explicit local view still costs a working-copy read, which is why it must not be the default.
+			const localList = await request("/api/tasks?crossBranch=false");
+			expect(localList.status).toBe(200);
+			expect(((await localList.json()) as Task[]).map((task) => task.id)).not.toContain("BACK-099");
+			expect(workingCopyScans).toBeGreaterThan(0);
+		} finally {
+			serverFilesystem.listTasks = originalListTasks;
+		}
+	});
+
 	it("reopens the local task after a browser save with an inherited active branch", async () => {
 		await restartWithActiveBranchCollision("BACK-1");
 

--- a/src/utils/task-builders.ts
+++ b/src/utils/task-builders.ts
@@ -35,13 +35,17 @@ function resolveUniqueDependency(dependency: string, matches: Task[]): string | 
 }
 
 /**
- * Validate that all dependencies exist in the current project.
+ * Validate that all dependencies exist in the working copy.
  *
  * Inputs are matched by task identity, so bare numeric IDs resolve under any configured prefix, and
  * identity fails closed exactly as it does for the task a command targets. That takes two checks,
  * mirroring the identity index itself: the corpus answers whether the input names more than one
- * identity, and `Core.getTask` answers whether that identity is claimed by more than one file -
- * which the corpus cannot, because it keeps one entry per ID.
+ * identity, and the working-copy lookup answers whether that identity is claimed by more than one
+ * file - which the corpus cannot, because it keeps one entry per ID.
+ *
+ * Resolution stays local for the same reason task reads do: a dependency validated against another
+ * branch would name a task no task command can show, and reaching for branches here would put a
+ * remote fetch inside the task lock.
  *
  * Returns the matched canonical IDs, deduplicated, plus the inputs that matched nothing.
  */
@@ -54,9 +58,10 @@ export async function validateDependencies(
 	if (dependencies.length === 0) {
 		return { valid, invalid };
 	}
-	// Task dependencies should honor cross-branch visibility when enabled in config,
-	// while draft dependencies remain local-only.
-	const [tasks, drafts] = await Promise.all([core.queryTasks(), core.filesystem.listDrafts()]);
+	const [tasks, drafts] = await Promise.all([
+		core.queryTasks({ includeCrossBranch: false }),
+		core.filesystem.listDrafts(),
+	]);
 	const known = [...tasks, ...drafts];
 	for (const dependency of dependencies) {
 		const resolved = resolveUniqueDependency(
@@ -67,9 +72,9 @@ export async function validateDependencies(
 			invalid.push(dependency);
 			continue;
 		}
-		// Called for its ambiguity check: it raises AmbiguousTaskIdError when several files claim
-		// this ID. Drafts resolve to null here and keep their own local-only lookup.
-		await core.getTask(resolved);
+		// Called for its ambiguity check: it raises AmbiguousTaskIdError when several working-copy
+		// files claim this ID. Drafts resolve to null here and keep their own local-only lookup.
+		await core.loadTaskById(resolved, { includeCrossBranch: false });
 		// Equivalent spellings of one task (1 and BACK-1) must not persist twice.
 		if (!valid.some((existing) => taskIdsEqual(existing, resolved))) {
 			valid.push(resolved);

--- a/src/utils/task-id-search.ts
+++ b/src/utils/task-id-search.ts
@@ -1,0 +1,33 @@
+const PREFIX_PATTERN = /^[a-zA-Z]+-/i;
+
+function parseTaskIdSegments(value: string): number[] | null {
+	const withoutPrefix = value.replace(PREFIX_PATTERN, "").toLowerCase();
+	if (!/^[0-9]+(?:\.[0-9]+)*$/.test(withoutPrefix)) {
+		return null;
+	}
+	return withoutPrefix.split(".").map((segment) => Number.parseInt(segment, 10));
+}
+
+/** Build the equivalent ID spellings shared by every task search index. */
+export function createTaskIdSearchVariants(id: string): string[] {
+	const lowerId = id.toLowerCase();
+	const segments = parseTaskIdSegments(id);
+	const prefix = id.match(PREFIX_PATTERN)?.[0] ?? "task-";
+
+	if (!segments) {
+		return id === lowerId ? [id] : [id, lowerId];
+	}
+
+	const canonicalSuffix = segments.join(".");
+	const variants = new Set<string>([
+		id,
+		lowerId,
+		`${prefix}${canonicalSuffix}`,
+		`${prefix.toLowerCase()}${canonicalSuffix}`,
+		canonicalSuffix,
+	]);
+	for (const segment of segments) {
+		variants.add(String(segment));
+	}
+	return Array.from(variants);
+}

--- a/src/utils/task-path.ts
+++ b/src/utils/task-path.ts
@@ -39,6 +39,16 @@ export function normalizeTaskIdentity(task: Task): Task {
 	};
 }
 
+/**
+ * Appended to a task not-found message produced by a working-copy lookup.
+ *
+ * Task lookups deliberately stay local, so a miss is not proof the ID is unused. The hint is a
+ * fixed sentence rather than a branch scan, because scanning branches is the cost local lookups
+ * exist to avoid.
+ */
+export const LOCAL_TASK_LOOKUP_HINT =
+	"Task lookups read only the local working copy; use 'backlog browser' to see tasks from other branches.";
+
 export class AmbiguousTaskIdError extends AmbiguousIdError {
 	readonly taskId: string;
 

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -14,6 +14,7 @@ import {
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "./modified-files.ts";
 import { normalizePriorityValue } from "./priority-config.ts";
 import { getTaskReadiness, type ReadinessGraph } from "./readiness.ts";
+import { createTaskIdSearchVariants } from "./task-id-search.ts";
 import { matchesTaskTypeFilter } from "./task-type-config.ts";
 
 export type LabelMatchMode = "any" | "all";
@@ -55,59 +56,6 @@ export interface TaskSearchIndex {
 	search(options: TaskSearchOptions): Task[];
 }
 
-// Regex pattern to match any prefix (letters followed by dash)
-const PREFIX_PATTERN = /^[a-zA-Z]+-/i;
-
-/**
- * Extract prefix from an ID if present (e.g., "task-" from "task-123")
- */
-function extractPrefix(id: string): string | null {
-	const match = id.match(PREFIX_PATTERN);
-	return match ? match[0] : null;
-}
-
-/**
- * Strip any prefix from an ID (e.g., "task-123" -> "123", "JIRA-456" -> "456")
- */
-function stripPrefix(id: string): string {
-	return id.replace(PREFIX_PATTERN, "");
-}
-
-function createTaskIdVariants(id: string): string[] {
-	const segments = parseTaskIdSegments(id);
-	const prefix = extractPrefix(id) ?? "task-"; // Default to task- if no prefix
-	const lowerId = id.toLowerCase();
-
-	if (!segments) {
-		// Non-numeric ID - just return the ID and its lowercase variant
-		return id === lowerId ? [id] : [id, lowerId];
-	}
-
-	const canonicalSuffix = segments.join(".");
-	const variants = new Set<string>();
-
-	// Add original ID and lowercase variant
-	variants.add(id);
-	variants.add(lowerId);
-
-	// Add with extracted/default prefix
-	variants.add(`${prefix}${canonicalSuffix}`);
-	variants.add(`${prefix.toLowerCase()}${canonicalSuffix}`);
-
-	// Add just the numeric part
-	variants.add(canonicalSuffix);
-
-	return Array.from(variants);
-}
-
-function parseTaskIdSegments(value: string): number[] | null {
-	const withoutPrefix = stripPrefix(value);
-	if (!/^[0-9]+(?:\.[0-9]+)*$/.test(withoutPrefix)) {
-		return null;
-	}
-	return withoutPrefix.split(".").map((segment) => Number.parseInt(segment, 10));
-}
-
 interface SearchableTask {
 	task: Task;
 	title: string;
@@ -144,8 +92,8 @@ function buildSearchableTask(task: Task): SearchableTask {
 		title: task.title,
 		bodyText: bodyParts.join(" "),
 		id: task.id,
-		idVariants: createTaskIdVariants(task.id),
-		dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdVariants(dependency)),
+		idVariants: createTaskIdSearchVariants(task.id),
+		dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdSearchVariants(dependency)),
 		statusLower: (task.status || "").toLowerCase(),
 		priorityLower: normalizePriorityValue(task.priority),
 		labelsLower: (task.labels || []).map((label) => label.toLowerCase()),


### PR DESCRIPTION
## What changed

- Make `queryTasks({ includeCrossBranch: false })` load and search working-copy tasks before initializing the cross-branch ContentStore.
- Route CLI `task view`, task shorthand, `task edit`, and task-list parent resolution through working-copy active/completed identity resolution.
- Resolve `task create --parent`, `task list --parent`, and dependency validation from the same working-copy corpus, so every task command answers the same way about the same ID.
- Preserve local ambiguity checks and the atomic in-lock edit reread while removing repeated branch scans and fetches.
- Remove the interactive task list's redundant full-corpus load.
- Share padded/dotted task-ID search variants between local and global search indexes.
- Keep the browser's `/api/tasks` default on the cross-branch ContentStore instead of re-reading the working copy per request.

## Behavior changes

**CLI task reads are local-only by design.** A task that exists only on another branch is no longer viewable or editable from the CLI; the browser, board, and MCP still see it. Task-ID allocation still consults other branches, so IDs stay collision-safe.

A local miss now says which corpus was searched, without scanning branches to produce the hint:

```
Task BACK-12 not found. Task lookups read only the local working copy; use 'backlog browser' to see tasks from other branches.
```

The same sentence is appended to `task view`, the task shorthand, `task edit`, `task list --parent`, `task create --parent`, and the missing-dependency error.

**Parent and dependency validation are now local and fail-closed.**

- `task create --parent` resolves against the working copy (active + completed) instead of the cross-branch corpus. Previously it accepted a parent that existed only on another branch, while `task list --parent` and `task view` reported that same ID as missing, and the created child's parent was unviewable.
- `task list --parent` now uses that same lookup, which also means a completed parent is no longer reported as missing by the filter alone while `task view` and `task create --parent` accept it. The filter reads the working copy once instead of twice.
- Dependency validation (`--dep` / `--depends-on` on create and edit) uses the same working-copy lookup. A dependency can no longer reference a task that exists only on another branch. This also removes a full cross-branch load and remote fetch from inside the task lock.
- Both keep the fail-closed local ambiguity check: an ID claimed by more than one working-copy file raises `AmbiguousTaskIdError` and changes nothing.
- These two validations live in Core, so the rule is the same for the CLI, MCP, and the browser. Two tests that pinned the old cross-branch acceptance were inverted.

**Unused parameters removed.** `archiveTask`, `completeTask`, `demoteTask`, and `editTaskOrDraft` gained task-read options that no caller passed; they are gone. Archive, complete, and demote keep their current cross-branch reads unchanged.

## Root cause

v1.49.0 routed local single-task reads and mutation resolution through the full cross-branch ContentStore. v1.50.0 correctly added an in-lock reread, but that reread repeated the same full refresh. A normal edit therefore performed up to three corpus scans and remote fetch attempts. `includeCrossBranch: false` only filtered results after the expensive load.

Backlog task locks were not the delay: task locks fail immediately on contention. The expensive work was unbounded fetch plus branch indexing.

## Impact

Same-checkout timings:

| Command | v1.50 | This branch |
|---|---:|---:|
| `task view BACK-623 --plain` | 4.42s | 0.85s |
| `task list --plain` | 4.15s | 0.21s |
| No-op `task edit` | 12.19s | 0.42s |

The old commands attempted remote fetches; the fixed commands did not. Cross-branch behavior remains the default for browser/MCP/global Core reads.

## Validation

- `tsc --noEmit`
- Biome check across 371 files
- Production build
- 178 focused/control tests covering Git-operation tripwires, CLI branch-only behavior, list/search, custom IDs, task views, Core identity behavior, atomic locks, board/worktree refresh, and cross-branch ContentStore preservation
- A broader ContentStore batch hit unrelated filesystem-watcher timeouts in the temporary worktree; its relevant cross-branch preservation invariant passed when run independently.

### Fix round

- Full suite: **2203 pass, 6 skip, 0 fail** across 229 files (`bun run test`), plus `tsc --noEmit`, `bun run check .` (371 files), and `bun run build`.
- New pins: create-`--parent` and dependency validation resolve locally under the fetch/branch tripwire; both fail closed on a working-copy active/completed identity collision; the parent filter, `task view`, and `task create --parent` agree about a completed parent and all fail closed on a duplicated ID; the CLI reports the working-copy hint for view, shorthand, edit, `--parent` on list and create, and missing dependencies; a branch-only task cannot become a parent or a dependency and leaves no file behind.
- `/api/tasks` with no query parameter is served from the ContentStore (zero working-copy scans, branch-only task present), while `?crossBranch=false` still reads the working copy; server watch, broadcast, and search suites pass unchanged.
- No change to task-ID allocation, which still consults other branches on purpose.
