### PR TITLE
BACK-588 - Make the TUI help popup robust to resize and wrapped lines

### DIFF
--- a/backlog/tasks/back-588 - Make-the-TUI-help-popup-robust-to-resize-and-wrapped-lines.md
+++ b/backlog/tasks/back-588 - Make-the-TUI-help-popup-robust-to-resize-and-wrapped-lines.md
@@ -1,14 +1,20 @@
 ---
 id: BACK-588
 title: Make the TUI help popup robust to resize and wrapped lines
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-07 20:45'
+updated_date: '2026-08-10 05:36'
 labels:
   - tui
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/pull/833'
+modified_files:
+  - src/ui/components/help-popup.ts
+  - src/ui/components/filter-popup.ts
+  - src/test/help-popup.test.ts
 priority: medium
 type: bug
 ordinal: 228000
@@ -28,15 +34,38 @@ In both cases the user ends up in a help popup whose last rows are unreachable, 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Resizing the terminal while the help popup is open reflows the popup to the new viewport; shrinking from 24 rows to 10 keeps the popup fully on-screen with its close/help rows visible
-- [ ] #2 After a resize the scroll bounds reflect the new size, so the last line of help content is still reachable and no content is stranded
-- [ ] #3 On narrow terminals where shortcut descriptions wrap, help content scrolls to its last line; verified with the full board shortcut set at 30x24
-- [ ] #4 Regression tests cover the resize-while-open case and the wrapped-description scroll case
+- [x] #1 Resizing the terminal while the help popup is open reflows the popup to the new viewport; shrinking from 24 rows to 10 keeps the popup fully on-screen with its close/help rows visible
+- [x] #2 After a resize the scroll bounds reflect the new size, so the last line of help content is still reachable and no content is stranded
+- [x] #3 On narrow terminals where shortcut descriptions wrap, help content scrolls to its last line; verified with the full board shortcut set at 30x24
+- [x] #4 Regression tests cover the resize-while-open case and the wrapped-description scroll case
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reflow the help popup with the existing popup chrome helper on initial render and every screen resize, measuring the scrollable viewport after rendering so wrapped lines and the current visible height define scroll state.
+2. Clamp the current offset to the recomputed bounds, update the footer hint from the measured result, and remove the resize listener when the popup closes.
+3. Add real-screen regression tests for a 24-to-10 row resize and the full board shortcut set at 30x24, including scrolling to the final rendered line.
+4. Run focused tests, TypeScript, Biome, and the broader relevant suite; inspect and simplify the final diff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reused createPopupChrome.reflow and the renderer's getScrollHeight result, so scroll bounds follow the exact post-tag, wrapped visual rows instead of logical shortcut count. Each initial layout and resize reparses content at the current width, clamps childBase to the new viewport, updates the scroll footer, and removes its resize listener on close.
+
+Validation: 27 focused TUI/help tests passed; bunx tsc --noEmit passed; bun run check . passed across 369 files; bun run build passed; git diff --check passed. Independent read-only review found no P0-P2 gaps.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made the TUI help popup reflow safely with terminal resizes and derive scrolling from actual wrapped renderer rows. Real-screen regressions prove a 24-to-10 row shrink remains fully visible and scrolls to the end, while the full board shortcut set at 30x24 reaches its final wrapped line. Verified with 27 focused tests, TypeScript, Biome, build, and diff checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/help-popup.test.ts
+++ b/src/test/help-popup.test.ts
@@ -1,5 +1,39 @@
 import { describe, expect, it } from "bun:test";
-import { getHelpPopupHeight, getHelpShortcuts } from "../ui/components/help-popup.ts";
+import { getHelpPopupHeight, getHelpShortcuts, openHelpPopup } from "../ui/components/help-popup.ts";
+import { createScreen } from "../ui/tui.ts";
+
+type TestWidget = {
+	atop?: number;
+	childBase?: number;
+	children?: unknown[];
+	content?: string;
+	emit?: (event: string, ...args: unknown[]) => void;
+	getScrollHeight?: () => number;
+	height?: number;
+	options?: { label?: string };
+	type?: string;
+};
+
+function collectWidgets(root: { children?: unknown[] }): TestWidget[] {
+	const widgets: TestWidget[] = [];
+	const visit = (node: TestWidget) => {
+		widgets.push(node);
+		for (const child of node.children ?? []) visit(child as TestWidget);
+	};
+	visit(root as TestWidget);
+	return widgets;
+}
+
+function pressKey(widget: TestWidget | undefined, name: string, ch = ""): void {
+	const key = { name, full: name, shift: false };
+	widget?.emit?.("keypress", ch, key);
+	widget?.emit?.(`key ${name}`, ch, key);
+}
+
+async function settleHelpPopup(): Promise<void> {
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	await new Promise<void>((resolve) => setImmediate(resolve));
+}
 
 const keysFor = (context: "board" | "task-list") => getHelpShortcuts(context).map((shortcut) => shortcut.key);
 
@@ -30,9 +64,81 @@ describe("help popup shortcuts", () => {
 			// 4 rows of chrome (borders, top spacer, help line) leave one row per shortcut.
 			expect(getHelpPopupHeight(count, 40) - 4).toBe(count);
 			expect(getHelpPopupHeight(count, 24) - 4).toBe(count);
-			for (const screenHeight of [10, 14, 18, 24, 30]) {
+			for (const screenHeight of [4, 6, 10, 14, 18, 24, 30]) {
 				expect(getHelpPopupHeight(count, screenHeight)).toBeLessThanOrEqual(screenHeight);
 			}
+		}
+	});
+
+	it("reflows an open popup and recomputes its scroll bounds after terminal resizes", async () => {
+		const screen = createScreen({ smartCSR: false });
+		const mutableScreen = screen as unknown as {
+			focused?: TestWidget;
+			width: number;
+			height: number;
+			emit(event: string): void;
+		};
+		Object.defineProperty(screen, "width", { configurable: true, value: 80, writable: true });
+		Object.defineProperty(screen, "height", { configurable: true, value: 24, writable: true });
+		try {
+			const result = openHelpPopup(screen);
+			await settleHelpPopup();
+
+			mutableScreen.height = 10;
+			mutableScreen.emit("resize");
+			let widgets = collectWidgets(screen as unknown as { children?: unknown[] });
+			const popup = widgets.find((widget) => widget.options?.label === " Keyboard Shortcuts ");
+			const help = widgets.find((widget) => widget.content?.includes("Close Help"));
+			const viewport = widgets.find((widget) => widget.type === "scrollable-box");
+			expect(popup).toBeDefined();
+			expect(popup?.height).toBeLessThanOrEqual(10);
+			expect(popup?.atop).toBeGreaterThanOrEqual(0);
+			expect((popup?.atop ?? 0) + (popup?.height ?? 0)).toBeLessThanOrEqual(10);
+			expect(help?.atop).toBeGreaterThanOrEqual(0);
+			expect(help?.atop).toBeLessThan(10);
+
+			const shortMaxOffset = (viewport?.getScrollHeight?.() ?? 0) - (viewport?.height ?? 0);
+			expect(shortMaxOffset).toBeGreaterThan(0);
+			for (let index = 0; index <= shortMaxOffset; index += 1) pressKey(mutableScreen.focused, "down");
+			expect(viewport?.childBase).toBe(shortMaxOffset);
+
+			mutableScreen.height = 24;
+			mutableScreen.emit("resize");
+			widgets = collectWidgets(screen as unknown as { children?: unknown[] });
+			const expandedViewport = widgets.find((widget) => widget.type === "scrollable-box");
+			expect(expandedViewport?.childBase).toBe(0);
+
+			pressKey(mutableScreen.focused, "escape", "\x1b");
+			await result;
+		} finally {
+			screen.destroy();
+		}
+	});
+
+	it("scrolls through wrapped board shortcuts to the final rendered line at 30x24", async () => {
+		const screen = createScreen({ smartCSR: false });
+		const eventScreen = screen as unknown as { focused?: TestWidget };
+		Object.defineProperty(screen, "width", { configurable: true, value: 30, writable: true });
+		Object.defineProperty(screen, "height", { configurable: true, value: 24, writable: true });
+		try {
+			const result = openHelpPopup(screen, "board");
+			await settleHelpPopup();
+			const widgets = collectWidgets(screen as unknown as { children?: unknown[] });
+			const viewport = widgets.find((widget) => widget.type === "scrollable-box");
+			const renderedLineCount = viewport?.getScrollHeight?.() ?? 0;
+			const visibleLineCount = viewport?.height ?? 0;
+			const maxOffset = renderedLineCount - visibleLineCount;
+
+			expect(renderedLineCount).toBeGreaterThan(getHelpShortcuts("board").length);
+			expect(maxOffset).toBeGreaterThan(0);
+			expect(widgets.some((widget) => widget.content?.includes("Scroll"))).toBe(true);
+			for (let index = 0; index <= maxOffset; index += 1) pressKey(eventScreen.focused, "down");
+			expect(viewport?.childBase).toBe(maxOffset);
+
+			pressKey(eventScreen.focused, "escape", "\x1b");
+			await result;
+		} finally {
+			screen.destroy();
 		}
 	});
 });

--- a/src/ui/components/filter-popup.ts
+++ b/src/ui/components/filter-popup.ts
@@ -30,7 +30,7 @@ function resolveDimension(value: string | number, total: number): number {
 }
 
 /** A viewport that clips its content, with `childBase` as the first visible row. */
-export type ScrollableViewport = BoxInterface & { childBase: number };
+export type ScrollableViewport = BoxInterface & { childBase: number; getScrollHeight(): number };
 
 /**
  * `box({ scrollable: true })` is a no-op in neo-neo-bblessed: the option is ignored, so the

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -56,25 +56,28 @@ export function getHelpShortcuts(context: HelpPopupContext = "board"): Shortcut[
 
 /** Popup rows spent on borders, the top spacer and the help line, leaving one row per shortcut. */
 const HELP_POPUP_CHROME_ROWS = 4;
+const HELP_POPUP_WIDTH = 60;
+
+function getHelpText(scrolls: boolean): string {
+	return scrolls ? " {cyan-fg}[↑↓]{/} Scroll | {cyan-fg}[Esc/q]{/} Close Help" : " {cyan-fg}[Esc/q]{/} Close Help";
+}
 
 export function getHelpPopupHeight(shortcutCount: number, screenHeight: number): number {
-	return Math.max(5, Math.min(shortcutCount + HELP_POPUP_CHROME_ROWS, screenHeight - 2));
+	const boundedScreenHeight = Math.max(1, screenHeight);
+	const preferredHeight = Math.max(5, Math.min(shortcutCount + HELP_POPUP_CHROME_ROWS, boundedScreenHeight - 2));
+	return Math.min(boundedScreenHeight, preferredHeight);
 }
 
 export async function openHelpPopup(screen: ScreenInterface, context: HelpPopupContext = "board"): Promise<void> {
 	return new Promise<void>((resolve) => {
 		let settled = false;
 		const shortcuts = getHelpShortcuts(context);
-		const screenHeight = typeof screen.height === "number" ? screen.height : 40;
-		const popupHeight = getHelpPopupHeight(shortcuts.length, screenHeight);
-		const scrolls = shortcuts.length > popupHeight - HELP_POPUP_CHROME_ROWS;
-		const { popup, close } = createPopupChrome({
+		let popupHeight = getHelpPopupHeight(shortcuts.length, screen.height);
+		const { popup, close, reflow } = createPopupChrome({
 			screen,
 			title: "Keyboard Shortcuts",
-			helpText: scrolls
-				? " {cyan-fg}[↑↓]{/} Scroll | {cyan-fg}[Esc/q]{/} Close Help"
-				: " {cyan-fg}[Esc/q]{/} Close Help",
-			width: 60,
+			helpText: getHelpText(false),
+			width: HELP_POPUP_WIDTH,
 			height: popupHeight,
 		});
 
@@ -90,10 +93,34 @@ export async function openHelpPopup(screen: ScreenInterface, context: HelpPopupC
 			content,
 			tags: true,
 		});
+		const getMaxScrollOffset = () => {
+			const visibleRows =
+				typeof contentBox.height === "number" ? contentBox.height : popupHeight - HELP_POPUP_CHROME_ROWS;
+			return Math.max(0, contentBox.getScrollHeight() - Math.max(1, visibleRows));
+		};
+		const applyLayout = () => {
+			popupHeight = getHelpPopupHeight(shortcuts.length, screen.height);
+			reflow(HELP_POPUP_WIDTH, popupHeight);
+			// Rendering reparses the content at its new width, producing the exact number of
+			// visual rows after tag removal and wrapping.
+			screen.render();
+			const maxOffset = getMaxScrollOffset();
+			contentBox.childBase = Math.min(maxOffset, Math.max(0, contentBox.childBase));
+			reflow(HELP_POPUP_WIDTH, popupHeight, getHelpText(maxOffset > 0));
+			screen.render();
+		};
+		const onResize = () => {
+			if (!settled) applyLayout();
+		};
 
 		const finish = () => {
 			if (settled) return;
 			settled = true;
+			(
+				screen as ScreenInterface & {
+					removeListener(event: string, listener: (...args: unknown[]) => void): void;
+				}
+			).removeListener("resize", onResize);
 			close();
 			screen.render();
 			resolve();
@@ -104,18 +131,20 @@ export async function openHelpPopup(screen: ScreenInterface, context: HelpPopupC
 			return false;
 		});
 
-		const maxScrollOffset = Math.max(0, shortcuts.length - (popupHeight - HELP_POPUP_CHROME_ROWS));
 		const scrollBy = (delta: number) => {
-			contentBox.childBase = Math.min(maxScrollOffset, Math.max(0, contentBox.childBase + delta));
+			const maxOffset = getMaxScrollOffset();
+			contentBox.childBase = Math.min(maxOffset, Math.max(0, contentBox.childBase + delta));
 			screen.render();
 			return false;
 		};
 		popup.key(["up"], () => scrollBy(-1));
 		popup.key(["down"], () => scrollBy(1));
+		screen.on("resize", onResize);
 
 		setImmediate(() => {
+			if (settled) return;
 			popup.focus();
-			screen.render();
+			applyLayout();
 		});
 	});
 }


### PR DESCRIPTION
## Summary

- reflow an open help popup when terminal dimensions change
- derive scroll bounds from rendered wrapped rows and clamp offsets after resize
- remove the resize listener on close and keep footer hints in sync

## Testing

- 27 focused TUI/help tests passed
- bunx tsc --noEmit
- bun run check .
- bun run build
- git diff --check
- real-screen coverage for 24-to-10 row resize and 30x24 wrapped shortcuts