### PR TITLE
BACK-622 - Return acceptance criteria progress in task JSON outputs

### DIFF
--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -105,9 +105,9 @@ Each successful response is one pretty-printed JSON document followed by a newli
 | `task view <id> --json` and `task <id> --json` | `{ "schemaVersion": 1, "kind": "task-view", "task": {...} }` |
 | `search [query] --json` | `{ "schemaVersion": 1, "kind": "search", "results": [...] }` |
 
-Task list and task search results use these compact fields: `id`, `title`, `status`, `type`, `priority`, `assignees`, `reporter`, `labels`, `milestone`, `parentTaskId`, `ordinal`, `createdAt`, and `updatedAt`.
+Task list and task search results use these compact fields: `id`, `title`, `status`, `type`, `priority`, `assignees`, `reporter`, `labels`, `milestone`, `parentTaskId`, `acceptanceCriteriaCompleted`, `acceptanceCriteriaCount`, `ordinal`, `createdAt`, and `updatedAt`. `acceptanceCriteriaCompleted` is the number of checked acceptance criteria and `acceptanceCriteriaCount` is the total; both are `0` when the task has no acceptance criteria.
 
-Task view adds `path`, `description`, `dependencies`, `references`, `documentation`, `modifiedFiles`, `subtasks`, `acceptanceCriteria`, `definitionOfDone`, `implementationPlan`, `implementationNotes`, `comments`, and `finalSummary`. `path` is relative to the project root. Checklist entries contain `index`, `text`, and `checked`. Comment entries contain `index`, `body`, `createdAt`, and `author`.
+Task view includes the same progress counts alongside the full checklist and adds `path`, `description`, `dependencies`, `references`, `documentation`, `modifiedFiles`, `subtasks`, `acceptanceCriteria`, `definitionOfDone`, `implementationPlan`, `implementationNotes`, `comments`, and `finalSummary`. `path` is relative to the project root. Checklist entries contain `index`, `text`, and `checked`. Comment entries contain `index`, `body`, `createdAt`, and `author`.
 
 Search keeps relevance order and discriminates every result with `type` and `data`. Task data uses the compact task fields. Document data contains `id`, `title`, `type`, `path`, `tags`, `createdAt`, and `updatedAt`. Decision data contains `id`, `title`, `status`, and `date`. Search scores are not part of the version 1 public contract.
 

--- a/backlog/tasks/back-622 - Return-acceptance-criteria-progress-in-task-JSON-outputs.md
+++ b/backlog/tasks/back-622 - Return-acceptance-criteria-progress-in-task-JSON-outputs.md
@@ -1,12 +1,17 @@
 ---
 id: BACK-622
 title: Return acceptance criteria progress in task JSON outputs
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-09 21:52'
+updated_date: '2026-08-10 05:30'
 labels: []
 dependencies: []
+modified_files:
+  - CLI-INSTRUCTIONS.md
+  - src/formatters/json-output.ts
+  - src/test/cli-json-output.test.ts
 ordinal: 260000
 ---
 
@@ -18,16 +23,38 @@ Machine-readable task summaries currently omit acceptance-criteria progress, so 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Task list JSON includes completed and total acceptance-criteria counts for every task summary
-- [ ] #2 Task detail JSON includes the same acceptance-criteria counts alongside the full checklist
-- [ ] #3 Task results in search JSON use the same acceptance-criteria count fields as task list output
-- [ ] #4 Tasks without acceptance criteria return zero for both counts
-- [ ] #5 Focused automated tests cover complete, partial, and empty acceptance-criteria progress
+- [x] #1 Task list JSON includes completed and total acceptance-criteria counts for every task summary
+- [x] #2 Task detail JSON includes the same acceptance-criteria counts alongside the full checklist
+- [x] #3 Task results in search JSON use the same acceptance-criteria count fields as task list output
+- [x] #4 Tasks without acceptance criteria return zero for both counts
+- [x] #5 Focused automated tests cover complete, partial, and empty acceptance-criteria progress
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Extend the shared task summary JSON formatter with additive schema-v1 fields `acceptanceCriteriaCompleted` and `acceptanceCriteriaCount`, deriving both from structured checklist items and defaulting to 0/0.
+2. Update the stable JSON contract documentation so list, task search, and detail semantics are explicit.
+3. Add focused CLI integration assertions proving complete, partial, and empty progress across task list, task detail/shorthand, and task search; then run the focused JSON/guidance tests, TypeScript, Biome, and diff checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented both counts in the shared task-summary JSON serializer, which is reused by list, detail, and task search. Kept schemaVersion 1 because the fields are backward-compatible additions and documented their stable semantics, including 0/0 for empty checklists.
+
+Validation: `bun test --timeout=10000 src/test/cli-json-output.test.ts src/test/cli-guidance.test.ts` passed 30 tests with 372 assertions; `bunx tsc --noEmit`, `bun run check .`, and `git diff --check` passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added `acceptanceCriteriaCompleted` and `acceptanceCriteriaCount` to every canonical task JSON summary and task detail while preserving the full checklist. Documented the additive schema-v1 contract and verified complete, partial, and empty progress across list, view/shorthand, and search with 30 passing focused tests, TypeScript, Biome, and diff checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/formatters/json-output.ts
+++ b/src/formatters/json-output.ts
@@ -14,6 +14,8 @@ type TaskSummaryJson = {
 	labels: string[];
 	milestone: string | null;
 	parentTaskId: string | null;
+	acceptanceCriteriaCompleted: number;
+	acceptanceCriteriaCount: number;
 	ordinal: number | null;
 	createdAt: string | null;
 	updatedAt: string | null;
@@ -93,6 +95,7 @@ function normalizePublicDate(value: string | undefined): string | null {
 }
 
 function toTaskSummaryJson(task: Task): TaskSummaryJson {
+	const acceptanceCriteria = task.acceptanceCriteriaItems ?? [];
 	return {
 		id: task.id,
 		title: task.title,
@@ -104,6 +107,8 @@ function toTaskSummaryJson(task: Task): TaskSummaryJson {
 		labels: task.labels ?? [],
 		milestone: nullable(task.milestone),
 		parentTaskId: nullable(task.parentTaskId),
+		acceptanceCriteriaCompleted: acceptanceCriteria.filter((criterion) => criterion.checked).length,
+		acceptanceCriteriaCount: acceptanceCriteria.length,
 		ordinal: task.ordinal ?? null,
 		createdAt: normalizePublicDate(task.createdDate),
 		updatedAt: normalizePublicDate(task.updatedDate),

--- a/src/test/cli-json-output.test.ts
+++ b/src/test/cli-json-output.test.ts
@@ -102,6 +102,8 @@ describe("CLI JSON output", () => {
 					labels: ["cli", "json"],
 					milestone: "m-1",
 					parentTaskId: null,
+					acceptanceCriteriaCompleted: 1,
+					acceptanceCriteriaCount: 1,
 					ordinal: 1000,
 					createdAt: "2026-07-14T09:30:00Z",
 					updatedAt: "2026-07-14T10:45:00Z",
@@ -148,6 +150,8 @@ describe("CLI JSON output", () => {
 			expect(output.task.path).toMatch(/^backlog\/tasks\/task-1 - JSON-task\.md$/);
 			expect(output.task.description).toBe("Machine-readable output");
 			expect(output.task.dependencies).toEqual(["TASK-2"]);
+			expect(output.task.acceptanceCriteriaCompleted).toBe(1);
+			expect(output.task.acceptanceCriteriaCount).toBe(1);
 			expect(output.task.acceptanceCriteria).toEqual([{ index: 1, text: "Produces JSON", checked: true }]);
 			expect(output.task.definitionOfDone).toEqual([{ index: 1, text: "Tests pass", checked: false }]);
 			expect(output.task.comments).toEqual([
@@ -196,6 +200,8 @@ describe("CLI JSON output", () => {
 		expect(output.kind).toBe("search");
 		expect(output.results.map((entry: { type: string }) => entry.type)).toEqual(["task", "document", "decision"]);
 		expect(output.results[0].data.id).toBe("TASK-1");
+		expect(output.results[0].data.acceptanceCriteriaCompleted).toBe(1);
+		expect(output.results[0].data.acceptanceCriteriaCount).toBe(1);
 		expect(output.results[1].data).toEqual({
 			id: "doc-1",
 			title: "JSON guide",
@@ -214,6 +220,74 @@ describe("CLI JSON output", () => {
 		for (const entry of output.results) {
 			expect(entry.score).toBeUndefined();
 		}
+	});
+
+	it("returns complete, partial, and empty acceptance-criteria progress across task JSON surfaces", async () => {
+		const core = new Core(TEST_DIR);
+		await core.createTask(
+			{
+				id: "task-2",
+				title: "Partial JSON task",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2026-07-15 09:00",
+				labels: [],
+				dependencies: [],
+				acceptanceCriteriaItems: [
+					{ index: 1, text: "Finished", checked: true },
+					{ index: 2, text: "Pending", checked: false },
+				],
+			},
+			false,
+		);
+		await core.createTask(
+			{
+				id: "task-3",
+				title: "Empty JSON task",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2026-07-15 10:00",
+				labels: [],
+				dependencies: [],
+			},
+			false,
+		);
+
+		const expectedProgress = {
+			"TASK-1": { acceptanceCriteriaCompleted: 1, acceptanceCriteriaCount: 1 },
+			"TASK-2": { acceptanceCriteriaCompleted: 1, acceptanceCriteriaCount: 2 },
+			"TASK-3": { acceptanceCriteriaCompleted: 0, acceptanceCriteriaCount: 0 },
+		};
+		const progressById = (tasks: Array<Record<string, unknown>>) =>
+			Object.fromEntries(
+				tasks.map((task) => [
+					task.id,
+					{
+						acceptanceCriteriaCompleted: task.acceptanceCriteriaCompleted,
+						acceptanceCriteriaCount: task.acceptanceCriteriaCount,
+					},
+				]),
+			);
+
+		const list = await runCli(["task", "list", "--json"]);
+		expect(list.exitCode).toBe(0);
+		expect(progressById(JSON.parse(list.stdout.toString()).tasks)).toEqual(expectedProgress);
+
+		for (const id of ["1", "2", "3"]) {
+			const view = await runCli(["task", "view", id, "--json"]);
+			expect(view.exitCode).toBe(0);
+			const task = JSON.parse(view.stdout.toString()).task;
+			expect(progressById([task])).toEqual({ [task.id]: expectedProgress[task.id as keyof typeof expectedProgress] });
+		}
+
+		const search = await runCli(["search", "JSON task", "--json"]);
+		expect(search.exitCode).toBe(0);
+		const taskResults = JSON.parse(search.stdout.toString()).results.filter(
+			(result: { type: string }) => result.type === "task",
+		);
+		expect(progressById(taskResults.map((result: { data: Record<string, unknown> }) => result.data))).toEqual(
+			expectedProgress,
+		);
 	});
 
 	it("uses the configured project-relative docs directory in search paths", async () => {


### PR DESCRIPTION
## Summary

- add completed and total acceptance-criteria counts to canonical task JSON summaries
- expose the same fields in list, search, view, and shorthand output with 0/0 for empty criteria
- document the additive schema-v1 fields

## Testing

- bun test --timeout=10000 src/test/cli-json-output.test.ts src/test/cli-guidance.test.ts (30 passed)
- bunx tsc --noEmit
- bun run check .
- git diff --check