### PR TITLE
BACK-401 - Add dueDate support for tasks and milestones across CLI, TUI, Web, and MCP

### DIFF
--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -44,6 +44,7 @@ Humans and agents can run `backlog instructions` for workflow guides and `backlo
 | Create with status | `backlog task create "Feature" -s "In Progress"`    |
 | Create with labels | `backlog task create "Feature" -l auth,backend`     |
 | Create with priority | `backlog task create "Feature" --priority high`     |
+| Create with due date | `backlog task create "Feature" --due-date "2026-08-10 14:30"` |
 | Create with plan | `backlog task create "Feature" --plan "1. Research\n2. Implement"`     |
 | Create with AC | `backlog task create "Feature" --ac "Must work,Must be tested"` |
 | Add DoD items on create | `backlog task create "Feature" --dod "Run tests"` |
@@ -82,9 +83,13 @@ Humans and agents can run `backlog instructions` for workflow guides and `backlo
 | Append final summary | `backlog task edit 7 --append-final-summary "More details"` |
 | Clear final summary | `backlog task edit 7 --clear-final-summary` |
 | Add deps    | `backlog task edit 7 --dep task-1 --dep task-2`     |
+| Set due date | `backlog task edit 7 --due-date "2026-08-10 14:30"` |
+| Clear due date | `backlog task edit 7 --clear-due-date` |
 | Archive     | `backlog task archive 7`                             |
 
 Task comments are append-only discussion entries with optional author labels. Use comments for review questions and collaboration notes; use implementation notes for execution progress and final summary for PR-ready completion notes. Comment bodies may contain Markdown, but standalone `---` lines are reserved as comment delimiters.
+
+Task and milestone due dates are UTC datetimes stored at minute precision. Use `YYYY-MM-DD HH:mm` or an ISO datetime with an explicit offset; date-only values are rejected.
 
 ### Stable JSON output
 
@@ -105,7 +110,7 @@ Each successful response is one pretty-printed JSON document followed by a newli
 | `task view <id> --json` and `task <id> --json` | `{ "schemaVersion": 1, "kind": "task-view", "task": {...} }` |
 | `search [query] --json` | `{ "schemaVersion": 1, "kind": "search", "results": [...] }` |
 
-Task list and task search results use these compact fields: `id`, `title`, `status`, `type`, `priority`, `assignees`, `reporter`, `labels`, `milestone`, `parentTaskId`, `acceptanceCriteriaCompleted`, `acceptanceCriteriaCount`, `ordinal`, `createdAt`, and `updatedAt`. `acceptanceCriteriaCompleted` is the number of checked acceptance criteria and `acceptanceCriteriaCount` is the total; both are `0` when the task has no acceptance criteria.
+Task list and task search results use these compact fields: `id`, `title`, `status`, `type`, `priority`, `assignees`, `reporter`, `labels`, `milestone`, `parentTaskId`, `acceptanceCriteriaCompleted`, `acceptanceCriteriaCount`, `ordinal`, `createdAt`, `updatedAt`, and `dueDate`. `acceptanceCriteriaCompleted` is the number of checked acceptance criteria and `acceptanceCriteriaCount` is the total; both are `0` when the task has no acceptance criteria.
 
 Task view includes the same progress counts alongside the full checklist and adds `path`, `description`, `dependencies`, `references`, `documentation`, `modifiedFiles`, `subtasks`, `acceptanceCriteria`, `definitionOfDone`, `implementationPlan`, `implementationNotes`, `comments`, and `finalSummary`. `path` is relative to the project root. Checklist entries contain `index`, `text`, and `checked`. Comment entries contain `index`, `body`, `createdAt`, and `author`.
 
@@ -181,7 +186,10 @@ Milestones are managed through milestone files. Use CLI commands instead of edit
 | List completed milestones too | `backlog milestone list --show-completed --plain` |
 | Add milestone | `backlog milestone add "Release 1.0"` |
 | Add with description | `backlog milestone add "Beta" --description "Beta scope"` |
+| Add with due date | `backlog milestone add "Beta" --due-date "2026-08-10 14:30"` |
 | Rename and update tasks | `backlog milestone rename "Release 1.0" "Release 2.0"` |
+| Set due date without renaming | `backlog milestone rename "Release 1.0" "Release 1.0" --due-date "2026-08-10 14:30"` |
+| Clear due date | `backlog milestone rename "Release 1.0" "Release 1.0" --clear-due-date` |
 | Rename without task updates | `backlog milestone rename m-1 "Release 2.0" --no-update-tasks` |
 | Remove and clear task milestones | `backlog milestone remove "Release 1.0"` |
 | Remove and keep task values | `backlog milestone remove "Release 1.0" --task-handling keep` |

--- a/backlog/tasks/back-401 - Add-dueDate-support-for-tasks-and-milestones-across-CLI-TUI-Web-and-MCP.md
+++ b/backlog/tasks/back-401 - Add-dueDate-support-for-tasks-and-milestones-across-CLI-TUI-Web-and-MCP.md
@@ -1,14 +1,52 @@
 ---
 id: BACK-401
 title: 'Add dueDate support for tasks and milestones across CLI, TUI, Web, and MCP'
-status: To Do
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-03-01 20:56'
+updated_date: '2026-08-10 06:07'
 labels: []
 dependencies: []
 references:
   - 'https://github.com/MrLesk/Backlog.md/issues/551'
+modified_files:
+  - CLI-INSTRUCTIONS.md
+  - src/cli.ts
+  - src/commands/task-wizard.ts
+  - src/core/backlog.ts
+  - src/file-system/operations.ts
+  - src/formatters/json-output.ts
+  - src/formatters/task-plain-text.ts
+  - src/markdown/parser.ts
+  - src/markdown/serializer.ts
+  - src/mcp/tools/milestones/handlers.ts
+  - src/mcp/tools/milestones/schemas.ts
+  - src/mcp/tools/tasks/handlers.ts
+  - src/mcp/utils/schema-generators.ts
+  - src/mcp/validation/validators.ts
+  - src/server/index.ts
+  - src/types/index.ts
+  - src/types/task-edit-args.ts
+  - src/ui/components/task-composer.ts
+  - src/ui/task-viewer-with-search.ts
+  - src/utils/task-edit-builder.ts
+  - src/utils/utc-datetime.ts
+  - src/web/components/MilestonesPage.tsx
+  - src/web/components/TaskDetailsModal.tsx
+  - src/web/components/TaskList.tsx
+  - src/web/lib/api.ts
+  - src/test/cli-due-date.test.ts
+  - src/test/cli-json-output.test.ts
+  - src/test/due-date.test.ts
+  - src/test/mcp-milestones.test.ts
+  - src/test/mcp-tasks.test.ts
+  - src/test/server-due-date-endpoint.test.ts
+  - src/test/task-wizard.test.ts
+  - src/test/tui-task-composer.test.ts
+  - src/test/web-milestones-page-search.test.tsx
+  - src/test/web-task-list-table-width.test.tsx
+  - src/test/web-task-types.test.tsx
 priority: medium
 ---
 
@@ -20,17 +58,51 @@ Introduce optional dueDate for tasks and milestones and expose it consistently a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Tasks support optional dueDate end-to-end: types, create/edit flows, markdown frontmatter persistence, and load/save parsing.
-- [ ] #2 Milestones support optional dueDate end-to-end: types, milestone file persistence/parsing, and list/create/update flows where applicable.
-- [ ] #3 CLI plain and interactive task surfaces include dueDate where task details/listing are shown, and task create/edit accepts dueDate input.
-- [ ] #4 Web UI and server API support dueDate for tasks and milestones in create/edit/list/view paths.
-- [ ] #5 MCP task and milestone schemas/handlers support dueDate only (no deadline alias) and return it in task/milestone outputs.
-- [ ] #6 Automated tests cover dueDate parsing/serialization and at least one path each for CLI, web/server, and MCP.
+- [x] #1 Tasks support optional dueDate end-to-end: types, create/edit flows, markdown frontmatter persistence, and load/save parsing.
+- [x] #2 Milestones support optional dueDate end-to-end: types, milestone file persistence/parsing, and list/create/update flows where applicable.
+- [x] #3 CLI plain and interactive task surfaces include dueDate where task details/listing are shown, and task create/edit accepts dueDate input.
+- [x] #4 Web UI and server API support dueDate for tasks and milestones in create/edit/list/view paths.
+- [x] #5 MCP task and milestone schemas/handlers support dueDate only (no deadline alias) and return it in task/milestone outputs.
+- [x] #6 Automated tests cover dueDate parsing/serialization and at least one path each for CLI, web/server, and MCP.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a shared strict UTC datetime normalizer and persist optional dueDate for tasks and milestones in Markdown.
+2. Thread dueDate create, edit, clear, and display behavior through CLI and TUI surfaces.
+3. Add dueDate to Web API, forms, lists, details, and milestone workflows.
+4. Add dueDate to MCP task and milestone schemas, handlers, and responses.
+5. Add focused parser, serializer, CLI, TUI, Web, server, MCP, and JSON tests; then run typecheck, Biome, build, and relevant suites.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Product decision: dueDate is a UTC datetime. Store it canonically as YYYY-MM-DD HH:mm; accept equivalent ISO datetime input, reject date-only values, and use null or the surface-specific clear flag to remove it.
+
+Implementation uses one shared normalizer for task and milestone persistence and server validation. Explicit offsets are converted to UTC at minute precision, and normalized values are guaranteed to remain four-digit and round-trippable. A malformed milestone file is skipped individually instead of hiding the valid collection.
+
+The public MCP edit schemas declare string-or-null dueDate fields, canonical CLI JSON exposes dueDate as RFC 3339 UTC, and CLI-INSTRUCTIONS documents the additive stable field and due-date commands. Web and TUI list/detail displays retain the time and identify UTC.
+
+Validation:
+- 126 cross-surface tests passed across UTC normalization and persistence, CLI due-date and JSON output, task wizard, MCP tasks and milestones, server handlers, and Web task/milestone/list paths.
+- 28 TUI composer model and interaction tests passed; 7 TUI task-detail tests passed.
+- bunx tsc --noEmit, bun run check ., bun run build, and git diff --check passed.
+- Independent final diff review found no remaining P1/P2 issues.
+
+Environment note: the unfiltered TUI composer file has one pre-existing filesystem-watcher delivery timeout in this sandbox; the same test fails unchanged at the base commit, while all feature-owned TUI selections pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added optional UTC dueDate support for tasks and milestones across Markdown persistence, types, CLI and interactive TUI, stable JSON, Web/server APIs and UI, and MCP schemas/handlers. Create, update, display, ISO-offset normalization, date-only rejection, and explicit clear behavior are consistent across surfaces, with focused regression coverage and public CLI documentation.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3798,7 +3798,9 @@ addHelpSchema(milestoneCmd.command("list"), {
 		const formatBucket = (bucket: (typeof buckets)[number]) => {
 			const id = bucket.milestone ?? bucket.label;
 			const label = bucket.label;
-			const milestone = milestones.find((candidate) => milestoneKey(candidate.id) === milestoneKey(id));
+			const milestone = [...milestones, ...archivedMilestones].find(
+				(candidate) => milestoneKey(candidate.id) === milestoneKey(id),
+			);
 			const dueDate = milestone?.dueDate
 				? `, due ${formatUtcDateForDisplay(milestone.dueDate, { appendUtcLabel: true })}`
 				: "";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -298,7 +298,8 @@ function formatPlainTaskListRow(task: Task, options: { includeStatus?: boolean }
 	const priorityIndicator = task.priority ? `[${task.priority.toUpperCase()}] ` : "";
 	const typeIndicator = task.type ? `[${task.type}] ` : "";
 	const statusIndicator = options.includeStatus && task.status ? ` (${task.status})` : "";
-	return `  ${priorityIndicator}${typeIndicator}${task.id} - ${task.title}${statusIndicator}`;
+	const dueDate = task.dueDate ? ` (due ${formatUtcDateForDisplay(task.dueDate, { appendUtcLabel: true })})` : "";
+	return `  ${priorityIndicator}${typeIndicator}${task.id} - ${task.title}${statusIndicator}${dueDate}`;
 }
 
 async function normalizeCliStatusList(core: Core, values: string[], optionName: string): Promise<string[] | null> {
@@ -465,6 +466,7 @@ function hasCreateFieldFlags(options: Record<string, unknown>): boolean {
 			options.type !== undefined ||
 			options.ordinal !== undefined ||
 			options.milestone !== undefined ||
+			options.dueDate !== undefined ||
 			options.plain ||
 			options.ac !== undefined ||
 			options.acceptanceCriteria !== undefined ||
@@ -496,6 +498,8 @@ function hasEditFieldFlags(options: Record<string, unknown>): boolean {
 			options.ordinal !== undefined ||
 			options.milestone !== undefined ||
 			options.clearMilestone ||
+			options.dueDate !== undefined ||
+			options.clearDueDate ||
 			options.clearLabels ||
 			options.plain ||
 			options.addLabel !== undefined ||
@@ -1740,6 +1744,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 		},
 		{ name: "priority", type: priorityType, description: "Task priority" },
 		{ name: "type", type: taskType, description: "Task type; case-insensitive" },
+		{ name: "due-date", type: "UTC datetime", description: "Optional due date and time" },
 		{ name: "acceptanceCriteria", type: "Markdown list item text", description: "Repeat --ac for multiple criteria" },
 		{ name: "ordinal", type: "Integer", description: "Non-negative manual ordering value" },
 		{ name: "parent", type: "Task ID", description: "Existing parent task for subtasks; not a milestone ID" },
@@ -1775,6 +1780,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 	.option("-l, --labels <labels>", "add task labels (comma-separated or repeatable)", createMultiValueAccumulator())
 	.option("--priority <priority>", "set task priority (configured priorities)")
 	.option("--type <type>", "set task type (configured task types)")
+	.option("--due-date <datetime>", "set due date as a UTC datetime")
 	.option("--plain", "use plain text output after creating")
 	.option("--ac <criteria>", "add acceptance criteria (can be used multiple times)", createMultiValueAccumulator())
 	.option(
@@ -1893,6 +1899,7 @@ addHelpSchema(taskCmd.command("create [title]"), {
 				title: title ?? "",
 				description: options.description || options.desc ? String(options.description || options.desc) : undefined,
 				status: createAsDraft ? "Draft" : options.status ? String(options.status) : undefined,
+				dueDate: typeof options.dueDate === "string" ? options.dueDate : undefined,
 				assignee: parseClearableStringList(options.assignee),
 				labels: parseDelimitedStringList(options.labels),
 				dependencies,
@@ -2728,6 +2735,8 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		{ name: "description", type: "Markdown", description: "Replacement description" },
 		{ name: "status", type: statusType, description: "Project task status; case-insensitive" },
 		{ name: "type", type: taskType, description: "Replacement task type; case-insensitive" },
+		{ name: "due-date", type: "UTC datetime", description: "Set the task due date and time" },
+		{ name: "clear-due-date", type: "Boolean", description: "Clear the task due date" },
 		{
 			name: "assignee",
 			type: "Comma-separated strings",
@@ -2816,6 +2825,8 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 	)
 	.option("--priority <priority>", "set task priority (configured priorities)")
 	.option("--type <type>", "set task type (configured task types; pass an empty value to clear)")
+	.option("--due-date <datetime>", "set due date as a UTC datetime")
+	.option("--clear-due-date", "clear task due date")
 	.option("--ordinal <number>", "set task ordinal for custom ordering")
 	.option("-m, --milestone <milestone>", "assign task to milestone by ID or title")
 	.option("--clear-milestone", "clear task milestone assignment")
@@ -3048,6 +3059,11 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 			process.exitCode = 1;
 			return;
 		}
+		if (options.dueDate !== undefined && options.clearDueDate) {
+			console.error("Cannot use --due-date and --clear-due-date together.");
+			process.exitCode = 1;
+			return;
+		}
 
 		let milestoneValue: string | null | undefined;
 		if (typeof options.milestone === "string") {
@@ -3199,6 +3215,11 @@ addHelpSchema(taskCmd.command("edit [taskId]"), {
 		}
 		if (milestoneValue !== undefined) {
 			editArgs.milestone = milestoneValue;
+		}
+		if (typeof options.dueDate === "string") {
+			editArgs.dueDate = options.dueDate;
+		} else if (options.clearDueDate) {
+			editArgs.dueDate = null;
 		}
 		if (labelValues.length > 0) {
 			editArgs.labels = labelValues;
@@ -3777,7 +3798,11 @@ addHelpSchema(milestoneCmd.command("list"), {
 		const formatBucket = (bucket: (typeof buckets)[number]) => {
 			const id = bucket.milestone ?? bucket.label;
 			const label = bucket.label;
-			return `  ${id}: ${label} (${bucket.doneCount}/${bucket.total} done)`;
+			const milestone = milestones.find((candidate) => milestoneKey(candidate.id) === milestoneKey(id));
+			const dueDate = milestone?.dueDate
+				? `, due ${formatUtcDateForDisplay(milestone.dueDate, { appendUtcLabel: true })}`
+				: "";
+			return `  ${id}: ${label} (${bucket.doneCount}/${bucket.total} done${dueDate})`;
 		};
 
 		console.log(`Active milestones (${active.length}):`);
@@ -3804,15 +3829,21 @@ addHelpSchema(milestoneCmd.command("list"), {
 addHelpSchema(milestoneCmd.command("add <name>"), {
 	reads: "Active milestone files for duplicate and alias validation",
 	required: [{ name: "name", type: "String", description: "Milestone name/title, trimmed before storage" }],
-	optional: [{ name: "description", type: "Markdown", description: "Optional milestone description" }],
+	optional: [
+		{ name: "description", type: "Markdown", description: "Optional milestone description" },
+		{ name: "due-date", type: "UTC datetime", description: "Optional milestone due date and time" },
+	],
 	writes: "Creates a milestone markdown file in the active milestones directory",
 	output: "Created milestone title and ID",
 	examples: ['backlog milestone add "Release 1.0"', 'backlog milestone add "Beta" --description "Beta scope"'],
 })
 	.description("add a milestone file")
 	.option("-d, --description <text>", "milestone description")
-	.action(async (name: string, options: { description?: string }) => {
-		await runMilestoneMutation((handlers) => handlers.addMilestone({ name, description: options.description }));
+	.option("--due-date <datetime>", "set due date as a UTC datetime")
+	.action(async (name: string, options: { description?: string; dueDate?: string }) => {
+		await runMilestoneMutation((handlers) =>
+			handlers.addMilestone({ name, description: options.description, dueDate: options.dueDate }),
+		);
 	});
 
 addHelpSchema(milestoneCmd.command("rename <from> <to>"), {
@@ -3827,6 +3858,8 @@ addHelpSchema(milestoneCmd.command("rename <from> <to>"), {
 			type: "Boolean",
 			description: "Update local task milestone references; default true, disable with --no-update-tasks",
 		},
+		{ name: "due-date", type: "UTC datetime", description: "Set the milestone due date and time" },
+		{ name: "clear-due-date", type: "Boolean", description: "Clear the milestone due date" },
 	],
 	writes: "Renames the milestone file and, by default, updates matching local task milestone values",
 	output: "Rename summary, task update count, and file move path when changed",
@@ -3837,11 +3870,25 @@ addHelpSchema(milestoneCmd.command("rename <from> <to>"), {
 })
 	.description("rename a milestone file and update local tasks by default")
 	.option("--no-update-tasks", "do not update local tasks that reference the milestone")
-	.action(async (from: string, to: string, options: { updateTasks?: boolean }) => {
-		await runMilestoneMutation((handlers) =>
-			handlers.renameMilestone({ from, to, updateTasks: options.updateTasks !== false }),
-		);
-	});
+	.option("--due-date <datetime>", "set due date as a UTC datetime")
+	.option("--clear-due-date", "clear milestone due date")
+	.action(
+		async (from: string, to: string, options: { updateTasks?: boolean; dueDate?: string; clearDueDate?: boolean }) => {
+			if (options.dueDate !== undefined && options.clearDueDate) {
+				console.error("Cannot use --due-date and --clear-due-date together.");
+				process.exitCode = 1;
+				return;
+			}
+			await runMilestoneMutation((handlers) =>
+				handlers.renameMilestone({
+					from,
+					to,
+					updateTasks: options.updateTasks !== false,
+					dueDate: options.clearDueDate ? null : options.dueDate,
+				}),
+			);
+		},
+	);
 
 addHelpSchema(milestoneCmd.command("remove <name>"), {
 	reads: "Active and archived milestone files, plus local tasks unless task handling is keep",

--- a/src/commands/task-wizard.ts
+++ b/src/commands/task-wizard.ts
@@ -6,6 +6,7 @@ import type { AcceptanceCriterion, Task, TaskCreateInput, TaskUpdateInput } from
 import { getPriorityOptions, normalizePriorityValue } from "../utils/priority-config.ts";
 import { normalizeStringList } from "../utils/task-builders.ts";
 import { getTaskTypeValues, resolveTaskTypeValue } from "../utils/task-type-config.ts";
+import { normalizeUtcDateTime } from "../utils/utc-datetime.ts";
 
 interface TaskWizardValues {
 	title: string;
@@ -13,6 +14,7 @@ interface TaskWizardValues {
 	status: string;
 	priority: string;
 	type: string;
+	dueDate: string;
 	assignee: string;
 	labels: string;
 	acceptanceCriteria: string;
@@ -437,6 +439,19 @@ async function runTaskWizardValues(params: {
 			},
 			{
 				type: "text",
+				name: "dueDate",
+				message: "Due date (UTC datetime; blank for none)",
+				validate: (value) => {
+					try {
+						normalizeUtcDateTime(value, "Due date");
+						return undefined;
+					} catch (error) {
+						return error instanceof Error ? error.message : "Invalid due date.";
+					}
+				},
+			},
+			{
+				type: "text",
 				name: "assignee",
 				message:
 					params.mode === "create"
@@ -542,6 +557,7 @@ async function runTaskWizardValues(params: {
 			status: canonicalStatus,
 			priority: normalizePriorityValue(values.priority) ?? "",
 			type: resolveTaskTypeValue(values.type, params.types) ?? values.type.trim(),
+			dueDate: normalizeUtcDateTime(values.dueDate, "Due date") ?? "",
 			assignee: values.assignee,
 			labels: values.labels,
 			acceptanceCriteria: values.acceptanceCriteria,
@@ -597,6 +613,7 @@ function toInitialWizardValues(input: { title?: string } & Partial<Task>): TaskW
 		status: input.status ?? "",
 		priority: input.priority ?? "",
 		type: input.type ?? "",
+		dueDate: input.dueDate ?? "",
 		assignee: formatListInput(input.assignee),
 		labels: formatListInput(input.labels),
 		acceptanceCriteria: formatChecklistInput(input.acceptanceCriteriaItems),
@@ -631,6 +648,7 @@ export async function runTaskCreateWizard(
 	const parsedPriority = priority.length > 0 ? priority : undefined;
 	const type = values.type.trim();
 	const parsedType = type.length > 0 ? type : undefined;
+	const dueDate = normalizeUtcDateTime(values.dueDate, "Due date");
 	const assignee = parseListInput(values.assignee);
 	const labels = parseListInput(values.labels);
 	const references = parseListInput(values.references);
@@ -648,6 +666,7 @@ export async function runTaskCreateWizard(
 		...(values.status.trim().length > 0 && { status: values.status }),
 		...(parsedPriority && { priority: parsedPriority }),
 		...(parsedType && { type: parsedType }),
+		...(dueDate && { dueDate }),
 		...(assignee.length > 0 && { assignee }),
 		...(labels.length > 0 && { labels }),
 		...(dependencies.length > 0 && { dependencies }),
@@ -694,6 +713,9 @@ export async function runTaskEditWizard(
 	}
 	if (values.type !== initial.type) {
 		updateInput.type = values.type;
+	}
+	if (values.dueDate !== initial.dueDate) {
+		updateInput.dueDate = values.dueDate || null;
 	}
 
 	const initialAssignee = parseListInput(initial.assignee);

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -77,6 +77,7 @@ import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { formatValidTaskTypeValues, matchesTaskTypeFilter, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
 import { isTerminalStatus } from "../utils/terminal-status.ts";
+import { normalizeUtcDateTime } from "../utils/utc-datetime.ts";
 import { migrateConfig, needsMigration } from "./config-migration.ts";
 import { ContentStore, type TaskCorpusSnapshot } from "./content-store.ts";
 import {
@@ -183,6 +184,7 @@ function buildUpdatedDateComparableTask(task: Task): Record<string, unknown> {
 		assignee: task.assignee ?? [],
 		reporter: task.reporter,
 		createdDate: task.createdDate,
+		dueDate: task.dueDate,
 		labels: task.labels ?? [],
 		milestone: task.milestone,
 		dependencies: task.dependencies ?? [],
@@ -1564,6 +1566,7 @@ export class Core {
 		const normalizedReferences = normalizeStringList(input.references) ?? [];
 		const normalizedDocumentation = normalizeStringList(input.documentation) ?? [];
 		const normalizedModifiedFiles = normalizeStringList(input.modifiedFiles) ?? [];
+		const dueDate = normalizeUtcDateTime(input.dueDate, "Due date");
 
 		const { valid: validDependencies, invalid: invalidDependencies } = await validateDependencies(
 			normalizedDependencies,
@@ -1632,6 +1635,7 @@ export class Core {
 				modifiedFiles: normalizedModifiedFiles,
 				rawContent: input.rawContent ?? "",
 				createdDate,
+				...(dueDate && { dueDate }),
 				...(parentTaskId && { parentTaskId }),
 				...(priority && { priority }),
 				...(type && { type }),
@@ -1795,6 +1799,15 @@ export class Core {
 		applyStringField(input.description, task.description, (next) => {
 			task.description = next;
 		});
+
+		if (input.dueDate !== undefined) {
+			const dueDate = input.dueDate === null ? undefined : normalizeUtcDateTime(input.dueDate, "Due date");
+			if (task.dueDate !== dueDate) {
+				if (dueDate) task.dueDate = dueDate;
+				else delete task.dueDate;
+				mutated = true;
+			}
+		}
 
 		if (input.status !== undefined) {
 			const canonicalStatus = await statusResolver(input.status);
@@ -2810,14 +2823,16 @@ export class Core {
 		identifier: string,
 		title: string,
 		autoCommit?: boolean,
+		dueDate?: string | null,
 	): Promise<{
 		success: boolean;
 		sourcePath?: string;
 		targetPath?: string;
 		milestone?: Milestone;
 		previousTitle?: string;
+		previousDueDate?: string;
 	}> {
-		const result = await this.fs.renameMilestone(identifier, title);
+		const result = await this.fs.renameMilestone(identifier, title, dueDate);
 		if (!result.success) {
 			return result;
 		}
@@ -2832,7 +2847,11 @@ export class Core {
 				await this.git.resetPaths(commitPaths, repoRoot);
 				const rollbackTitle = result.previousTitle ?? title;
 				try {
-					await this.fs.renameMilestone(result.milestone?.id ?? identifier, rollbackTitle);
+					await this.fs.renameMilestone(
+						result.milestone?.id ?? identifier,
+						rollbackTitle,
+						result.previousDueDate ?? null,
+					);
 				} catch {
 					// Ignore rollback failure and propagate original commit error.
 				}

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -32,6 +32,7 @@ import {
 } from "../utils/task-path.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
 import { matchesTaskTypeFilter } from "../utils/task-type-config.ts";
+import { normalizeUtcDateTime } from "../utils/utc-datetime.ts";
 
 // Interface for task path resolution context
 interface TaskPathContext {
@@ -1450,11 +1451,11 @@ export class FileSystem {
 		return `${id} - ${safeTitle}.md`;
 	}
 
-	private serializeMilestoneContent(id: string, title: string, rawContent: string): string {
+	private serializeMilestoneContent(id: string, title: string, rawContent: string, dueDate?: string): string {
 		return `---
 id: ${id}
 title: "${title.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"
----
+${dueDate ? `due_date: "${dueDate}"\n` : ""}---
 
 ${rawContent.trim()}
 `;
@@ -1569,24 +1570,26 @@ ${rawContent.trim()}
 	}
 
 	// Milestone operations
+	private async listMilestonesInDirectory(milestonesDir: string): Promise<Milestone[]> {
+		const milestoneFiles = await Array.fromAsync(
+			new Bun.Glob("m-*.md").scan({ cwd: milestonesDir, followSymlinks: true }),
+		);
+		const milestones: Milestone[] = [];
+		for (const file of milestoneFiles) {
+			if (file.toLowerCase() === "readme.md") continue;
+			try {
+				const content = await Bun.file(join(milestonesDir, file)).text();
+				milestones.push(parseMilestone(content));
+			} catch {
+				// Match task loading: one malformed file must not hide every valid item.
+			}
+		}
+		return milestones.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+	}
+
 	async listMilestones(): Promise<Milestone[]> {
 		try {
-			const milestonesDir = await this.getMilestonesDir();
-			const milestoneFiles = await Array.fromAsync(
-				new Bun.Glob("m-*.md").scan({ cwd: milestonesDir, followSymlinks: true }),
-			);
-			const milestones: Milestone[] = [];
-			for (const file of milestoneFiles) {
-				// Filter out README files
-				if (file.toLowerCase() === "readme.md") {
-					continue;
-				}
-				const filepath = join(milestonesDir, file);
-				const content = await Bun.file(filepath).text();
-				milestones.push(parseMilestone(content));
-			}
-			// Sort by ID for consistent ordering
-			return milestones.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+			return await this.listMilestonesInDirectory(await this.getMilestonesDir());
 		} catch {
 			return [];
 		}
@@ -1594,20 +1597,7 @@ ${rawContent.trim()}
 
 	async listArchivedMilestones(): Promise<Milestone[]> {
 		try {
-			const milestonesDir = await this.getArchiveMilestonesDir();
-			const milestoneFiles = await Array.fromAsync(
-				new Bun.Glob("m-*.md").scan({ cwd: milestonesDir, followSymlinks: true }),
-			);
-			const milestones: Milestone[] = [];
-			for (const file of milestoneFiles) {
-				if (file.toLowerCase() === "readme.md") {
-					continue;
-				}
-				const filepath = join(milestonesDir, file);
-				const content = await Bun.file(filepath).text();
-				milestones.push(parseMilestone(content));
-			}
-			return milestones.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+			return await this.listMilestonesInDirectory(await this.getArchiveMilestonesDir());
 		} catch {
 			return [];
 		}
@@ -1627,7 +1617,8 @@ ${rawContent.trim()}
 		}
 	}
 
-	async createMilestone(title: string, description?: string): Promise<Milestone> {
+	async createMilestone(title: string, description?: string, dueDate?: string): Promise<Milestone> {
+		const normalizedDueDate = normalizeUtcDateTime(dueDate, "Due date");
 		return await this.withCreateLock(async () => {
 			const milestonesDir = await this.getMilestonesDir();
 
@@ -1679,35 +1670,34 @@ ${rawContent.trim()}
 				`## Description
 
 ${description || `Milestone: ${title}`}`,
+				normalizedDueDate,
 			);
 
 			const filepath = join(milestonesDir, filename);
 			await Bun.write(filepath, content);
 
-			return {
-				id,
-				title,
-				description: description || `Milestone: ${title}`,
-				rawContent: parseMilestone(content).rawContent,
-			};
+			return parseMilestone(content);
 		});
 	}
 
 	async renameMilestone(
 		identifier: string,
 		title: string,
+		dueDate?: string | null,
 	): Promise<{
 		success: boolean;
 		sourcePath?: string;
 		targetPath?: string;
 		milestone?: Milestone;
 		previousTitle?: string;
+		previousDueDate?: string;
 	}> {
 		const normalizedTitle = title.trim();
 		if (!normalizedTitle) {
 			return { success: false };
 		}
 
+		const normalizedDueDate = dueDate === null ? undefined : normalizeUtcDateTime(dueDate, "Due date");
 		let sourcePath: string | undefined;
 		let targetPath: string | undefined;
 		let movedFile = false;
@@ -1730,7 +1720,8 @@ ${description || `Milestone: ${title}`}`,
 				milestone.title,
 				normalizedTitle,
 			);
-			const updatedContent = this.serializeMilestoneContent(milestone.id, normalizedTitle, nextRawContent);
+			const nextDueDate = dueDate === undefined ? milestone.dueDate : normalizedDueDate;
+			const updatedContent = this.serializeMilestoneContent(milestone.id, normalizedTitle, nextRawContent, nextDueDate);
 
 			if (sourcePath !== targetPath) {
 				if (await Bun.file(targetPath).exists()) {
@@ -1747,6 +1738,7 @@ ${description || `Milestone: ${title}`}`,
 				targetPath,
 				milestone: parseMilestone(updatedContent),
 				previousTitle: milestone.title,
+				previousDueDate: milestone.dueDate,
 			};
 		} catch {
 			try {

--- a/src/formatters/json-output.ts
+++ b/src/formatters/json-output.ts
@@ -19,6 +19,7 @@ type TaskSummaryJson = {
 	ordinal: number | null;
 	createdAt: string | null;
 	updatedAt: string | null;
+	dueDate: string | null;
 };
 
 type ChecklistItemJson = {
@@ -112,6 +113,7 @@ function toTaskSummaryJson(task: Task): TaskSummaryJson {
 		ordinal: task.ordinal ?? null,
 		createdAt: normalizePublicDate(task.createdDate),
 		updatedAt: normalizePublicDate(task.updatedDate),
+		dueDate: normalizePublicDate(task.dueDate),
 	};
 }
 

--- a/src/formatters/task-plain-text.ts
+++ b/src/formatters/task-plain-text.ts
@@ -112,6 +112,9 @@ export function formatTaskPlainText(task: Task, options: TaskPlainTextOptions = 
 	if (task.updatedDate) {
 		lines.push(`Updated: ${formatDateForDisplay(task.updatedDate, plainDateDisplayOptions)}`);
 	}
+	if (task.dueDate) {
+		lines.push(`Due: ${formatDateForDisplay(task.dueDate, plainDateDisplayOptions)}`);
+	}
 
 	if (task.labels?.length) {
 		lines.push(`Labels: ${task.labels.join(", ")}`);

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -48,7 +48,8 @@ function preprocessFrontmatter(frontmatter: string): string {
 				const scalarMatch = raw.match(/^(.*?)(\s+#.*)?$/);
 				const value = (scalarMatch?.[1] ?? raw).trim();
 				const comment = scalarMatch?.[2] ?? "";
-				if (value && !value.startsWith("'") && !value.startsWith('"')) {
+				const isYamlNull = /^(?:null|~)$/i.test(value);
+				if (value && !isYamlNull && !value.startsWith("'") && !value.startsWith('"')) {
 					return `${prefix}"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"${comment}`;
 				}
 			}

--- a/src/markdown/parser.ts
+++ b/src/markdown/parser.ts
@@ -1,5 +1,6 @@
 import type { AcceptanceCriterion, Decision, Document, Milestone, ParsedMarkdown, Task } from "../types/index.ts";
 import { normalizePriorityValue } from "../utils/priority-config.ts";
+import { normalizeUtcDateTime } from "../utils/utc-datetime.ts";
 import { parseFrontmatter } from "./frontmatter.ts";
 import {
 	AcceptanceCriteriaManager,
@@ -40,6 +41,18 @@ function preprocessFrontmatter(frontmatter: string): string {
 	return frontmatter
 		.split(/\r?\n/) // Handle both Windows (\r\n) and Unix (\n) line endings
 		.map((line) => {
+			const dueDateMatch = line.match(/^(\s*due_date:\s*)(.*)$/);
+			if (dueDateMatch) {
+				const prefix = dueDateMatch[1] ?? "";
+				const raw = dueDateMatch[2] ?? "";
+				const scalarMatch = raw.match(/^(.*?)(\s+#.*)?$/);
+				const value = (scalarMatch?.[1] ?? raw).trim();
+				const comment = scalarMatch?.[2] ?? "";
+				if (value && !value.startsWith("'") && !value.startsWith('"')) {
+					return `${prefix}"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"${comment}`;
+				}
+			}
+
 			// Handle both assignee and reporter fields that start with @
 			const match = line.match(/^(\s*(?:assignee|reporter):\s*)(.*)$/);
 			if (!match) return line;
@@ -173,6 +186,7 @@ export function parseTask(content: string): Task {
 		reporter: frontmatter.reporter ? String(frontmatter.reporter) : undefined,
 		createdDate: normalizeDate(frontmatter.created_date),
 		updatedDate: frontmatter.updated_date ? normalizeDate(frontmatter.updated_date) : undefined,
+		dueDate: normalizeUtcDateTime(frontmatter.due_date, "due_date"),
 		labels: Array.isArray(frontmatter.labels) ? frontmatter.labels.map(String) : [],
 		milestone: frontmatter.milestone ? String(frontmatter.milestone) : undefined,
 		dependencies: Array.isArray(frontmatter.dependencies) ? frontmatter.dependencies.map(String) : [],
@@ -232,6 +246,7 @@ export function parseMilestone(content: string): Milestone {
 	return {
 		id: String(frontmatter.id || ""),
 		title: String(frontmatter.title || ""),
+		dueDate: normalizeUtcDateTime(frontmatter.due_date, "due_date"),
 		description: extractSection(rawContent, "Description") || "",
 		rawContent,
 	};

--- a/src/markdown/serializer.ts
+++ b/src/markdown/serializer.ts
@@ -56,6 +56,7 @@ export function serializeTask(task: Task): string {
 		...(task.reporter && { reporter: task.reporter }),
 		created_date: task.createdDate,
 		...(task.updatedDate && { updated_date: task.updatedDate }),
+		...(task.dueDate && { due_date: task.dueDate }),
 		labels: task.labels,
 		...(task.milestone && { milestone: task.milestone }),
 		dependencies: task.dependencies,

--- a/src/mcp/tools/milestones/handlers.ts
+++ b/src/mcp/tools/milestones/handlers.ts
@@ -1,6 +1,8 @@
 import { rename as moveFile } from "node:fs/promises";
 import type { Core } from "../../../core/backlog.ts";
 import type { Milestone, Task } from "../../../types/index.ts";
+import { formatUtcDateForDisplay } from "../../../utils/utc-date-display.ts";
+import { normalizeUtcDateTime } from "../../../utils/utc-datetime.ts";
 import { BacklogToolError } from "../../errors/mcp-errors.ts";
 import type { CallToolResult } from "../../types.ts";
 import {
@@ -14,12 +16,14 @@ import {
 export type MilestoneAddArgs = {
 	name: string;
 	description?: string;
+	dueDate?: string;
 };
 
 export type MilestoneRenameArgs = {
 	from: string;
 	to: string;
 	updateTasks?: boolean;
+	dueDate?: string | null;
 };
 
 export type MilestoneRemoveArgs = {
@@ -320,7 +324,11 @@ export class MilestoneHandlers {
 			.sort((a, b) => a.localeCompare(b));
 
 		const blocks: string[] = [];
-		const milestoneLines = fileMilestones.map((m) => `${m.id}: ${m.title}`);
+		const milestoneLines = fileMilestones.map((m) =>
+			m.dueDate
+				? `${m.id}: ${m.title} (due ${formatUtcDateForDisplay(m.dueDate, { appendUtcLabel: true })})`
+				: `${m.id}: ${m.title}`,
+		);
 		blocks.push(formatListBlock(`Milestones (${fileMilestones.length}):`, milestoneLines));
 		blocks.push(formatListBlock(`Milestones found on tasks without files (${unconfigured.length}):`, unconfigured));
 		blocks.push(
@@ -345,6 +353,12 @@ export class MilestoneHandlers {
 		if (!name) {
 			throw new BacklogToolError("Milestone name cannot be empty.", "VALIDATION_ERROR");
 		}
+		let dueDate: string | undefined;
+		try {
+			dueDate = normalizeUtcDateTime(args.dueDate, "Due date");
+		} catch (error) {
+			throw new BacklogToolError(error instanceof Error ? error.message : String(error), "VALIDATION_ERROR");
+		}
 
 		// Check for duplicates in existing milestone files
 		const existing = await this.listFileMilestones();
@@ -365,7 +379,7 @@ export class MilestoneHandlers {
 		await this.core.ensureConfigLoaded();
 
 		// Create milestone file
-		const milestone = await this.core.filesystem.createMilestone(name, args.description);
+		const milestone = await this.core.filesystem.createMilestone(name, args.description, dueDate);
 		const milestonePath = await this.core.filesystem.getMilestoneFilePath(milestone.id);
 		await this.commitMilestoneMutation(`backlog: Add milestone ${milestone.id}`, {
 			taskFilePaths: milestonePath ? [milestonePath] : [],
@@ -375,7 +389,7 @@ export class MilestoneHandlers {
 			content: [
 				{
 					type: "text",
-					text: `Created milestone "${milestone.title}" (${milestone.id}).`,
+					text: `Created milestone "${milestone.title}" (${milestone.id}).${milestone.dueDate ? `\nDue: ${formatUtcDateForDisplay(milestone.dueDate, { appendUtcLabel: true })}` : ""}`,
 				},
 			],
 		};
@@ -394,7 +408,20 @@ export class MilestoneHandlers {
 		if (!sourceMilestone) {
 			throw new BacklogToolError(`Milestone not found: "${fromName}"`, "NOT_FOUND");
 		}
-		if (toName === sourceMilestone.title.trim()) {
+		let requestedDueDate: string | undefined;
+		try {
+			requestedDueDate =
+				args.dueDate === undefined
+					? sourceMilestone.dueDate
+					: args.dueDate === null
+						? undefined
+						: normalizeUtcDateTime(args.dueDate, "Due date");
+		} catch (error) {
+			throw new BacklogToolError(error instanceof Error ? error.message : String(error), "VALIDATION_ERROR");
+		}
+		const titleChanged = toName !== sourceMilestone.title.trim();
+		const dueDateChanged = requestedDueDate !== sourceMilestone.dueDate;
+		if (!titleChanged && !dueDateChanged) {
 			return {
 				content: [
 					{
@@ -423,7 +450,7 @@ export class MilestoneHandlers {
 		}
 
 		const targetMilestone = sourceMilestone.id;
-		const shouldUpdateTasks = args.updateTasks ?? true;
+		const shouldUpdateTasks = titleChanged && (args.updateTasks ?? true);
 		const tasks = shouldUpdateTasks ? await this.listLocalTasks() : [];
 		const matchKeys = shouldUpdateTasks
 			? buildTaskMatchKeysForMilestone(fromName, sourceMilestone, !hasTitleCollision)
@@ -432,7 +459,7 @@ export class MilestoneHandlers {
 		let updatedTaskIds: string[] = [];
 		const updatedTaskFilePaths = new Set<string>();
 
-		const renameResult = await this.core.renameMilestone(sourceMilestone.id, toName, false);
+		const renameResult = await this.core.renameMilestone(sourceMilestone.id, toName, false, args.dueDate);
 		if (!renameResult.success || !renameResult.milestone) {
 			throw new BacklogToolError(`Failed to rename milestone "${sourceMilestone.title}".`, "INTERNAL_ERROR");
 		}
@@ -453,7 +480,12 @@ export class MilestoneHandlers {
 				updatedTaskIds = updatedTaskIds.sort((a, b) => a.localeCompare(b));
 			} catch {
 				const rollbackTaskFailures = await this.rollbackTaskMilestones(previousMilestones);
-				const rollbackRenameResult = await this.core.renameMilestone(sourceMilestone.id, sourceMilestone.title, false);
+				const rollbackRenameResult = await this.core.renameMilestone(
+					sourceMilestone.id,
+					sourceMilestone.title,
+					false,
+					sourceMilestone.dueDate ?? null,
+				);
 				const rollbackDetails: string[] = [];
 				if (!rollbackRenameResult.success) {
 					rollbackDetails.push("failed to rollback milestone file rename");
@@ -469,14 +501,20 @@ export class MilestoneHandlers {
 			}
 		}
 		try {
-			await this.commitMilestoneMutation(`backlog: Rename milestone ${sourceMilestone.id}`, {
+			const commitAction = titleChanged ? "Rename" : "Update";
+			await this.commitMilestoneMutation(`backlog: ${commitAction} milestone ${sourceMilestone.id}`, {
 				sourcePath: renameResult.sourcePath,
 				targetPath: renameResult.targetPath,
 				taskFilePaths: updatedTaskFilePaths,
 			});
 		} catch {
 			const rollbackTaskFailures = await this.rollbackTaskMilestones(previousMilestones);
-			const rollbackRenameResult = await this.core.renameMilestone(sourceMilestone.id, sourceMilestone.title, false);
+			const rollbackRenameResult = await this.core.renameMilestone(
+				sourceMilestone.id,
+				sourceMilestone.title,
+				false,
+				sourceMilestone.dueDate ?? null,
+			);
 			const rollbackDetails: string[] = [];
 			if (!rollbackRenameResult.success) {
 				rollbackDetails.push("failed to rollback milestone file rename");
@@ -491,14 +529,24 @@ export class MilestoneHandlers {
 			);
 		}
 
-		const summaryLines: string[] = [
-			`Renamed milestone "${sourceMilestone.title}" (${sourceMilestone.id}) → "${renamedMilestone.title}" (${renamedMilestone.id}).`,
-		];
+		const summaryLines: string[] = [];
+		if (titleChanged) {
+			summaryLines.push(
+				`Renamed milestone "${sourceMilestone.title}" (${sourceMilestone.id}) → "${renamedMilestone.title}" (${renamedMilestone.id}).`,
+			);
+		}
+		if (dueDateChanged) {
+			summaryLines.push(
+				renamedMilestone.dueDate
+					? `Due: ${formatUtcDateForDisplay(renamedMilestone.dueDate, { appendUtcLabel: true })}`
+					: "Cleared milestone due date.",
+			);
+		}
 		if (shouldUpdateTasks) {
 			summaryLines.push(
 				`Updated ${updatedTaskIds.length} local task${updatedTaskIds.length === 1 ? "" : "s"}: ${formatTaskIdList(updatedTaskIds)}`,
 			);
-		} else {
+		} else if (titleChanged) {
 			summaryLines.push("Skipped updating tasks (updateTasks=false).");
 		}
 		if (renameResult.sourcePath && renameResult.targetPath && renameResult.sourcePath !== renameResult.targetPath) {

--- a/src/mcp/tools/milestones/schemas.ts
+++ b/src/mcp/tools/milestones/schemas.ts
@@ -21,6 +21,11 @@ export const milestoneAddSchema: JsonSchema = {
 			maxLength: 2000,
 			description: "Optional description for the milestone",
 		},
+		dueDate: {
+			type: "string",
+			maxLength: 64,
+			description: "Optional UTC milestone due datetime; date-only values are rejected",
+		},
 	},
 	required: ["name"],
 	additionalProperties: false,
@@ -45,6 +50,11 @@ export const milestoneRenameSchema: JsonSchema = {
 			type: "boolean",
 			description: "Whether to update local tasks that reference the milestone (default: true)",
 			default: true,
+		},
+		dueDate: {
+			type: ["string", "null"],
+			maxLength: 64,
+			description: "Set the UTC milestone due datetime, or pass null to clear it",
 		},
 	},
 	required: ["from", "to"],

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -17,6 +17,7 @@ import { buildTaskUpdateInput } from "../../../utils/task-edit-builder.ts";
 import { createTaskSearchIndex } from "../../../utils/task-search.ts";
 import { sortByOrdinalAndPriority } from "../../../utils/task-sorting.ts";
 import { getTerminalStatus, isTerminalStatus } from "../../../utils/terminal-status.ts";
+import { formatUtcDateForDisplay } from "../../../utils/utc-date-display.ts";
 import { BacklogToolError } from "../../errors/mcp-errors.ts";
 import type { McpServer } from "../../server.ts";
 import type { CallToolResult } from "../../types.ts";
@@ -31,6 +32,7 @@ export type TaskCreateArgs = {
 	type?: string;
 	ordinal?: number;
 	status?: string;
+	dueDate?: string;
 	milestone?: string;
 	parentTaskId?: string;
 	acceptanceCriteria?: string[];
@@ -89,7 +91,8 @@ export class TaskHandlers {
 		const typeIndicator = task.type ? `[${task.type}] ` : "";
 		const status = task.status || (task.source === "completed" ? "Done" : "");
 		const statusText = options.includeStatus && status ? ` (${status})` : "";
-		return `  ${priorityIndicator}${typeIndicator}${task.id} - ${task.title}${statusText}`;
+		const dueDate = task.dueDate ? ` (due ${formatUtcDateForDisplay(task.dueDate, { appendUtcLabel: true })})` : "";
+		return `  ${priorityIndicator}${typeIndicator}${task.id} - ${task.title}${statusText}${dueDate}`;
 	}
 
 	private async loadTaskOrThrow(id: string): Promise<Task> {
@@ -119,6 +122,7 @@ export class TaskHandlers {
 			const { task: createdTask } = await this.core.createTaskFromInput({
 				title: args.title,
 				description: args.description,
+				dueDate: args.dueDate,
 				status: args.status,
 				priority: args.priority,
 				type: args.type,

--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -120,6 +120,14 @@ function generatePriorityFieldSchema(config: Pick<BacklogConfig, "priorities">):
 	};
 }
 
+function generateDueDateFieldSchema(description: string, clearable = false): JsonSchema {
+	return {
+		type: clearable ? ["string", "null"] : "string",
+		maxLength: 64,
+		description: `${description} Use a UTC datetime such as 2026-08-10 14:30 or an ISO datetime with an explicit offset. Date-only values are rejected.`,
+	};
+}
+
 /**
  * Generates the task_create input schema with dynamic status enum
  */
@@ -137,6 +145,7 @@ export function generateTaskCreateSchema(config: BacklogConfig): JsonSchema {
 				maxLength: 10000,
 			},
 			status: generateStatusFieldSchema(config),
+			dueDate: generateDueDateFieldSchema("Optional task due date and time."),
 			priority: generatePriorityFieldSchema(config),
 			type: generateTypeFieldSchema(config),
 			ordinal: {
@@ -256,6 +265,7 @@ export function generateTaskEditSchema(config: BacklogConfig): JsonSchema {
 				maxLength: 10000,
 			},
 			status: generateStatusFieldSchema(config),
+			dueDate: generateDueDateFieldSchema("Set the task due date and time, or pass null to clear it.", true),
 			priority: generatePriorityFieldSchema(config),
 			type: generateTypeFieldSchema(config),
 			ordinal: {

--- a/src/mcp/validation/validators.ts
+++ b/src/mcp/validation/validators.ts
@@ -2,7 +2,7 @@
  * JSON Schema validator interface
  */
 export interface JsonSchema {
-	type?: string; // Optional to allow "any type" schemas
+	type?: string | string[]; // Optional to allow "any type" schemas; arrays support nullable public schemas
 	properties?: Record<string, JsonSchema>;
 	required?: string[];
 	items?: JsonSchema;
@@ -98,8 +98,15 @@ function validateField(
 		return { isValid: true, errors: [], sanitizedValue: value };
 	}
 
+	// Nullable schemas use a JSON Schema type union. Null has already returned above, so
+	// validate the value against the union's concrete type.
+	const schemaType = Array.isArray(schema.type) ? schema.type.find((type) => type !== "null") : schema.type;
+	if (!schemaType) {
+		return { isValid: false, errors: [`Unknown schema type '${String(schema.type)}' for field '${fieldName}'`] };
+	}
+
 	// Type validation
-	switch (schema.type) {
+	switch (schemaType) {
 		case "string": {
 			if (typeof value !== "string") {
 				errors.push(`Field '${fieldName}' must be a string`);
@@ -203,7 +210,7 @@ function validateField(
 		}
 
 		default: {
-			errors.push(`Unknown schema type '${schema.type}' for field '${fieldName}'`);
+			errors.push(`Unknown schema type '${schemaType}' for field '${fieldName}'`);
 		}
 	}
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,6 +27,7 @@ import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priori
 import { formatValidStatuses, getCanonicalStatuses, getValidStatuses } from "../utils/status.ts";
 import { isValidTaskId } from "../utils/task-id.ts";
 import { isAmbiguousTaskIdError } from "../utils/task-path.ts";
+import { normalizeUtcDateTime } from "../utils/utc-datetime.ts";
 import { getVersion } from "../utils/version.ts";
 
 // Regex pattern to match any prefix (letters followed by dash)
@@ -40,6 +41,23 @@ const DOCUMENT_TYPES = new Set<Document["type"]>(DOCUMENT_TYPE_VALUES);
  */
 function isDraftId(taskId: string): boolean {
 	return extractAnyPrefix(taskId) === DRAFT_PREFIX;
+}
+
+type DueDatePayloadResult = { ok: true; value: string | null | undefined } | { ok: false; error: string };
+
+function parseDueDatePayload(value: unknown, clearable: boolean): DueDatePayloadResult {
+	if (value === undefined) return { ok: true, value: undefined };
+	if (value === null) {
+		return clearable ? { ok: true, value: null } : { ok: false, error: "Due date must be a string." };
+	}
+	if (typeof value !== "string") {
+		return { ok: false, error: `Due date must be a string${clearable ? " or null" : ""}.` };
+	}
+	try {
+		return { ok: true, value: normalizeUtcDateTime(value, "Due date") };
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error.message : String(error) };
+	}
 }
 
 class DocumentPayloadValidationError extends Error {
@@ -892,6 +910,8 @@ export class BacklogServer {
 		if (!payload || typeof payload.title !== "string" || payload.title.trim().length === 0) {
 			return Response.json({ error: "Title is required" }, { status: 400 });
 		}
+		const dueDate = parseDueDatePayload(payload.dueDate, false);
+		if (!dueDate.ok) return Response.json({ error: dueDate.error }, { status: 400 });
 
 		const acceptanceCriteria = Array.isArray(payload.acceptanceCriteriaItems)
 			? payload.acceptanceCriteriaItems
@@ -914,6 +934,7 @@ export class BacklogServer {
 
 			const { task: createdTask } = await this.core.createTaskFromInput({
 				title: payload.title,
+				dueDate: dueDate.value ?? undefined,
 				description: payload.description,
 				status: payload.status,
 				priority: payload.priority,
@@ -968,11 +989,17 @@ export class BacklogServer {
 
 	private async handleUpdateTask(req: Request, taskId: string): Promise<Response> {
 		const updates = await req.json();
+		const dueDate = parseDueDatePayload(updates?.dueDate, true);
+		if (!dueDate.ok) return Response.json({ error: dueDate.error }, { status: 400 });
 
 		const updateInput: TaskUpdateInput = {};
 
 		if ("title" in updates && typeof updates.title === "string") {
 			updateInput.title = updates.title;
+		}
+
+		if ("dueDate" in updates) {
+			updateInput.dueDate = dueDate.value ?? null;
 		}
 
 		if ("description" in updates && typeof updates.description === "string") {
@@ -1508,12 +1535,14 @@ export class BacklogServer {
 
 	private async handleCreateMilestone(req: Request): Promise<Response> {
 		try {
-			const body = (await req.json()) as { title?: string; description?: string };
+			const body = (await req.json()) as { title?: string; description?: string; dueDate?: unknown };
 			const title = body.title?.trim();
 
 			if (!title) {
 				return Response.json({ error: "Milestone title is required" }, { status: 400 });
 			}
+			const dueDate = parseDueDatePayload(body.dueDate, false);
+			if (!dueDate.ok) return Response.json({ error: dueDate.error }, { status: 400 });
 
 			// Check for duplicates
 			const existingMilestones = await this.core.filesystem.listMilestones();
@@ -1552,7 +1581,7 @@ export class BacklogServer {
 				return Response.json({ error: "A milestone with this title or ID already exists" }, { status: 400 });
 			}
 
-			const milestone = await this.core.filesystem.createMilestone(title, body.description);
+			const milestone = await this.core.filesystem.createMilestone(title, body.description, dueDate.value ?? undefined);
 			return Response.json(milestone, { status: 201 });
 		} catch (error) {
 			console.error("Error creating milestone:", error);
@@ -1565,6 +1594,8 @@ export class BacklogServer {
 			const body = await this.readOptionalJsonBody(req);
 			const title = typeof body.title === "string" ? body.title.trim() : "";
 			const updateTasks = typeof body.updateTasks === "boolean" ? body.updateTasks : true;
+			const dueDate = parseDueDatePayload(body.dueDate, true);
+			if (!dueDate.ok) return Response.json({ error: dueDate.error }, { status: 400 });
 
 			if (!title) {
 				return Response.json({ error: "Milestone title is required" }, { status: 400 });
@@ -1575,6 +1606,7 @@ export class BacklogServer {
 				from: milestoneId,
 				to: title,
 				updateTasks,
+				dueDate: "dueDate" in body ? (dueDate.value ?? null) : undefined,
 			});
 			const milestone =
 				(await this.core.filesystem.loadMilestone(sourceMilestone?.id ?? milestoneId)) ??

--- a/src/test/cli-due-date.test.ts
+++ b/src/test/cli-due-date.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+const CLI_PATH = getTestCliPath();
+
+describe("CLI due dates", () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("cli-due-date");
+		await mkdir(testDir, { recursive: true });
+		await $`git init -b main`.cwd(testDir).quiet();
+		await initializeTestProject(new Core(testDir), "CLI due dates");
+	});
+
+	afterEach(async () => {
+		await safeCleanup(testDir);
+	});
+
+	it("creates, lists, edits, and clears task due dates", async () => {
+		const created = await $`bun ${CLI_PATH} task create "Ship release" --due-date "2026-08-10T16:30+02:00" --plain`
+			.cwd(testDir)
+			.text();
+		expect(created).toContain("Due: 2026-08-10 14:30 (UTC)");
+
+		const listed = await $`bun ${CLI_PATH} task list --plain`.cwd(testDir).text();
+		expect(listed).toContain("due 2026-08-10 14:30 (UTC)");
+
+		const edited = await $`bun ${CLI_PATH} task edit 1 --due-date "2026-08-12T09:15Z" --plain`.cwd(testDir).text();
+		expect(edited).toContain("Due: 2026-08-12 09:15 (UTC)");
+
+		await $`bun ${CLI_PATH} task edit 1 --clear-due-date`.cwd(testDir).quiet();
+		const task = await new Core(testDir).filesystem.loadTask("task-1");
+		expect(task?.dueDate).toBeUndefined();
+	});
+
+	it("rejects invalid and conflicting task due date flags", async () => {
+		const invalid = await $`bun ${CLI_PATH} task create "Invalid due" --due-date 2026-08-10`
+			.cwd(testDir)
+			.nothrow()
+			.quiet();
+		expect(invalid.exitCode).toBe(1);
+		expect(invalid.stderr.toString()).toContain("Date-only values are not supported");
+
+		await $`bun ${CLI_PATH} task create "Valid task"`.cwd(testDir).quiet();
+		const conflict = await $`bun ${CLI_PATH} task edit 1 --due-date "2026-08-10 12:00" --clear-due-date`
+			.cwd(testDir)
+			.nothrow()
+			.quiet();
+		expect(conflict.exitCode).toBe(1);
+		expect(conflict.stderr.toString()).toContain("Cannot use --due-date and --clear-due-date together");
+	});
+
+	it("supports milestone due dates through add and rename", async () => {
+		const added = await $`bun ${CLI_PATH} milestone add "Release" --due-date "2026-09-01T12:00Z"`.cwd(testDir).text();
+		expect(added).toContain("Due: 2026-09-01 12:00 (UTC)");
+
+		await $`bun ${CLI_PATH} milestone rename Release Release --due-date "2026-09-02T13:30Z"`.cwd(testDir).quiet();
+		let milestone = await new Core(testDir).filesystem.loadMilestone("m-0");
+		expect(milestone?.dueDate).toBe("2026-09-02 13:30");
+
+		await $`bun ${CLI_PATH} milestone rename Release Release --clear-due-date`.cwd(testDir).quiet();
+		milestone = await new Core(testDir).filesystem.loadMilestone("m-0");
+		expect(milestone?.dueDate).toBeUndefined();
+	});
+});

--- a/src/test/cli-json-output.test.ts
+++ b/src/test/cli-json-output.test.ts
@@ -31,6 +31,7 @@ describe("CLI JSON output", () => {
 				reporter: "@sam",
 				createdDate: "2026-07-14 09:30",
 				updatedDate: "2026-07-14 10:45",
+				dueDate: "2026-08-10 14:30",
 				labels: ["cli", "json"],
 				milestone: "m-1",
 				dependencies: ["TASK-2"],
@@ -107,6 +108,7 @@ describe("CLI JSON output", () => {
 					ordinal: 1000,
 					createdAt: "2026-07-14T09:30:00Z",
 					updatedAt: "2026-07-14T10:45:00Z",
+					dueDate: "2026-08-10T14:30:00Z",
 				},
 			],
 		});
@@ -164,6 +166,7 @@ describe("CLI JSON output", () => {
 			]);
 			expect(output.task.subtasks).toEqual([]);
 			expect(output.task.finalSummary).toBe("Ready for review");
+			expect(output.task.dueDate).toBe("2026-08-10T14:30:00Z");
 			expect(output.task.rawContent).toBeUndefined();
 			expect(output.task.filePath).toBeUndefined();
 			expect(output.task.branch).toBeUndefined();

--- a/src/test/due-date.test.ts
+++ b/src/test/due-date.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { parseMilestone, parseTask } from "../markdown/parser.ts";
+import { serializeTask } from "../markdown/serializer.ts";
+import type { Task } from "../types/index.ts";
+import { normalizeUtcDateTime } from "../utils/utc-datetime.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+describe("UTC due date model", () => {
+	it("normalizes supported datetimes to minute-precision UTC", () => {
+		expect(normalizeUtcDateTime("2026-08-10 14:30")).toBe("2026-08-10 14:30");
+		expect(normalizeUtcDateTime("2026-08-10T14:30")).toBe("2026-08-10 14:30");
+		expect(normalizeUtcDateTime("2026-08-10T16:30:45+02:00")).toBe("2026-08-10 14:30");
+		expect(normalizeUtcDateTime("2026-08-10T14:30:59.999Z")).toBe("2026-08-10 14:30");
+	});
+
+	it("rejects date-only and invalid datetimes", () => {
+		expect(() => normalizeUtcDateTime("2026-08-10", "Due date")).toThrow("Date-only values are not supported");
+		expect(() => normalizeUtcDateTime("2026-02-30 12:00", "Due date")).toThrow("valid UTC datetime");
+		expect(() => normalizeUtcDateTime("2026-08-10T14:30+15:00", "Due date")).toThrow("valid UTC datetime");
+		expect(() => normalizeUtcDateTime("9999-12-31T23:59-14:00", "Due date")).toThrow("valid UTC datetime");
+	});
+
+	it("keeps offset-normalized four-digit years round-trippable", () => {
+		const normalized = normalizeUtcDateTime("0100-01-01T00:00+14:00", "Due date");
+		expect(normalized).toBe("0099-12-31 10:00");
+		expect(normalizeUtcDateTime(normalized, "Due date")).toBe(normalized);
+	});
+
+	it("round-trips task and milestone due dates through Markdown", () => {
+		const task: Task = {
+			id: "TASK-1",
+			title: "Due task",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-08-01 09:00",
+			dueDate: "2026-08-10 14:30",
+			labels: [],
+			dependencies: [],
+		};
+		const serialized = serializeTask(task);
+		expect(serialized).toContain("due_date:");
+		expect(parseTask(serialized).dueDate).toBe("2026-08-10 14:30");
+
+		const milestone = parseMilestone(`---
+id: m-1
+title: Release
+due_date: 2026-08-10T16:30+02:00
+---
+
+## Description
+
+Release milestone
+`);
+		expect(milestone.dueDate).toBe("2026-08-10 14:30");
+	});
+
+	it("rejects date-only due_date frontmatter instead of accepting YAML dates", () => {
+		expect(() =>
+			parseTask(`---
+id: TASK-1
+title: Invalid due date
+status: To Do
+assignee: []
+created_date: 2026-08-01
+due_date: 2026-08-10
+labels: []
+dependencies: []
+---
+`),
+		).toThrow("Date-only values are not supported");
+	});
+});
+
+describe("due date persistence operations", () => {
+	let testDir: string;
+	let core: Core;
+
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("due-date");
+		await mkdir(testDir, { recursive: true });
+		await $`git init -b main`.cwd(testDir).quiet();
+		core = new Core(testDir);
+		await core.filesystem.ensureBacklogStructure();
+		await initializeTestProject(core, "Due date project");
+	});
+
+	afterEach(async () => {
+		await safeCleanup(testDir);
+	});
+
+	it("creates, updates, and clears a task due date", async () => {
+		const { task } = await core.createTaskFromInput({
+			title: "Deadline task",
+			dueDate: "2026-08-10T16:30+02:00",
+		});
+		expect(task.dueDate).toBe("2026-08-10 14:30");
+
+		const updated = await core.updateTaskFromInput(task.id, { dueDate: "2026-08-12T09:15Z" });
+		expect(updated.dueDate).toBe("2026-08-12 09:15");
+		expect((await core.filesystem.loadTask(task.id))?.dueDate).toBe("2026-08-12 09:15");
+
+		const cleared = await core.updateTaskFromInput(task.id, { dueDate: null });
+		expect(cleared.dueDate).toBeUndefined();
+		expect(await Bun.file(cleared.filePath ?? "").text()).not.toContain("due_date:");
+	});
+
+	it("creates, updates, and clears a milestone due date", async () => {
+		const milestone = await core.filesystem.createMilestone("Release", undefined, "2026-09-01T12:00Z");
+		expect(milestone.dueDate).toBe("2026-09-01 12:00");
+
+		const updated = await core.filesystem.renameMilestone(milestone.id, milestone.title, "2026-09-02T13:30Z");
+		expect(updated.milestone?.dueDate).toBe("2026-09-02 13:30");
+
+		const cleared = await core.filesystem.renameMilestone(milestone.id, milestone.title, null);
+		expect(cleared.milestone?.dueDate).toBeUndefined();
+		const path = await core.filesystem.getMilestoneFilePath(milestone.id);
+		expect(await Bun.file(path ?? "").text()).not.toContain("due_date:");
+	});
+
+	it("does not hide valid milestones when another file has an invalid due date", async () => {
+		await core.filesystem.createMilestone("Valid release", undefined, "2026-09-01T12:00Z");
+		await Bun.write(
+			join(testDir, "backlog", "milestones", "m-1 - Invalid-release.md"),
+			`---
+id: m-1
+title: "Invalid release"
+due_date: 2026-09-01
+---
+
+## Description
+
+Invalid release
+`,
+		);
+
+		expect((await core.filesystem.listMilestones()).map((milestone) => milestone.title)).toEqual(["Valid release"]);
+	});
+});

--- a/src/test/due-date.test.ts
+++ b/src/test/due-date.test.ts
@@ -73,6 +73,31 @@ dependencies: []
 `),
 		).toThrow("Date-only values are not supported");
 	});
+
+	it("treats YAML null due_date values as absent", () => {
+		for (const value of ["null", "NULL", "~"]) {
+			const task = parseTask(`---
+id: TASK-1
+title: No due date
+status: To Do
+assignee: []
+created_date: 2026-08-01
+due_date: ${value}
+labels: []
+dependencies: []
+---
+`);
+			expect(task.dueDate).toBeUndefined();
+
+			const milestone = parseMilestone(`---
+id: m-1
+title: No due date
+due_date: ${value}
+---
+`);
+			expect(milestone.dueDate).toBeUndefined();
+		}
+	});
 });
 
 describe("due date persistence operations", () => {

--- a/src/test/mcp-milestones.test.ts
+++ b/src/test/mcp-milestones.test.ts
@@ -78,6 +78,47 @@ describe("MCP milestone tools", () => {
 		if (errors.length > 1) throw new AggregateError(errors, "MCP server and fixture cleanup both failed");
 	});
 
+	it("creates, lists, updates, and clears milestone dueDate", async () => {
+		const tools = await server.testInterface.listTools();
+		const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+		const addSchema = toolByName.get("milestone_add")?.inputSchema as {
+			properties?: Record<string, { type?: string | string[] }>;
+		};
+		const renameSchema = toolByName.get("milestone_rename")?.inputSchema as {
+			properties?: Record<string, { type?: string | string[] }>;
+		};
+		expect(addSchema.properties?.dueDate).toBeDefined();
+		expect(renameSchema.properties?.dueDate?.type).toEqual(["string", "null"]);
+
+		const added = await server.testInterface.callTool({
+			params: {
+				name: "milestone_add",
+				arguments: { name: "Dated release", dueDate: "2026-09-01T14:00+02:00" },
+			},
+		});
+		expect(getText(added.content)).toContain("Due: 2026-09-01 12:00 (UTC)");
+
+		const listed = await server.testInterface.callTool({ params: { name: "milestone_list", arguments: {} } });
+		expect(getText(listed.content)).toContain("m-0: Dated release (due 2026-09-01 12:00 (UTC))");
+
+		const updated = await server.testInterface.callTool({
+			params: {
+				name: "milestone_rename",
+				arguments: { from: "m-0", to: "Dated release", dueDate: "2026-09-02T13:30Z" },
+			},
+		});
+		expect(getText(updated.content)).toContain("Due: 2026-09-02 13:30 (UTC)");
+		expect((await server.filesystem.loadMilestone("m-0"))?.dueDate).toBe("2026-09-02 13:30");
+
+		await server.testInterface.callTool({
+			params: {
+				name: "milestone_rename",
+				arguments: { from: "m-0", to: "Dated release", dueDate: null },
+			},
+		});
+		expect((await server.filesystem.loadMilestone("m-0"))?.dueDate).toBeUndefined();
+	});
+
 	it("assigns and clears a milestone without blocking the content store", async () => {
 		await server.testInterface.callTool({
 			params: { name: "milestone_add", arguments: { name: "Release 1.0" } },

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -137,6 +137,43 @@ describe("MCP task tools (MVP)", () => {
 		expect(searchText).not.toContain("Implementation Plan:");
 	});
 
+	it("creates, reports, edits, and clears dueDate", async () => {
+		const tools = await mcpServer.testInterface.listTools();
+		const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+		const createDueDateSchema = (toolByName.get("task_create")?.inputSchema as JsonSchema | undefined)?.properties
+			?.dueDate;
+		const editDueDateSchema = (toolByName.get("task_edit")?.inputSchema as JsonSchema | undefined)?.properties?.dueDate;
+		expect(createDueDateSchema?.type).toBe("string");
+		expect(editDueDateSchema?.type).toEqual(["string", "null"]);
+		expect(editDueDateSchema?.description).toContain("null to clear");
+
+		const createResult = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: { title: "Due task", dueDate: "2026-08-10T16:30+02:00" },
+			},
+		});
+		expect(getText(createResult.content)).toContain("Due: 2026-08-10 14:30 (UTC)");
+		expect((await mcpServer.getTask("task-1"))?.dueDate).toBe("2026-08-10 14:30");
+
+		const listResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_list", arguments: {} },
+		});
+		expect(getText(listResult.content)).toContain("due 2026-08-10 14:30 (UTC)");
+
+		const editResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_edit", arguments: { id: "task-1", dueDate: null } },
+		});
+		expect(editResult.isError).not.toBe(true);
+		expect((await mcpServer.getTask("task-1"))?.dueDate).toBeUndefined();
+
+		const invalidResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_edit", arguments: { id: "task-1", dueDate: "2026-08-10" } },
+		});
+		expect(invalidResult.isError).toBe(true);
+		expect(getText(invalidResult.content)).toContain("Date-only values are not supported");
+	});
+
 	it("adapts duplicate diagnosis to the canonical CLI without agent repair prompts", async () => {
 		const makeTask = (id: string, title: string): Task => ({
 			id,

--- a/src/test/server-due-date-endpoint.test.ts
+++ b/src/test/server-due-date-endpoint.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { $ } from "bun";
+import { FileSystem } from "../file-system/operations.ts";
+import { BacklogServer } from "../server/index.ts";
+import type { Milestone, Task } from "../types/index.ts";
+import { createUniqueTestDir, safeCleanup, withTimeout } from "./test-utils.ts";
+
+type DueDateServerHandlers = {
+	handleCreateTask(request: Request): Promise<Response>;
+	handleGetTask(taskId: string): Promise<Response>;
+	handleUpdateTask(request: Request, taskId: string): Promise<Response>;
+	handleCreateMilestone(request: Request): Promise<Response>;
+	handleListMilestones(): Promise<Response>;
+	handleUpdateMilestone(request: Request, milestoneId: string): Promise<Response>;
+};
+
+describe("BacklogServer due date endpoints", () => {
+	let testDir: string;
+	let server: BacklogServer | null;
+	let handlers: DueDateServerHandlers;
+
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("server-due-date");
+		await mkdir(testDir, { recursive: true });
+		await $`git init -b main`.cwd(testDir).quiet();
+		const filesystem = new FileSystem(testDir);
+		await filesystem.ensureBacklogStructure();
+		await filesystem.saveConfig({
+			projectName: "Server due dates",
+			statuses: ["To Do", "In Progress", "Done"],
+			labels: [],
+			milestones: [],
+			dateFormat: "YYYY-MM-DD",
+			remoteOperations: false,
+			checkActiveBranches: false,
+			autoCommit: false,
+		});
+		server = new BacklogServer(testDir);
+		handlers = server as unknown as DueDateServerHandlers;
+	});
+
+	afterEach(async () => {
+		await server?.stop();
+		server = null;
+		await safeCleanup(testDir);
+	});
+
+	const jsonRequest = (path: string, method: string, body: unknown) =>
+		new Request(`http://localhost${path}`, {
+			method,
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+
+	it("round-trips task dueDate through create, view, and update", async () => {
+		const invalidCreateType = await handlers.handleCreateTask(
+			jsonRequest("/api/tasks", "POST", { title: "Invalid task due type", dueDate: 123 }),
+		);
+		expect(invalidCreateType.status).toBe(400);
+
+		const createdResponse = await withTimeout(
+			handlers.handleCreateTask(
+				jsonRequest("/api/tasks", "POST", {
+					title: "Web due task",
+					dueDate: "2026-08-10T16:30+02:00",
+				}),
+			),
+			"server task creation",
+			2_000,
+		);
+		expect(createdResponse.status).toBe(201);
+		const created = (await createdResponse.json()) as Task;
+		expect(created.dueDate).toBe("2026-08-10 14:30");
+
+		const viewed = (await (await handlers.handleGetTask(created.id)).json()) as Task;
+		expect(viewed.dueDate).toBe("2026-08-10 14:30");
+
+		const clearedResponse = await handlers.handleUpdateTask(
+			jsonRequest(`/api/tasks/${created.id}`, "PUT", { dueDate: null }),
+			created.id,
+		);
+		expect(clearedResponse.status).toBe(200);
+		expect(((await clearedResponse.json()) as Task).dueDate).toBeUndefined();
+
+		const invalidResponse = await handlers.handleUpdateTask(
+			jsonRequest(`/api/tasks/${created.id}`, "PUT", { dueDate: "2026-08-10" }),
+			created.id,
+		);
+		expect(invalidResponse.status).toBe(400);
+		expect(await invalidResponse.text()).toContain("Date-only values are not supported");
+		const invalidUpdateType = await handlers.handleUpdateTask(
+			jsonRequest(`/api/tasks/${created.id}`, "PUT", { dueDate: false }),
+			created.id,
+		);
+		expect(invalidUpdateType.status).toBe(400);
+	});
+
+	it("round-trips milestone dueDate through create, list, and update", async () => {
+		const invalidCreateType = await handlers.handleCreateMilestone(
+			jsonRequest("/api/milestones", "POST", { title: "Invalid milestone due type", dueDate: [] }),
+		);
+		expect(invalidCreateType.status).toBe(400);
+
+		const createdResponse = await withTimeout(
+			handlers.handleCreateMilestone(
+				jsonRequest("/api/milestones", "POST", {
+					title: "Web release",
+					dueDate: "2026-09-01T14:00+02:00",
+				}),
+			),
+			"server milestone creation",
+			2_000,
+		);
+		expect(createdResponse.status).toBe(201);
+		const created = (await createdResponse.json()) as Milestone;
+		expect(created.dueDate).toBe("2026-09-01 12:00");
+
+		const listed = (await (await handlers.handleListMilestones()).json()) as Milestone[];
+		expect(listed[0]?.dueDate).toBe("2026-09-01 12:00");
+
+		const updatedResponse = await handlers.handleUpdateMilestone(
+			jsonRequest(`/api/milestones/${created.id}`, "PUT", {
+				title: created.title,
+				dueDate: "2026-09-02T13:30Z",
+			}),
+			created.id,
+		);
+		expect(updatedResponse.status).toBe(200);
+		const updated = (await updatedResponse.json()) as { milestone?: Milestone };
+		expect(updated.milestone?.dueDate).toBe("2026-09-02 13:30");
+
+		const clearedResponse = await handlers.handleUpdateMilestone(
+			jsonRequest(`/api/milestones/${created.id}`, "PUT", {
+				title: created.title,
+				dueDate: null,
+			}),
+			created.id,
+		);
+		expect(clearedResponse.status).toBe(200);
+		expect(((await clearedResponse.json()) as { milestone?: Milestone }).milestone?.dueDate).toBeUndefined();
+		const invalidUpdateType = await handlers.handleUpdateMilestone(
+			jsonRequest(`/api/milestones/${created.id}`, "PUT", { title: created.title, dueDate: {} }),
+			created.id,
+		);
+		expect(invalidUpdateType.status).toBe(400);
+	});
+
+	it("keeps unexpected milestone creation failures as internal errors", async () => {
+		const filesystem = (
+			server as unknown as {
+				core: {
+					filesystem: {
+						createMilestone: (title: string, description?: string, dueDate?: string) => Promise<Milestone>;
+					};
+				};
+			}
+		).core.filesystem;
+		const createMilestone = filesystem.createMilestone;
+		const consoleError = console.error;
+		filesystem.createMilestone = async () => {
+			throw new Error("simulated storage failure");
+		};
+		console.error = () => {};
+		try {
+			const response = await handlers.handleCreateMilestone(
+				jsonRequest("/api/milestones", "POST", { title: "Internal failure", dueDate: "2026-09-01T12:00Z" }),
+			);
+			expect(response.status).toBe(500);
+			expect(await response.json()).toEqual({ error: "Failed to create milestone" });
+		} finally {
+			filesystem.createMilestone = createMilestone;
+			console.error = consoleError;
+		}
+	});
+});

--- a/src/test/task-wizard.test.ts
+++ b/src/test/task-wizard.test.ts
@@ -41,6 +41,7 @@ describe("task wizard", () => {
 			status: "In Progress",
 			priority: "medium",
 			type: "epic",
+			dueDate: "2026-08-10T16:30+02:00",
 			assignee: "alice, @bob",
 			labels: "cli, wizard",
 			acceptanceCriteria: "[x] First criterion, Second criterion",
@@ -64,6 +65,7 @@ describe("task wizard", () => {
 		expect(input?.status).toBe("In Progress");
 		expect(input?.priority).toBe("medium");
 		expect(input?.type).toBe("Epic");
+		expect(input?.dueDate).toBe("2026-08-10 14:30");
 		expect(input?.assignee).toEqual(["alice", "@bob"]);
 		expect(input?.labels).toEqual(["cli", "wizard"]);
 		expect(input?.acceptanceCriteria).toEqual([
@@ -89,6 +91,7 @@ describe("task wizard", () => {
 			type: "Bug",
 			assignee: ["alice"],
 			createdDate: "2026-02-20 12:00",
+			dueDate: "2026-08-10 14:30",
 			labels: ["existing"],
 			dependencies: ["task-1"],
 			references: ["docs/old.md"],
@@ -112,6 +115,7 @@ describe("task wizard", () => {
 			status: "In Progress",
 			priority: "high",
 			type: "Epic",
+			dueDate: "",
 			assignee: "alice, bob",
 			labels: "existing, cli",
 			acceptanceCriteria: "[x] New AC 1, [ ] New AC 2",
@@ -136,6 +140,7 @@ describe("task wizard", () => {
 		expect(updateInput?.status).toBe("In Progress");
 		expect(updateInput?.priority).toBe("high");
 		expect(updateInput?.type).toBe("Epic");
+		expect(updateInput?.dueDate).toBeNull();
 		expect(updateInput?.assignee).toEqual(["alice", "bob"]);
 		expect(updateInput?.labels).toEqual(["existing", "cli"]);
 		expect(updateInput?.dependencies).toEqual(["task-2", "3"]);

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -271,19 +271,19 @@ describe("TUI task composer model", () => {
 
 	it("fits shipped selector content at 100x30 and 80x24, then stacks details at 50x18", () => {
 		expect(getTaskComposerLayout(100, 30)).toMatchObject({
-			compact: false,
+			compact: true,
 			popupWidth: 74,
 			popupHeight: 20,
-			descriptionHeight: 6,
-			detailsTop: 12,
-			detailsHeight: 3,
-			actionsTop: 15,
+			descriptionHeight: 3,
+			detailsTop: 9,
+			detailsHeight: 4,
+			actionsTop: 13,
 		});
 		expect(getTaskComposerLayout(80, 24)).toMatchObject({
-			compact: false,
+			compact: true,
 			popupWidth: 74,
 			popupHeight: 20,
-			actionsTop: 15,
+			actionsTop: 13,
 		});
 		expect(getTaskComposerLayout(50, 18)).toMatchObject({
 			compact: true,
@@ -299,7 +299,7 @@ describe("TUI task composer model", () => {
 	it("derives compact selector layout from configured content instead of a screen breakpoint", () => {
 		const statuses = ["To Do", "Waiting for external approval", "Done"];
 		expect(getTaskComposerLayout(100, 30, { statuses }).compact).toBe(true);
-		expect(getTaskComposerLayout(140, 30, { statuses }).compact).toBe(false);
+		expect(getTaskComposerLayout(140, 30, { statuses }).compact).toBe(true);
 
 		const types = ["A very long configured type value that exceeds a compact column"];
 		expect(getTaskComposerLayout(100, 30, { types })).toMatchObject({
@@ -1456,10 +1456,12 @@ describe("TUI task composer interaction", () => {
 			expect(eventScreen.focused?.content).toBe("Status: To Do ▼");
 			expect(eventScreen.focused?.style).toMatchObject({ inverse: true, bold: true });
 			pressKey(eventScreen.focused, "right");
-			expect(eventScreen.focused?.content).toBe("Type: None ▼");
-			pressKey(eventScreen.focused, "right");
-			expect(eventScreen.focused?.content).toBe("Priority: None ▼");
+			expect(eventScreen.focused?.content).toBe("Status: To Do ▼");
 			pressKey(eventScreen.focused, "down");
+			expect(eventScreen.focused?.content).toBe("Type: None ▼");
+			pressKey(eventScreen.focused, "down");
+			expect(eventScreen.focused?.content).toBe("Create task");
+			pressKey(eventScreen.focused, "right");
 			expect(eventScreen.focused?.content).toBe("Cancel");
 			pressKey(eventScreen.focused, "left");
 			expect(eventScreen.focused?.content).toBe("Create task");
@@ -1615,6 +1617,7 @@ describe("TUI task composer interaction", () => {
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
+			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Create task");
 			pressKey(eventScreen.focused, "enter", "\r");
 			await waitUntil(() => eventScreen.focused?.options?.label === " Title ", "invalid title focus");
@@ -1629,6 +1632,7 @@ describe("TUI task composer interaction", () => {
 			pressKey(eventScreen.focused, "down");
 			await settleComposerFocus();
 			eventScreen.focused?.setValue?.("Kept description");
+			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
@@ -1779,14 +1783,14 @@ describe("TUI task composer interaction", () => {
 			let actions = widgets.find((widget) => widget.content === "Actions");
 			let status = widgets.find((widget) => widget.content === "Status: To Do ▼");
 			let type = widgets.find((widget) => widget.content === "Type: None ▼");
-			expect(description?.position).toMatchObject({ top: 3, height: 6 });
-			expect(details?.position).toMatchObject({ top: 12, height: 3 });
-			expect(actions?.position).toMatchObject({ top: 15, height: 1 });
-			expect(actions?.hidden).toBe(false);
+			expect(description?.position).toMatchObject({ top: 3, height: 3 });
+			expect(details?.position).toMatchObject({ top: 9, height: 4 });
+			expect(actions?.position).toMatchObject({ top: 13, height: 1 });
+			expect(actions?.hidden).toBe(true);
 			// Selectors sit inside the details frame but are positioned in viewport coordinates.
-			expect(status?.position).toMatchObject({ top: 13, left: 3 });
-			expect(type?.position).toMatchObject({ top: 13, left: "35%" });
-			expect(widgets.some((widget) => widget.content?.includes("[↑↓/←→/Tab]"))).toBe(true);
+			expect(status?.position).toMatchObject({ top: 10, left: 3 });
+			expect(type?.position).toMatchObject({ top: 11, left: 3 });
+			expect(widgets.some((widget) => widget.content?.includes("[↑↓←→/Tab]"))).toBe(true);
 
 			mutableScreen.width = 50;
 			mutableScreen.height = 18;
@@ -1813,8 +1817,8 @@ describe("TUI task composer interaction", () => {
 			widgets = collectWidgets(screen as unknown as { children?: unknown[] });
 			details = widgets.find((widget) => widget.options?.label === " Details ");
 			type = widgets.find((widget) => widget.content === "Type: None ▼");
-			expect(details?.position).toMatchObject({ top: 12, height: 3 });
-			expect(type?.position).toMatchObject({ top: 13, left: "35%" });
+			expect(details?.position).toMatchObject({ top: 9, height: 4 });
+			expect(type?.position).toMatchObject({ top: 11, left: 3 });
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "escape", "\x1b");
 			expect(await withTimeout(resultPromise, "resized composer cancellation", 1000)).toBeNull();
 		} finally {
@@ -1893,6 +1897,7 @@ describe("TUI task composer interaction", () => {
 			);
 			const focused = (screen as unknown as { focused?: TestWidget }).focused;
 			focused?.setValue?.("Actual composer task");
+			pressKey((screen as unknown as { focused?: TestWidget }).focused, "down");
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "down");
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "down");
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "down");

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -443,7 +443,7 @@ describe("TUI task composer canonical persistence", () => {
 			expect(description?.getValue?.()).toBe("left Y𠮷 right");
 			expect(description?.getCursor?.()).toEqual({ x: -8, y: 0 });
 
-			for (let step = 0; step < 4; step += 1) pressKey(eventScreen.focused, "tab", "\t");
+			for (let step = 0; step < 5; step += 1) pressKey(eventScreen.focused, "tab", "\t");
 			expect(eventScreen.focused?.content).toBe("Create task");
 			pressKey(eventScreen.focused, "enter", "\r");
 			expect((await withTimeout(resultPromise, "Unicode-safe composer persistence", 1000))?.id).toBe("TASK-1");
@@ -1740,9 +1740,9 @@ describe("TUI task composer interaction", () => {
 			const status = widgets.find((widget) => widget.content === "Status: To Do ▼");
 			const type = widgets.find((widget) => widget.content === "Type: None ▼");
 			const priority = widgets.find((widget) => widget.content === "Priority: None ▼");
-			expect(status?.position?.top).toBe(7);
-			expect(type?.position?.top).toBe(8);
-			expect(priority?.position?.top).toBe(9);
+			expect(status?.position?.top).toBe(10);
+			expect(type?.position?.top).toBe(11);
+			expect(priority?.position?.top).toBe(12);
 			type?.setContent?.(`Type: ${typeValue} ▼`);
 			expect(type?.width).toBeGreaterThanOrEqual(Bun.stringWidth(type?.content ?? ""));
 			expect(priority?.width).toBeGreaterThanOrEqual(Bun.stringWidth(priority?.content ?? ""));

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -1749,7 +1749,7 @@ describe("TUI task composer interaction", () => {
 			expect(status?.width).toBeGreaterThanOrEqual(Bun.stringWidth(status?.content ?? ""));
 
 			const eventScreen = screen as unknown as { focused?: TestWidget };
-			for (let step = 0; step < 5; step += 1) pressKey(eventScreen.focused, "down");
+			for (let step = 0; step < 6; step += 1) pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Create task");
 			pressKey(eventScreen.focused, "up");
 			expect(eventScreen.focused?.content).toBe("Priority: None ▼");

--- a/src/test/tui-task-composer.test.ts
+++ b/src/test/tui-task-composer.test.ts
@@ -234,6 +234,7 @@ describe("TUI task composer model", () => {
 				status: "Review",
 				type: "Feature",
 				priority: "urgent",
+				dueDate: "2026-08-10T16:30+02:00",
 			}),
 		).toEqual({
 			title: "Capture intent",
@@ -241,12 +242,31 @@ describe("TUI task composer model", () => {
 			status: "Review",
 			type: "Feature",
 			priority: "urgent",
+			dueDate: "2026-08-10 14:30",
 		});
 
-		expect(toTaskCreateInput({ title: "Minimal", description: "", status: "To Do", type: "", priority: "" })).toEqual({
+		expect(
+			toTaskCreateInput({ title: "Minimal", description: "", status: "To Do", type: "", priority: "", dueDate: "" }),
+		).toEqual({
 			title: "Minimal",
 			status: "To Do",
 		});
+	});
+
+	it("rejects date-only due dates before persistence", async () => {
+		const controller = new TaskComposerController(["To Do", "Done"]);
+		controller.values.title = "Invalid due date";
+		controller.values.dueDate = "2026-08-10";
+		let calls = 0;
+
+		expect(
+			await controller.create(async () => {
+				calls += 1;
+				return task();
+			}),
+		).toBeNull();
+		expect(calls).toBe(0);
+		expect(controller.error).toContain("Date-only values are not supported");
 	});
 
 	it("fits shipped selector content at 100x30 and 80x24, then stacks details at 50x18", () => {
@@ -255,24 +275,24 @@ describe("TUI task composer model", () => {
 			popupWidth: 74,
 			popupHeight: 20,
 			descriptionHeight: 6,
-			detailsTop: 9,
+			detailsTop: 12,
 			detailsHeight: 3,
-			actionsTop: 12,
+			actionsTop: 15,
 		});
 		expect(getTaskComposerLayout(80, 24)).toMatchObject({
 			compact: false,
 			popupWidth: 74,
 			popupHeight: 20,
-			actionsTop: 12,
+			actionsTop: 15,
 		});
 		expect(getTaskComposerLayout(50, 18)).toMatchObject({
 			compact: true,
 			stackSelectors: true,
 			popupHeight: 16,
 			descriptionHeight: 3,
-			detailsTop: 6,
+			detailsTop: 9,
 			detailsHeight: 5,
-			actionsTop: 11,
+			actionsTop: 14,
 		});
 	});
 
@@ -285,8 +305,9 @@ describe("TUI task composer model", () => {
 		expect(getTaskComposerLayout(100, 30, { types })).toMatchObject({
 			compact: true,
 			stackSelectors: true,
+			detailsTop: 9,
 			detailsHeight: 5,
-			actionsTop: 11,
+			actionsTop: 14,
 		});
 	});
 
@@ -324,6 +345,7 @@ describe("TUI task composer model", () => {
 			status: "Review",
 			type: "",
 			priority: "",
+			dueDate: "",
 		});
 	});
 });
@@ -1097,6 +1119,7 @@ describe("TUI task composer interaction", () => {
 			const widgets = collectWidgets(screen as unknown as { children?: unknown[] });
 			const title = widgets.find((widget) => widget.options?.label === " Title ");
 			const description = widgets.find((widget) => widget.options?.label === " Description ");
+			const dueDate = widgets.find((widget) => widget.options?.label === " Due (UTC) ");
 			const status = widgets.find((widget) => widget.content === "Status: To Do ▼");
 
 			clickWidget(description);
@@ -1110,6 +1133,9 @@ describe("TUI task composer interaction", () => {
 			typeText(eventScreen.focused, "Clicked description");
 			expect(description?.getValue?.()).toBe("Clicked description");
 
+			pressKey(eventScreen.focused, "tab", "\t");
+			expect(eventScreen.focused).toBe(dueDate);
+			expect(dueDate?.style?.border?.fg).toBe("yellow");
 			pressKey(eventScreen.focused, "tab", "\t");
 			expect(eventScreen.focused).toBe(status);
 			expect(status?.style).toMatchObject({ inverse: true, bold: true });
@@ -1392,7 +1418,16 @@ describe("TUI task composer interaction", () => {
 
 			expect(eventScreen.focused?.options?.label).toBe(" Title ");
 			// Tab walks the whole order forward and wraps back to the title.
-			for (const expected of [" Description ", undefined, undefined, undefined, undefined, undefined, " Title "]) {
+			for (const expected of [
+				" Description ",
+				" Due (UTC) ",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				" Title ",
+			]) {
 				pressKey(eventScreen.focused, "tab", "\t");
 				if (expected) expect(eventScreen.focused?.options?.label).toBe(expected);
 			}
@@ -1406,6 +1441,8 @@ describe("TUI task composer interaction", () => {
 				expect(eventScreen.focused?.content).toBe(expected);
 			}
 			pressKey(eventScreen.focused, "S-tab", "\t");
+			expect(eventScreen.focused?.options?.label).toBe(" Due (UTC) ");
+			pressKey(eventScreen.focused, "S-tab", "\t");
 			expect(eventScreen.focused?.options?.label).toBe(" Description ");
 			pressKey(eventScreen.focused, "S-tab", "\t");
 			expect(eventScreen.focused?.options?.label).toBe(" Title ");
@@ -1413,6 +1450,8 @@ describe("TUI task composer interaction", () => {
 
 			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.options?.label).toBe(" Description ");
+			pressKey(eventScreen.focused, "down");
+			expect(eventScreen.focused?.options?.label).toBe(" Due (UTC) ");
 			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Status: To Do ▼");
 			expect(eventScreen.focused?.style).toMatchObject({ inverse: true, bold: true });
@@ -1449,6 +1488,7 @@ describe("TUI task composer interaction", () => {
 				persist: async () => task(),
 			});
 			await settleComposerFocus();
+			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Status: To Do ▼");
@@ -1509,6 +1549,8 @@ describe("TUI task composer interaction", () => {
 			expect(eventScreen.focused?.options?.label).toBe(" Description ");
 			expect(eventScreen.focused?.getCursor?.().y).toBe(0);
 			pressKey(eventScreen.focused, "down");
+			expect(eventScreen.focused?.options?.label).toBe(" Due (UTC) ");
+			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Status: To Do ▼");
 
 			pressKey(eventScreen.focused, "escape", "\x1b");
@@ -1532,6 +1574,7 @@ describe("TUI task composer interaction", () => {
 				persist: async () => task(),
 			});
 			await settleComposerFocus();
+			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Status: To Do ▼");
@@ -1571,6 +1614,7 @@ describe("TUI task composer interaction", () => {
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
+			pressKey(eventScreen.focused, "down");
 			expect(eventScreen.focused?.content).toBe("Create task");
 			pressKey(eventScreen.focused, "enter", "\r");
 			await waitUntil(() => eventScreen.focused?.options?.label === " Title ", "invalid title focus");
@@ -1585,6 +1629,7 @@ describe("TUI task composer interaction", () => {
 			pressKey(eventScreen.focused, "down");
 			await settleComposerFocus();
 			eventScreen.focused?.setValue?.("Kept description");
+			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "down");
 			pressKey(eventScreen.focused, "enter", "\r");
@@ -1735,12 +1780,12 @@ describe("TUI task composer interaction", () => {
 			let status = widgets.find((widget) => widget.content === "Status: To Do ▼");
 			let type = widgets.find((widget) => widget.content === "Type: None ▼");
 			expect(description?.position).toMatchObject({ top: 3, height: 6 });
-			expect(details?.position).toMatchObject({ top: 9, height: 3 });
-			expect(actions?.position).toMatchObject({ top: 12, height: 1 });
+			expect(details?.position).toMatchObject({ top: 12, height: 3 });
+			expect(actions?.position).toMatchObject({ top: 15, height: 1 });
 			expect(actions?.hidden).toBe(false);
 			// Selectors sit inside the details frame but are positioned in viewport coordinates.
-			expect(status?.position).toMatchObject({ top: 10, left: 3 });
-			expect(type?.position).toMatchObject({ top: 10, left: "35%" });
+			expect(status?.position).toMatchObject({ top: 13, left: 3 });
+			expect(type?.position).toMatchObject({ top: 13, left: "35%" });
 			expect(widgets.some((widget) => widget.content?.includes("[↑↓/←→/Tab]"))).toBe(true);
 
 			mutableScreen.width = 50;
@@ -1753,13 +1798,13 @@ describe("TUI task composer interaction", () => {
 			status = widgets.find((widget) => widget.content === "Status: To Do ▼");
 			type = widgets.find((widget) => widget.content === "Type: None ▼");
 			expect(description?.position).toMatchObject({ top: 3, height: 3 });
-			expect(details?.position).toMatchObject({ top: 6, height: 5 });
-			expect(actions?.position).toMatchObject({ top: 11, height: 1 });
+			expect(details?.position).toMatchObject({ top: 9, height: 5 });
+			expect(actions?.position).toMatchObject({ top: 14, height: 1 });
 			expect(actions?.hidden).toBe(true);
-			expect(status?.position).toMatchObject({ top: 7, left: 3 });
-			expect(type?.position).toMatchObject({ top: 8, left: 3 });
+			expect(status?.position).toMatchObject({ top: 10, left: 3 });
+			expect(type?.position).toMatchObject({ top: 11, left: 3 });
 			const priority = widgets.find((widget) => widget.content === "Priority: None ▼");
-			expect(priority?.position).toMatchObject({ top: 9, left: 3 });
+			expect(priority?.position).toMatchObject({ top: 12, left: 3 });
 			expect(widgets.some((widget) => widget.content?.includes("[↑↓←→/Tab]"))).toBe(true);
 
 			mutableScreen.width = 80;
@@ -1768,8 +1813,8 @@ describe("TUI task composer interaction", () => {
 			widgets = collectWidgets(screen as unknown as { children?: unknown[] });
 			details = widgets.find((widget) => widget.options?.label === " Details ");
 			type = widgets.find((widget) => widget.content === "Type: None ▼");
-			expect(details?.position).toMatchObject({ top: 9, height: 3 });
-			expect(type?.position).toMatchObject({ top: 10, left: "35%" });
+			expect(details?.position).toMatchObject({ top: 12, height: 3 });
+			expect(type?.position).toMatchObject({ top: 13, left: "35%" });
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "escape", "\x1b");
 			expect(await withTimeout(resultPromise, "resized composer cancellation", 1000)).toBeNull();
 		} finally {
@@ -1848,6 +1893,7 @@ describe("TUI task composer interaction", () => {
 			);
 			const focused = (screen as unknown as { focused?: TestWidget }).focused;
 			focused?.setValue?.("Actual composer task");
+			pressKey((screen as unknown as { focused?: TestWidget }).focused, "down");
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "down");
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "down");
 			pressKey((screen as unknown as { focused?: TestWidget }).focused, "down");

--- a/src/test/tui-task-type.test.ts
+++ b/src/test/tui-task-type.test.ts
@@ -36,6 +36,11 @@ describe("TUI task type display", () => {
 		expect(untyped).not.toContain("{magenta-fg}");
 	});
 
+	it("shows due dates on board task cards", () => {
+		const task = createTask({ dueDate: "2026-08-10 14:30" });
+		expect(formatTaskListItem(task)).toContain("due 2026-08-10 14:30 (UTC)");
+	});
+
 	it("shows the type field in task details and hides it for untyped tasks", async () => {
 		const screen = createScreen({ smartCSR: false });
 		const originalIsTTY = process.stdout.isTTY;

--- a/src/test/web-milestones-page-search.test.tsx
+++ b/src/test/web-milestones-page-search.test.tsx
@@ -84,6 +84,7 @@ const renderPage = (
 	tasks: Task[] = baseTasks,
 	options: {
 		onRefreshData?: () => Promise<void>;
+		dateFormat?: string;
 	} = {},
 ): HTMLElement => {
 	setupDom();
@@ -100,6 +101,7 @@ const renderPage = (
 					archivedMilestones={[]}
 					onEditTask={() => {}}
 					onRefreshData={options.onRefreshData}
+					dateFormat={options.dateFormat}
 				/>
 			</MemoryRouter>,
 		);
@@ -175,6 +177,11 @@ describe("Web milestones page search", () => {
 
 		expect(text.indexOf("Release 1")).toBeLessThan(text.indexOf("Release 2"));
 		expect(text).toContain("Due (UTC):");
+	});
+
+	it("uses the configured date format for milestone due dates", () => {
+		const container = renderPage(baseTasks, { dateFormat: "dd/mm/yyyy hh:mm" });
+		expect(container.textContent).toContain("Due (UTC): 01/09/2026 12:00");
 	});
 
 	it("searching one milestone still renders other milestone sections", () => {

--- a/src/test/web-milestones-page-search.test.tsx
+++ b/src/test/web-milestones-page-search.test.tsx
@@ -23,6 +23,7 @@ const milestoneEntities: Milestone[] = [
 	{
 		id: "m-1",
 		title: "Release 1",
+		dueDate: "2026-09-01 12:00",
 		description: "Milestone: Release 1",
 		rawContent: "## Description\n\nMilestone: Release 1",
 	},
@@ -173,6 +174,7 @@ describe("Web milestones page search", () => {
 		const text = container.textContent ?? "";
 
 		expect(text.indexOf("Release 1")).toBeLessThan(text.indexOf("Release 2"));
+		expect(text).toContain("Due (UTC):");
 	});
 
 	it("searching one milestone still renders other milestone sections", () => {
@@ -260,10 +262,10 @@ describe("Web milestones page search", () => {
 	});
 
 	it("submits milestone edits through the API and refreshes data", async () => {
-		let updateArgs: [string, string] | undefined;
+		let updateArgs: [string, string, string | null | undefined] | undefined;
 		let refreshCount = 0;
-		apiClient.updateMilestone = async (id: string, title: string) => {
-			updateArgs = [id, title];
+		apiClient.updateMilestone = async (id: string, title: string, dueDate?: string | null) => {
+			updateArgs = [id, title, dueDate];
 			return { success: true, milestone: { ...milestoneEntities[0]!, title } };
 		};
 
@@ -280,10 +282,14 @@ describe("Web milestones page search", () => {
 		const input = container.querySelector("#edit-milestone-name") as HTMLInputElement | null;
 		expect(input).toBeTruthy();
 		setInputValue(input as HTMLInputElement, "Release 1.1");
+		const dueDateInput = container.querySelector("#edit-milestone-due-date") as HTMLInputElement | null;
+		expect(dueDateInput?.value).toBe("2026-09-01T12:00");
+		setInputValue(dueDateInput as HTMLInputElement, "2026-09-02T13:30");
 		await submitForm(input?.closest("form") as HTMLFormElement);
 
 		expect(updateArgs?.[0]).toBe("m-1");
 		expect(updateArgs?.[1]).toBe("Release 1.1");
+		expect(updateArgs?.[2]).toBe("2026-09-02T13:30");
 		expect(refreshCount).toBe(1);
 	});
 

--- a/src/test/web-task-list-table-width.test.tsx
+++ b/src/test/web-task-list-table-width.test.tsx
@@ -59,7 +59,15 @@ const renderTaskList = (): HTMLElement => {
 		activeRoot?.render(
 			<MemoryRouter>
 				<TaskList
-					tasks={[createTask({ id: "task-101", title: "Fit the task table", labels: ["ui"], assignee: ["@alex"] })]}
+					tasks={[
+						createTask({
+							id: "task-101",
+							title: "Fit the task table",
+							dueDate: "2026-08-10 14:30",
+							labels: ["ui"],
+							assignee: ["@alex"],
+						}),
+					]}
 					availableStatuses={["To Do", "In Progress", "Done"]}
 					availableLabels={["ui"]}
 					availableMilestones={[]}
@@ -103,6 +111,7 @@ describe("TaskList table width budget", () => {
 
 		expect(headers).toEqual(EXPECTED_HEADERS);
 		expect(container.querySelectorAll("tbody tr td")).toHaveLength(EXPECTED_HEADERS.length);
+		expect(container.textContent).toContain("Due (UTC): 2026-08-10 14:30");
 	});
 
 	it("leaves Title as the only flexible column", () => {

--- a/src/test/web-task-types.test.tsx
+++ b/src/test/web-task-types.test.tsx
@@ -179,6 +179,14 @@ describe("Web task type UI", () => {
 			/>,
 		);
 		const untypedHtml = renderToString(<TaskCard task={createTask()} onUpdate={() => {}} onEdit={() => {}} />);
+		const datedHtml = renderToString(
+			<TaskCard
+				task={createTask({ dueDate: "2026-08-10 14:30" })}
+				onUpdate={() => {}}
+				onEdit={() => {}}
+				dateFormat="dd/mm/yyyy hh:mm"
+			/>,
+		);
 
 		expect(bugHtml).toContain('data-task-type="bug"');
 		expect(bugHtml).toContain("bg-red-100");
@@ -188,6 +196,7 @@ describe("Web task type UI", () => {
 		expect(customHtml).toContain("bg-blue-100");
 		expect(docsHtml).toContain("bg-cyan-100");
 		expect(untypedHtml).not.toContain("data-task-type");
+		expect(datedHtml).toContain("Due (UTC): 10/08/2026 14:30");
 	});
 
 	it("creates a task with a configured custom type and defaults to untyped", async () => {

--- a/src/test/web-task-types.test.tsx
+++ b/src/test/web-task-types.test.tsx
@@ -196,7 +196,8 @@ describe("Web task type UI", () => {
 		expect(customHtml).toContain("bg-blue-100");
 		expect(docsHtml).toContain("bg-cyan-100");
 		expect(untypedHtml).not.toContain("data-task-type");
-		expect(datedHtml).toContain("Due (UTC): 10/08/2026 14:30");
+		expect(datedHtml).toContain("Due (UTC):");
+		expect(datedHtml).toContain("10/08/2026 14:30");
 	});
 
 	it("creates a task with a configured custom type and defaults to untyped", async () => {

--- a/src/test/web-task-types.test.tsx
+++ b/src/test/web-task-types.test.tsx
@@ -112,6 +112,49 @@ afterEach(() => {
 });
 
 describe("Web task type UI", () => {
+	it("displays and clears a task due date through the edit form", async () => {
+		const container = setupDom();
+		const task = createTask({ dueDate: "2026-08-10 14:30" });
+		const receivedUpdates: TaskUpdateRequest[] = [];
+		apiClient.updateTask = async (_taskId, updates) => {
+			receivedUpdates.push(updates);
+			return { ...task, dueDate: updates.dueDate ?? undefined };
+		};
+
+		activeRoot = createRoot(container);
+		await act(async () => {
+			activeRoot?.render(
+				<ThemeProvider>
+					<TaskDetailsModal task={task} isOpen onClose={() => {}} />
+				</ThemeProvider>,
+			);
+			await Promise.resolve();
+		});
+		expect(container.textContent).toContain("Due (UTC):");
+
+		const editButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.trim() === "Edit",
+		);
+		expect(editButton).toBeTruthy();
+		await act(async () => {
+			editButton?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		const dueDateInput = container.querySelector('input[type="datetime-local"]') as HTMLInputElement | null;
+		expect(dueDateInput?.value).toBe("2026-08-10T14:30");
+		await setInputValue(dueDateInput as HTMLInputElement, "");
+		const saveButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.trim() === "Save",
+		);
+		await act(async () => {
+			saveButton?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+		await waitFor(() => receivedUpdates.length === 1);
+		expect(receivedUpdates[0]?.dueDate).toBeNull();
+	});
+
 	it("shows distinct type badges on cards and no badge for untyped tasks", () => {
 		const bugHtml = renderToString(
 			<TaskCard task={createTask({ type: "bug" })} onUpdate={() => {}} onEdit={() => {}} />,
@@ -178,8 +221,11 @@ describe("Web task type UI", () => {
 		]);
 
 		const titleInput = container.querySelector("input[placeholder='Enter task title']") as HTMLInputElement | null;
+		const dueDateInput = container.querySelector('input[type="datetime-local"]') as HTMLInputElement | null;
 		expect(titleInput).toBeTruthy();
+		expect(dueDateInput).toBeTruthy();
 		await setInputValue(titleInput as HTMLInputElement, "Customer interview");
+		await setInputValue(dueDateInput as HTMLInputElement, "2026-08-11T09:45");
 		await setSelectValue(typeSelect as HTMLSelectElement, "Customer Request");
 
 		const createButton = Array.from(container.querySelectorAll("button")).find(
@@ -194,6 +240,7 @@ describe("Web task type UI", () => {
 
 		expect(submitted?.title).toBe("Customer interview");
 		expect(submitted?.type).toBe("Customer Request");
+		expect(submitted?.dueDate).toBe("2026-08-11T09:45");
 		// A blank assignee field is omitted so the configured defaultAssignee still applies;
 		// an explicit empty list means "unassigned" everywhere else.
 		expect(submitted && "assignee" in submitted).toBe(false);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,7 @@ export interface Task {
 	reporter?: string;
 	createdDate: string;
 	updatedDate?: string;
+	dueDate?: string;
 	labels: string[];
 	milestone?: string;
 	dependencies: string[];
@@ -104,6 +105,7 @@ export function isLocalEditableTask(task: Task): boolean {
 
 export interface TaskCreateInput {
 	title: string;
+	dueDate?: string;
 	description?: string;
 	status?: TaskStatus;
 	priority?: string;
@@ -128,6 +130,7 @@ export interface TaskCreateInput {
 
 export interface TaskUpdateInput {
 	title?: string;
+	dueDate?: string | null;
 	description?: string;
 	status?: TaskStatus;
 	priority?: string;
@@ -198,6 +201,7 @@ export interface Decision {
 export interface Milestone {
 	id: string;
 	title: string;
+	dueDate?: string;
 	description: string;
 	readonly rawContent: string; // Raw markdown content without frontmatter
 }

--- a/src/types/task-edit-args.ts
+++ b/src/types/task-edit-args.ts
@@ -1,5 +1,6 @@
 export interface TaskEditArgs {
 	title?: string;
+	dueDate?: string | null;
 	description?: string;
 	status?: string;
 	priority?: string;

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -166,7 +166,7 @@ export function formatTaskListItem(
 	const progressPrefix = progress ? `${progress} ` : "";
 
 	// Cross-branch tasks are dimmed to indicate read-only status
-	const content = `${progressPrefix}{bold}${task.id}{/bold}${type} - ${task.title}${dueDate}${assignee}${labels}${branch}`;
+	const content = `${progressPrefix}{bold}${task.id}{/bold}${type}${dueDate} - ${task.title}${assignee}${labels}${branch}`;
 	if (isMoving) {
 		return `{magenta-fg}► ${content}{/}`;
 	}

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -20,6 +20,7 @@ import { applySharedTaskFilters, createTaskSearchIndex, type LabelMatchMode } fr
 import { compareTaskIds } from "../utils/task-sorting.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
 import { formatAcceptanceCriteriaProgress } from "./acceptance-criteria-progress.ts";
+import { formatUtcDateForDisplay } from "../utils/utc-date-display.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
 import { createFilterHeader, type FilterHeader, type FilterState } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
@@ -144,11 +145,19 @@ function prepareBoardColumns(tasks: Task[], statuses: string[]): ColumnData[] {
 	});
 }
 
-export function formatTaskListItem(task: Task, isMoving = false, availableWidth = Number.POSITIVE_INFINITY): string {
+export function formatTaskListItem(
+	task: Task,
+	isMoving = false,
+	availableWidth = Number.POSITIVE_INFINITY,
+	dateFormat?: string,
+): string {
 	const assignee = task.assignee?.[0]
 		? ` {cyan-fg}${task.assignee[0].startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
 		: "";
 	const labels = task.labels?.length ? ` {yellow-fg}[${task.labels.join(", ")}]{/}` : "";
+	const dueDate = task.dueDate
+		? ` {gray-fg}(due ${formatUtcDateForDisplay(task.dueDate, { dateFormat, appendUtcLabel: true })}){/}`
+		: "";
 	const typeBadge = formatTaskTypeBadge(task.type);
 	const type = typeBadge ? ` ${typeBadge}` : "";
 	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
@@ -157,7 +166,7 @@ export function formatTaskListItem(task: Task, isMoving = false, availableWidth 
 	const progressPrefix = progress ? `${progress} ` : "";
 
 	// Cross-branch tasks are dimmed to indicate read-only status
-	const content = `${progressPrefix}{bold}${task.id}{/bold}${type} - ${task.title}${assignee}${labels}${branch}`;
+	const content = `${progressPrefix}{bold}${task.id}{/bold}${type} - ${task.title}${dueDate}${assignee}${labels}${branch}`;
 	if (isMoving) {
 		return `{magenta-fg}► ${content}{/}`;
 	}
@@ -171,8 +180,9 @@ function buildRenderedTaskListItems(
 	tasks: Task[],
 	movingTaskId?: string,
 	availableWidth = Number.POSITIVE_INFINITY,
+	dateFormat?: string,
 ): { rich: string[]; plain: string[] } {
-	const rich = tasks.map((task) => formatTaskListItem(task, movingTaskId === task.id, availableWidth));
+	const rich = tasks.map((task) => formatTaskListItem(task, movingTaskId === task.id, availableWidth, dateFormat));
 	return {
 		rich,
 		plain: rich.map((item) => stripBlessedFgTags(item)),
@@ -535,7 +545,7 @@ export async function renderBoardTui(
 		const getFormattedItems = (tasks: Task[]) => {
 			const columnCount = Math.max(1, currentColumnsData.length);
 			const availableWidth = Math.max(1, Math.floor(getTerminalWidth() / columnCount) - 4);
-			return buildRenderedTaskListItems(tasks, moveOp?.taskId, availableWidth);
+			return buildRenderedTaskListItems(tasks, moveOp?.taskId, availableWidth, options?.dateFormat);
 		};
 
 		const createColumnViews = (data: ColumnData[]) => {

--- a/src/ui/components/task-composer.ts
+++ b/src/ui/components/task-composer.ts
@@ -4,6 +4,7 @@ import { DEFAULT_STATUSES } from "../../constants/index.ts";
 import type { Task, TaskCreateInput } from "../../types/index.ts";
 import { getPriorityOptions } from "../../utils/priority-config.ts";
 import { getTaskTypeValues } from "../../utils/task-type-config.ts";
+import { normalizeUtcDateTime } from "../../utils/utc-datetime.ts";
 import {
 	createPopupChrome,
 	createScrollableViewport,
@@ -14,7 +15,7 @@ import {
 const DRAFT_STATUS = "Draft";
 
 /** Tab order, matching the top-to-bottom reading order of the composer. */
-const FIELD_ORDER = ["title", "description", "status", "type", "priority", "create", "cancel"] as const;
+const FIELD_ORDER = ["title", "description", "dueDate", "status", "type", "priority", "create", "cancel"] as const;
 
 /** The widget's wrapped lines (`real`), the logical lines they belong to, and how many there are. */
 export type CaretLines = {
@@ -128,6 +129,7 @@ export type TaskComposerValues = {
 	status: string;
 	type: string;
 	priority: string;
+	dueDate: string;
 };
 
 export type TaskComposerLayout = {
@@ -214,7 +216,7 @@ export function getTaskComposerLayout(
 	const compact = normalSelectorWidth < longestSelectorWidth || visibleFormHeight < expandedContentHeight;
 	const stackSelectors = compact && longestCompactColumn > compactSelectorWidth;
 	const descriptionHeight = compact ? 3 : expandedDescriptionHeight;
-	const detailsTop = TEXT_INPUT_HEIGHT + descriptionHeight;
+	const detailsTop = TEXT_INPUT_HEIGHT + descriptionHeight + TEXT_INPUT_HEIGHT;
 	const detailsHeight = compact ? (stackSelectors ? 5 : 4) : expandedDetailsHeight;
 	const actionsTop = detailsTop + detailsHeight;
 	return {
@@ -245,7 +247,7 @@ function getTaskComposerHelpText(screenWidth: number, compact: boolean): string 
 	return " {cyan-fg}[↑↓/←→/Tab]{/} Navigate | {cyan-fg}[Enter/Space]{/} Choose | {cyan-fg}[Esc]{/} Cancel";
 }
 
-type TaskComposerField = "title" | "description" | "status" | "type" | "priority" | "create" | "cancel";
+type TaskComposerField = "title" | "description" | "dueDate" | "status" | "type" | "priority" | "create" | "cancel";
 
 function uniqueChoices(values: readonly string[], excludedValue?: string): string[] {
 	const choices: string[] = [];
@@ -290,6 +292,7 @@ export function createTaskComposerValues(statuses: readonly string[]): TaskCompo
 		status: getTaskComposerWorkflowStatuses(statuses)[0] ?? "To Do",
 		type: "",
 		priority: "",
+		dueDate: "",
 	};
 }
 
@@ -297,10 +300,12 @@ export function toTaskCreateInput(values: TaskComposerValues): TaskCreateInput {
 	const title = values.title.trim();
 	if (!title) throw new Error("Title is required.");
 	const description = values.description.trim();
+	const dueDate = normalizeUtcDateTime(values.dueDate, "Due date");
 	return {
 		title,
 		status: values.status,
 		...(description && { description }),
+		...(dueDate && { dueDate }),
 		...(values.type && { type: values.type }),
 		...(values.priority && { priority: values.priority }),
 	};
@@ -408,6 +413,21 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 			style: { border: { fg: "gray" } },
 		});
 
+		const dueDateInput = textbox({
+			parent: form,
+			top: 3 + layout.descriptionHeight,
+			left: 1,
+			right: 1,
+			height: 3,
+			border: { type: "line" },
+			label: " Due (UTC) ",
+			keys: true,
+			mouse: true,
+			inputOnFocus: false,
+			ignoreKeys: true,
+			style: { border: { fg: "gray" } },
+		});
+
 		const detailsGroup = box({
 			parent: form,
 			top: layout.detailsTop,
@@ -481,6 +501,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 		const widgets: Record<TaskComposerField, BoxInterface | TextboxInterface> = {
 			title: titleInput,
 			description: descriptionInput,
+			dueDate: dueDateInput,
 			status: statusField,
 			type: typeField,
 			priority: priorityField,
@@ -494,6 +515,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 			return {
 				title: 0,
 				description: 3,
+				dueDate: 3 + layout.descriptionHeight,
 				status: layout.detailsTop + 1,
 				type: secondSelectorRow,
 				priority: layout.stackSelectors ? secondSelectorRow + 1 : secondSelectorRow,
@@ -514,7 +536,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 
 		const setBorder = (widget: BoxInterface | TextboxInterface, active: boolean) => {
 			const style = (widget.style ?? {}) as { border?: { fg?: string }; inverse?: boolean; bold?: boolean };
-			const isTextInput = widget === titleInput || widget === descriptionInput;
+			const isTextInput = widget === titleInput || widget === descriptionInput || widget === dueDateInput;
 			if (isTextInput) {
 				style.border ??= {};
 				style.border.fg = active ? "yellow" : "gray";
@@ -527,6 +549,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 		const syncInputs = () => {
 			controller.values.title = titleInput.getValue();
 			controller.values.description = descriptionInput.getValue();
+			controller.values.dueDate = dueDateInput.getValue();
 		};
 		const cancelInputIfReading = (input: TextboxInterface) => {
 			if ((input as TextboxInterface & { _reading?: boolean })._reading) input.cancel();
@@ -542,6 +565,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 			layout = getTaskComposerLayout(options.screen.width, options.screen.height, options);
 			reflow(layout.popupWidth, layout.popupHeight, getTaskComposerHelpText(options.screen.width, layout.compact));
 			descriptionInput.height = layout.descriptionHeight;
+			dueDateInput.top = 3 + layout.descriptionHeight;
 			detailsGroup.top = layout.detailsTop;
 			detailsGroup.height = layout.detailsHeight;
 			actionsLabel.top = layout.actionsTop;
@@ -574,7 +598,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 		};
 
 		const focusField = (field: TaskComposerField) => {
-			if (activeField === "title" || activeField === "description") {
+			if (activeField === "title" || activeField === "description" || activeField === "dueDate") {
 				syncInputs();
 				cancelInputIfReading(widgets[activeField] as TextboxInterface);
 			}
@@ -586,7 +610,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 			}
 			const widget = widgets[field];
 			widget.focus();
-			if (field === "title" || field === "description") {
+			if (field === "title" || field === "description" || field === "dueDate") {
 				(widget as TextboxInterface).readInput();
 			}
 			// blessed scrolls a focused widget into view using its offset within its immediate
@@ -598,7 +622,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 		const navigate = (direction: "up" | "down" | "left" | "right") => {
 			let next = activeField;
 			if (layout.compact) {
-				if (activeField === "status" && direction === "up") next = "description";
+				if (activeField === "status" && direction === "up") next = "dueDate";
 				if (activeField === "status" && direction === "down") next = "type";
 				if (activeField === "type" && direction === "up") next = "status";
 				if (activeField === "type" && direction === "down") next = layout.stackSelectors ? "priority" : "create";
@@ -610,7 +634,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 				if (activeField === "cancel" && direction === "up") next = "priority";
 			} else {
 				if (["status", "type", "priority"].includes(activeField)) {
-					if (direction === "up") next = "description";
+					if (direction === "up") next = "dueDate";
 					if (direction === "down") next = activeField === "priority" ? "cancel" : "create";
 				}
 				if (activeField === "create" && direction === "up") next = "status";
@@ -653,6 +677,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 			}
 			cancelInputIfReading(titleInput);
 			cancelInputIfReading(descriptionInput);
+			cancelInputIfReading(dueDateInput);
 			close();
 			resolve(task);
 		};
@@ -737,7 +762,6 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 			strWidth?: (value: string) => number;
 			_updateCursor?: () => void;
 		};
-
 		const readCaretLines = (input: ComposerInput, value: string): CaretLines => ({
 			real: input._clines?.real ?? [value],
 			rtof: input._clines?.rtof ?? [0],
@@ -804,9 +828,10 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 		};
 		ownInputKeys(titleInput as ComposerInput);
 		ownInputKeys(descriptionInput as ComposerInput);
+		ownInputKeys(dueDateInput as ComposerInput);
 
 		let cursorBeforeKey: { y: number; lines: number } | null = null;
-		for (const input of [titleInput, descriptionInput] as ComposerInput[]) {
+		for (const input of [titleInput, descriptionInput, dueDateInput] as ComposerInput[]) {
 			input.on("keypress", () => {
 				cursorBeforeKey = {
 					y: input.getCursor?.().y ?? 0,
@@ -839,9 +864,18 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 			return false;
 		});
 		descriptionInput.key(["down"], () => {
-			if (cursorBeforeKey?.y === 0) focusField("status");
+			if (cursorBeforeKey?.y === 0) focusField("dueDate");
 			return false;
 		});
+		dueDateInput.key(["up"], () => {
+			focusField("description");
+			return false;
+		});
+		dueDateInput.key(["down"], () => {
+			focusField("status");
+			return false;
+		});
+		dueDateInput.on("submit", () => focusField("status"));
 
 		for (const field of ["status", "type", "priority"] as const) {
 			const widget = widgets[field];

--- a/src/ui/components/task-composer.ts
+++ b/src/ui/components/task-composer.ts
@@ -211,7 +211,11 @@ export function getTaskComposerLayout(
 	const expandedDetailsHeight = 3;
 	const expandedActionsHeight = 2;
 	const expandedContentHeight =
-		TEXT_INPUT_HEIGHT + expandedDescriptionHeight + expandedDetailsHeight + expandedActionsHeight;
+		TEXT_INPUT_HEIGHT +
+		expandedDescriptionHeight +
+		TEXT_INPUT_HEIGHT +
+		expandedDetailsHeight +
+		expandedActionsHeight;
 	const visibleFormHeight = Math.max(0, popupHeight - POPUP_FORM_VERTICAL_CHROME);
 	const compact = normalSelectorWidth < longestSelectorWidth || visibleFormHeight < expandedContentHeight;
 	const stackSelectors = compact && longestCompactColumn > compactSelectorWidth;
@@ -698,7 +702,8 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 				return;
 			}
 			showError();
-			if (!controller.values.title.trim()) focusField("title");
+			if (controller.error.startsWith("Due date")) focusField("dueDate");
+			else if (!controller.values.title.trim()) focusField("title");
 			else focusField("create");
 		};
 
@@ -887,7 +892,7 @@ export async function openTaskComposer(options: TaskComposerOptions): Promise<Ta
 
 		// Pointer activation uses the same transition as keyboard navigation so text inputs
 		// enter read mode and every field has one source of truth for focus styling and scrolling.
-		for (const field of ["title", "description", "status", "type", "priority"] as const) {
+		for (const field of ["title", "description", "dueDate", "status", "type", "priority"] as const) {
 			widgets[field].on("click", () => {
 				focusField(field);
 				if (field === "status" || field === "type" || field === "priority") void openPicker(field);

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -89,7 +89,7 @@ export function formatTaskViewerListItem(
 	const branchText = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
 	const progressText = progress ? ` ${progress}` : "";
 
-	const content = `${wrapStatusColor(status, statusColor)}${progressText} {bold}${task.id}{/bold}${typeText} - ${task.title}${priorityText}${dueDateText}${assigneeText}${labelsText}${branchText}`;
+	const content = `${wrapStatusColor(status, statusColor)}${progressText} {bold}${task.id}{/bold}${typeText}${dueDateText} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
 	return isCrossBranch ? `{gray-fg}${content}{/}` : content;
 }
 

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -65,7 +65,11 @@ function getPriorityDisplay(priority?: string): string {
 	}
 }
 
-export function formatTaskViewerListItem(task: Task, availableWidth = Number.POSITIVE_INFINITY): string {
+export function formatTaskViewerListItem(
+	task: Task,
+	availableWidth = Number.POSITIVE_INFINITY,
+	dateFormat?: string,
+): string {
 	const progress = formatAcceptanceCriteriaProgress(task, availableWidth);
 	// The compact status icon keeps task identity visible beside the progress indicator. Its
 	// shape still distinguishes active work from the terminal-status checkmark.
@@ -78,11 +82,14 @@ export function formatTaskViewerListItem(task: Task, availableWidth = Number.POS
 	const typeBadge = formatTaskTypeBadge(task.type);
 	const typeText = typeBadge ? ` ${typeBadge}` : "";
 	const priorityText = getPriorityDisplay(task.priority);
+	const dueDateText = task.dueDate
+		? ` {gray-fg}(due ${formatDateForDisplay(task.dueDate, { dateFormat, appendUtcLabel: true })}){/}`
+		: "";
 	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 	const branchText = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
 	const progressText = progress ? ` ${progress}` : "";
 
-	const content = `${wrapStatusColor(status, statusColor)}${progressText} {bold}${task.id}{/bold}${typeText} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
+	const content = `${wrapStatusColor(status, statusColor)}${progressText} {bold}${task.id}{/bold}${typeText} - ${task.title}${priorityText}${dueDateText}${assigneeText}${labelsText}${branchText}`;
 	return isCrossBranch ? `{gray-fg}${content}{/}` : content;
 }
 
@@ -939,7 +946,7 @@ export async function viewTaskEnhanced(
 			left: 1,
 			width: "100%-4",
 			height: "100%-3",
-			itemRenderer: (task: Task) => formatTaskViewerListItem(task, getTaskListSummaryWidth()),
+			itemRenderer: (task: Task) => formatTaskViewerListItem(task, getTaskListSummaryWidth(), dateFormat),
 			onSelect: (selected: Task | Task[]) => {
 				const selectedTask = Array.isArray(selected) ? selected[0] : selected;
 				void applySelection(selectedTask || null);
@@ -1560,6 +1567,9 @@ export function generateDetailContent(
 	metadata.push(`{bold}Created:{/bold} ${formatDateForDisplay(task.createdDate, { dateFormat })}`);
 	if (task.updatedDate && task.updatedDate !== task.createdDate) {
 		metadata.push(`{bold}Updated:{/bold} ${formatDateForDisplay(task.updatedDate, { dateFormat })}`);
+	}
+	if (task.dueDate) {
+		metadata.push(`{bold}Due:{/bold} ${formatDateForDisplay(task.dueDate, { dateFormat, appendUtcLabel: true })}`);
 	}
 	if (task.priority) {
 		const priorityDisplay = getPriorityDisplay(task.priority);

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -37,6 +37,12 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		updateInput.title = args.title;
 	}
 
+	if (args.dueDate === null) {
+		updateInput.dueDate = null;
+	} else if (typeof args.dueDate === "string") {
+		updateInput.dueDate = args.dueDate.trim().length > 0 ? args.dueDate : null;
+	}
+
 	if (typeof args.description === "string") {
 		updateInput.description = args.description;
 	}

--- a/src/utils/utc-datetime.ts
+++ b/src/utils/utc-datetime.ts
@@ -1,0 +1,79 @@
+const DATE_TIME_PATTERN =
+	/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(Z|[+-]\d{2}:?\d{2})?$/;
+
+function createUtcDate(year: number, month: number, day: number, hour: number, minute: number, second: number): Date {
+	const value = new Date(0);
+	value.setUTCFullYear(year, month - 1, day);
+	value.setUTCHours(hour, minute, second, 0);
+	return value;
+}
+
+function isValidUtcComponents(year: number, month: number, day: number, hour: number, minute: number, second: number) {
+	const value = createUtcDate(year, month, day, hour, minute, second);
+	return (
+		value.getUTCFullYear() === year &&
+		value.getUTCMonth() === month - 1 &&
+		value.getUTCDate() === day &&
+		value.getUTCHours() === hour &&
+		value.getUTCMinutes() === minute &&
+		value.getUTCSeconds() === second
+	);
+}
+
+function invalidUtcDateTime(fieldName: string): Error {
+	return new Error(
+		`${fieldName} must be a valid UTC datetime (for example, 2026-08-10 14:30 or 2026-08-10T14:30Z). Date-only values are not supported.`,
+	);
+}
+
+function formatUtcMinute(value: Date, fieldName: string): string {
+	if (Number.isNaN(value.getTime())) throw invalidUtcDateTime(fieldName);
+	const year = value.getUTCFullYear();
+	if (year < 0 || year > 9999) throw invalidUtcDateTime(fieldName);
+	const pad = (part: number, length = 2) => String(part).padStart(length, "0");
+	return `${pad(year, 4)}-${pad(value.getUTCMonth() + 1)}-${pad(value.getUTCDate())} ${pad(value.getUTCHours())}:${pad(value.getUTCMinutes())}`;
+}
+
+/**
+ * Normalize an optional datetime to the Markdown source-of-truth representation.
+ * Datetimes without an offset are interpreted as UTC; explicit offsets are converted to UTC.
+ */
+export function normalizeUtcDateTime(value: unknown, fieldName = "Datetime"): string | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (value instanceof Date) {
+		return formatUtcMinute(value, fieldName);
+	}
+
+	const input = String(value).trim();
+	if (!input) return undefined;
+	const match = input.match(DATE_TIME_PATTERN);
+	if (!match) throw invalidUtcDateTime(fieldName);
+
+	const [, rawYear, rawMonth, rawDay, rawHour, rawMinute, rawSecond = "0", rawFraction, rawOffset] = match;
+	const year = Number(rawYear);
+	const month = Number(rawMonth);
+	const day = Number(rawDay);
+	const hour = Number(rawHour);
+	const minute = Number(rawMinute);
+	const second = Number(rawSecond);
+	if (!isValidUtcComponents(year, month, day, hour, minute, second)) {
+		throw invalidUtcDateTime(fieldName);
+	}
+
+	let timestamp = createUtcDate(year, month, day, hour, minute, second).getTime();
+	if (rawFraction) {
+		timestamp += Number(`0.${rawFraction}`) * 1000;
+	}
+	if (rawOffset && rawOffset !== "Z") {
+		const sign = rawOffset[0] === "+" ? 1 : -1;
+		const offsetDigits = rawOffset.slice(1).replace(":", "");
+		const offsetHours = Number(offsetDigits.slice(0, 2));
+		const offsetMinutes = Number(offsetDigits.slice(2, 4));
+		if (offsetHours > 14 || offsetMinutes > 59 || (offsetHours === 14 && offsetMinutes !== 0)) {
+			throw invalidUtcDateTime(fieldName);
+		}
+		timestamp -= sign * (offsetHours * 60 + offsetMinutes) * 60_000;
+	}
+
+	return formatUtcMinute(new Date(timestamp), fieldName);
+}

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -767,6 +767,7 @@ function AppContent() {
                 archivedMilestones={archivedMilestones}
                 onEditTask={handleEditTask}
                 onRefreshData={refreshData}
+                dateFormat={config?.dateFormat}
               />
             }
           />

--- a/src/web/components/Board.tsx
+++ b/src/web/components/Board.tsx
@@ -695,6 +695,7 @@ const Board: React.FC<BoardProps> = ({
                             targetMilestone={lane.milestone ?? null}
                             priorityOrder={availablePriorities}
                             availableTypes={typeOptions}
+                            dateFormat={dateFormat}
                             onDragStart={handleColumnDragStart}
                             onDragEnd={handleColumnDragEnd}
                             onCleanup={status === terminalStatus ? () => setShowCleanupModal(true) : undefined}
@@ -724,6 +725,7 @@ const Board: React.FC<BoardProps> = ({
                   laneId={DEFAULT_LANE_KEY}
                   priorityOrder={availablePriorities}
                   availableTypes={typeOptions}
+                  dateFormat={dateFormat}
                   onDragStart={handleColumnDragStart}
                   onDragEnd={handleColumnDragEnd}
                   onCleanup={status === terminalStatus ? () => setShowCleanupModal(true) : undefined}

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -6,6 +6,7 @@ import { buildMilestoneBuckets, collectArchivedMilestoneKeys, isDoneStatus, mile
 import { type Milestone, type MilestoneBucket, type Task } from "../../types";
 import MilestoneTaskRow from "./MilestoneTaskRow";
 import Modal from "./Modal";
+import { formatStoredUtcDateForDisplay } from "../utils/date-display";
 
 interface MilestoneSearchEntry {
 	id: string;
@@ -59,6 +60,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 	onRefreshData,
 }) => {
 	const [newMilestone, setNewMilestone] = useState("");
+	const [newMilestoneDueDate, setNewMilestoneDueDate] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<string | null>(null);
 	const [isSaving, setIsSaving] = useState(false);
@@ -73,6 +75,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 	const [removingMilestoneKey, setRemovingMilestoneKey] = useState<string | null>(null);
 	const [editingBucket, setEditingBucket] = useState<MilestoneBucket | null>(null);
 	const [editMilestoneName, setEditMilestoneName] = useState("");
+	const [editMilestoneDueDate, setEditMilestoneDueDate] = useState("");
 	const [removingBucket, setRemovingBucket] = useState<MilestoneBucket | null>(null);
 	const [removeTaskHandling, setRemoveTaskHandling] = useState<RemoveTaskHandling>("clear");
 	const [removeReassignTo, setRemoveReassignTo] = useState("");
@@ -233,6 +236,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 	const closeAddModal = () => {
 		setShowAddModal(false);
 		setNewMilestone("");
+		setNewMilestoneDueDate("");
 		setError(null);
 	};
 
@@ -249,8 +253,9 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		setError(null);
 		setSuccess(null);
 		try {
-			await apiClient.createMilestone(value);
+			await apiClient.createMilestone(value, undefined, newMilestoneDueDate || undefined);
 			setNewMilestone("");
+			setNewMilestoneDueDate("");
 			setSuccess(`Added milestone "${value}"`);
 			setShowAddModal(false);
 			if (onRefreshData) {
@@ -310,6 +315,8 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		if (!bucket.milestone) return;
 		setEditingBucket(bucket);
 		setEditMilestoneName(bucket.label || bucket.milestone);
+		const milestone = milestoneEntities.find((candidate) => milestoneKey(candidate.id) === milestoneKey(bucket.milestone));
+		setEditMilestoneDueDate(milestone?.dueDate?.replace(" ", "T") ?? "");
 		setModalError(null);
 		setError(null);
 		setSuccess(null);
@@ -318,6 +325,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 	const closeEditModal = () => {
 		setEditingBucket(null);
 		setEditMilestoneName("");
+		setEditMilestoneDueDate("");
 		setModalError(null);
 	};
 
@@ -351,9 +359,9 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		setError(null);
 		setSuccess(null);
 		try {
-			await apiClient.updateMilestone(bucket.milestone, value);
+			await apiClient.updateMilestone(bucket.milestone, value, editMilestoneDueDate || null);
 			closeEditModal();
-			setSuccess(`Renamed milestone "${previousLabel}" to "${value}"`);
+			setSuccess(previousLabel === value ? `Updated milestone "${value}"` : `Renamed milestone "${previousLabel}" to "${value}"`);
 			if (onRefreshData) {
 				await onRefreshData();
 			}
@@ -489,6 +497,9 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		const isArchiving = archivingMilestoneKey === bucket.key;
 		const isSavingMilestone = savingMilestoneKey === bucket.key;
 		const isRemoving = removingMilestoneKey === bucket.key;
+		const milestoneEntity = milestoneEntities.find(
+			(milestone) => milestoneKey(milestone.id) === milestoneKey(bucket.milestone ?? ""),
+		);
 
 		return (
 			<div
@@ -507,9 +518,14 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 				<div className="px-5 py-4">
 					{/* Header row */}
 					<div className="flex items-center justify-between gap-4">
-						<h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">
-							{bucket.label}
-						</h3>
+						<div className="min-w-0">
+							<h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">{bucket.label}</h3>
+							{milestoneEntity?.dueDate && (
+								<p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+									Due (UTC): {formatStoredUtcDateForDisplay(milestoneEntity.dueDate)}
+								</p>
+							)}
+						</div>
 						{isEmpty ? (
 							<span className="text-sm text-gray-400 dark:text-gray-500">
 								{isDragging ? "Drop here" : "No tasks"}
@@ -910,6 +926,18 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 						/>
 						{error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
 					</div>
+					<div className="space-y-2">
+						<label htmlFor="new-milestone-due-date" className="text-sm font-medium text-gray-900 dark:text-gray-100">
+							Due (UTC)
+						</label>
+						<input
+							id="new-milestone-due-date"
+							type="datetime-local"
+							value={newMilestoneDueDate}
+							onChange={(event) => setNewMilestoneDueDate(event.target.value)}
+							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
+					</div>
 					<div className="flex justify-end gap-2">
 						<button
 							type="button"
@@ -948,6 +976,18 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 							Renaming updates local tasks that reference this milestone.
 						</p>
 						{modalError && <p className="text-xs text-red-600 dark:text-red-400">{modalError}</p>}
+					</div>
+					<div className="space-y-2">
+						<label htmlFor="edit-milestone-due-date" className="text-sm font-medium text-gray-900 dark:text-gray-100">
+							Due (UTC)
+						</label>
+						<input
+							id="edit-milestone-due-date"
+							type="datetime-local"
+							value={editMilestoneDueDate}
+							onChange={(event) => setEditMilestoneDueDate(event.target.value)}
+							className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
+						/>
 					</div>
 					<div className="flex justify-end gap-2">
 						<button

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -88,6 +88,10 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		() => collectArchivedMilestoneKeys(archivedMilestones, milestoneEntities),
 		[archivedMilestones, milestoneEntities],
 	);
+	const allMilestoneEntities = useMemo(
+		() => [...milestoneEntities, ...archivedMilestones],
+		[milestoneEntities, archivedMilestones],
+	);
 	const buckets = useMemo(
 		() => buildMilestoneBuckets(tasks, milestoneEntities, statuses, { archivedMilestoneIds, archivedMilestones }),
 		[tasks, milestoneEntities, statuses, archivedMilestoneIds, archivedMilestones],
@@ -499,7 +503,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 		const isArchiving = archivingMilestoneKey === bucket.key;
 		const isSavingMilestone = savingMilestoneKey === bucket.key;
 		const isRemoving = removingMilestoneKey === bucket.key;
-		const milestoneEntity = milestoneEntities.find(
+		const milestoneEntity = allMilestoneEntities.find(
 			(milestone) => milestoneKey(milestone.id) === milestoneKey(bucket.milestone ?? ""),
 		);
 

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -49,6 +49,7 @@ interface MilestonesPageProps {
 	archivedMilestones: Milestone[];
 	onEditTask: (task: Task) => void;
 	onRefreshData?: () => Promise<void>;
+	dateFormat?: string;
 }
 
 const MilestonesPage: React.FC<MilestonesPageProps> = ({
@@ -58,6 +59,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 	archivedMilestones,
 	onEditTask,
 	onRefreshData,
+	dateFormat,
 }) => {
 	const [newMilestone, setNewMilestone] = useState("");
 	const [newMilestoneDueDate, setNewMilestoneDueDate] = useState("");
@@ -522,7 +524,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 							<h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">{bucket.label}</h3>
 							{milestoneEntity?.dueDate && (
 								<p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-									Due (UTC): {formatStoredUtcDateForDisplay(milestoneEntity.dueDate)}
+									Due (UTC): {formatStoredUtcDateForDisplay(milestoneEntity.dueDate, dateFormat)}
 								</p>
 							)}
 						</div>

--- a/src/web/components/TaskCard.tsx
+++ b/src/web/components/TaskCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { type Task } from '../../types';
 import { formatPriorityLabel } from '../../utils/priority-config';
 import AcceptanceCriteriaProgress, { getAcceptanceCriteriaProgressCounts } from './AcceptanceCriteriaProgress';
+import { formatStoredUtcDateForDisplay } from '../utils/date-display';
 import TaskTypeBadge from './TaskTypeBadge';
 
 interface TaskCardProps {
@@ -13,9 +14,10 @@ interface TaskCardProps {
   status?: string;
   laneId?: string;
   availableTypes?: string[];
+  dateFormat?: string;
 }
 
-const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEnd, status, laneId, availableTypes }) => {
+const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEnd, status, laneId, availableTypes, dateFormat }) => {
   const [isDragging, setIsDragging] = React.useState(false);
   const [showBranchTooltip, setShowBranchTooltip] = React.useState(false);
 
@@ -189,8 +191,9 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDragStart, onDragEn
         )}
 
         {/* Footer with date */}
-        <div className="flex items-center justify-between text-[10px] text-gray-400 dark:text-gray-500 mt-2 pt-1.5 border-t border-gray-100 dark:border-gray-600/50 transition-colors duration-200">
+        <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 text-[10px] text-gray-400 dark:text-gray-500 mt-2 pt-1.5 border-t border-gray-100 dark:border-gray-600/50 transition-colors duration-200">
           <span>{formatRelativeDate(task.createdDate)}</span>
+          {task.dueDate && <span>Due (UTC): {formatStoredUtcDateForDisplay(task.dueDate, dateFormat)}</span>}
           {task.assignee.length > 0 && (
             <span className="truncate max-w-[80px]" title={task.assignee.join(', ')}>
               {task.assignee[0]}

--- a/src/web/components/TaskColumn.tsx
+++ b/src/web/components/TaskColumn.tsx
@@ -20,6 +20,7 @@ interface TaskColumnProps {
   targetMilestone?: string | null;
   priorityOrder?: string[];
   availableTypes?: string[];
+  dateFormat?: string;
 }
 
 type CreatedDateSortDirection = 'asc' | 'desc';
@@ -65,6 +66,7 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
   targetMilestone,
   priorityOrder,
   availableTypes,
+  dateFormat,
 }) => {
   const [isDragOver, setIsDragOver] = React.useState(false);
   const [draggedTaskId, setDraggedTaskId] = React.useState<string | null>(null);
@@ -334,6 +336,7 @@ const TaskColumn: React.FC<TaskColumnProps> = ({
               status={title}
               laneId={laneId}
               availableTypes={availableTypes}
+              dateFormat={dateFormat}
             />
             
             {/* Drop indicator for after this task */}

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -36,7 +36,8 @@ interface Props {
 
 type Mode = "preview" | "edit" | "create";
 
-type TaskUpdatePayload = Partial<Task> & {
+type TaskUpdatePayload = Omit<Partial<Task>, "dueDate"> & {
+	dueDate?: string | null;
   definitionOfDoneAdd?: string[];
   definitionOfDoneRemove?: number[];
   definitionOfDoneCheck?: number[];
@@ -68,6 +69,7 @@ type TaskDetailsFormState = {
   references: string[];
   modifiedFiles: string[];
   milestone: string;
+  dueDate: string;
 };
 
 const containsCommentDelimiterLine = (value: string): boolean => /^\s*---\s*$/m.test(value.replace(/\r\n/g, "\n"));
@@ -131,6 +133,7 @@ const buildTaskDetailsFormState = ({
   references: task?.references || [],
   modifiedFiles: task?.modifiedFiles || [],
   milestone: task?.milestone || "",
+  dueDate: task?.dueDate?.replace(" ", "T") || "",
 });
 
 const SectionHeader: React.FC<{ title: string; right?: React.ReactNode }> = ({ title, right }) => (
@@ -357,6 +360,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const [references, setReferences] = useState<string[]>(task?.references || []);
   const [modifiedFiles, setModifiedFiles] = useState<string[]>(task?.modifiedFiles || []);
   const [milestone, setMilestone] = useState<string>(task?.milestone || "");
+  const [dueDate, setDueDate] = useState<string>(task?.dueDate?.replace(" ", "T") || "");
   const canonicalTypeSelection = resolveTaskTypeValue(taskType, typeOptions);
   const typeSelectionValue = canonicalTypeSelection ?? taskType;
   const milestoneSelectionValue = resolveMilestoneToId(milestone);
@@ -414,6 +418,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
     plan: task?.implementationPlan || "",
     notes: task?.implementationNotes || "",
     finalSummary: task?.finalSummary || "",
+    dueDate: task?.dueDate?.replace(" ", "T") || "",
     criteria: JSON.stringify(task?.acceptanceCriteriaItems || []),
     definitionOfDone: JSON.stringify(task?.definitionOfDoneItems || (isCreateMode ? defaultDefinitionOfDone : [])),
   }), [task, defaultDefinitionOfDone, isCreateMode]);
@@ -425,10 +430,11 @@ export const TaskDetailsModal: React.FC<Props> = ({
       plan !== baseline.plan ||
       notes !== baseline.notes ||
       finalSummary !== baseline.finalSummary ||
+      dueDate !== baseline.dueDate ||
       JSON.stringify(criteria) !== baseline.criteria ||
       JSON.stringify(definitionOfDone) !== baseline.definitionOfDone
     );
-  }, [title, description, plan, notes, finalSummary, criteria, definitionOfDone, baseline]);
+  }, [title, description, plan, notes, finalSummary, dueDate, criteria, definitionOfDone, baseline]);
 
   useEffect(() => {
     modeRef.current = mode;
@@ -553,6 +559,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
       setMilestone((current) =>
         preserveDirtyRefreshValue(current, previousFormState.milestone, nextFormState.milestone),
       );
+      setDueDate((current) => preserveDirtyRefreshValue(current, previousFormState.dueDate, nextFormState.dueDate));
       setMode(shouldPreserveEditMode ? "edit" : isCreateMode ? "create" : modeRef.current);
       preserveEditModeAfterCommentRefresh.current = false;
       previousTaskId.current = nextTaskId;
@@ -583,6 +590,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
     setReferences(nextFormState.references);
     setModifiedFiles(nextFormState.modifiedFiles);
     setMilestone(nextFormState.milestone);
+    setDueDate(nextFormState.dueDate);
     setMode(isCreateMode ? "create" : "preview");
     preserveEditModeAfterCommentRefresh.current = false;
     previousTaskId.current = nextTaskId;
@@ -605,6 +613,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
       taskType.trim() !== "" ||
       priority.trim() !== "" ||
       milestone.trim() !== "" ||
+      dueDate.trim() !== "" ||
       // The prefilled default is not the user's work, but removing or replacing it is.
       !areJsonEqual(assignee, createModeAssignee) ||
       labels.length > 0 ||
@@ -648,6 +657,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
       setCommentBody("");
       setCommentAuthor("");
       setFinalSummary(task?.finalSummary || "");
+      setDueDate(task?.dueDate?.replace(" ", "T") || "");
       setCriteria(task?.acceptanceCriteriaItems || []);
       setDefinitionOfDone(task?.definitionOfDoneItems || []);
       setMode("preview");
@@ -779,6 +789,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
         priority: priority === "" ? undefined : priority,
         dependencies,
         milestone: milestone.trim().length > 0 ? milestone.trim() : undefined,
+        dueDate: dueDate.trim().length > 0 ? dueDate.trim() : isCreateMode ? undefined : null,
       };
 
       if (isCreateMode) {
@@ -788,7 +799,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
       if (isCreateMode && onSubmit) {
         Object.assign(taskData, buildDefinitionOfDoneCreatePayload());
         // Create new task
-        await onSubmit(taskData);
+        await onSubmit({ ...taskData, dueDate: taskData.dueDate ?? undefined } as Partial<Task>);
         // Only close if successful (no error thrown)
         onClose();
       } else if (task) {
@@ -1568,8 +1579,22 @@ export const TaskDetailsModal: React.FC<Props> = ({
 	              {task.updatedDate && (
 	                <div><span className="font-semibold text-gray-800 dark:text-gray-100">Updated:</span> <span className="text-gray-700 dark:text-gray-200">{formatStoredUtcDateForDisplay(task.updatedDate, dateFormat)}</span></div>
 	              )}
+	              {task.dueDate && mode === "preview" && (
+	                <div><span className="font-semibold text-gray-800 dark:text-gray-100">Due (UTC):</span> <span className="text-gray-700 dark:text-gray-200">{formatStoredUtcDateForDisplay(task.dueDate, dateFormat)}</span></div>
+	              )}
 	            </div>
 	          )}
+          {mode !== "preview" && (
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+              <SectionHeader title="Due (UTC)" />
+              <input
+                type="datetime-local"
+                value={dueDate}
+                onChange={(event) => setDueDate(event.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:border-transparent"
+              />
+            </div>
+          )}
           {/* Title (editable for existing tasks) */}
           {task && (
             <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -11,7 +11,11 @@ import { collectAvailableLabels } from "../../utils/label-filter.ts";
 import { compareTaskIds, compareTaskIdsDescending } from "../../utils/task-sorting.ts";
 import { isTerminalStatus } from "../../utils/terminal-status.ts";
 import { collectArchivedMilestoneKeys, getMilestoneLabel, milestoneKey } from "../utils/milestones";
-import { formatStoredUtcDateForCompactDisplay, parseStoredUtcDate } from "../utils/date-display";
+import {
+	formatStoredUtcDateForCompactDisplay,
+	formatStoredUtcDateForDisplay,
+	parseStoredUtcDate,
+} from "../utils/date-display";
 import {
 	formatPriorityLabel,
 	getPriorityOptions,
@@ -907,6 +911,11 @@ const TaskList: React.FC<TaskListProps> = ({
 													)}
 												</div>
 												<AcceptanceCriteriaProgress task={task} cells={10} className="mt-1" />
+												{task.dueDate && (
+													<div className="mt-1 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+														Due (UTC): {formatStoredUtcDateForDisplay(task.dueDate, dateFormat)}
+													</div>
+												)}
 											</td>
 											<td className="px-3 py-2.5">
 												<span className={`inline-flex rounded-circle px-2 py-0.5 text-[11px] font-medium ${getStatusColor(task.status)}`}>

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -21,8 +21,9 @@ export interface ReorderTaskPayload {
 	targetMilestone?: string | null;
 }
 
-export type TaskUpdateRequest = Omit<Partial<Task>, "milestone"> & {
+export type TaskUpdateRequest = Omit<Partial<Task>, "milestone" | "dueDate"> & {
 	milestone?: string | null;
+	dueDate?: string | null;
 	commentsAppend?: string[];
 	commentAuthor?: string;
 };
@@ -522,13 +523,13 @@ export class ApiClient {
 		return response.json();
 	}
 
-	async createMilestone(title: string, description?: string): Promise<Milestone> {
+	async createMilestone(title: string, description?: string, dueDate?: string): Promise<Milestone> {
 		const response = await fetch(`${API_BASE}/milestones`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ title, description }),
+			body: JSON.stringify({ title, description, dueDate }),
 		});
 		if (!response.ok) {
 			const data = await response.json().catch(() => ({}));
@@ -540,13 +541,14 @@ export class ApiClient {
 	async updateMilestone(
 		id: string,
 		title: string,
+		dueDate?: string | null,
 	): Promise<{ success: boolean; milestone?: Milestone | null; message?: string }> {
 		const response = await fetch(`${API_BASE}/milestones/${encodeURIComponent(id)}`, {
 			method: "PUT",
 			headers: {
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ title }),
+			body: JSON.stringify({ title, dueDate }),
 		});
 		if (!response.ok) {
 			const data = await response.json().catch(() => ({}));


### PR DESCRIPTION
## Summary

- add optional UTC datetime dueDate persistence for tasks and milestones
- support create, edit, clear, list, and detail flows across CLI/TUI, Web/server, and MCP
- canonicalize ISO offsets to minute-precision UTC and reject date-only values
- document the additive stable JSON field

## Testing

- 126 cross-surface due-date, CLI, JSON, MCP, server, and Web tests passed
- 35 focused TUI tests passed
- independent final diff review found no P1/P2 issues
- bunx tsc --noEmit
- bun run check .
- bun run build
- git diff --check