### PR TITLE
BACK-551 - Show acceptance criteria completion on TUI task summaries

### DIFF
--- a/backlog/tasks/back-551 - Show-acceptance-criteria-completion-on-TUI-task-summaries.md
+++ b/backlog/tasks/back-551 - Show-acceptance-criteria-completion-on-TUI-task-summaries.md
@@ -1,12 +1,19 @@
 ---
 id: BACK-551
 title: Show acceptance criteria completion on TUI task summaries
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-07-17 21:36'
+updated_date: '2026-08-10 05:38'
 labels:
   - tui
 dependencies: []
+modified_files:
+  - src/ui/acceptance-criteria-progress.ts
+  - src/ui/board.ts
+  - src/ui/task-viewer-with-search.ts
+  - src/test/tui-acceptance-criteria-progress.test.ts
 type: feature
 ordinal: 195000
 ---
@@ -19,20 +26,43 @@ Help people understand how much accepted task scope has been verified while scan
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 In-progress task summaries and cards in the TUI show a compact completion bar followed by the exact checked/total fraction, for example [██████░░░░] 4/7.
-- [ ] #2 The visible indicator has no AC label and no percentage.
-- [ ] #3 The completion value is derived live from checked and total acceptance criteria and is not persisted as separate progress state.
-- [ ] #4 The bar uses 10 cells when available terminal width permits and 5 cells in constrained layouts.
-- [ ] #5 A task with no acceptance criteria does not display 0% or otherwise imply measurable completion.
-- [ ] #6 A task with every acceptance criterion checked still retains and clearly presents its actual In Progress status rather than implying that the task is Done.
-- [ ] #7 Colors are theme-safe, and the bar plus exact fraction remain understandable when color is unavailable.
-- [ ] #8 CLI and MCP output remain unchanged.
-- [ ] #9 TUI rendering tests cover partial completion, no acceptance criteria, all criteria checked while still In Progress, and both supported bar widths.
+- [x] #1 In-progress task summaries and cards in the TUI show a compact completion bar followed by the exact checked/total fraction, for example [██████░░░░] 4/7.
+- [x] #2 The visible indicator has no AC label and no percentage.
+- [x] #3 The completion value is derived live from checked and total acceptance criteria and is not persisted as separate progress state.
+- [x] #4 The bar uses 10 cells when available terminal width permits and 5 cells in constrained layouts.
+- [x] #5 A task with no acceptance criteria does not display 0% or otherwise imply measurable completion.
+- [x] #6 A task with every acceptance criterion checked still retains and clearly presents its actual In Progress status rather than implying that the task is Done.
+- [x] #7 Colors are theme-safe, and the bar plus exact fraction remain understandable when color is unavailable.
+- [x] #8 CLI and MCP output remain unchanged.
+- [x] #9 TUI rendering tests cover partial completion, no acceptance criteria, all criteria checked while still In Progress, and both supported bar widths.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add one pure TUI acceptance-criteria progress formatter that derives checked and total counts from acceptanceCriteriaItems, renders only In Progress tasks, and selects a 10- or 5-cell bar from available row width.
+2. Reuse the formatter in board cards and interactive task-list summaries while preserving status, identity, selection, cross-branch styling, and responsive rerendering.
+3. Add deterministic rendering tests for partial, empty, fully checked, non-progress, wide, and constrained cases across both summary surfaces.
+4. Run focused tests, TypeScript, Biome, build, and unchanged CLI JSON coverage; inspect the final diff for simplification and scope.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a shared, color-independent TUI formatter that reads acceptanceCriteriaItems live and renders responsive 10-cell or 5-cell completion bars only for In Progress tasks. Board cards and task-list summaries reuse it; progress-bearing list rows use the existing active-status icon so constrained layouts retain task identity.
+
+Verification: 61 focused TUI, board, selection, and CLI JSON tests passed; 32 MCP task tests passed; 4 loopback browser/server tests passed outside the sandbox; bunx tsc --noEmit, bun run check ., bun run build, and git diff --check passed. Rendered PTY QA at 120x30 and 80x24 verified board and list wide/compact bars, uncluttered no-criteria tasks, and fully checked tasks retaining the active status. The full suite attempt also hit the pre-existing TUI watcher timeout, reproduced from unchanged HEAD, plus sandbox-only port binding failures; the port tests passed when rerun with loopback access.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a shared responsive acceptance-criteria progress indicator to TUI board cards and task-list summaries. It derives checked/total values directly from each task, uses 10 cells on wide rows and 5 on constrained rows, omits tasks without criteria, and preserves active-status meaning without relying on color. Verified with 93 focused TUI/CLI JSON/MCP tests, 4 loopback server tests, PTY rendering at 120x30 and 80x24, TypeScript, Biome, build, and diff checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/tui-acceptance-criteria-progress.test.ts
+++ b/src/test/tui-acceptance-criteria-progress.test.ts
@@ -31,10 +31,10 @@ describe("TUI acceptance-criteria progress", () => {
 	it("renders the exact wide and constrained bars from live checklist state", () => {
 		const task = makeTask();
 
-		expect(formatAcceptanceCriteriaProgress(task, 32)).toBe("[██████░░░░] 4/7");
-		expect(formatAcceptanceCriteriaProgress(task, 31)).toBe("[███░░] 4/7");
+		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[██████░░░░] 4/7");
+		expect(formatAcceptanceCriteriaProgress(task, 39)).toBe("[███░░] 4/7");
 		if (task.acceptanceCriteriaItems?.[4]) task.acceptanceCriteriaItems[4].checked = true;
-		expect(formatAcceptanceCriteriaProgress(task, 32)).toBe("[███████░░░] 5/7");
+		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[███████░░░] 5/7");
 	});
 
 	it("omits progress when criteria are absent or the task is not in progress", () => {
@@ -55,6 +55,13 @@ describe("TUI acceptance-criteria progress", () => {
 		expect(task.status).toBe("In Progress");
 		expect(listItem).toContain("◒ [██████████] 2/2");
 		expect(listItem).not.toContain("✔");
+	});
+
+	it("normalizes configured status casing before choosing the active-work icon", () => {
+		const task = makeTask({ status: " IN PROGRESS " });
+		const listItem = stripBlessedFgTags(formatTaskViewerListItem(task, 40));
+
+		expect(listItem).toContain("◒ [██████░░░░] 4/7");
 	});
 
 	it("reuses the same responsive indicator in board cards and task-list summaries", () => {

--- a/src/test/tui-acceptance-criteria-progress.test.ts
+++ b/src/test/tui-acceptance-criteria-progress.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import type { AcceptanceCriterion, Task } from "../types/index.ts";
+import { formatAcceptanceCriteriaProgress } from "../ui/acceptance-criteria-progress.ts";
+import { formatTaskListItem } from "../ui/board.ts";
+import { formatTaskViewerListItem } from "../ui/task-viewer-with-search.ts";
+import { stripBlessedFgTags } from "../ui/utils/strip-tags.ts";
+
+function makeCriteria(total: number, checked: number): AcceptanceCriterion[] {
+	return Array.from({ length: total }, (_, index) => ({
+		index: index + 1,
+		text: `Criterion ${index + 1}`,
+		checked: index < checked,
+	}));
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "BACK-551",
+		title: "Show progress",
+		status: "In Progress",
+		assignee: [],
+		createdDate: "2026-07-17",
+		labels: [],
+		dependencies: [],
+		acceptanceCriteriaItems: makeCriteria(7, 4),
+		...overrides,
+	};
+}
+
+describe("TUI acceptance-criteria progress", () => {
+	it("renders the exact wide and constrained bars from live checklist state", () => {
+		const task = makeTask();
+
+		expect(formatAcceptanceCriteriaProgress(task, 32)).toBe("[██████░░░░] 4/7");
+		expect(formatAcceptanceCriteriaProgress(task, 31)).toBe("[███░░] 4/7");
+		if (task.acceptanceCriteriaItems?.[4]) task.acceptanceCriteriaItems[4].checked = true;
+		expect(formatAcceptanceCriteriaProgress(task, 32)).toBe("[███████░░░] 5/7");
+	});
+
+	it("omits progress when criteria are absent or the task is not in progress", () => {
+		expect(formatAcceptanceCriteriaProgress(makeTask({ acceptanceCriteriaItems: [] }), 40)).toBe("");
+		expect(formatAcceptanceCriteriaProgress(makeTask({ status: "To Do" }), 40)).toBe("");
+		expect(formatAcceptanceCriteriaProgress(makeTask({ status: "Done" }), 40)).toBe("");
+	});
+
+	it("keeps fully checked work visibly In Progress without color-dependent meaning", () => {
+		const task = makeTask({ acceptanceCriteriaItems: makeCriteria(2, 2) });
+		const progress = formatAcceptanceCriteriaProgress(task, 40);
+		const listItem = stripBlessedFgTags(formatTaskViewerListItem(task, 40));
+
+		expect(progress).toBe("[██████████] 2/2");
+		expect(progress).not.toContain("AC");
+		expect(progress).not.toContain("%");
+		expect(progress).not.toContain("{");
+		expect(task.status).toBe("In Progress");
+		expect(listItem).toContain("◒ [██████████] 2/2");
+		expect(listItem).not.toContain("✔");
+	});
+
+	it("reuses the same responsive indicator in board cards and task-list summaries", () => {
+		const task = makeTask();
+		const wideBoardCard = stripBlessedFgTags(formatTaskListItem(task, false, 40));
+		const compactBoardCard = stripBlessedFgTags(formatTaskListItem(task, false, 20));
+		const compactListItem = stripBlessedFgTags(formatTaskViewerListItem(task, 20));
+
+		expect(wideBoardCard).toContain("[██████░░░░] 4/7 {bold}BACK-551{/bold}");
+		expect(compactBoardCard).toContain("[███░░] 4/7 {bold}BACK-551{/bold}");
+		expect(compactListItem).toContain("◒ [███░░] 4/7 {bold}BACK-551{/bold}");
+	});
+});

--- a/src/ui/acceptance-criteria-progress.ts
+++ b/src/ui/acceptance-criteria-progress.ts
@@ -1,7 +1,8 @@
 import type { Task } from "../types/index.ts";
 
 // A 10-cell indicator occupies about half this width, leaving room for task identity and title.
-const WIDE_PROGRESS_MIN_WIDTH = 32;
+// Keep enough room for the task identity and a meaningful title after the indicator.
+const WIDE_PROGRESS_MIN_WIDTH = 40;
 const WIDE_PROGRESS_CELLS = 10;
 const COMPACT_PROGRESS_CELLS = 5;
 

--- a/src/ui/acceptance-criteria-progress.ts
+++ b/src/ui/acceptance-criteria-progress.ts
@@ -1,0 +1,22 @@
+import type { Task } from "../types/index.ts";
+
+// A 10-cell indicator occupies about half this width, leaving room for task identity and title.
+const WIDE_PROGRESS_MIN_WIDTH = 32;
+const WIDE_PROGRESS_CELLS = 10;
+const COMPACT_PROGRESS_CELLS = 5;
+
+function isInProgress(status: string): boolean {
+	return status.trim().toLowerCase() === "in progress";
+}
+
+/** Format live acceptance-criteria completion for one-line TUI task summaries. */
+export function formatAcceptanceCriteriaProgress(task: Task, availableWidth = Number.POSITIVE_INFINITY): string {
+	const criteria = task.acceptanceCriteriaItems ?? [];
+	if (!isInProgress(task.status) || criteria.length === 0) return "";
+
+	const checked = criteria.filter((criterion) => criterion.checked).length;
+	const cells = availableWidth >= WIDE_PROGRESS_MIN_WIDTH ? WIDE_PROGRESS_CELLS : COMPACT_PROGRESS_CELLS;
+	const filled = Math.round((checked / criteria.length) * cells);
+
+	return `[${"█".repeat(filled)}${"░".repeat(cells - filled)}] ${checked}/${criteria.length}`;
+}

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -19,6 +19,7 @@ import { getPriorityOptions } from "../utils/priority-config.ts";
 import { applySharedTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { compareTaskIds } from "../utils/task-sorting.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
+import { formatAcceptanceCriteriaProgress } from "./acceptance-criteria-progress.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
 import { createFilterHeader, type FilterHeader, type FilterState } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
@@ -143,7 +144,7 @@ function prepareBoardColumns(tasks: Task[], statuses: string[]): ColumnData[] {
 	});
 }
 
-export function formatTaskListItem(task: Task, isMoving = false): string {
+export function formatTaskListItem(task: Task, isMoving = false, availableWidth = Number.POSITIVE_INFINITY): string {
 	const assignee = task.assignee?.[0]
 		? ` {cyan-fg}${task.assignee[0].startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
 		: "";
@@ -152,9 +153,11 @@ export function formatTaskListItem(task: Task, isMoving = false): string {
 	const type = typeBadge ? ` ${typeBadge}` : "";
 	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 	const branch = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
+	const progress = formatAcceptanceCriteriaProgress(task, availableWidth);
+	const progressPrefix = progress ? `${progress} ` : "";
 
 	// Cross-branch tasks are dimmed to indicate read-only status
-	const content = `{bold}${task.id}{/bold}${type} - ${task.title}${assignee}${labels}${branch}`;
+	const content = `${progressPrefix}{bold}${task.id}{/bold}${type} - ${task.title}${assignee}${labels}${branch}`;
 	if (isMoving) {
 		return `{magenta-fg}► ${content}{/}`;
 	}
@@ -164,8 +167,12 @@ export function formatTaskListItem(task: Task, isMoving = false): string {
 	return content;
 }
 
-function buildRenderedTaskListItems(tasks: Task[], movingTaskId?: string): { rich: string[]; plain: string[] } {
-	const rich = tasks.map((task) => formatTaskListItem(task, movingTaskId === task.id));
+function buildRenderedTaskListItems(
+	tasks: Task[],
+	movingTaskId?: string,
+	availableWidth = Number.POSITIVE_INFINITY,
+): { rich: string[]; plain: string[] } {
+	const rich = tasks.map((task) => formatTaskListItem(task, movingTaskId === task.id, availableWidth));
 	return {
 		rich,
 		plain: rich.map((item) => stripBlessedFgTags(item)),
@@ -526,7 +533,9 @@ export async function renderBoardTui(
 		};
 
 		const getFormattedItems = (tasks: Task[]) => {
-			return buildRenderedTaskListItems(tasks, moveOp?.taskId);
+			const columnCount = Math.max(1, currentColumnsData.length);
+			const availableWidth = Math.max(1, Math.floor(getTerminalWidth() / columnCount) - 4);
+			return buildRenderedTaskListItems(tasks, moveOp?.taskId, availableWidth);
 		};
 
 		const createColumnViews = (data: ColumnData[]) => {

--- a/src/ui/status-icon.ts
+++ b/src/ui/status-icon.ts
@@ -12,16 +12,16 @@ export interface StatusStyle {
  */
 export function getStatusStyle(status: string): StatusStyle {
 	const statusMap: Record<string, StatusStyle> = {
-		Done: { icon: "✔", color: "green" },
-		"In Progress": { icon: "◒", color: "yellow" },
-		Blocked: { icon: "●", color: "red" },
-		"To Do": { icon: "○", color: "default" },
-		Review: { icon: "◆", color: "blue" },
-		Testing: { icon: "▣", color: "cyan" },
+		done: { icon: "✔", color: "green" },
+		"in progress": { icon: "◒", color: "yellow" },
+		blocked: { icon: "●", color: "red" },
+		"to do": { icon: "○", color: "default" },
+		review: { icon: "◆", color: "blue" },
+		testing: { icon: "▣", color: "cyan" },
 	};
 
 	// Return the mapped style or default for unknown statuses
-	return statusMap[status] || { icon: "○", color: "default" };
+	return statusMap[status.trim().toLowerCase()] || { icon: "○", color: "default" };
 }
 
 /**

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -31,6 +31,7 @@ import { canonicalTaskId, taskIdsEqual } from "../utils/task-id.ts";
 import { applyTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
+import { formatAcceptanceCriteriaProgress } from "./acceptance-criteria-progress.ts";
 import { formatChecklistItem } from "./checklist.ts";
 import { transformCodePaths } from "./code-path.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
@@ -46,7 +47,7 @@ import { openHelpPopup } from "./components/help-popup.ts";
 import { formatFooterContent, TASK_LIST_FOOTER_CONTENT } from "./footer-content.ts";
 import { formatHeading } from "./heading.ts";
 import { createLoadingScreen } from "./loading.ts";
-import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-icon.ts";
+import { formatStatusWithIcon, getStatusColor, getStatusIcon, wrapStatusColor } from "./status-icon.ts";
 import { completeTaskFromTui, formatTaskCompletionBlockedMessage } from "./task-lifecycle.ts";
 import { formatTaskTypeBadge } from "./task-type.ts";
 import { addScrollKeys, createScreen, formatTuiTitle } from "./tui.ts";
@@ -62,6 +63,27 @@ function getPriorityDisplay(priority?: string): string {
 		default:
 			return "";
 	}
+}
+
+export function formatTaskViewerListItem(task: Task, availableWidth = Number.POSITIVE_INFINITY): string {
+	const progress = formatAcceptanceCriteriaProgress(task, availableWidth);
+	// The compact status icon keeps task identity visible beside the progress indicator. Its
+	// shape still distinguishes active work from the terminal-status checkmark.
+	const status = progress ? getStatusIcon(task.status) : formatStatusWithIcon(task.status);
+	const statusColor = getStatusColor(task.status);
+	const assigneeText = task.assignee?.length
+		? ` {cyan-fg}${task.assignee[0]?.startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
+		: "";
+	const labelsText = task.labels?.length ? ` {yellow-fg}[${task.labels.join(", ")}]{/}` : "";
+	const typeBadge = formatTaskTypeBadge(task.type);
+	const typeText = typeBadge ? ` ${typeBadge}` : "";
+	const priorityText = getPriorityDisplay(task.priority);
+	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
+	const branchText = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
+	const progressText = progress ? ` ${progress}` : "";
+
+	const content = `${wrapStatusColor(status, statusColor)}${progressText} {bold}${task.id}{/bold}${typeText} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
+	return isCrossBranch ? `{gray-fg}${content}{/}` : content;
 }
 
 export function buildTaskViewerMilestoneFilterModel(
@@ -618,6 +640,10 @@ export async function viewTaskEnhanced(
 		return typeof screen.width === "number" ? screen.width : 80;
 	}
 
+	function getTaskListSummaryWidth(): number {
+		return Math.max(1, Math.floor(getTerminalWidth() * 0.4) - 4);
+	}
+
 	function syncPaneLayout() {
 		const headerHeight = filterHeader.getHeight();
 		const helpHeight = typeof helpBar.height === "number" ? helpBar.height : 1;
@@ -913,23 +939,7 @@ export async function viewTaskEnhanced(
 			left: 1,
 			width: "100%-4",
 			height: "100%-3",
-			itemRenderer: (task: Task) => {
-				const statusIcon = formatStatusWithIcon(task.status);
-				const statusColor = getStatusColor(task.status);
-				const assigneeText = task.assignee?.length
-					? ` {cyan-fg}${task.assignee[0]?.startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
-					: "";
-				const labelsText = task.labels?.length ? ` {yellow-fg}[${task.labels.join(", ")}]{/}` : "";
-				const typeBadge = formatTaskTypeBadge(task.type);
-				const typeText = typeBadge ? ` ${typeBadge}` : "";
-				const priorityText = getPriorityDisplay(task.priority);
-				const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
-				const branchText = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
-
-				const content = `${wrapStatusColor(statusIcon, statusColor)} {bold}${task.id}{/bold}${typeText} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
-				// Dim cross-branch tasks to indicate read-only status
-				return isCrossBranch ? `{gray-fg}${content}{/}` : content;
-			},
+			itemRenderer: (task: Task) => formatTaskViewerListItem(task, getTaskListSummaryWidth()),
 			onSelect: (selected: Task | Task[]) => {
 				const selectedTask = Array.isArray(selected) ? selected[0] : selected;
 				void applySelection(selectedTask || null);
@@ -1329,6 +1339,7 @@ export async function viewTaskEnhanced(
 	// Handle resize
 	screen.on("resize", () => {
 		filterHeader.rebuild();
+		taskList?.updateItems(filteredTasks);
 		updateHelpBar();
 	});
 


### PR DESCRIPTION
## Summary

- add one shared live acceptance-criteria progress formatter for TUI summaries
- show responsive 10-cell and 5-cell bars on board cards and task-list rows
- preserve active status meaning and omit tasks without acceptance criteria

## Testing

- 93 focused TUI, CLI JSON, and MCP tests passed
- 4 loopback browser/server tests passed
- bunx tsc --noEmit
- bun run check .
- bun run build
- PTY QA at 120x30 and 80x24