### PR TITLE
BACK-424 - Support multiple status filters in Web task lists

### DIFF
--- a/backlog/tasks/back-424 - Support-multiple-status-filters-in-Web-task-lists.md
+++ b/backlog/tasks/back-424 - Support-multiple-status-filters-in-Web-task-lists.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-424
 title: Support multiple status filters in Web task lists
-status: To Do
+status: Done
 assignee:
-  - '@alex-agent'
+  - '@codex'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-08-10 05:35'
 labels:
   - web-ui
   - filters
@@ -23,15 +24,37 @@ Track GitHub issue #502: allow filtering Web UI task lists by more than one stat
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The Web task list can filter by multiple selected statuses.
-- [ ] #2 Filter state is reflected in the URL or existing persisted filter state.
-- [ ] #3 Clear/reset behavior returns the list to the unfiltered status set.
-- [ ] #4 Tests cover multi-status selection and reset.
+- [x] #1 The Web task list can filter by multiple selected statuses.
+- [x] #2 Filter state is reflected in the URL or existing persisted filter state.
+- [x] #3 Clear/reset behavior returns the list to the unfiltered status set.
+- [x] #4 Tests cover multi-status selection and reset.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Represent included Web task-list statuses as an ordered array parsed from repeated status URL parameters, preserving the existing single-status URL shape.
+2. Reuse the existing checkbox filter control and array-capable search API, keeping include/exclude/priority/label/milestone URL synchronization and reset behavior consistent.
+3. Add focused component tests for legacy single-status URLs, multi-status selection/search/URL persistence, terminal cleanup visibility, and clearing filters; then run scoped and repository checks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the scalar included-status filter with an ordered array and reused the existing checkbox dropdown. Selected statuses are serialized as repeated status query parameters; a single selection keeps the existing single-parameter URL. The Web search client and server already accept status arrays, so no new API surface was needed.
+
+Validation: 48 scoped component/search/server tests passed; bunx tsc --noEmit, bun run check . (369 files), and bun run build passed. Rendered QA at 1280x800 selected To Do + In Progress, produced ?status=To+Do&status=In+Progress, and showed 38 matching rows with no other statuses; Clear filters restored all 145 rows. The status menu remained usable at 390x844 with the sidebar collapsed. Browser console had no warnings or errors.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added multi-select status filtering to the Web task list with repeated URL parameters and legacy single-status URL compatibility. Verified multi-selection, API requests, reset behavior, terminal cleanup visibility, responsive interaction, TypeScript, formatting, build, and 48 scoped tests.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -401,6 +401,34 @@ describe("TaskList labels filter menu", () => {
 		expect(container.textContent).not.toContain("Done hidden");
 	});
 
+	it("canonicalizes case-insensitive status deep links before toggling them", async () => {
+		const doneTask = createTask({ id: "task-101", title: "Done task", status: "Done" });
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () => [{ type: "task", score: 0, task: doneTask }],
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(["/?status=done&status=DONE"], {
+			tasks: [doneTask],
+			availableStatuses: ["To Do", "In Progress", "Done"],
+		});
+		await waitFor(() => fetchCalls.length === 1 && getRenderedTaskIds(container).join(",") === "task-101");
+
+		expect(new URL(fetchCalls[0] ?? "", "http://localhost").searchParams.getAll("status")).toEqual(["Done"]);
+		expect(getStatusButton(container).textContent).toContain("Done");
+
+		await selectStatus(container, "Done");
+		await waitFor(() => getStatusButton(container).textContent?.includes("All") === true);
+		expect(new URLSearchParams(getLocationSearch(container)).getAll("status")).toEqual([]);
+	});
+
 	it("clears all selected statuses and restores the unfiltered task list", async () => {
 		const filteredTasks = [
 			createTask({ id: "task-101", title: "Todo task", status: "To Do" }),

--- a/src/test/web-task-list-labels-menu.test.tsx
+++ b/src/test/web-task-list-labels-menu.test.tsx
@@ -116,15 +116,6 @@ const getSelectByFirstOption = (container: HTMLElement, firstOptionText: string)
 	return select as HTMLSelectElement;
 };
 
-const setSelectValue = async (select: HTMLSelectElement, value: string) => {
-	await act(async () => {
-		const valueSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, "value")?.set;
-		valueSetter?.call(select, value);
-		select.dispatchEvent(new window.Event("change", { bubbles: true }));
-		await Promise.resolve();
-	});
-};
-
 const waitFor = async (predicate: () => boolean) => {
 	for (let attempt = 0; attempt < 10; attempt += 1) {
 		if (predicate()) {
@@ -142,10 +133,29 @@ const getLabelsButton = (container: HTMLElement): HTMLButtonElement => {
 	return button as HTMLButtonElement;
 };
 
+const getStatusButton = (container: HTMLElement): HTMLButtonElement => {
+	const button = container.querySelector("button[aria-controls='task-list-status-menu']");
+	expect(button).toBeTruthy();
+	return button as HTMLButtonElement;
+};
+
 const getExcludeStatusButton = (container: HTMLElement): HTMLButtonElement => {
 	const button = container.querySelector("button[aria-controls='task-list-exclude-status-menu']");
 	expect(button).toBeTruthy();
 	return button as HTMLButtonElement;
+};
+
+const selectStatus = async (container: HTMLElement, status: string) => {
+	const menu = container.querySelector("#task-list-status-menu");
+	if (!menu) {
+		await clickElement(getStatusButton(container));
+	}
+	const statusLabel = Array.from(container.querySelectorAll("#task-list-status-menu label")).find(
+		(label) => label.textContent?.trim() === status,
+	);
+	const checkbox = statusLabel?.querySelector("input");
+	expect(checkbox).toBeTruthy();
+	await clickElement(checkbox as HTMLInputElement);
 };
 
 const getLabelOptions = (container: HTMLElement): string[] =>
@@ -326,6 +336,111 @@ describe("TaskList labels filter menu", () => {
 		expect(container.querySelector("#task-list-labels-menu")).toBeNull();
 	});
 
+	it("preserves legacy single-status URLs and sends one search status", async () => {
+		const progressTask = createTask({ id: "task-201", title: "Progress task", status: "In Progress" });
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () => [{ type: "task", score: 0, task: progressTask }],
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(["/?status=In%20Progress"], {
+			tasks: [progressTask, createTask({ id: "task-202", title: "Todo task", status: "To Do" })],
+			availableStatuses: ["To Do", "In Progress", "Done"],
+		});
+		await waitFor(() => fetchCalls.length === 1 && getRenderedTaskIds(container).join(",") === "task-201");
+
+		expect(new URL(fetchCalls[0] ?? "", "http://localhost").searchParams.getAll("status")).toEqual([
+			"In Progress",
+		]);
+		expect(new URLSearchParams(getLocationSearch(container)).getAll("status")).toEqual(["In Progress"]);
+		expect(getStatusButton(container).textContent).toContain("In Progress");
+	});
+
+	it("selects multiple statuses and persists each status in search and URL state", async () => {
+		const filteredTasks = [
+			createTask({ id: "task-101", title: "Todo visible", status: "To Do" }),
+			createTask({ id: "task-102", title: "Progress visible", status: "In Progress" }),
+			createTask({ id: "task-103", title: "Done hidden", status: "Done" }),
+		];
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			const statuses = new URL(url, "http://localhost").searchParams.getAll("status");
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () =>
+					filteredTasks
+						.filter((task) => statuses.includes(task.status))
+						.map((task) => ({ type: "task", score: 0, task })),
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(undefined, {
+			tasks: filteredTasks,
+			availableStatuses: ["To Do", "In Progress", "Done"],
+		});
+
+		await selectStatus(container, "To Do");
+		await selectStatus(container, "In Progress");
+		await waitFor(() => getRenderedTaskIds(container).join(",") === "task-102,task-101");
+
+		const latestSearch = new URL(fetchCalls.at(-1) ?? "", "http://localhost").searchParams;
+		expect(latestSearch.getAll("status")).toEqual(["To Do", "In Progress"]);
+		expect(new URLSearchParams(getLocationSearch(container)).getAll("status")).toEqual(["To Do", "In Progress"]);
+		expect(getStatusButton(container).textContent).toContain("2 selected");
+		expect(container.textContent).not.toContain("Done hidden");
+	});
+
+	it("clears all selected statuses and restores the unfiltered task list", async () => {
+		const filteredTasks = [
+			createTask({ id: "task-101", title: "Todo task", status: "To Do" }),
+			createTask({ id: "task-102", title: "Progress task", status: "In Progress" }),
+			createTask({ id: "task-103", title: "Done task", status: "Done" }),
+		];
+		const fetchCalls: string[] = [];
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			fetchCalls.push(url);
+			return {
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: async () => [
+					{ type: "task", score: 0, task: filteredTasks[1] },
+					{ type: "task", score: 0, task: filteredTasks[0] },
+				],
+			} as Response;
+		}) as typeof fetch;
+
+		const container = renderTaskList(["/?status=To%20Do&status=In%20Progress"], {
+			tasks: filteredTasks,
+			availableStatuses: ["To Do", "In Progress", "Done"],
+		});
+		await waitFor(() => fetchCalls.length === 1 && getRenderedTaskIds(container).length === 2);
+
+		const clearFiltersButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.trim() === "Clear filters",
+		);
+		expect(clearFiltersButton).toBeTruthy();
+		await clickElement(clearFiltersButton as HTMLButtonElement);
+		await waitFor(() => getRenderedTaskIds(container).length === 3);
+
+		expect(new URLSearchParams(getLocationSearch(container)).getAll("status")).toEqual([]);
+		expect(getStatusButton(container).textContent).toContain("All");
+		expect(getRenderedTaskIds(container)).toEqual(["task-103", "task-102", "task-101"]);
+		expect(fetchCalls).toHaveLength(1);
+	});
+
 	it("persists excluded statuses and sends them to task search", async () => {
 		const filteredTasks = [
 			createTask({ id: "task-101", title: "Todo visible", status: "To Do" }),
@@ -456,7 +571,7 @@ describe("TaskList labels filter menu", () => {
 			tasks: [closedTask],
 			availableStatuses: ["To Do", "Review", "Closed"],
 		});
-		await setSelectValue(getSelectByFirstOption(container, "All statuses"), "Closed");
+		await selectStatus(container, "Closed");
 		await waitFor(() => fetchCalls.length === 1 && (container.textContent ?? "").includes("Clean Up"));
 
 		expect(container.textContent).toContain("Clean Up");
@@ -482,7 +597,7 @@ describe("TaskList labels filter menu", () => {
 			tasks: [reviewTask],
 			availableStatuses: ["To Do", "Review", "Closed"],
 		});
-		await setSelectValue(getSelectByFirstOption(container, "All statuses"), "Review");
+		await selectStatus(container, "Review");
 		await waitFor(() => fetchCalls.length === 1 && (container.textContent ?? "").includes("Review task"));
 
 		expect(container.textContent).not.toContain("Clean Up");

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -75,6 +75,17 @@ function getAssigneeInitials(value: string): string {
 	return `${first.charAt(0)}${second.charAt(0)}`.toUpperCase();
 }
 
+function getStatusFilters(searchParams: URLSearchParams): string[] {
+	return searchParams
+		.getAll("status")
+		.map((status) => status.trim())
+		.filter((status) => status.length > 0);
+}
+
+function areEqualStringArrays(left: string[], right: string[]): boolean {
+	return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
 const TaskList: React.FC<TaskListProps> = ({
 	onEditTask,
 	onNewTask,
@@ -90,7 +101,7 @@ const TaskList: React.FC<TaskListProps> = ({
 	isLoading = false,
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
-	const [statusFilter, setStatusFilter] = useState(() => searchParams.get("status") ?? "");
+	const [statusFilter, setStatusFilter] = useState<string[]>(() => getStatusFilters(searchParams));
 	const initialExcludeStatusParams = useMemo(() => {
 		const statuses = [...searchParams.getAll("excludeStatus")];
 		const statusesCsv = searchParams.get("excludeStatuses");
@@ -123,7 +134,7 @@ const TaskList: React.FC<TaskListProps> = ({
 	const tableBodyScrollRef = useRef<HTMLDivElement | null>(null);
 	const isSyncingTableScrollRef = useRef(false);
 	const statusOptions = availableStatuses.length > 0 ? availableStatuses : [...DEFAULT_STATUSES];
-	const isFilteringTerminalStatus = isTerminalStatus(statusFilter, statusOptions);
+	const isFilteringTerminalStatus = statusFilter.some((status) => isTerminalStatus(status, statusOptions));
 	const milestoneAliasToCanonical = useMemo(() => {
 		const aliasMap = new Map<string, string>();
 		const collectIdAliasKeys = (value: string): string[] => {
@@ -267,12 +278,16 @@ const TaskList: React.FC<TaskListProps> = ({
 		return uniqueMilestones;
 	}, [availableMilestones]);
 	const hasActiveFilters = Boolean(
-		statusFilter || excludedStatusFilter.length > 0 || priorityFilter || labelFilter.length > 0 || milestoneFilter,
+		statusFilter.length > 0 ||
+			excludedStatusFilter.length > 0 ||
+			priorityFilter ||
+			labelFilter.length > 0 ||
+			milestoneFilter,
 	);
 	const totalTasks = sortedBaseTasks.length;
 
 	useEffect(() => {
-		const paramStatus = searchParams.get("status") ?? "";
+		const paramStatuses = getStatusFilters(searchParams);
 		const paramExcludedStatuses = [...searchParams.getAll("excludeStatus")];
 		const excludedStatusesCsv = searchParams.get("excludeStatuses");
 		if (excludedStatusesCsv) {
@@ -291,10 +306,10 @@ const TaskList: React.FC<TaskListProps> = ({
 		}
 		const normalizedLabels = paramLabels.map((label) => label.trim()).filter((label) => label.length > 0);
 
-		if (paramStatus !== statusFilter) {
-			setStatusFilter(paramStatus);
+		if (!areEqualStringArrays(paramStatuses, statusFilter)) {
+			setStatusFilter(paramStatuses);
 		}
-		if (normalizedExcludedStatuses.join("|") !== excludedStatusFilter.join("|")) {
+		if (!areEqualStringArrays(normalizedExcludedStatuses, excludedStatusFilter)) {
 			setExcludedStatusFilter(normalizedExcludedStatuses);
 		}
 		if (!isLoading && rawParamPriority !== paramPriority) {
@@ -316,7 +331,7 @@ const TaskList: React.FC<TaskListProps> = ({
 		if (paramMilestone !== milestoneFilter) {
 			setMilestoneFilter(paramMilestone);
 		}
-		if (normalizedLabels.join("|") !== labelFilter.join("|")) {
+		if (!areEqualStringArrays(normalizedLabels, labelFilter)) {
 			setLabelFilter(normalizedLabels);
 		}
 	}, [availablePriorities, isLoading, searchParams, setSearchParams]);
@@ -344,7 +359,10 @@ const TaskList: React.FC<TaskListProps> = ({
 		};
 
 		const shouldUseApi =
-			Boolean(statusFilter) || excludedStatusFilter.length > 0 || Boolean(priorityFilter) || labelFilter.length > 0;
+			statusFilter.length > 0 ||
+			excludedStatusFilter.length > 0 ||
+			Boolean(priorityFilter) ||
+			labelFilter.length > 0;
 
 		if (!hasActiveFilters) {
 			return;
@@ -362,7 +380,7 @@ const TaskList: React.FC<TaskListProps> = ({
 			try {
 				const results = await apiClient.search({
 					types: ["task"],
-					status: statusFilter || undefined,
+					status: statusFilter.length > 0 ? statusFilter : undefined,
 					excludeStatus: excludedStatusFilter.length > 0 ? excludedStatusFilter : undefined,
 					priority: priorityFilter || undefined,
 					labels: labelFilter.length > 0 ? labelFilter : undefined,
@@ -401,15 +419,17 @@ const TaskList: React.FC<TaskListProps> = ({
 	]);
 
 	const syncUrl = (
-		nextStatus: string,
+		nextStatuses: string[],
 		nextExcludedStatuses: string[],
 		nextPriority: string,
 		nextLabels: string[],
 		nextMilestone: string,
 	) => {
 		const params = new URLSearchParams();
-		if (nextStatus) {
-			params.set("status", nextStatus);
+		for (const status of nextStatuses) {
+			if (status.trim()) {
+				params.append("status", status.trim());
+			}
 		}
 		for (const status of nextExcludedStatuses) {
 			if (status.trim()) {
@@ -430,9 +450,10 @@ const TaskList: React.FC<TaskListProps> = ({
 		setSearchParams(params, { replace: true });
 	};
 
-	const handleStatusChange = (value: string) => {
-		setStatusFilter(value);
-		syncUrl(value, excludedStatusFilter, priorityFilter, labelFilter, milestoneFilter);
+	const handleStatusChange = (next: string[]) => {
+		const normalized = next.map((status) => status.trim()).filter((status) => status.length > 0);
+		setStatusFilter(normalized);
+		syncUrl(normalized, excludedStatusFilter, priorityFilter, labelFilter, milestoneFilter);
 	};
 
 	const handleExcludeStatusChange = (next: string[]) => {
@@ -458,12 +479,12 @@ const TaskList: React.FC<TaskListProps> = ({
 	};
 
 	const handleClearFilters = () => {
-		setStatusFilter("");
+		setStatusFilter([]);
 		setExcludedStatusFilter([]);
 		setPriorityFilter("");
 		setLabelFilter([]);
 		setMilestoneFilter("");
-		syncUrl("", [], "", [], "");
+		syncUrl([], [], "", [], "");
 		setDisplayTasks(sortedBaseTasks);
 		setError(null);
 	};
@@ -671,18 +692,17 @@ const TaskList: React.FC<TaskListProps> = ({
 
 				<div className="flex flex-wrap items-center gap-3 justify-between">
 						<div className="flex flex-wrap items-center gap-3 flex-1 min-w-0">
-							<select
-								value={statusFilter}
-								onChange={(event) => handleStatusChange(event.target.value)}
-								className="min-w-[120px] h-10 py-2 px-3 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 transition-colors duration-200"
-							>
-								<option value="">All statuses</option>
-								{statusOptions.map((status) => (
-									<option key={status} value={status}>
-										{status}
-									</option>
-								))}
-							</select>
+							<LabelFilterDropdown
+								availableLabels={statusOptions}
+								selectedLabels={statusFilter}
+								onChange={handleStatusChange}
+								menuId="task-list-status-menu"
+								label="Status"
+								emptyLabel="All"
+								noOptionsLabel="No statuses"
+								clearLabel="Clear status filter"
+								className="min-w-[180px]"
+							/>
 
 							<LabelFilterDropdown
 								availableLabels={statusOptions}

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -82,6 +82,28 @@ function getStatusFilters(searchParams: URLSearchParams): string[] {
 		.filter((status) => status.length > 0);
 }
 
+function normalizeStatusFilters(statuses: string[], availableStatuses: string[]): string[] {
+	const canonicalStatuses = new Map(
+		availableStatuses
+			.map((status) => status.trim())
+			.filter((status) => status.length > 0)
+			.map((status) => [status.toLowerCase(), status] as const),
+	);
+	const seen = new Set<string>();
+
+	return statuses.reduce<string[]>((normalized, status) => {
+		const trimmed = status.trim();
+		if (!trimmed) return normalized;
+		const canonical = canonicalStatuses.get(trimmed.toLowerCase()) ?? trimmed;
+		const key = canonical.toLowerCase();
+		if (!seen.has(key)) {
+			seen.add(key);
+			normalized.push(canonical);
+		}
+		return normalized;
+	}, []);
+}
+
 function areEqualStringArrays(left: string[], right: string[]): boolean {
 	return left.length === right.length && left.every((value, index) => value === right[index]);
 }
@@ -101,7 +123,13 @@ const TaskList: React.FC<TaskListProps> = ({
 	isLoading = false,
 }) => {
 	const [searchParams, setSearchParams] = useSearchParams();
-	const [statusFilter, setStatusFilter] = useState<string[]>(() => getStatusFilters(searchParams));
+	const statusOptions = useMemo(
+		() => (availableStatuses.length > 0 ? availableStatuses : [...DEFAULT_STATUSES]),
+		[availableStatuses],
+	);
+	const [statusFilter, setStatusFilter] = useState<string[]>(() =>
+		normalizeStatusFilters(getStatusFilters(searchParams), statusOptions),
+	);
 	const initialExcludeStatusParams = useMemo(() => {
 		const statuses = [...searchParams.getAll("excludeStatus")];
 		const statusesCsv = searchParams.get("excludeStatuses");
@@ -133,7 +161,6 @@ const TaskList: React.FC<TaskListProps> = ({
 	const tableHeaderScrollRef = useRef<HTMLDivElement | null>(null);
 	const tableBodyScrollRef = useRef<HTMLDivElement | null>(null);
 	const isSyncingTableScrollRef = useRef(false);
-	const statusOptions = availableStatuses.length > 0 ? availableStatuses : [...DEFAULT_STATUSES];
 	const isFilteringTerminalStatus = statusFilter.some((status) => isTerminalStatus(status, statusOptions));
 	const milestoneAliasToCanonical = useMemo(() => {
 		const aliasMap = new Map<string, string>();
@@ -287,7 +314,7 @@ const TaskList: React.FC<TaskListProps> = ({
 	const totalTasks = sortedBaseTasks.length;
 
 	useEffect(() => {
-		const paramStatuses = getStatusFilters(searchParams);
+		const paramStatuses = normalizeStatusFilters(getStatusFilters(searchParams), statusOptions);
 		const paramExcludedStatuses = [...searchParams.getAll("excludeStatus")];
 		const excludedStatusesCsv = searchParams.get("excludeStatuses");
 		if (excludedStatusesCsv) {
@@ -334,7 +361,7 @@ const TaskList: React.FC<TaskListProps> = ({
 		if (!areEqualStringArrays(normalizedLabels, labelFilter)) {
 			setLabelFilter(normalizedLabels);
 		}
-	}, [availablePriorities, isLoading, searchParams, setSearchParams]);
+	}, [availablePriorities, isLoading, searchParams, setSearchParams, statusOptions]);
 
 	useEffect(() => {
 		if (!hasActiveFilters) {
@@ -451,7 +478,7 @@ const TaskList: React.FC<TaskListProps> = ({
 	};
 
 	const handleStatusChange = (next: string[]) => {
-		const normalized = next.map((status) => status.trim()).filter((status) => status.length > 0);
+		const normalized = normalizeStatusFilters(next, statusOptions);
 		setStatusFilter(normalized);
 		syncUrl(normalized, excludedStatusFilter, priorityFilter, labelFilter, milestoneFilter);
 	};


### PR DESCRIPTION
## Summary

- support multiple included statuses in the Web task list
- persist selections as repeated status URL parameters while preserving legacy single-value URLs
- reuse the existing accessible checkbox filter and array-capable search API

## Testing

- 48 scoped component, search, and server tests passed
- bunx tsc --noEmit
- bun run check .
- bun run build
- rendered browser QA at desktop and mobile widths