### PR TITLE
BACK-589 - Improve composer usability at extreme terminal sizes

### DIFF
--- a/backlog/tasks/back-589 - Improve-composer-usability-at-extreme-terminal-sizes.md
+++ b/backlog/tasks/back-589 - Improve-composer-usability-at-extreme-terminal-sizes.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-589
 title: Improve composer usability at extreme terminal sizes
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-07 20:45'
+updated_date: '2026-08-10 05:47'
 labels:
   - tui
 dependencies: []
@@ -28,16 +30,43 @@ The goal is a composer that stays legible and obviously editable across the term
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 At terminal heights of 8 to 10 rows, the focused composer field always shows at least one editable row with a visible cursor
-- [ ] #2 Selector values render without clipping at 80 and 100 columns for the longest shipped status value, including the trailing selector cue
-- [ ] #3 Compact layout engages whenever the longest label and value would not fit the available field width, not only below a fixed 64-column threshold
-- [ ] #4 PTY-rendered evidence at 8 and 10 rows and at 80 and 100 columns is recorded on the task
-- [ ] #5 Regression tests cover the short-height layout and the narrow-width selector layout
+- [x] #1 At terminal heights of 8 to 10 rows, the focused composer field always shows at least one editable row with a visible cursor
+- [x] #2 Selector values render without clipping at 80 and 100 columns for the longest shipped status value, including the trailing selector cue
+- [x] #3 Compact layout engages whenever the longest label and value would not fit the available field width, not only below a fixed 64-column threshold
+- [x] #4 PTY-rendered evidence at 8 and 10 rows and at 80 and 100 columns is recorded on the task
+- [x] #5 Regression tests cover the short-height layout and the narrow-width selector layout
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace the fixed width breakpoint with selector-content constraints: size the popup up to the available terminal width, and use the compact selector layout only when the longest configured label/value plus the selector cue cannot fit a normal selector column.
+2. Derive the short-popup minimum from the popup chrome and the three rows required by a bordered text input so Title and Description each scroll into a viewport with an editable row at 8-10 terminal rows; preserve focus, navigation, picker, and persistence behavior.
+3. Add deterministic layout and rendered-widget regression coverage for 8-10 rows, 80/100 columns, the shipped In Progress status, and longer configured selector values.
+4. Run the focused composer suite, TypeScript, Biome, and build; exercise the built TUI in PTYs at 80x8, 100x8, 80x10, and 100x10, then record cursor and selector-cue evidence on the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented constraint-based composer geometry. The popup now grows only enough for the longest configured selector content measured with Bun.stringWidth, stacks selector rows when that content cannot fit a normal column, and reserves popup chrome plus a complete three-row bordered input at extreme heights. Interaction, picker, focus graph, and persistence paths are unchanged.
+
+Deterministic rendered-widget evidence: the focused Title and Description inputs were exercised at 80x8, 80x9, and 80x10. In every case the popup was 8 rows, the scrollable form was 3 rows, the focused widget was actively reading, its first editable row was within the form viewport, getCursor returned a caret, and the terminal cursor was visible. At 80x24 and 100x24, Status: In Progress ▼ measured 21 terminal cells and the rendered selector width was 21 cells, including the trailing cue. A long configured status at 100 columns switched to the stacked selector geometry and rendered without clipping.
+
+PTY evidence from the compiled dist/backlog against a filesystem-only fixture: 80x8 cursor=(7,3), 100x8 cursor=(17,3), 80x10 cursor=(7,4), and 100x10 cursor=(17,4); each coordinate is the visible editable Title row. After selecting In Progress in each PTY, capture-pane showed the complete Status: In Progress cue cell followed by padding, plus complete Type and Priority selectors. This tmux/neo-neo-bblessed capture backend renders the Unicode ▼ fallback glyph as ?, so the deterministic widget assertion separately verifies the literal ▼ code point and its 21/21-cell fit.
+
+Validation: 33 composer model, interaction, and board-outcome tests passed (270 assertions), including all five new layout regressions. bunx tsc --noEmit, bun run check ., bun run build, and git diff --check passed. The complete composer file was also attempted twice: all 63 other tests passed, while the unrelated watchTasks delivery case timed out after its fixed 3-second filesystem-event wait both in-suite and alone; no watcher or persistence code is touched by this change.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made the TUI task composer usable at extreme sizes by deriving popup and compact geometry from actual selector display widths and the minimum visible bordered-input height. Added rendered-widget regressions for both text cursors at 8-10 rows, unclipped In Progress selector cues at 80/100 columns, and content-driven stacking; verified the compiled UI in four tmux PTYs plus 33 focused tests, TypeScript, Biome, and build.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -267,11 +267,12 @@ describe("TUI task composer model", () => {
 		});
 		expect(getTaskComposerLayout(50, 18)).toMatchObject({
 			compact: true,
+			stackSelectors: true,
 			popupHeight: 16,
 			descriptionHeight: 3,
 			detailsTop: 6,
-			detailsHeight: 4,
-			actionsTop: 10,
+			detailsHeight: 5,
+			actionsTop: 11,
 		});
 	});
 
@@ -1436,7 +1437,7 @@ describe("TUI task composer interaction", () => {
 		}
 	});
 
-	it("adapts the spatial focus graph to the narrow two-row selector layout", async () => {
+	it("adapts the spatial focus graph to the narrow stacked selector layout", async () => {
 		const screen = createScreen({ smartCSR: false });
 		Object.defineProperty(screen, "width", { configurable: true, value: 50, writable: true });
 		Object.defineProperty(screen, "height", { configurable: true, value: 18, writable: true });
@@ -1453,9 +1454,14 @@ describe("TUI task composer interaction", () => {
 			expect(eventScreen.focused?.content).toBe("Status: To Do ▼");
 			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Type: None ▼");
-			pressKey(eventScreen.focused, "right");
+			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Priority: None ▼");
 			pressKey(eventScreen.focused, "down");
+			expect(eventScreen.focused?.content).toBe("Create task");
+			pressKey(eventScreen.focused, "up");
+			expect(eventScreen.focused?.content).toBe("Priority: None ▼");
+			pressKey(eventScreen.focused, "down");
+			pressKey(eventScreen.focused, "right");
 			expect(eventScreen.focused?.content).toBe("Cancel");
 			pressKey(eventScreen.focused, "left");
 			expect(eventScreen.focused?.content).toBe("Create task");
@@ -1747,11 +1753,13 @@ describe("TUI task composer interaction", () => {
 			status = widgets.find((widget) => widget.content === "Status: To Do ▼");
 			type = widgets.find((widget) => widget.content === "Type: None ▼");
 			expect(description?.position).toMatchObject({ top: 3, height: 3 });
-			expect(details?.position).toMatchObject({ top: 6, height: 4 });
-			expect(actions?.position).toMatchObject({ top: 10, height: 1 });
+			expect(details?.position).toMatchObject({ top: 6, height: 5 });
+			expect(actions?.position).toMatchObject({ top: 11, height: 1 });
 			expect(actions?.hidden).toBe(true);
 			expect(status?.position).toMatchObject({ top: 7, left: 3 });
-			expect(type?.position).toMatchObject({ top: 8, left: 3, width: "44%" });
+			expect(type?.position).toMatchObject({ top: 8, left: 3 });
+			const priority = widgets.find((widget) => widget.content === "Priority: None ▼");
+			expect(priority?.position).toMatchObject({ top: 9, left: 3 });
 			expect(widgets.some((widget) => widget.content?.includes("[↑↓←→/Tab]"))).toBe(true);
 
 			mutableScreen.width = 80;

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -80,6 +80,7 @@ type TestWidget = {
 	width?: number | string;
 	emit?: (event: string, ...args: unknown[]) => void;
 	setValue?: (value: string) => void;
+	setContent?: (value: string) => void;
 };
 
 function collectWidgets(root: { children?: unknown[] }): TestWidget[] {
@@ -1691,8 +1692,9 @@ describe("TUI task composer interaction", () => {
 			expect(status?.position?.top).toBe(7);
 			expect(type?.position?.top).toBe(8);
 			expect(priority?.position?.top).toBe(9);
-			expect(type?.width).toBe("100%-6");
-			expect(priority?.width).toBe("100%-6");
+			type?.setContent?.(`Type: ${typeValue} ▼`);
+			expect(type?.width).toBeGreaterThanOrEqual(Bun.stringWidth(type?.content ?? ""));
+			expect(priority?.width).toBeGreaterThanOrEqual(Bun.stringWidth(priority?.content ?? ""));
 			expect(status?.width).toBeGreaterThanOrEqual(Bun.stringWidth(status?.content ?? ""));
 
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "escape", "\x1b");

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -1697,7 +1697,13 @@ describe("TUI task composer interaction", () => {
 			expect(priority?.width).toBeGreaterThanOrEqual(Bun.stringWidth(priority?.content ?? ""));
 			expect(status?.width).toBeGreaterThanOrEqual(Bun.stringWidth(status?.content ?? ""));
 
-			pressKey((screen as unknown as { focused?: TestWidget }).focused, "escape", "\x1b");
+			const eventScreen = screen as unknown as { focused?: TestWidget };
+			for (let step = 0; step < 5; step += 1) pressKey(eventScreen.focused, "down");
+			expect(eventScreen.focused?.content).toBe("Create task");
+			pressKey(eventScreen.focused, "up");
+			expect(eventScreen.focused?.content).toBe("Priority: None ▼");
+
+			pressKey(eventScreen.focused, "escape", "\x1b");
 			expect(await withTimeout(resultPromise, "content-constrained composer cancellation", 1000)).toBeNull();
 		} finally {
 			screen.destroy();

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -278,6 +278,14 @@ describe("TUI task composer model", () => {
 		const statuses = ["To Do", "Waiting for external approval", "Done"];
 		expect(getTaskComposerLayout(100, 30, { statuses }).compact).toBe(true);
 		expect(getTaskComposerLayout(140, 30, { statuses }).compact).toBe(false);
+
+		const types = ["A very long configured type value that exceeds a compact column"];
+		expect(getTaskComposerLayout(100, 30, { types })).toMatchObject({
+			compact: true,
+			stackSelectors: true,
+			detailsHeight: 5,
+			actionsTop: 11,
+		});
 	});
 
 	it("keeps the composer inside short terminals so no row is pushed off-screen", () => {
@@ -1668,18 +1676,23 @@ describe("TUI task composer interaction", () => {
 		Object.defineProperty(screen, "width", { configurable: true, value: 100, writable: true });
 		Object.defineProperty(screen, "height", { configurable: true, value: 30, writable: true });
 		try {
-			const statusValue = "Waiting for external approval";
+			const typeValue = "A very long configured type value that exceeds a compact column";
 			const resultPromise = openTaskComposer({
 				screen,
-				statuses: [statusValue, "Done"],
+				statuses: ["To Do", "Done"],
+				types: [typeValue],
 				persist: async () => task(),
 			});
 			await settleComposerFocus();
 			const widgets = collectWidgets(screen as unknown as { children?: unknown[] });
-			const status = widgets.find((widget) => widget.content === `Status: ${statusValue} ▼`);
+			const status = widgets.find((widget) => widget.content === "Status: To Do ▼");
 			const type = widgets.find((widget) => widget.content === "Type: None ▼");
+			const priority = widgets.find((widget) => widget.content === "Priority: None ▼");
 			expect(status?.position?.top).toBe(7);
 			expect(type?.position?.top).toBe(8);
+			expect(priority?.position?.top).toBe(9);
+			expect(type?.width).toBe("100%-6");
+			expect(priority?.width).toBe("100%-6");
 			expect(status?.width).toBeGreaterThanOrEqual(Bun.stringWidth(status?.content ?? ""));
 
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "escape", "\x1b");

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -248,16 +248,22 @@ describe("TUI task composer model", () => {
 		});
 	});
 
-	it("keeps the composer compact at 100x30 and 80x24, then stacks details at 50x18", () => {
+	it("fits shipped selector content at 100x30 and 80x24, then stacks details at 50x18", () => {
 		expect(getTaskComposerLayout(100, 30)).toMatchObject({
 			compact: false,
+			popupWidth: 74,
 			popupHeight: 20,
 			descriptionHeight: 6,
 			detailsTop: 9,
 			detailsHeight: 3,
 			actionsTop: 12,
 		});
-		expect(getTaskComposerLayout(80, 24)).toMatchObject({ compact: false, popupHeight: 20, actionsTop: 12 });
+		expect(getTaskComposerLayout(80, 24)).toMatchObject({
+			compact: false,
+			popupWidth: 74,
+			popupHeight: 20,
+			actionsTop: 12,
+		});
 		expect(getTaskComposerLayout(50, 18)).toMatchObject({
 			compact: true,
 			popupHeight: 16,
@@ -268,12 +274,21 @@ describe("TUI task composer model", () => {
 		});
 	});
 
+	it("derives compact selector layout from configured content instead of a screen breakpoint", () => {
+		const statuses = ["To Do", "Waiting for external approval", "Done"];
+		expect(getTaskComposerLayout(100, 30, { statuses }).compact).toBe(true);
+		expect(getTaskComposerLayout(140, 30, { statuses }).compact).toBe(false);
+	});
+
 	it("keeps the composer inside short terminals so no row is pushed off-screen", () => {
 		for (const screenHeight of [6, 8, 10, 12, 14, 16, 20, 24, 40]) {
 			const { popupHeight } = getTaskComposerLayout(80, screenHeight);
 			expect(popupHeight).toBeLessThanOrEqual(screenHeight);
 		}
 		expect(getTaskComposerLayout(80, 10).popupHeight).toBe(8);
+		for (const screenHeight of [8, 9, 10]) {
+			expect(getTaskComposerLayout(80, screenHeight).popupHeight).toBeGreaterThanOrEqual(8);
+		}
 	});
 
 	it("does not persist invalid input and preserves values after a failed attempt", async () => {
@@ -1568,6 +1583,107 @@ describe("TUI task composer interaction", () => {
 					status: "To Do",
 				},
 			]);
+		} finally {
+			screen.destroy();
+		}
+	});
+
+	it("keeps an editable row and visible cursor for both text fields at 8-10 terminal rows", async () => {
+		for (const screenHeight of [8, 9, 10]) {
+			const screen = createScreen({ smartCSR: false });
+			Object.defineProperty(screen, "width", { configurable: true, value: 80, writable: true });
+			Object.defineProperty(screen, "height", { configurable: true, value: screenHeight, writable: true });
+			const eventScreen = screen as unknown as {
+				focused?: TestWidget;
+				program?: { cursorHidden?: boolean };
+			};
+			try {
+				const resultPromise = openTaskComposer({
+					screen,
+					statuses: ["To Do", "In Progress", "Done"],
+					persist: async () => task(),
+				});
+				await settleComposerFocus();
+				const widgets = collectWidgets(screen as unknown as { children?: unknown[] });
+				const form = widgets.find((widget) => widget.type === "scrollable-box");
+				const title = widgets.find((widget) => widget.options?.label === " Title ");
+				const description = widgets.find((widget) => widget.options?.label === " Description ");
+				expect(form?.height).toBeGreaterThanOrEqual(3);
+
+				const expectEditableRowVisible = (input: TestWidget | undefined) => {
+					const fieldTop = Number(input?.position?.top ?? 0);
+					const firstEditableRow = fieldTop + 1;
+					const viewportTop = form?.childBase ?? 0;
+					const viewportBottom = viewportTop + (form?.height ?? 0);
+					expect(firstEditableRow).toBeGreaterThanOrEqual(viewportTop);
+					expect(firstEditableRow).toBeLessThan(viewportBottom);
+					expect(input?._reading).toBe(true);
+					expect(input?.getCursor?.()).toBeDefined();
+					expect(eventScreen.program?.cursorHidden).toBe(false);
+				};
+
+				expect(eventScreen.focused).toBe(title);
+				expectEditableRowVisible(title);
+				pressKey(eventScreen.focused, "tab", "\t");
+				expect(eventScreen.focused).toBe(description);
+				expectEditableRowVisible(description);
+
+				pressKey(eventScreen.focused, "escape", "\x1b");
+				expect(await withTimeout(resultPromise, `short ${screenHeight}-row composer cancellation`, 1000)).toBeNull();
+			} finally {
+				screen.destroy();
+			}
+		}
+	});
+
+	it("renders the longest shipped status and selector cue without clipping at 80 and 100 columns", async () => {
+		for (const screenWidth of [80, 100]) {
+			const screen = createScreen({ smartCSR: false });
+			Object.defineProperty(screen, "width", { configurable: true, value: screenWidth, writable: true });
+			Object.defineProperty(screen, "height", { configurable: true, value: 24, writable: true });
+			try {
+				const resultPromise = openTaskComposer({
+					screen,
+					statuses: ["In Progress", "To Do", "Done"],
+					persist: async () => task(),
+				});
+				await settleComposerFocus();
+				const status = collectWidgets(screen as unknown as { children?: unknown[] }).find(
+					(widget) => widget.content === "Status: In Progress ▼",
+				);
+				expect(status).toBeDefined();
+				expect(status?.content?.endsWith(" ▼")).toBe(true);
+				expect(status?.width).toBeGreaterThanOrEqual(Bun.stringWidth(status?.content ?? ""));
+
+				pressKey((screen as unknown as { focused?: TestWidget }).focused, "escape", "\x1b");
+				expect(await withTimeout(resultPromise, `${screenWidth}-column composer cancellation`, 1000)).toBeNull();
+			} finally {
+				screen.destroy();
+			}
+		}
+	});
+
+	it("stacks selector rows when configured content cannot fit a normal column", async () => {
+		const screen = createScreen({ smartCSR: false });
+		Object.defineProperty(screen, "width", { configurable: true, value: 100, writable: true });
+		Object.defineProperty(screen, "height", { configurable: true, value: 30, writable: true });
+		try {
+			const statusValue = "Waiting for external approval";
+			const resultPromise = openTaskComposer({
+				screen,
+				statuses: [statusValue, "Done"],
+				persist: async () => task(),
+			});
+			await settleComposerFocus();
+			const widgets = collectWidgets(screen as unknown as { children?: unknown[] });
+			const status = widgets.find((widget) => widget.content === `Status: ${statusValue} ▼`);
+			const type = widgets.find((widget) => widget.content === "Type: None ▼");
+			expect(status?.position?.top).toBe(7);
+			expect(type?.position?.top).toBe(8);
+			expect(status?.width).toBeGreaterThanOrEqual(Bun.stringWidth(status?.content ?? ""));
+
+			pressKey((screen as unknown as { focused?: TestWidget }).focused, "escape", "\x1b");
+			expect(await withTimeout(resultPromise, "content-constrained composer cancellation", 1000)).toBeNull();
 		} finally {
 			screen.destroy();
 		}

--- a/src/ui/components/task-composer.ts
+++ b/src/ui/components/task-composer.ts
@@ -1,5 +1,6 @@
 import type { BoxInterface, ScreenInterface, TextboxInterface } from "neo-neo-bblessed";
 import { box, textarea, textbox } from "neo-neo-bblessed";
+import { DEFAULT_STATUSES } from "../../constants/index.ts";
 import type { Task, TaskCreateInput } from "../../types/index.ts";
 import { getPriorityOptions } from "../../utils/priority-config.ts";
 import { getTaskTypeValues } from "../../utils/task-type-config.ts";
@@ -131,7 +132,7 @@ export type TaskComposerValues = {
 
 export type TaskComposerLayout = {
 	compact: boolean;
-	popupWidth: string | number;
+	popupWidth: number;
 	popupHeight: number;
 	descriptionHeight: number;
 	detailsTop: number;
@@ -140,19 +141,75 @@ export type TaskComposerLayout = {
 	contentHeight: number;
 };
 
-export function getTaskComposerLayout(screenWidth: number, screenHeight: number): TaskComposerLayout {
-	const compact = screenWidth < 64 || screenHeight < 20;
-	const descriptionHeight = compact ? 3 : 6;
-	const detailsTop = 3 + descriptionHeight;
-	const detailsHeight = compact ? 4 : 3;
+export type TaskComposerLayoutOptions = {
+	statuses?: readonly string[];
+	types?: readonly string[];
+	priorities?: readonly string[];
+};
+
+const TEXT_INPUT_HEIGHT = 3;
+// Two popup borders, then the form's top offset and two reserved footer rows.
+const POPUP_FORM_VERTICAL_CHROME = 5;
+// Two popup borders and the form's one-column inset on each side.
+const POPUP_FORM_HORIZONTAL_CHROME = 4;
+// createPopupChrome's backdrop extends two columns beyond each side of the popup.
+const POPUP_OUTER_HORIZONTAL_MARGIN = 4;
+const PREFERRED_POPUP_WIDTH = 72;
+const NORMAL_SELECTOR_WIDTH_RATIO = 0.3;
+
+function selectorContent(label: string, value: string): string {
+	return `${label}: ${displayChoice(value)} ▼`;
+}
+
+function getLongestSelectorContentWidth(options: TaskComposerLayoutOptions): number {
+	const selectors: Array<[string, FilterPopupChoice[]]> = [
+		["Status", getTaskComposerStatusChoices(options.statuses ?? DEFAULT_STATUSES)],
+		["Type", getTaskComposerTypeChoices(options.types)],
+		["Priority", getTaskComposerPriorityChoices(options.priorities)],
+	];
+	return Math.max(
+		...selectors.flatMap(([label, choices]) =>
+			choices.map((choice) => Bun.stringWidth(selectorContent(label, choice.value))),
+		),
+	);
+}
+
+export function getTaskComposerLayout(
+	screenWidth: number,
+	screenHeight: number,
+	options: TaskComposerLayoutOptions = {},
+): TaskComposerLayout {
+	const longestSelectorWidth = getLongestSelectorContentWidth(options);
+	const requiredPopupWidth =
+		Math.ceil(longestSelectorWidth / NORMAL_SELECTOR_WIDTH_RATIO) + POPUP_FORM_HORIZONTAL_CHROME;
+	const availablePopupWidth = Math.max(1, screenWidth - POPUP_OUTER_HORIZONTAL_MARGIN);
+	const popupWidth = Math.min(availablePopupWidth, Math.max(PREFERRED_POPUP_WIDTH, requiredPopupWidth));
+	const popupHeight = Math.min(
+		20,
+		screenHeight,
+		Math.max(screenHeight - 2, POPUP_FORM_VERTICAL_CHROME + TEXT_INPUT_HEIGHT),
+	);
+	const normalSelectorWidth = Math.floor(
+		Math.max(0, popupWidth - POPUP_FORM_HORIZONTAL_CHROME) * NORMAL_SELECTOR_WIDTH_RATIO,
+	);
+	const expandedDescriptionHeight = 6;
+	const expandedDetailsHeight = 3;
+	const expandedActionsHeight = 2;
+	const expandedContentHeight =
+		TEXT_INPUT_HEIGHT + expandedDescriptionHeight + expandedDetailsHeight + expandedActionsHeight;
+	const visibleFormHeight = Math.max(0, popupHeight - POPUP_FORM_VERTICAL_CHROME);
+	const compact = normalSelectorWidth < longestSelectorWidth || visibleFormHeight < expandedContentHeight;
+	const descriptionHeight = compact ? 3 : expandedDescriptionHeight;
+	const detailsTop = TEXT_INPUT_HEIGHT + descriptionHeight;
+	const detailsHeight = compact ? 4 : expandedDetailsHeight;
 	const actionsTop = detailsTop + detailsHeight;
 	return {
 		compact,
-		popupWidth: screenWidth < 76 ? "96%" : 72,
+		popupWidth,
 		// The popup must never be taller than the screen: blessed centers it by subtracting
-		// half its height, so an oversized popup starts at a negative row and its actions,
-		// error and help rows fall outside the terminal.
-		popupHeight: Math.min(20, Math.max(3, screenHeight - 2)),
+		// half its height. At extreme sizes it also needs enough rows for popup chrome and one
+		// complete bordered input, otherwise the editable row and cursor are both clipped.
+		popupHeight,
 		descriptionHeight,
 		detailsTop,
 		detailsHeight,
@@ -284,7 +341,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 		let settled = false;
 		let pickerOpen = false;
 		let activeField: TaskComposerField = "title";
-		let layout = getTaskComposerLayout(options.screen.width, options.screen.height);
+		let layout = getTaskComposerLayout(options.screen.width, options.screen.height, options);
 		const { popup, close, reflow } = createPopupChrome({
 			screen: options.screen,
 			title: "Create Task",
@@ -349,7 +406,6 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 		// The selectors and buttons sit inside the details frame visually, but stay direct
 		// children of the viewport: blessed drops grandchildren of a scrolled viewport, which
 		// would make them invisible on short terminals.
-		const selectorContent = (label: string, value: string) => `${label}: ${displayChoice(value)} ▼`;
 		const createSelector = (label: string, value: string) =>
 			box({
 				parent: form,
@@ -468,7 +524,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 		};
 
 		const applyLayout = () => {
-			layout = getTaskComposerLayout(options.screen.width, options.screen.height);
+			layout = getTaskComposerLayout(options.screen.width, options.screen.height, options);
 			reflow(layout.popupWidth, layout.popupHeight, getTaskComposerHelpText(options.screen.width, layout.compact));
 			descriptionInput.height = layout.descriptionHeight;
 			detailsGroup.top = layout.detailsTop;

--- a/src/ui/components/task-composer.ts
+++ b/src/ui/components/task-composer.ts
@@ -132,6 +132,7 @@ export type TaskComposerValues = {
 
 export type TaskComposerLayout = {
 	compact: boolean;
+	stackSelectors: boolean;
 	popupWidth: number;
 	popupHeight: number;
 	descriptionHeight: number;
@@ -156,22 +157,31 @@ const POPUP_FORM_HORIZONTAL_CHROME = 4;
 const POPUP_OUTER_HORIZONTAL_MARGIN = 4;
 const PREFERRED_POPUP_WIDTH = 72;
 const NORMAL_SELECTOR_WIDTH_RATIO = 0.3;
+const COMPACT_SELECTOR_WIDTH_RATIO = 0.44;
 
 function selectorContent(label: string, value: string): string {
 	return `${label}: ${displayChoice(value)} ▼`;
 }
 
-function getLongestSelectorContentWidth(options: TaskComposerLayoutOptions): number {
+function getSelectorContentWidths(options: TaskComposerLayoutOptions): {
+	longest: number;
+	longestCompactColumn: number;
+} {
 	const selectors: Array<[string, FilterPopupChoice[]]> = [
 		["Status", getTaskComposerStatusChoices(options.statuses ?? DEFAULT_STATUSES)],
 		["Type", getTaskComposerTypeChoices(options.types)],
 		["Priority", getTaskComposerPriorityChoices(options.priorities)],
 	];
-	return Math.max(
-		...selectors.flatMap(([label, choices]) =>
-			choices.map((choice) => Bun.stringWidth(selectorContent(label, choice.value))),
-		),
-	);
+	let longest = 0;
+	let longestCompactColumn = 0;
+	for (const [label, choices] of selectors) {
+		for (const choice of choices) {
+			const width = Bun.stringWidth(selectorContent(label, choice.value));
+			longest = Math.max(longest, width);
+			if (label === "Type" || label === "Priority") longestCompactColumn = Math.max(longestCompactColumn, width);
+		}
+	}
+	return { longest, longestCompactColumn };
 }
 
 export function getTaskComposerLayout(
@@ -179,7 +189,7 @@ export function getTaskComposerLayout(
 	screenHeight: number,
 	options: TaskComposerLayoutOptions = {},
 ): TaskComposerLayout {
-	const longestSelectorWidth = getLongestSelectorContentWidth(options);
+	const { longest: longestSelectorWidth, longestCompactColumn } = getSelectorContentWidths(options);
 	const requiredPopupWidth =
 		Math.ceil(longestSelectorWidth / NORMAL_SELECTOR_WIDTH_RATIO) + POPUP_FORM_HORIZONTAL_CHROME;
 	const availablePopupWidth = Math.max(1, screenWidth - POPUP_OUTER_HORIZONTAL_MARGIN);
@@ -192,6 +202,9 @@ export function getTaskComposerLayout(
 	const normalSelectorWidth = Math.floor(
 		Math.max(0, popupWidth - POPUP_FORM_HORIZONTAL_CHROME) * NORMAL_SELECTOR_WIDTH_RATIO,
 	);
+	const compactSelectorWidth = Math.floor(
+		Math.max(0, popupWidth - POPUP_FORM_HORIZONTAL_CHROME) * COMPACT_SELECTOR_WIDTH_RATIO,
+	);
 	const expandedDescriptionHeight = 6;
 	const expandedDetailsHeight = 3;
 	const expandedActionsHeight = 2;
@@ -199,12 +212,14 @@ export function getTaskComposerLayout(
 		TEXT_INPUT_HEIGHT + expandedDescriptionHeight + expandedDetailsHeight + expandedActionsHeight;
 	const visibleFormHeight = Math.max(0, popupHeight - POPUP_FORM_VERTICAL_CHROME);
 	const compact = normalSelectorWidth < longestSelectorWidth || visibleFormHeight < expandedContentHeight;
+	const stackSelectors = compact && longestCompactColumn > compactSelectorWidth;
 	const descriptionHeight = compact ? 3 : expandedDescriptionHeight;
 	const detailsTop = TEXT_INPUT_HEIGHT + descriptionHeight;
-	const detailsHeight = compact ? 4 : expandedDetailsHeight;
+	const detailsHeight = compact ? (stackSelectors ? 5 : 4) : expandedDetailsHeight;
 	const actionsTop = detailsTop + detailsHeight;
 	return {
 		compact,
+		stackSelectors,
 		popupWidth,
 		// The popup must never be taller than the screen: blessed centers it by subtracting
 		// half its height. At extreme sizes it also needs enough rows for popup chrome and one
@@ -481,7 +496,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 				description: 3,
 				status: layout.detailsTop + 1,
 				type: secondSelectorRow,
-				priority: secondSelectorRow,
+				priority: layout.stackSelectors ? secondSelectorRow + 1 : secondSelectorRow,
 				create: actionsRow,
 				cancel: actionsRow,
 			};
@@ -536,8 +551,13 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 			const tops = getFieldTops();
 			if (layout.compact) {
 				setFieldGeometry(statusField, { top: tops.status, left: 3, width: "100%-6" });
-				setFieldGeometry(typeField, { top: tops.type, left: 3, width: "44%" });
-				setFieldGeometry(priorityField, { top: tops.priority, left: "50%", width: "44%" });
+				if (layout.stackSelectors) {
+					setFieldGeometry(typeField, { top: tops.type, left: 3, width: "100%-6" });
+					setFieldGeometry(priorityField, { top: tops.priority, left: 3, width: "100%-6" });
+				} else {
+					setFieldGeometry(typeField, { top: tops.type, left: 3, width: "44%" });
+					setFieldGeometry(priorityField, { top: tops.priority, left: "50%", width: "44%" });
+				}
 				setFieldGeometry(createAction, { top: tops.create, left: 3, width: "44%" });
 				setFieldGeometry(cancelAction, { top: tops.cancel, left: "50%", width: "44%" });
 			} else {
@@ -581,10 +601,10 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 				if (activeField === "status" && direction === "up") next = "description";
 				if (activeField === "status" && direction === "down") next = "type";
 				if (activeField === "type" && direction === "up") next = "status";
-				if (activeField === "type" && direction === "down") next = "create";
-				if (activeField === "type" && direction === "right") next = "priority";
-				if (activeField === "priority" && direction === "up") next = "status";
-				if (activeField === "priority" && direction === "down") next = "cancel";
+				if (activeField === "type" && direction === "down") next = layout.stackSelectors ? "priority" : "create";
+				if (activeField === "type" && direction === "right" && !layout.stackSelectors) next = "priority";
+				if (activeField === "priority" && direction === "up") next = layout.stackSelectors ? "type" : "status";
+				if (activeField === "priority" && direction === "down") next = layout.stackSelectors ? "create" : "cancel";
 				if (activeField === "priority" && direction === "left") next = "type";
 				if (activeField === "create" && direction === "up") next = "type";
 				if (activeField === "cancel" && direction === "up") next = "priority";

--- a/src/ui/components/task-composer.ts
+++ b/src/ui/components/task-composer.ts
@@ -606,7 +606,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 				if (activeField === "priority" && direction === "up") next = layout.stackSelectors ? "type" : "status";
 				if (activeField === "priority" && direction === "down") next = layout.stackSelectors ? "create" : "cancel";
 				if (activeField === "priority" && direction === "left") next = "type";
-				if (activeField === "create" && direction === "up") next = "type";
+				if (activeField === "create" && direction === "up") next = layout.stackSelectors ? "priority" : "type";
 				if (activeField === "cancel" && direction === "up") next = "priority";
 			} else {
 				if (["status", "type", "priority"].includes(activeField)) {

--- a/src/ui/components/task-composer.ts
+++ b/src/ui/components/task-composer.ts
@@ -203,7 +203,7 @@ export function getTaskComposerLayout(
 		Math.max(0, popupWidth - POPUP_FORM_HORIZONTAL_CHROME) * NORMAL_SELECTOR_WIDTH_RATIO,
 	);
 	const compactSelectorWidth = Math.floor(
-		Math.max(0, popupWidth - 2) * COMPACT_SELECTOR_WIDTH_RATIO,
+		Math.max(0, popupWidth - POPUP_FORM_HORIZONTAL_CHROME) * COMPACT_SELECTOR_WIDTH_RATIO,
 	);
 	const expandedDescriptionHeight = 6;
 	const expandedDetailsHeight = 3;

--- a/src/ui/components/task-composer.ts
+++ b/src/ui/components/task-composer.ts
@@ -203,7 +203,7 @@ export function getTaskComposerLayout(
 		Math.max(0, popupWidth - POPUP_FORM_HORIZONTAL_CHROME) * NORMAL_SELECTOR_WIDTH_RATIO,
 	);
 	const compactSelectorWidth = Math.floor(
-		Math.max(0, popupWidth - POPUP_FORM_HORIZONTAL_CHROME) * COMPACT_SELECTOR_WIDTH_RATIO,
+		Math.max(0, popupWidth - 2) * COMPACT_SELECTOR_WIDTH_RATIO,
 	);
 	const expandedDescriptionHeight = 6;
 	const expandedDetailsHeight = 3;


### PR DESCRIPTION
## Summary

- derive composer geometry from actual selector display widths
- keep a complete editable row and visible cursor at 8-to-10-row terminal heights
- stack selector rows when configured content cannot fit instead of relying on a fixed breakpoint

## Testing

- 33 focused composer tests passed
- rendered widget coverage at 8, 9, and 10 rows and 80/100 columns
- compiled PTY QA at 80x8, 100x8, 80x10, and 100x10
- bunx tsc --noEmit
- bun run check .
- bun run build
- git diff --check