### PR TITLE
BACK-590 - Support mouse clicks in the TUI task composer

### DIFF
--- a/backlog/tasks/back-590 - Support-mouse-clicks-in-the-TUI-task-composer.md
+++ b/backlog/tasks/back-590 - Support-mouse-clicks-in-the-TUI-task-composer.md
@@ -1,14 +1,19 @@
 ---
 id: BACK-590
 title: Support mouse clicks in the TUI task composer
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-07 20:45'
+updated_date: '2026-08-10 05:55'
 labels:
   - tui
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/pull/833'
+modified_files:
+  - src/ui/components/task-composer.ts
+  - src/test/tui-task-composer.test.ts
 priority: low
 type: enhancement
 ordinal: 230000
@@ -26,17 +31,40 @@ Mouse input is already enabled elsewhere in the TUI, so clicks in the composer s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Clicking any composer text field focuses it and immediately accepts typed characters, with the caret visible in the clicked field
-- [ ] #2 Only the clicked field shows the focused highlight; the previously focused control is visibly deselected
-- [ ] #3 Clicking a selector (Status, Type, Priority) opens its picker
-- [ ] #4 Clicking back into Title after keyboard navigation away behaves identically to clicking it the first time
-- [ ] #5 Evidence from a PTY session or widget harness is recorded on the task
-- [ ] #6 Regression tests cover click-to-edit on a text field and click-to-open on a selector
+- [x] #1 Clicking any composer text field focuses it and immediately accepts typed characters, with the caret visible in the clicked field
+- [x] #2 Only the clicked field shows the focused highlight; the previously focused control is visibly deselected
+- [x] #3 Clicking a selector (Status, Type, Priority) opens its picker
+- [x] #4 Clicking back into Title after keyboard navigation away behaves identically to clicking it the first time
+- [x] #5 Evidence from a PTY session or widget harness is recorded on the task
+- [x] #6 Regression tests cover click-to-edit on a text field and click-to-open on a selector
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Route pointer activation for Title, Description, Status, Type, and Priority through one composer field-click handler that always calls the existing focusField transition first; text fields then inherit its readInput/caret behavior, while selectors open their existing picker.
+2. Keep keyboard navigation, selector choice logic, action clicks, persistence, and layout unchanged; ensure repeated clicks cancel and restart the same text reader through focusField rather than creating a parallel mouse-input lifecycle.
+3. Add rendered-widget regressions that click Description, navigate away and click Title repeatedly, verify exclusive focus/read mode/caret/text entry, and click each selector to verify its picker and focus restoration.
+4. Run the focused composer interaction/model suite, TypeScript, Biome, and build; record deterministic widget evidence on the task and finalize the acceptance criteria.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a single pointer-activation path for Title, Description, Status, Type, and Priority. Every field click enters the existing focusField transition; text fields therefore reuse readInput/caret handling and selectors invoke the existing picker. The handler stops event bubbling so Blessed cannot auto-focus the widget a second time and immediately blur/cancel a freshly started text reader. Keyboard navigation, action clicks, persistence, and layout are unchanged.
+
+Deterministic widget evidence (neo-neo-bblessed createScreen at 100x30): clicking Description made it screen.focused with _reading=true, getCursor defined, cursorHidden=false, a yellow border, the prior Title border gray, and accepted Clicked description. After Tab focused Status, clicking Title made Title exclusively active and accepted First; clicking the already-active Title restarted the same reader and accepted again, producing First again. Clicking Status, Type, and Priority opened their exact configured choice lists; Enter restored focus to the clicked selector with inverse/bold focus styling.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Composer mouse activation now shares the existing focusField/readInput transition with keyboard navigation. Text fields retain a visible caret, editable reader, and exclusive highlight even on repeated Title clicks; selector clicks open their existing pickers and restore selector focus. Added deterministic rendered-widget coverage for text entry, repeated activation, focus styling, cursor visibility, and all three selector pickers. Validation passed: 31 focused composer/model/board-outcome tests (239 assertions), bunx tsc --noEmit, bun run check ., bun run build, and git diff --check.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -59,6 +59,7 @@ async function installFailingHook(testDir: string, body = "exit 1"): Promise<str
 
 type TestWidget = {
 	_clines?: { length: number };
+	_reading?: boolean;
 	childBase?: number;
 	content?: string;
 	type?: string;
@@ -104,6 +105,10 @@ function pressKey(widget: TestWidget | undefined, name: string, ch = ""): void {
 	const key = { name: keyName, full: name, shift };
 	widget?.emit?.("keypress", ch, key);
 	widget?.emit?.(`key ${name}`, ch, key);
+}
+
+function clickWidget(widget: TestWidget | undefined): void {
+	widget?.emit?.("click", { button: "left", x: 0, y: 0 });
 }
 
 function typeText(widget: TestWidget | undefined, value: string): void {
@@ -963,6 +968,112 @@ describe("TUI task composer interaction", () => {
 
 			expect(await withTimeout(resultPromise, "composer cancel", 1000)).toBeNull();
 			expect(writes).toBe(0);
+		} finally {
+			screen.destroy();
+		}
+	});
+
+	it("clicks text fields into exclusive read mode and handles repeated Title clicks", async () => {
+		const screen = createScreen({ smartCSR: false });
+		Object.defineProperty(screen, "width", { configurable: true, value: 100, writable: true });
+		Object.defineProperty(screen, "height", { configurable: true, value: 30, writable: true });
+		const eventScreen = screen as unknown as {
+			focused?: TestWidget;
+			program?: { cursorHidden?: boolean };
+		};
+		try {
+			const resultPromise = openTaskComposer({
+				screen,
+				statuses: ["To Do", "Done"],
+				persist: async () => task(),
+			});
+			await settleComposerFocus();
+			const widgets = collectWidgets(screen as unknown as { children?: unknown[] });
+			const title = widgets.find((widget) => widget.options?.label === " Title ");
+			const description = widgets.find((widget) => widget.options?.label === " Description ");
+			const status = widgets.find((widget) => widget.content === "Status: To Do ▼");
+
+			clickWidget(description);
+			await settleComposerFocus();
+			expect(eventScreen.focused).toBe(description);
+			expect(description?._reading).toBe(true);
+			expect(description?.getCursor?.()).toBeDefined();
+			expect(eventScreen.program?.cursorHidden).toBe(false);
+			expect(description?.style?.border?.fg).toBe("yellow");
+			expect(title?.style?.border?.fg).toBe("gray");
+			typeText(eventScreen.focused, "Clicked description");
+			expect(description?.getValue?.()).toBe("Clicked description");
+
+			pressKey(eventScreen.focused, "tab", "\t");
+			expect(eventScreen.focused).toBe(status);
+			expect(status?.style).toMatchObject({ inverse: true, bold: true });
+
+			clickWidget(title);
+			await settleComposerFocus();
+			expect(eventScreen.focused).toBe(title);
+			expect(title?._reading).toBe(true);
+			expect(title?.style?.border?.fg).toBe("yellow");
+			expect(description?.style?.border?.fg).toBe("gray");
+			expect(status?.style).toMatchObject({ inverse: false, bold: false });
+			typeText(eventScreen.focused, "First");
+
+			// Clicking the already active Title takes the same cancel/readInput path and remains editable.
+			clickWidget(title);
+			await settleComposerFocus();
+			expect(eventScreen.focused).toBe(title);
+			expect(title?._reading).toBe(true);
+			typeText(eventScreen.focused, " again");
+			expect(title?.getValue?.()).toBe("First again");
+
+			pressKey(eventScreen.focused, "escape", "\x1b");
+			expect(await withTimeout(resultPromise, "mouse text-field cancellation", 1000)).toBeNull();
+		} finally {
+			screen.destroy();
+		}
+	});
+
+	it("opens every selector picker from a click and restores exclusive selector focus", async () => {
+		const screen = createScreen({ smartCSR: false });
+		Object.defineProperty(screen, "width", { configurable: true, value: 100, writable: true });
+		Object.defineProperty(screen, "height", { configurable: true, value: 30, writable: true });
+		const eventScreen = screen as unknown as { focused?: TestWidget };
+		try {
+			const resultPromise = openTaskComposer({
+				screen,
+				statuses: ["To Do", "Done"],
+				types: ["Bug", "Feature"],
+				priorities: ["High", "Low"],
+				persist: async () => task(),
+			});
+			await settleComposerFocus();
+			const widgets = collectWidgets(screen as unknown as { children?: unknown[] });
+			const selectors = [
+				{
+					widget: widgets.find((candidate) => candidate.content === "Status: To Do ▼"),
+					choices: ["Draft", "To Do", "Done"],
+				},
+				{
+					widget: widgets.find((candidate) => candidate.content === "Type: None ▼"),
+					choices: ["None", "Bug", "Feature"],
+				},
+				{
+					widget: widgets.find((candidate) => candidate.content === "Priority: None ▼"),
+					choices: ["None", "High", "Low"],
+				},
+			];
+
+			for (const { widget, choices } of selectors) {
+				clickWidget(widget);
+				await settleComposerFocus();
+				expect(eventScreen.focused?.items?.map((item) => item.content)).toEqual(choices);
+				pressKey(eventScreen.focused, "enter", "\r");
+				await settleComposerFocus();
+				expect(eventScreen.focused).toBe(widget);
+				expect(widget?.style).toMatchObject({ inverse: true, bold: true });
+			}
+
+			pressKey(eventScreen.focused, "escape", "\x1b");
+			expect(await withTimeout(resultPromise, "mouse selector cancellation", 1000)).toBeNull();
 		} finally {
 			screen.destroy();
 		}

--- a/src/ui/components/task-composer.ts
+++ b/src/ui/components/task-composer.ts
@@ -705,7 +705,18 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 				void openPicker(field);
 				return false;
 			});
-			widget.on("click", () => void openPicker(field));
+		}
+
+		// Pointer activation uses the same transition as keyboard navigation so text inputs
+		// enter read mode and every field has one source of truth for focus styling and scrolling.
+		for (const field of ["title", "description", "status", "type", "priority"] as const) {
+			widgets[field].on("click", () => {
+				focusField(field);
+				if (field === "status" || field === "type" || field === "priority") void openPicker(field);
+				// The screen otherwise auto-focuses clickable widgets after this event bubbles,
+				// which blurs a text field immediately after readInput starts.
+				return false;
+			});
 		}
 
 		for (const field of ["status", "type", "priority", "create", "cancel"] as const) {


### PR DESCRIPTION
## Summary

- route text and selector clicks through the existing composer focus transition
- enter text read mode with a visible caret and exclusive focus styling
- open all three selector pickers from pointer activation

## Testing

- 31 focused composer tests passed
- deterministic real-widget click, caret, focus, text-entry, and picker evidence
- bunx tsc --noEmit
- bun run check .
- bun run build
- git diff --check