### PR TITLE
BACK-552 - Show acceptance criteria progress on browser task summaries

### DIFF
--- a/backlog/tasks/back-552 - Show-acceptance-criteria-progress-on-browser-task-summaries.md
+++ b/backlog/tasks/back-552 - Show-acceptance-criteria-progress-on-browser-task-summaries.md
@@ -1,11 +1,18 @@
 ---
 id: BACK-552
 title: Show acceptance criteria progress on browser task summaries
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-07-17 21:36'
+updated_date: '2026-08-10 05:39'
 labels: []
 dependencies: []
+modified_files:
+  - src/web/components/AcceptanceCriteriaProgress.tsx
+  - src/web/components/TaskCard.tsx
+  - src/web/components/TaskList.tsx
+  - src/test/web-task-acceptance-progress.test.tsx
 type: feature
 ordinal: 196000
 ---
@@ -20,17 +27,41 @@ This task covers the browser only. CLI and MCP output are out of scope.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 In Progress task summaries or cards with acceptance criteria show a compact segmented completion bar followed by the exact checked/total fraction, without an AC label or percentage
-- [ ] #2 The displayed completion is derived from the task current checked and total acceptance criteria and reflects acceptance-criteria changes without storing a separate progress value
-- [ ] #3 The browser uses a 10-cell bar when space allows and a 5-cell bar in narrower available space, preserving the desktop-first layout and best-effort narrow behavior
-- [ ] #4 An In Progress task with no acceptance criteria does not display a value that implies 0% completion
-- [ ] #5 An In Progress task with every acceptance criterion checked remains visibly In Progress and the completion display does not imply that its task status is Done
-- [ ] #6 Browser tests cover partial completion, no acceptance criteria, all criteria checked while In Progress, and the 10-cell and 5-cell layouts
+- [x] #1 In Progress task summaries or cards with acceptance criteria show a compact segmented completion bar followed by the exact checked/total fraction, without an AC label or percentage
+- [x] #2 The displayed completion is derived from the task current checked and total acceptance criteria and reflects acceptance-criteria changes without storing a separate progress value
+- [x] #3 The browser uses a 10-cell bar when space allows and a 5-cell bar in narrower available space, preserving the desktop-first layout and best-effort narrow behavior
+- [x] #4 An In Progress task with no acceptance criteria does not display a value that implies 0% completion
+- [x] #5 An In Progress task with every acceptance criterion checked remains visibly In Progress and the completion display does not imply that its task status is Done
+- [x] #6 Browser tests cover partial completion, no acceptance criteria, all criteria checked while In Progress, and the 10-cell and 5-cell layouts
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add one shared browser acceptance-progress component that derives checked and total counts directly from Task.acceptanceCriteriaItems, renders only for In Progress tasks with criteria, and supports explicit 5-cell and 10-cell layouts.
+2. Integrate the 5-cell layout into constrained board cards and the 10-cell layout into task-list title summaries without changing Task, CLI, MCP, or API schemas.
+3. Add focused rendered tests for partial progress, no criteria, all criteria checked while In Progress, both cell counts, and rerendered criterion changes; then run targeted tests, typecheck, Biome, and rendered browser QA.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented one shared browser-only AcceptanceCriteriaProgress component that derives checked/total directly from Task.acceptanceCriteriaItems. Board cards use 5 cells and task-list summaries use 10 cells. It renders only for normalized In Progress status with at least one criterion; a full bar stays blue while the existing task status remains visible. No Task, API, CLI, MCP, or persisted progress field changed.
+
+Final validation: the rendered web slice passed 11/11, covering exact 4/7 output at both cell counts, absent criteria, all criteria checked with an In Progress status cell, and recalculation after updated task props. bunx tsc --noEmit, bun run check ., and bun run build passed.
+
+In-app Browser QA was attempted against a controlled local project and the source server started successfully, but this session exposed no connected browser backend, so no visual screenshot was available. A full bun run test attempt reached unrelated failures: the existing TUI composer watcher-delivery case timed out, and sandboxed loopback-listener tests failed with EPERM. The scoped test path permitted by the Definition of Done is green.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added derived acceptance-criteria progress to In Progress browser summaries: five cells on board cards and ten cells in the task list, with exact checked/total counts and no persistence or public-surface changes. Verified partial, empty, complete, and updated states with 11 rendered web tests; TypeScript, Biome, and the production build pass.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/web-task-acceptance-progress.test.tsx
+++ b/src/test/web-task-acceptance-progress.test.tsx
@@ -100,6 +100,13 @@ describe("browser task acceptance criteria progress", () => {
 		expect(progress?.textContent).not.toContain("Acceptance criteria");
 	});
 
+	it("includes card progress in the accessible name", () => {
+		const container = renderCard(createTask({ acceptanceCriteriaItems: createCriteria(4, 7) }));
+		const card = container.querySelector("[role='button']");
+
+		expect(card?.getAttribute("aria-label")).toBe("Open task-1: Task summary. Acceptance criteria progress: 4 of 7");
+	});
+
 	it("does not render progress for an In Progress task without criteria", () => {
 		const container = renderCard(createTask({ acceptanceCriteriaItems: [] }));
 

--- a/src/test/web-task-acceptance-progress.test.tsx
+++ b/src/test/web-task-acceptance-progress.test.tsx
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import type { Task } from "../types/index.ts";
+import TaskCard from "../web/components/TaskCard.tsx";
+import TaskList from "../web/components/TaskList.tsx";
+
+const createCriteria = (checked: number, total: number) =>
+	Array.from({ length: total }, (_, index) => ({
+		index: index + 1,
+		text: `Criterion ${index + 1}`,
+		checked: index < checked,
+	}));
+
+const createTask = (overrides: Partial<Task> = {}): Task => ({
+	id: "task-1",
+	title: "Task summary",
+	status: "In Progress",
+	assignee: [],
+	labels: [],
+	dependencies: [],
+	createdDate: "2026-01-01",
+	...overrides,
+});
+
+let activeRoot: Root | null = null;
+let activeDom: JSDOM | null = null;
+
+const setupDom = (): HTMLElement => {
+	activeDom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: "http://localhost",
+	});
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = activeDom.window as unknown as Window & typeof globalThis;
+	globalThis.document = activeDom.window.document as unknown as Document;
+	globalThis.navigator = activeDom.window.navigator as unknown as Navigator;
+	globalThis.localStorage = activeDom.window.localStorage as unknown as Storage;
+
+	const container = document.getElementById("root");
+	expect(container).toBeTruthy();
+	activeRoot = createRoot(container as HTMLElement);
+	return container as HTMLElement;
+};
+
+const renderCard = (task: Task): HTMLElement => {
+	const container = setupDom();
+	act(() => {
+		activeRoot?.render(<TaskCard task={task} onUpdate={() => {}} onEdit={() => {}} />);
+	});
+	return container;
+};
+
+const renderList = (task: Task): HTMLElement => {
+	const container = setupDom();
+	act(() => {
+		activeRoot?.render(
+			<MemoryRouter>
+				<TaskList
+					tasks={[task]}
+					availableStatuses={["To Do", "In Progress", "Done"]}
+					availableLabels={[]}
+					availableMilestones={[]}
+					milestoneEntities={[]}
+					archivedMilestones={[]}
+					onEditTask={() => {}}
+					onNewTask={() => {}}
+				/>
+			</MemoryRouter>,
+		);
+	});
+	return container;
+};
+
+const getProgress = (container: HTMLElement): HTMLElement | null =>
+	container.querySelector("[data-acceptance-criteria-progress]");
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => {
+			activeRoot?.unmount();
+		});
+		activeRoot = null;
+	}
+	activeDom?.window.close();
+	activeDom = null;
+});
+
+describe("browser task acceptance criteria progress", () => {
+	it("renders partial progress with five cells on a board card", () => {
+		const container = renderCard(createTask({ acceptanceCriteriaItems: createCriteria(4, 7) }));
+		const progress = getProgress(container);
+
+		expect(progress).toBeTruthy();
+		expect(progress?.dataset.cellCount).toBe("5");
+		expect(progress?.children[0]?.textContent).toBe("[███░░]");
+		expect(progress?.children[1]?.textContent).toBe("4/7");
+		expect(progress?.textContent).not.toContain("%");
+		expect(progress?.textContent).not.toContain("Acceptance criteria");
+	});
+
+	it("does not render progress for an In Progress task without criteria", () => {
+		const container = renderCard(createTask({ acceptanceCriteriaItems: [] }));
+
+		expect(getProgress(container)).toBeNull();
+	});
+
+	it("renders ten-cell partial progress in the wide list summary", () => {
+		const container = renderList(createTask({ acceptanceCriteriaItems: createCriteria(4, 7) }));
+		const progress = getProgress(container);
+
+		expect(progress).toBeTruthy();
+		expect(progress?.dataset.cellCount).toBe("10");
+		expect(progress?.children[0]?.textContent).toBe("[██████░░░░]");
+		expect(progress?.children[1]?.textContent).toBe("4/7");
+	});
+
+	it("keeps an all-checked task visibly In Progress in the wide list summary", () => {
+		const container = renderList(createTask({ acceptanceCriteriaItems: createCriteria(3, 3) }));
+		const progress = getProgress(container);
+		const statusCell = container.querySelector("tbody tr td:nth-child(3)");
+
+		expect(progress).toBeTruthy();
+		expect(progress?.dataset.cellCount).toBe("10");
+		expect(progress?.children[0]?.textContent).toBe("[██████████]");
+		expect(progress?.children[1]?.textContent).toBe("3/3");
+		expect(progress?.className).toContain("text-blue-600");
+		expect(statusCell?.textContent?.trim()).toBe("In Progress");
+	});
+
+	it("derives progress again when the task criteria change", () => {
+		const container = renderCard(createTask({ acceptanceCriteriaItems: createCriteria(2, 5) }));
+		expect(getProgress(container)?.children[0]?.textContent).toBe("[██░░░]");
+		expect(getProgress(container)?.children[1]?.textContent).toBe("2/5");
+
+		act(() => {
+			activeRoot?.render(
+				<TaskCard
+					task={createTask({ acceptanceCriteriaItems: createCriteria(4, 5) })}
+					onUpdate={() => {}}
+					onEdit={() => {}}
+				/>,
+			);
+		});
+
+		expect(getProgress(container)?.children[0]?.textContent).toBe("[████░]");
+		expect(getProgress(container)?.children[1]?.textContent).toBe("4/5");
+	});
+});

--- a/src/web/components/AcceptanceCriteriaProgress.tsx
+++ b/src/web/components/AcceptanceCriteriaProgress.tsx
@@ -1,0 +1,39 @@
+import type { Task } from "../../types";
+
+interface AcceptanceCriteriaProgressProps {
+	task: Pick<Task, "status" | "acceptanceCriteriaItems">;
+	cells: 5 | 10;
+	className?: string;
+}
+
+const normalizeStatus = (status: string) => status.trim().toLowerCase().replace(/\s+/g, "");
+
+export default function AcceptanceCriteriaProgress({
+	task,
+	cells,
+	className = "",
+}: AcceptanceCriteriaProgressProps) {
+	const criteria = task.acceptanceCriteriaItems ?? [];
+	if (normalizeStatus(task.status) !== "inprogress" || criteria.length === 0) return null;
+
+	const checked = criteria.reduce((total, criterion) => total + Number(criterion.checked), 0);
+	const filledCells = Math.round((checked / criteria.length) * cells);
+	const bar = `[${"█".repeat(filledCells)}${"░".repeat(cells - filledCells)}]`;
+
+	return (
+		<span
+			className={`inline-flex items-center gap-1 whitespace-nowrap font-mono text-[10px] font-medium text-blue-600 dark:text-blue-300 ${className}`}
+			data-acceptance-criteria-progress
+			data-cell-count={cells}
+			role="progressbar"
+			aria-label="Acceptance criteria progress"
+			aria-valuemin={0}
+			aria-valuemax={criteria.length}
+			aria-valuenow={checked}
+			title={`${checked} of ${criteria.length} acceptance criteria checked`}
+		>
+			<span aria-hidden="true">{bar}</span>
+			<span>{checked}/{criteria.length}</span>
+		</span>
+	);
+}

--- a/src/web/components/AcceptanceCriteriaProgress.tsx
+++ b/src/web/components/AcceptanceCriteriaProgress.tsx
@@ -8,16 +8,27 @@ interface AcceptanceCriteriaProgressProps {
 
 const normalizeStatus = (status: string) => status.trim().toLowerCase().replace(/\s+/g, "");
 
+export function getAcceptanceCriteriaProgressCounts(
+	task: Pick<Task, "status" | "acceptanceCriteriaItems">,
+): { checked: number; total: number } | null {
+	const criteria = task.acceptanceCriteriaItems ?? [];
+	if (normalizeStatus(task.status) !== "inprogress" || criteria.length === 0) return null;
+
+	return {
+		checked: criteria.reduce((total, criterion) => total + Number(criterion.checked), 0),
+		total: criteria.length,
+	};
+}
+
 export default function AcceptanceCriteriaProgress({
 	task,
 	cells,
 	className = "",
 }: AcceptanceCriteriaProgressProps) {
-	const criteria = task.acceptanceCriteriaItems ?? [];
-	if (normalizeStatus(task.status) !== "inprogress" || criteria.length === 0) return null;
+	const progress = getAcceptanceCriteriaProgressCounts(task);
+	if (!progress) return null;
 
-	const checked = criteria.reduce((total, criterion) => total + Number(criterion.checked), 0);
-	const filledCells = Math.round((checked / criteria.length) * cells);
+	const filledCells = Math.round((progress.checked / progress.total) * cells);
 	const bar = `[${"█".repeat(filledCells)}${"░".repeat(cells - filledCells)}]`;
 
 	return (
@@ -28,12 +39,12 @@ export default function AcceptanceCriteriaProgress({
 			role="progressbar"
 			aria-label="Acceptance criteria progress"
 			aria-valuemin={0}
-			aria-valuemax={criteria.length}
-			aria-valuenow={checked}
-			title={`${checked} of ${criteria.length} acceptance criteria checked`}
+			aria-valuemax={progress.total}
+			aria-valuenow={progress.checked}
+			title={`${progress.checked} of ${progress.total} acceptance criteria checked`}
 		>
 			<span aria-hidden="true">{bar}</span>
-			<span>{checked}/{criteria.length}</span>
+			<span>{progress.checked}/{progress.total}</span>
 		</span>
 	);
 }

--- a/src/web/components/TaskCard.tsx
+++ b/src/web/components/TaskCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { type Task } from '../../types';
 import { formatPriorityLabel } from '../../utils/priority-config';
-import AcceptanceCriteriaProgress from './AcceptanceCriteriaProgress';
+import AcceptanceCriteriaProgress, { getAcceptanceCriteriaProgressCounts } from './AcceptanceCriteriaProgress';
 import TaskTypeBadge from './TaskTypeBadge';
 
 interface TaskCardProps {
@@ -21,6 +21,10 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEn
 
   // Check if task is from another branch (read-only)
   const isFromOtherBranch = Boolean(task.branch);
+  const acceptanceCriteriaProgress = getAcceptanceCriteriaProgressCounts(task);
+  const accessibleLabel = acceptanceCriteriaProgress
+    ? `Open ${task.id}: ${task.title}. Acceptance criteria progress: ${acceptanceCriteriaProgress.checked} of ${acceptanceCriteriaProgress.total}`
+    : `Open ${task.id}: ${task.title}`;
 
   const handleDragStart = (e: React.DragEvent) => {
     // Prevent dragging cross-branch tasks
@@ -115,7 +119,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEn
         draggable={!isFromOtherBranch}
 		role="button"
 		tabIndex={0}
-		aria-label={`Open ${task.id}: ${task.title}`}
+		aria-label={accessibleLabel}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onClick={() => onEdit(task)}

--- a/src/web/components/TaskCard.tsx
+++ b/src/web/components/TaskCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type Task } from '../../types';
 import { formatPriorityLabel } from '../../utils/priority-config';
+import AcceptanceCriteriaProgress from './AcceptanceCriteriaProgress';
 import TaskTypeBadge from './TaskTypeBadge';
 
 interface TaskCardProps {
@@ -161,6 +162,8 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEn
         }`}>
           {task.title}
         </h4>
+
+        <AcceptanceCriteriaProgress task={task} cells={5} className="mt-2" />
 
         {/* Labels - limit to 3 */}
         {task.labels.length > 0 && (

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -19,6 +19,7 @@ import {
 	resolvePriorityValue,
 } from "../../utils/priority-config.ts";
 import CleanupModal from "./CleanupModal";
+import AcceptanceCriteriaProgress from "./AcceptanceCriteriaProgress";
 import LabelFilterDropdown from "./LabelFilterDropdown";
 import { SuccessToast } from "./SuccessToast";
 
@@ -833,22 +834,22 @@ const TaskList: React.FC<TaskListProps> = ({
 											</td>
 											<td className="px-3 py-2.5">
 												<div className="flex items-center gap-2 min-w-0">
-											<button
-												type="button"
-												onClick={(event) => {
-													event.stopPropagation();
-													onEditTask(task);
-												}}
-												className={`block truncate text-sm ${
-													isFromOtherBranch
-														? "text-gray-600 dark:text-gray-300"
-														: "text-gray-900 dark:text-gray-100"
-												} rounded text-left focus:outline-none focus:ring-2 focus:ring-stone-500`}
-												title={task.title}
-												aria-label={`Open ${task.id}: ${task.title}`}
-											>
-												{task.title}
-											</button>
+													<button
+														type="button"
+														onClick={(event) => {
+															event.stopPropagation();
+															onEditTask(task);
+														}}
+														className={`block truncate text-sm ${
+															isFromOtherBranch
+																? "text-gray-600 dark:text-gray-300"
+																: "text-gray-900 dark:text-gray-100"
+														} rounded text-left focus:outline-none focus:ring-2 focus:ring-stone-500`}
+														title={task.title}
+														aria-label={`Open ${task.id}: ${task.title}`}
+													>
+														{task.title}
+													</button>
 													{isFromOtherBranch && task.branch && (
 														<span
 															className="inline-flex shrink-0 items-center rounded-circle bg-amber-100 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
@@ -858,6 +859,7 @@ const TaskList: React.FC<TaskListProps> = ({
 														</span>
 													)}
 												</div>
+												<AcceptanceCriteriaProgress task={task} cells={10} className="mt-1" />
 											</td>
 											<td className="px-3 py-2.5">
 												<span className={`inline-flex rounded-circle px-2 py-0.5 text-[11px] font-medium ${getStatusColor(task.status)}`}>


### PR DESCRIPTION
## Summary

- add one derived browser acceptance-criteria progress component
- render five-cell bars on board cards and ten-cell bars in task-list summaries
- keep task status explicit and omit progress when no criteria exist

## Testing

- 11 relevant rendered Web tests passed
- bunx tsc --noEmit
- bun run check .
- bun run build
- in-app Browser QA attempted but no browser backend was connected