### PR TITLE
BACK-419 - Add Web UI demote-to-draft action

### DIFF
--- a/backlog/tasks/back-419 - Add-Web-UI-demote-to-draft-action.md
+++ b/backlog/tasks/back-419 - Add-Web-UI-demote-to-draft-action.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-419
 title: Add Web UI demote-to-draft action
-status: To Do
+status: Done
 assignee:
-  - '@alex-agent'
+  - '@codex'
 created_date: '2026-04-25 12:14'
+updated_date: '2026-08-10 06:07'
 labels:
   - web-ui
   - drafts
@@ -23,15 +24,43 @@ Track part of GitHub issue #405: expose demote-to-draft from the Web UI.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Task detail UI exposes a demote-to-draft action when applicable.
-- [ ] #2 The action uses the existing demote semantics and refreshes the UI after success.
-- [ ] #3 A confirmation or equivalent guard prevents accidental demotion.
-- [ ] #4 Tests cover the Web UI/API path.
+- [x] #1 Task detail UI exposes a demote-to-draft action when applicable.
+- [x] #2 The action uses the existing demote semantics and refreshes the UI after success.
+- [x] #3 A confirmation or equivalent guard prevents accidental demotion.
+- [x] #4 Tests cover the Web UI/API path.
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Make ContentStore task transitions publish versioned removals so a stale concurrent refresh cannot resurrect a demoted task; add a deterministic gated regression.
+2. Bind Web demotion work to the current modal/task identity and prevent stale completion, close, or state effects; derive draft applicability from explicit entity context rather than the task ID prefix.
+3. Add a non-retrying API request path for demotion so response loss or post-move server errors are not replaced by a later 404.
+4. Extend modal/API tests for deferred close/reopen behavior, real draft provenance, completed/cross-branch records, and a custom DRAFT task prefix.
+5. Run focused Core/server/Web tests, TypeScript, Biome, build, inspect the diff, then re-finalize and amend the existing commit.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented a thin POST /api/tasks/:id/demote route over Core.demoteTask, preserving canonical draft ID allocation, locking, ambiguity handling, file movement, and auto-commit semantics. The task modal offers a confirmed, disabled-while-running action only for local active tasks; drafts, completed records, and cross-branch tasks remain inapplicable. Success refreshes the task corpus, publishes the drafts-updated browser event, and closes the modal.
+
+Validation: 34 focused lifecycle/server/modal tests passed with 153 assertions, including actual Core demotion, 404, ambiguity 409/no writes, confirmation cancellation, success refresh ordering, API failure, keyboard shortcuts, and unsaved navigation. bunx tsc --noEmit, bun run check ., bun run build, and git diff --check passed. Rendered QA passed at the default desktop viewport and 390x844: the action is visible and usable without clipping or overlap, the native confirmation guard appeared, page identity/content were correct, and desktop console warnings/errors were empty.
+
+Final data-flow review found and closed a stale-cache race: Core.demoteTask now transitions an initialized ContentStore immediately, matching archive/complete. The endpoint regression initializes Web search before demotion and proves the immediate post-success search no longer returns the moved task. Expanded verification passed 86 tests with 221 assertions across Core, CLI lifecycle, endpoint, and modal suites; build, TypeScript, Biome, and diff checks passed again.
+
+Review fixes: ContentStore transitions now publish versioned removals across full and local working-copy refreshes while preserving duplicate-path ambiguity; the modal binds in-flight demotion to its task identity and blocks close while current work is pending; demotion uses a no-retry request path that preserves the original server error; applicability uses explicit draft/source/branch provenance so active tasks remain eligible even with a custom DRAFT prefix. Regression validation passed: ContentStore 64 tests/254 assertions; Web modal, API, and route 37 tests/225 assertions; demote endpoint 3 tests/16 assertions; CLI task-state 13 tests/47 assertions; draft auto-commit 6 tests/42 assertions; TypeScript, Biome, build, and diff checks passed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added the Web demote-to-draft action over Core semantics, with confirmation, explicit provenance checks, no-retry mutation handling, versioned cache removal, and stale modal-request guards. Verified with focused Core, server, CLI, draft-lifecycle, and Web suites plus TypeScript, Biome, build, and diff checks.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2963,9 +2963,18 @@ export class Core {
 			movedPaths.push({ previousPath, savedPath });
 		});
 		const moved = movedPaths[0];
+		if (success) {
+			this.contentStore?.transitionTask(task.id);
+		}
 
 		if (success && moved && (await this.shouldAutoCommit(autoCommit))) {
-			await this.commitWrittenFile(`backlog: Demote task ${task.id}`, [moved.previousPath], moved.savedPath);
+			try {
+				await this.commitWrittenFile(`backlog: Demote task ${task.id}`, [moved.previousPath], moved.savedPath);
+			} catch (error) {
+				const failure = error instanceof Error ? error : new Error(String(error));
+				(failure as Error & { moved?: boolean }).moved = true;
+				throw failure;
+			}
 		}
 
 		return success;

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2958,14 +2958,19 @@ export class Core {
 	async demoteTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
 		const task = await this.loadTaskForMutation(taskId);
 		if (!task) return false;
-		const movedPaths: Array<{ previousPath: string; savedPath: string }> = [];
-		const success = await this.fs.demoteTask(task.id, (previousPath, savedPath) => {
-			movedPaths.push({ previousPath, savedPath });
+		// Direct demotion is a read-modify-write too. Hold the task lock across the
+		// filesystem read and move so an in-flight task update cannot recreate the
+		// active file after this operation has written the draft.
+		const { success, moved } = await this.fs.withTaskLock(task, async () => {
+			const movedPaths: Array<{ previousPath: string; savedPath: string }> = [];
+			const success = await this.fs.demoteTask(task.id, (previousPath, savedPath) => {
+				movedPaths.push({ previousPath, savedPath });
+			});
+			if (success) {
+				this.contentStore?.transitionTask(task.id);
+			}
+			return { success, moved: movedPaths[0] };
 		});
-		const moved = movedPaths[0];
-		if (success) {
-			this.contentStore?.transitionTask(task.id);
-		}
 
 		if (success && moved) {
 			try {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2584,11 +2584,18 @@ export class Core {
 	async updateTasksBulk(tasks: Task[], commitMessage?: string, autoCommit?: boolean): Promise<void> {
 		const filePaths: string[] = [];
 		const updateAll = async () => {
-			for (const task of tasks) {
-				// Bulk writes are still per-task mutations. Keep each write under the same
-				// lock used by direct edits so a reorder cannot recreate a task after demotion.
-				filePaths.push(await this.fs.withTaskLock(task, () => this.updateTask(task, false)));
-			}
+			// Acquire every task lock before the first write. Reorders can rebalance
+			// several files, so locking one at a time would leave a partial update when
+			// a later task is contended.
+			const updateLocked = async (index: number): Promise<void> => {
+				const task = tasks[index];
+				if (!task) return;
+				await this.fs.withTaskLock(task, async () => {
+					await updateLocked(index + 1);
+					filePaths.push(await this.updateTask(task, false));
+				});
+			};
+			await updateLocked(0);
 		};
 		if (this.contentStore) await this.contentStore.batchTaskUpdates(updateAll);
 		else await updateAll();
@@ -2965,16 +2972,35 @@ export class Core {
 		// Direct demotion is a read-modify-write too. Hold the task lock across the
 		// filesystem read and move so an in-flight task update cannot recreate the
 		// active file after this operation has written the draft.
-		const { success, moved } = await this.fs.withTaskLock(task, async () => {
-			const movedPaths: Array<{ previousPath: string; savedPath: string }> = [];
-			const success = await this.fs.demoteTask(task.id, (previousPath, savedPath) => {
-				movedPaths.push({ previousPath, savedPath });
+		const demotion = {
+			success: false,
+			moved: undefined as { previousPath: string; savedPath: string } | undefined,
+		};
+		let result: typeof demotion;
+		try {
+			result = await this.fs.withTaskLock(task, async () => {
+				const movedPaths: Array<{ previousPath: string; savedPath: string }> = [];
+				const success = await this.fs.demoteTask(task.id, (previousPath, savedPath) => {
+					movedPaths.push({ previousPath, savedPath });
+				});
+				if (success) {
+					this.contentStore?.transitionTask(task.id);
+				}
+				demotion.success = success;
+				demotion.moved = movedPaths[0];
+				return demotion;
 			});
-			if (success) {
-				this.contentStore?.transitionTask(task.id);
+		} catch (error) {
+			// The lock wrapper can fail while releasing after the move completed. Keep
+			// the mutation outcome visible to the Web API and other clients.
+			if (demotion.success && demotion.moved) {
+				const failure = error instanceof Error ? error : new Error(String(error));
+				(failure as Error & { demotionState?: string }).demotionState = "moved";
+				throw failure;
 			}
-			return { success, moved: movedPaths[0] };
-		});
+			throw error;
+		}
+		const { success, moved } = result;
 
 		if (success && moved) {
 			try {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2581,24 +2581,20 @@ export class Core {
 		return await this.updateTaskFromInput(taskId, input, autoCommit, options);
 	}
 
-	async updateTasksBulk(tasks: Task[], commitMessage?: string, autoCommit?: boolean): Promise<void> {
+	private async writeTasksBulk(tasks: Task[]): Promise<string[]> {
 		const filePaths: string[] = [];
 		const updateAll = async () => {
-			// Acquire every task lock before the first write. Reorders can rebalance
-			// several files, so locking one at a time would leave a partial update when
-			// a later task is contended.
-			const updateLocked = async (index: number): Promise<void> => {
-				const task = tasks[index];
-				if (!task) return;
-				await this.fs.withTaskLock(task, async () => {
-					await updateLocked(index + 1);
-					filePaths.push(await this.updateTask(task, false));
-				});
-			};
-			await updateLocked(0);
+			for (const task of tasks) {
+				filePaths.push(await this.updateTask(task, false));
+			}
 		};
 		if (this.contentStore) await this.contentStore.batchTaskUpdates(updateAll);
 		else await updateAll();
+		return filePaths;
+	}
+
+	async updateTasksBulk(tasks: Task[], commitMessage?: string, autoCommit?: boolean): Promise<void> {
+		const filePaths = await this.fs.withTaskLocks(tasks, async () => await this.writeTasksBulk(tasks));
 
 		// Commit all changes at once if auto-commit is enabled
 		if (await this.shouldAutoCommit(autoCommit)) {
@@ -2748,33 +2744,32 @@ export class Core {
 		const fromPath = taskPath;
 		const toPath = join(await this.fs.getArchiveTasksDir(), taskFilename);
 
-		try {
-			await moveFile(fromPath, toPath);
-		} catch {
-			return false;
-		}
-		this.contentStore?.transitionTask(normalizedTaskId);
-
 		const activeTasks = await this.fs.listTasks();
 		const sanitizedTasks = this.sanitizeArchivedTaskLinks(activeTasks, normalizedTaskId);
-		if (sanitizedTasks.length > 0) {
-			await this.updateTasksBulk(sanitizedTasks, undefined, false);
-		}
 
-		if (await this.shouldAutoCommit(autoCommit)) {
-			// Stage the file move for proper Git tracking
-			const repoRoot = await this.git.stageFileMove(fromPath, toPath);
-			const commitPaths = [fromPath, toPath];
-			for (const sanitizedTask of sanitizedTasks) {
-				if (sanitizedTask.filePath) {
-					await this.git.addFile(sanitizedTask.filePath);
-					commitPaths.push(sanitizedTask.filePath);
-				}
+		return await this.fs.withTaskLocks([taskToArchive, ...sanitizedTasks], async () => {
+			try {
+				await moveFile(fromPath, toPath);
+			} catch {
+				return false;
 			}
-			await this.git.commitFiles(`backlog: Archive task ${normalizedTaskId}`, commitPaths, repoRoot);
-		}
+			this.contentStore?.transitionTask(normalizedTaskId);
 
-		return true;
+			const sanitizedPaths =
+				sanitizedTasks.length > 0 ? await this.writeTasksBulk(sanitizedTasks) : [];
+
+			if (await this.shouldAutoCommit(autoCommit)) {
+				// Stage the file move for proper Git tracking
+				const repoRoot = await this.git.stageFileMove(fromPath, toPath);
+				const commitPaths = [fromPath, toPath, ...sanitizedPaths];
+				for (const sanitizedPath of sanitizedPaths) {
+					await this.git.addFile(sanitizedPath);
+				}
+				await this.git.commitFiles(`backlog: Archive task ${normalizedTaskId}`, commitPaths, repoRoot);
+			}
+
+			return true;
+		});
 	}
 
 	async archiveMilestone(

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2584,7 +2584,11 @@ export class Core {
 	async updateTasksBulk(tasks: Task[], commitMessage?: string, autoCommit?: boolean): Promise<void> {
 		const filePaths: string[] = [];
 		const updateAll = async () => {
-			for (const task of tasks) filePaths.push(await this.updateTask(task, false));
+			for (const task of tasks) {
+				// Bulk writes are still per-task mutations. Keep each write under the same
+				// lock used by direct edits so a reorder cannot recreate a task after demotion.
+				filePaths.push(await this.fs.withTaskLock(task, () => this.updateTask(task, false)));
+			}
 		};
 		if (this.contentStore) await this.contentStore.batchTaskUpdates(updateAll);
 		else await updateAll();

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2967,12 +2967,14 @@ export class Core {
 			this.contentStore?.transitionTask(task.id);
 		}
 
-		if (success && moved && (await this.shouldAutoCommit(autoCommit))) {
+		if (success && moved) {
 			try {
-				await this.commitWrittenFile(`backlog: Demote task ${task.id}`, [moved.previousPath], moved.savedPath);
+				if (await this.shouldAutoCommit(autoCommit)) {
+					await this.commitWrittenFile(`backlog: Demote task ${task.id}`, [moved.previousPath], moved.savedPath);
+				}
 			} catch (error) {
 				const failure = error instanceof Error ? error : new Error(String(error));
-				(failure as Error & { moved?: boolean }).moved = true;
+				(failure as Error & { demotionState?: string }).demotionState = "moved";
 				throw failure;
 			}
 		}

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2744,7 +2744,7 @@ export class Core {
 		const fromPath = taskPath;
 		const toPath = join(await this.fs.getArchiveTasksDir(), taskFilename);
 
-		const activeTasks = await this.fs.listTasks();
+		const activeTasks = (await this.fs.listTasks()).filter((task) => !taskIdsEqual(task.id, normalizedTaskId));
 		const sanitizedTasks = this.sanitizeArchivedTaskLinks(activeTasks, normalizedTaskId);
 
 		return await this.fs.withTaskLocks([taskToArchive, ...sanitizedTasks], async () => {

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -844,8 +844,6 @@ export class ContentStore {
 			decisions: this.nextContentRefreshGeneration("decisions"),
 		};
 		const before = this.getSnapshot();
-		const beforeActiveTasks = this.activeTasks.slice();
-		const beforeCompletedTasks = this.completedTasks.slice();
 		const itemVersions: Record<ContentCollection, Map<string, number>> = {
 			tasks: new Map(this.contentItemVersions.tasks),
 			documents: new Map(this.contentItemVersions.documents),
@@ -868,8 +866,6 @@ export class ContentStore {
 
 		const reconciledTaskCorpus = this.mergeConcurrentWorkingCopyCorpus(
 			taskCorpus,
-			beforeActiveTasks,
-			beforeCompletedTasks,
 			itemVersions.tasks,
 			targetRoot,
 		);
@@ -1567,8 +1563,6 @@ export class ContentStore {
 			const generation = this.nextContentRefreshGeneration("tasks");
 			const before = {
 				items: this.cachedTasks.slice(),
-				activeTasks: this.activeTasks.slice(),
-				completedTasks: this.completedTasks.slice(),
 				versions: new Map(this.contentItemVersions.tasks),
 			};
 			let corpus: TaskCorpusSnapshot;
@@ -1587,8 +1581,6 @@ export class ContentStore {
 				return false;
 			const reconciledCorpus = this.mergeConcurrentWorkingCopyCorpus(
 				corpus,
-				before.activeTasks,
-				before.completedTasks,
 				before.versions,
 				targetRoot,
 			);
@@ -1712,16 +1704,12 @@ export class ContentStore {
 
 	private mergeConcurrentWorkingCopyCorpus(
 		loaded: TaskCorpusSnapshot,
-		beforeActiveTasks: Task[],
-		beforeCompletedTasks: Task[],
 		beforeVersions: ReadonlyMap<string, number>,
 		targetRoot: string,
 	): TaskCorpusSnapshot {
 		const { activeTasks, completedTasks } = this.mergeConcurrentWorkingCopyTasks(
 			loaded.activeTasks,
 			loaded.completedTasks,
-			beforeActiveTasks,
-			beforeCompletedTasks,
 			beforeVersions,
 			targetRoot,
 		);
@@ -1738,55 +1726,22 @@ export class ContentStore {
 	private mergeConcurrentWorkingCopyTasks(
 		loadedActiveTasks: Task[],
 		loadedCompletedTasks: Task[],
-		beforeActiveTasks: Task[],
-		beforeCompletedTasks: Task[],
 		beforeVersions: ReadonlyMap<string, number>,
 		targetRoot: string,
 	): { activeTasks: Task[]; completedTasks: Task[] } {
-		const activeTasks = this.mergeConcurrentWorkingCopyTaskList(
+		const activeTasks = this.mergeConcurrentTaskCorpus(
 			loadedActiveTasks,
-			beforeActiveTasks,
 			this.activeTasks,
 			beforeVersions,
 			targetRoot,
 		);
-		const completedTasks = this.mergeConcurrentWorkingCopyTaskList(
+		const completedTasks = this.mergeConcurrentTaskCorpus(
 			loadedCompletedTasks,
-			beforeCompletedTasks,
 			this.completedTasks,
 			beforeVersions,
 			targetRoot,
 		);
 		return { activeTasks, completedTasks };
-	}
-
-	private mergeConcurrentWorkingCopyTaskList(
-		loaded: Task[],
-		before: Task[],
-		current: Task[],
-		beforeVersions: ReadonlyMap<string, number>,
-		targetRoot: string,
-	): Task[] {
-		const changedIds = new Set<string>();
-		for (const [id, version] of this.contentItemVersions.tasks) {
-			if (version !== beforeVersions.get(id) && this.contentItemPublicationRoots.tasks.get(id) === targetRoot) {
-				changedIds.add(id);
-			}
-		}
-		for (const task of [...before, ...current]) {
-			const id = normalizeTaskId(task.id);
-			if (
-				beforeVersions.get(id) !== this.contentItemVersions.tasks.get(id) &&
-				this.contentItemPublicationRoots.tasks.get(id) === targetRoot
-			) {
-				changedIds.add(id);
-			}
-		}
-		if (changedIds.size === 0) return loaded;
-		return [
-			...loaded.filter((task) => !changedIds.has(normalizeTaskId(task.id))),
-			...current.filter((task) => changedIds.has(normalizeTaskId(task.id))),
-		];
 	}
 
 	private mergeConcurrentChanges<T>(

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -1719,7 +1719,7 @@ export class ContentStore {
 			activeTasks,
 			completedTasks,
 			identityIndex,
-			tasks: identityIndex ? identityIndex.getTasks(false) : loaded.tasks,
+			tasks: identityIndex ? identityIndex.getTasks(false) : activeTasks,
 		};
 	}
 

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -844,6 +844,8 @@ export class ContentStore {
 			decisions: this.nextContentRefreshGeneration("decisions"),
 		};
 		const before = this.getSnapshot();
+		const beforeActiveTasks = this.activeTasks.slice();
+		const beforeCompletedTasks = this.completedTasks.slice();
 		const itemVersions: Record<ContentCollection, Map<string, number>> = {
 			tasks: new Map(this.contentItemVersions.tasks),
 			documents: new Map(this.contentItemVersions.documents),
@@ -864,8 +866,15 @@ export class ContentStore {
 			return false;
 		}
 
+		const reconciledTaskCorpus = this.mergeConcurrentWorkingCopyCorpus(
+			taskCorpus,
+			beforeActiveTasks,
+			beforeCompletedTasks,
+			itemVersions.tasks,
+			targetRoot,
+		);
 		const mergedTasks = this.mergeConcurrentChanges(
-			taskCorpus.tasks,
+			reconciledTaskCorpus.tasks,
 			before.tasks,
 			this.tasksForPublicationRoot(targetRoot),
 			(task) => normalizeTaskId(task.id),
@@ -877,9 +886,9 @@ export class ContentStore {
 		publish({
 			tasks: mergedTasks,
 			taskCorpus: {
-				...taskCorpus,
+				...reconciledTaskCorpus,
 				tasks: mergedTasks,
-				activeTasks: taskCorpus.identityIndex ? taskCorpus.activeTasks : mergedTasks,
+				activeTasks: reconciledTaskCorpus.identityIndex ? reconciledTaskCorpus.activeTasks : mergedTasks,
 			},
 			documents: this.mergeConcurrentChanges(
 				documents,
@@ -1556,7 +1565,12 @@ export class ContentStore {
 		await this.reconcileOrSchedule(`task:${normalizedExpectedId}`, epoch, async () => {
 			const targetRoot = this.currentRoot();
 			const generation = this.nextContentRefreshGeneration("tasks");
-			const before = { items: this.cachedTasks.slice(), versions: new Map(this.contentItemVersions.tasks) };
+			const before = {
+				items: this.cachedTasks.slice(),
+				activeTasks: this.activeTasks.slice(),
+				completedTasks: this.completedTasks.slice(),
+				versions: new Map(this.contentItemVersions.tasks),
+			};
 			let corpus: TaskCorpusSnapshot;
 			try {
 				const loaded = await this.loadTasksWithLoader();
@@ -1571,8 +1585,15 @@ export class ContentStore {
 				!this.isContentRefreshCurrent("tasks", generation)
 			)
 				return false;
+			const reconciledCorpus = this.mergeConcurrentWorkingCopyCorpus(
+				corpus,
+				before.activeTasks,
+				before.completedTasks,
+				before.versions,
+				targetRoot,
+			);
 			const merged = this.mergeConcurrentChanges(
-				corpus.tasks,
+				reconciledCorpus.tasks,
 				before.items,
 				this.cachedTasks,
 				(task) => normalizeTaskId(task.id),
@@ -1582,14 +1603,15 @@ export class ContentStore {
 				targetRoot,
 			);
 			const visibleChanged = this.hasTaskCollectionChanged(merged);
-			const identityChanged = this.taskIdentityIndex?.getFingerprint() !== corpus.identityIndex?.getFingerprint();
+			const identityChanged =
+				this.taskIdentityIndex?.getFingerprint() !== reconciledCorpus.identityIndex?.getFingerprint();
 			const corpusChanged =
-				this.hasTaskListChanged(this.activeTasks, corpus.activeTasks) ||
-				this.hasTaskListChanged(this.completedTasks, corpus.completedTasks) ||
-				this.hasBranchTaskStateChanged(corpus.branchStateEntries ?? []) ||
-				JSON.stringify(this.taskCorpusConfig) !== JSON.stringify(corpus.config);
+				this.hasTaskListChanged(this.activeTasks, reconciledCorpus.activeTasks) ||
+				this.hasTaskListChanged(this.completedTasks, reconciledCorpus.completedTasks) ||
+				this.hasBranchTaskStateChanged(reconciledCorpus.branchStateEntries ?? []) ||
+				JSON.stringify(this.taskCorpusConfig) !== JSON.stringify(reconciledCorpus.config);
 			if (!visibleChanged && !identityChanged && !corpusChanged) return false;
-			this.installTaskCorpus(corpus, merged);
+			this.installTaskCorpus(reconciledCorpus, merged);
 			this.notify("tasks");
 			return false;
 		});
@@ -1678,6 +1700,80 @@ export class ContentStore {
 		const changedIds = new Set<string>();
 		for (const [id, version] of this.contentItemVersions.tasks) {
 			if (version !== versionsBeforeLoad.get(id) && this.contentItemPublicationRoots.tasks.get(id) === targetRoot) {
+				changedIds.add(id);
+			}
+		}
+		if (changedIds.size === 0) return loaded;
+		return [
+			...loaded.filter((task) => !changedIds.has(normalizeTaskId(task.id))),
+			...current.filter((task) => changedIds.has(normalizeTaskId(task.id))),
+		];
+	}
+
+	private mergeConcurrentWorkingCopyCorpus(
+		loaded: TaskCorpusSnapshot,
+		beforeActiveTasks: Task[],
+		beforeCompletedTasks: Task[],
+		beforeVersions: ReadonlyMap<string, number>,
+		targetRoot: string,
+	): TaskCorpusSnapshot {
+		const { activeTasks, completedTasks } = this.mergeConcurrentWorkingCopyTasks(
+			loaded.activeTasks,
+			loaded.completedTasks,
+			beforeActiveTasks,
+			beforeCompletedTasks,
+			beforeVersions,
+			targetRoot,
+		);
+		const identityIndex = loaded.identityIndex?.withWorkingCopyCorpus(activeTasks, completedTasks);
+		return {
+			...loaded,
+			activeTasks,
+			completedTasks,
+			identityIndex,
+			tasks: identityIndex ? identityIndex.getTasks(false) : loaded.tasks,
+		};
+	}
+
+	private mergeConcurrentWorkingCopyTasks(
+		loadedActiveTasks: Task[],
+		loadedCompletedTasks: Task[],
+		beforeActiveTasks: Task[],
+		beforeCompletedTasks: Task[],
+		beforeVersions: ReadonlyMap<string, number>,
+		targetRoot: string,
+	): { activeTasks: Task[]; completedTasks: Task[] } {
+		const activeTasks = this.mergeConcurrentWorkingCopyTaskList(
+			loadedActiveTasks,
+			beforeActiveTasks,
+			this.activeTasks,
+			beforeVersions,
+			targetRoot,
+		);
+		const completedTasks = this.mergeConcurrentWorkingCopyTaskList(
+			loadedCompletedTasks,
+			beforeCompletedTasks,
+			this.completedTasks,
+			beforeVersions,
+			targetRoot,
+		);
+		return { activeTasks, completedTasks };
+	}
+
+	private mergeConcurrentWorkingCopyTaskList(
+		loaded: Task[],
+		before: Task[],
+		current: Task[],
+		beforeVersions: ReadonlyMap<string, number>,
+		targetRoot: string,
+	): Task[] {
+		const changedIds = new Set<string>();
+		for (const task of [...before, ...current]) {
+			const id = normalizeTaskId(task.id);
+			if (
+				beforeVersions.get(id) !== this.contentItemVersions.tasks.get(id) &&
+				this.contentItemPublicationRoots.tasks.get(id) === targetRoot
+			) {
 				changedIds.add(id);
 			}
 		}

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -1768,6 +1768,11 @@ export class ContentStore {
 		targetRoot: string,
 	): Task[] {
 		const changedIds = new Set<string>();
+		for (const [id, version] of this.contentItemVersions.tasks) {
+			if (version !== beforeVersions.get(id) && this.contentItemPublicationRoots.tasks.get(id) === targetRoot) {
+				changedIds.add(id);
+			}
+		}
 		for (const task of [...before, ...current]) {
 			const id = normalizeTaskId(task.id);
 			if (

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -630,6 +630,26 @@ export class FileSystem {
 		);
 	}
 
+	/**
+	 * Hold a stable set of task locks for one operation. The callback runs only after every
+	 * lock is acquired, so a contended task cannot leave an earlier write from a bulk operation
+	 * on disk. Sorting also keeps multi-task operations from acquiring the same locks in opposite
+	 * orders and deadlocking each other.
+	 */
+	async withTaskLocks<T>(tasks: Array<Pick<Task, "id" | "filePath">>, fn: () => Promise<T>): Promise<T> {
+		const uniqueTasks = Array.from(
+			new Map(tasks.map((task) => [task.id.trim().toLowerCase(), task])).values(),
+		).sort((left, right) => left.id.localeCompare(right.id));
+
+		const acquire = async (index: number): Promise<T> => {
+			const task = uniqueTasks[index];
+			if (!task) return await fn();
+			return await this.withTaskLock(task, async () => await acquire(index + 1));
+		};
+
+		return await acquire(0);
+	}
+
 	private async withLockTarget<T>(
 		targetPath: string,
 		lockDir: string,

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1145,8 +1145,11 @@ export class FileSystem {
 			} catch (error) {
 				try {
 					await unlink(savedPath);
-				} catch {
-					// Preserve the original failure; the response still reports an operational error.
+				} catch (cleanupError) {
+					const failure = error instanceof Error ? error : new Error(String(error));
+					(failure as Error & { demotionState?: string }).demotionState = "partial";
+					failure.cause = cleanupError;
+					throw failure;
 				}
 				throw error;
 			}

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1114,42 +1114,46 @@ export class FileSystem {
 	}
 
 	async demoteTask(taskId: string, onMoved?: (fromPath: string, toPath: string) => void): Promise<boolean> {
-		try {
-			return await this.withCreateLock(async () => {
-				// Load the task
-				const task = await this.loadTask(taskId);
-				if (!task?.filePath) return false;
+		return await this.withCreateLock(async () => {
+			// Load the task. A missing task is the only false result; filesystem failures must reach
+			// callers so the Web API can distinguish an operational failure from a 404.
+			const task = await this.loadTask(taskId);
+			if (!task?.filePath) return false;
 
-				// Get existing draft IDs to generate next ID
-				// Draft prefix is always "draft" (not configurable like task prefix)
-				const existingDrafts = await this.listDrafts();
-				const existingIds = existingDrafts.map((d) => d.id);
+			// Get existing draft IDs to generate next ID
+			// Draft prefix is always "draft" (not configurable like task prefix)
+			const existingDrafts = await this.listDrafts();
+			const existingIds = existingDrafts.map((d) => d.id);
 
-				// Generate new draft ID
-				const config = await this.loadConfig();
-				const newDraftId = generateNextId(existingIds, "draft", config?.zeroPaddedIds);
+			// Generate new draft ID
+			const config = await this.loadConfig();
+			const newDraftId = generateNextId(existingIds, "draft", config?.zeroPaddedIds);
 
-				// Update task with new draft ID and save as draft
-				const demotedDraft: Task = {
-					...task,
-					id: newDraftId,
-					filePath: undefined, // Will be set by saveDraft
-				};
+			// Update task with new draft ID and save as draft
+			const demotedDraft: Task = {
+				...task,
+				id: newDraftId,
+				filePath: undefined, // Will be set by saveDraft
+			};
 
-				const savedPath = await this.saveDraft(demotedDraft);
+			const savedPath = await this.saveDraft(demotedDraft);
 
-				// Delete old task file
+			// Delete old task file. If that fails, remove the newly written draft so a retry cannot
+			// encounter two copies of the task.
+			try {
 				await unlink(task.filePath);
-				onMoved?.(task.filePath, savedPath);
-
-				return true;
-			});
-		} catch (error) {
-			if (isCreateLockError(error) || isAmbiguousTaskIdError(error)) {
+			} catch (error) {
+				try {
+					await unlink(savedPath);
+				} catch {
+					// Preserve the original failure; the response still reports an operational error.
+				}
 				throw error;
 			}
-			return false;
-		}
+			onMoved?.(task.filePath, savedPath);
+
+			return true;
+		});
 	}
 
 	// Draft operations

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1146,9 +1146,10 @@ export class BacklogServer {
 			if (!conflict) {
 				console.error("Error demoting task:", error);
 			}
+			const status = knownDemotionState ? 500 : conflict ? 409 : 500;
 			return Response.json(
 				{ error: message, ...(knownDemotionState ? { demotionState: knownDemotionState } : {}) },
-				{ status: conflict ? 409 : 500 },
+				{ status },
 			);
 		}
 	}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1140,6 +1140,9 @@ export class BacklogServer {
 				typeof error === "object" && error !== null &&
 				(error as { demotionState?: unknown }).demotionState;
 			const knownDemotionState = demotionState === "moved" || demotionState === "partial" ? demotionState : undefined;
+			if (knownDemotionState) {
+				this.broadcastTasksUpdated();
+			}
 			if (!conflict) {
 				console.error("Error demoting task:", error);
 			}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1135,7 +1135,7 @@ export class BacklogServer {
 			return Response.json({ success: true });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to demote task";
-			const conflict = isAmbiguousTaskIdError(error) || isCreateLockError(error);
+			const conflict = isAmbiguousTaskIdError(error) || isCreateLockError(error) || isTaskLockError(error);
 			const demotionState =
 				typeof error === "object" && error !== null &&
 				(error as { demotionState?: unknown }).demotionState;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1136,14 +1136,17 @@ export class BacklogServer {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to demote task";
 			const conflict = isAmbiguousTaskIdError(error) || isCreateLockError(error);
-			const moved =
-				typeof error === "object" &&
-				error !== null &&
-				(error as { moved?: unknown }).moved === true;
+			const demotionState =
+				typeof error === "object" && error !== null &&
+				(error as { demotionState?: unknown }).demotionState;
+			const knownDemotionState = demotionState === "moved" || demotionState === "partial" ? demotionState : undefined;
 			if (!conflict) {
 				console.error("Error demoting task:", error);
 			}
-			return Response.json({ error: message, ...(moved ? { moved: true } : {}) }, { status: conflict ? 409 : 500 });
+			return Response.json(
+				{ error: message, ...(knownDemotionState ? { demotionState: knownDemotionState } : {}) },
+				{ status: conflict ? 409 : 500 },
+			);
 		}
 	}
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -376,6 +376,9 @@ export class BacklogServer {
 					"/api/tasks/:id/complete": {
 						POST: async (req: Request & { params: { id: string } }) => await this.handleCompleteTask(req.params.id),
 					},
+					"/api/tasks/:id/demote": {
+						POST: async (req: Request & { params: { id: string } }) => await this.handleDemoteTask(req.params.id),
+					},
 					"/api/statuses": {
 						GET: async () => await this.handleGetStatuses(),
 					},
@@ -1118,6 +1121,29 @@ export class BacklogServer {
 				console.error("Error completing task:", error);
 			}
 			return Response.json({ error: message }, { status: isAmbiguousTaskIdError(error) ? 409 : 500 });
+		}
+	}
+
+	private async handleDemoteTask(taskId: string): Promise<Response> {
+		try {
+			const success = await this.core.demoteTask(taskId);
+			if (!success) {
+				return Response.json({ error: "Task not found" }, { status: 404 });
+			}
+
+			this.broadcastTasksUpdated();
+			return Response.json({ success: true });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Failed to demote task";
+			const conflict = isAmbiguousTaskIdError(error) || isCreateLockError(error);
+			const moved =
+				typeof error === "object" &&
+				error !== null &&
+				(error as { moved?: unknown }).moved === true;
+			if (!conflict) {
+				console.error("Error demoting task:", error);
+			}
+			return Response.json({ error: message, ...(moved ? { moved: true } : {}) }, { status: conflict ? 409 : 500 });
 		}
 	}
 

--- a/src/test/atomic-task-edit.test.ts
+++ b/src/test/atomic-task-edit.test.ts
@@ -176,6 +176,28 @@ describe("atomic task editing", () => {
 		}
 	});
 
+	it("blocks direct demotion while another task mutation holds the lock", async () => {
+		const task = await createContendedTask();
+		const lockEntered = createDeferred<void>();
+		const releaseLock = createDeferred<void>();
+		const heldLock = setup.fs.withTaskLock(task, async () => {
+			lockEntered.resolve();
+			await releaseLock.promise;
+		});
+		await withTimeout(lockEntered.promise, "the lock to be held", 5_000);
+
+		const other = new Core(testDir);
+		try {
+			await expect(other.demoteTask(CONTENDED_ID, false)).rejects.toThrow(CONTENTION_MESSAGE);
+			expect(await setup.fs.loadTask(CONTENDED_ID)).not.toBeNull();
+			expect(await setup.fs.listDrafts()).toEqual([]);
+		} finally {
+			releaseLock.resolve();
+			await heldLock;
+			other.disposeContentStore();
+		}
+	});
+
 	it("keeps concurrent edits of different tasks independent", async () => {
 		await setup.createTaskFromInput({ title: "Task A" }, false);
 		await setup.createTaskFromInput({ title: "Task B" }, false);
@@ -282,6 +304,40 @@ describe("atomic task editing", () => {
 				method: "PUT",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ ...task, labels: ["from-web"] }),
+			});
+
+			expect(response.status).toBe(409);
+			expect((await response.json()).error).toBe(CONTENTION_MESSAGE);
+		} finally {
+			releaseLock.resolve();
+			await heldLock;
+			await server.stop();
+		}
+	});
+
+	it("returns HTTP 409 from the web demotion endpoint on contention", async () => {
+		const task = await createContendedTask();
+		const server = new BacklogServer(testDir);
+		await server.start(0, false);
+		const port = server.getPort() ?? 0;
+		expect(port).toBeGreaterThan(0);
+
+		const lockEntered = createDeferred<void>();
+		const releaseLock = createDeferred<void>();
+		const heldLock = setup.fs.withTaskLock(task, async () => {
+			lockEntered.resolve();
+			await releaseLock.promise;
+		});
+
+		try {
+			await retry(async () => {
+				const ping = await fetch(`http://127.0.0.1:${port}/api/tasks`);
+				if (!ping.ok) throw new Error(`server not ready: ${ping.status}`);
+			});
+			await withTimeout(lockEntered.promise, "the lock to be held", 5_000);
+
+			const response = await fetch(`http://127.0.0.1:${port}/api/tasks/${CONTENDED_ID}/demote`, {
+				method: "POST",
 			});
 
 			expect(response.status).toBe(409);

--- a/src/test/content-store.test.ts
+++ b/src/test/content-store.test.ts
@@ -839,6 +839,82 @@ describe("ContentStore", () => {
 		search.dispose();
 	});
 
+	it("does not let an older task refresh resurrect a transitioned task", async () => {
+		store.dispose();
+		const heldRefresh = createDeferredGate();
+		let loadCount = 0;
+		const staleSnapshot = (): TaskCorpusSnapshot => {
+			const identityIndex = new TaskIdentityIndex(
+				[
+					{
+						id: sampleTask.id,
+						type: "task",
+						branch: "local",
+						path: join(filesystem.tasksDir, "task-1 - Sample Task.md"),
+						lastModified: new Date("2026-08-01T11:00:00Z"),
+						task: sampleTask,
+						workingCopy: true,
+					},
+				],
+				{ repositoryRoot: null, projectRoot: TEST_DIR, backlogDirectory: "backlog" },
+				["To Do", "In Progress", "Done"],
+				"most_progressed",
+			);
+			return {
+				tasks: identityIndex.getTasks(false),
+				activeTasks: [sampleTask],
+				completedTasks: [],
+				identityIndex,
+			};
+		};
+		store = new ContentStore(filesystem, async () => {
+			loadCount += 1;
+			if (loadCount === 2) {
+				heldRefresh.markStarted();
+				await heldRefresh.waitForRelease;
+			}
+			return staleSnapshot();
+		});
+		await store.ensureInitialized();
+
+		const refresh = store.refreshTasks();
+		await withTimeout(heldRefresh.started, "held stale task refresh");
+		store.transitionTask(sampleTask.id);
+		expect(store.getTasks()).toEqual([]);
+
+		heldRefresh.release();
+		await refresh;
+
+		expect(store.getTasks()).toEqual([]);
+		expect(store.getTaskCorpusSnapshot().activeTasks).toEqual([]);
+		expect(store.resolveTaskForMutation(sampleTask.id)).toEqual({ status: "not-found" });
+	});
+
+	it("does not let an older local corpus refresh resurrect a transitioned task", async () => {
+		const taskPath = await filesystem.saveTask(sampleTask);
+		await store.ensureInitialized();
+		const heldRefresh = createDeferredGate();
+		const listTasks = filesystem.listTasks.bind(filesystem);
+		filesystem.listTasks = async () => {
+			const tasks = await listTasks();
+			heldRefresh.markStarted();
+			await heldRefresh.waitForRelease;
+			return tasks;
+		};
+
+		const refresh = store.refreshLocalTaskCorpus();
+		await withTimeout(heldRefresh.started, "held stale local task refresh");
+		await unlink(taskPath);
+		store.transitionTask(sampleTask.id);
+		expect(store.getTasks()).toEqual([]);
+
+		heldRefresh.release();
+		await refresh;
+
+		expect(store.getTasks()).toEqual([]);
+		expect(store.getTaskCorpusSnapshot().activeTasks).toEqual([]);
+	});
+
 	it("publishes a validated task refresh without a microtask overwrite window", async () => {
 		store.dispose();
 		const taskWithTitle = (title: string): Task => ({ ...sampleTask, title });

--- a/src/test/server-demote-endpoint.test.ts
+++ b/src/test/server-demote-endpoint.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { Core } from "../core/backlog.ts";
+import { serializeTask } from "../markdown/serializer.ts";
+import { BacklogServer } from "../server/index.ts";
+import type { SearchResult, Task } from "../types/index.ts";
+import { createUniqueTestDir, retry, safeCleanup } from "./test-utils.ts";
+
+let testDir: string;
+let server: BacklogServer | null = null;
+let serverPort = 0;
+let core: Core;
+
+function task(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "TASK-1",
+		title: "Demote me",
+		status: "To Do",
+		assignee: [],
+		labels: [],
+		dependencies: [],
+		createdDate: "2026-01-01",
+		...overrides,
+	};
+}
+
+beforeEach(async () => {
+	testDir = createUniqueTestDir("server-demote");
+	await mkdir(testDir, { recursive: true });
+	core = new Core(testDir);
+	await core.filesystem.ensureBacklogStructure();
+	await core.filesystem.saveConfig({
+		projectName: "Server demote",
+		statuses: ["To Do", "In Progress", "Done"],
+		labels: [],
+		milestones: [],
+		dateFormat: "YYYY-MM-DD",
+		remoteOperations: false,
+		checkActiveBranches: false,
+		autoCommit: false,
+	});
+	await core.createTask(task(), false);
+
+	server = new BacklogServer(testDir);
+	await server.start(0, false);
+	serverPort = server.getPort() ?? 0;
+	await retry(async () => {
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/status`);
+		if (!response.ok) throw new Error("Server is not ready");
+	});
+});
+
+afterEach(async () => {
+	await server?.stop();
+	server = null;
+	await safeCleanup(testDir);
+});
+
+describe("BacklogServer demote endpoint", () => {
+	it("moves an active task through the canonical Core demotion", async () => {
+		const beforeSearch = (await fetch(`http://127.0.0.1:${serverPort}/api/search`).then((result) =>
+			result.json(),
+		)) as SearchResult[];
+		expect(beforeSearch.some((result) => result.type === "task" && result.task.id === "TASK-1")).toBe(true);
+
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks/TASK-1/demote`, { method: "POST" });
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ success: true });
+		expect(await core.filesystem.loadTask("TASK-1")).toBeNull();
+
+		const drafts = await core.filesystem.listDrafts();
+		expect(drafts).toHaveLength(1);
+		expect(drafts[0]).toMatchObject({ id: "DRAFT-1", title: "Demote me", status: "To Do" });
+
+		const refreshedSearch = (await fetch(`http://127.0.0.1:${serverPort}/api/search`).then((result) =>
+			result.json(),
+		)) as SearchResult[];
+		expect(refreshedSearch.some((result) => result.type === "task" && result.task.id === "TASK-1")).toBe(false);
+	});
+
+	it("returns 404 without writing when the task does not exist", async () => {
+		const before = await core.filesystem.listDrafts();
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks/TASK-999/demote`, {
+			method: "POST",
+		});
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({ error: "Task not found" });
+		expect(await core.filesystem.listDrafts()).toEqual(before);
+		expect(await core.filesystem.loadTask("TASK-1")).not.toBeNull();
+	});
+
+	it("returns 409 without moving either file when the task ID is ambiguous", async () => {
+		const duplicatePath = join(core.filesystem.tasksDir, "task-01 - Duplicate.md");
+		await Bun.write(duplicatePath, serializeTask(task({ id: "TASK-01", title: "Duplicate" })));
+
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/tasks/TASK-1/demote`, { method: "POST" });
+
+		expect(response.status).toBe(409);
+		expect(await response.json()).toEqual({ error: expect.stringContaining("ambiguous") });
+		expect(await core.filesystem.listDrafts()).toEqual([]);
+		expect(await Bun.file(duplicatePath).exists()).toBe(true);
+		expect((await core.filesystem.listTasks()).map((entry) => entry.title).sort()).toEqual(["Demote me", "Duplicate"]);
+	});
+});

--- a/src/test/web-api-demote.test.ts
+++ b/src/test/web-api-demote.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { ApiClient, ApiError } from "../web/lib/api.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("Web demote API client", () => {
+	it("does not retry demotion and preserves the first server error", async () => {
+		let calls = 0;
+		globalThis.fetch = (async () => {
+			calls += 1;
+			return Response.json({ error: "Git commit failed after moving the task" }, { status: 500 });
+		}) as unknown as typeof globalThis.fetch;
+
+		const client = new ApiClient({ retries: 3 });
+		const error = await client.demoteTask("TASK-1").then(
+			() => null,
+			(reason: unknown) => reason,
+		);
+
+		expect(calls).toBe(1);
+		expect(error).toBeInstanceOf(ApiError);
+		expect(error).toMatchObject({
+			message: "Git commit failed after moving the task",
+			status: 500,
+		});
+	});
+});

--- a/src/test/web-task-details-modal-demote.test.tsx
+++ b/src/test/web-task-details-modal-demote.test.tsx
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Task } from "../types/index.ts";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
+import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
+import { apiClient } from "../web/lib/api.ts";
+
+let root: Root | null = null;
+let dom: JSDOM | null = null;
+
+const localTask: Task = {
+	id: "BACK-419",
+	title: "Demote action",
+	status: "To Do",
+	assignee: [],
+	labels: [],
+	dependencies: [],
+	createdDate: "2026-01-01",
+	source: "local",
+};
+
+function setupDom(): HTMLElement {
+	dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: "http://localhost",
+	});
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = dom.window as unknown as Window & typeof globalThis;
+	globalThis.document = dom.window.document as Document;
+	globalThis.navigator = dom.window.navigator as Navigator;
+	globalThis.localStorage = dom.window.localStorage;
+	globalThis.Element = dom.window.Element;
+	globalThis.HTMLElement = dom.window.HTMLElement;
+	globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+	globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(callback, 0);
+	globalThis.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
+	window.matchMedia = () =>
+		({
+			matches: false,
+			media: "",
+			onchange: null,
+			addListener: () => {},
+			removeListener: () => {},
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			dispatchEvent: () => false,
+		}) as MediaQueryList;
+
+	const container = document.getElementById("root");
+	if (!container) throw new Error("Missing test root");
+	root = createRoot(container);
+	return container;
+}
+
+async function renderModal(
+	task: Task,
+	props: {
+		isDraftMode?: boolean;
+		isOpen?: boolean;
+		onClose?: () => void;
+		onSaved?: () => Promise<void> | void;
+	} = {},
+): Promise<void> {
+	await act(async () => {
+		root?.render(
+			<ThemeProvider>
+				<TaskDetailsModal
+					task={task}
+					isOpen={props.isOpen ?? true}
+					isDraftMode={props.isDraftMode}
+					onClose={props.onClose ?? (() => {})}
+					onSaved={props.onSaved}
+				/>
+			</ThemeProvider>,
+		);
+		await Promise.resolve();
+	});
+}
+
+function findDemoteButton(container: HTMLElement): HTMLButtonElement | undefined {
+	return Array.from(container.querySelectorAll("button")).find((button) => button.title === "Move task to drafts");
+}
+
+async function click(element: Element): Promise<void> {
+	await act(async () => {
+		element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+		await Promise.resolve();
+	});
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 20; attempt += 1) {
+		if (predicate()) return;
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+	}
+	throw new Error("Condition was not met");
+}
+
+afterEach(() => {
+	if (root) {
+		act(() => root?.unmount());
+		root = null;
+	}
+	dom?.window.close();
+	dom = null;
+});
+
+describe("Web task demotion", () => {
+	it("shows the action for a local active task", async () => {
+		const container = setupDom();
+		await renderModal(localTask);
+
+		expect(findDemoteButton(container)).toBeTruthy();
+	});
+
+	it("hides the action when demotion is not applicable", async () => {
+		const container = setupDom();
+		const inapplicable: Array<{ task: Task; isDraftMode?: boolean }> = [
+			{ task: { ...localTask, id: "DRAFT-1", status: "Draft" }, isDraftMode: true },
+			{ task: { ...localTask, source: "completed" } },
+			{ task: { ...localTask, source: "local-branch", branch: "tasks/elsewhere" } },
+		];
+
+		for (const candidate of inapplicable) {
+			await renderModal(candidate.task, { isDraftMode: candidate.isDraftMode });
+			expect(findDemoteButton(container), candidate.task.id).toBeUndefined();
+		}
+	});
+
+	it("shows the action for an active task whose configured prefix is DRAFT", async () => {
+		const container = setupDom();
+		await renderModal({ ...localTask, id: "DRAFT-419" });
+
+		expect(findDemoteButton(container)).toBeTruthy();
+	});
+
+	it("requires confirmation before calling the API", async () => {
+		const container = setupDom();
+		let apiCalls = 0;
+		const originalDemoteTask = apiClient.demoteTask.bind(apiClient);
+		apiClient.demoteTask = async () => {
+			apiCalls += 1;
+		};
+		window.confirm = () => false;
+
+		try {
+			await renderModal(localTask);
+			await click(findDemoteButton(container) as HTMLButtonElement);
+			expect(apiCalls).toBe(0);
+		} finally {
+			apiClient.demoteTask = originalDemoteTask;
+		}
+	});
+
+	it("refreshes tasks and drafts before closing after success", async () => {
+		const container = setupDom();
+		const events: string[] = [];
+		const originalDemoteTask = apiClient.demoteTask.bind(apiClient);
+		apiClient.demoteTask = async (id) => {
+			events.push(`api:${id}`);
+		};
+		window.confirm = () => true;
+		window.addEventListener("drafts-updated", () => events.push("drafts"), { once: true });
+
+		try {
+			await renderModal(localTask, {
+				onSaved: async () => {
+					events.push("saved");
+				},
+				onClose: () => events.push("closed"),
+			});
+			await click(findDemoteButton(container) as HTMLButtonElement);
+			await waitFor(() => events.includes("closed"));
+
+			expect(events).toEqual(["api:BACK-419", "drafts", "saved", "closed"]);
+		} finally {
+			apiClient.demoteTask = originalDemoteTask;
+		}
+	});
+
+	it("keeps the modal open and reports an API failure", async () => {
+		const container = setupDom();
+		let closeCalls = 0;
+		const originalDemoteTask = apiClient.demoteTask.bind(apiClient);
+		apiClient.demoteTask = async () => {
+			throw new Error("Demotion failed");
+		};
+		window.confirm = () => true;
+
+		try {
+			await renderModal(localTask, { onClose: () => closeCalls++ });
+			await click(findDemoteButton(container) as HTMLButtonElement);
+			await waitFor(() => container.textContent?.includes("Demotion failed") ?? false);
+
+			expect(closeCalls).toBe(0);
+			expect(findDemoteButton(container)?.disabled).toBe(false);
+			expect(container.querySelector("[role='alert']")?.textContent).toContain("Demotion failed");
+		} finally {
+			apiClient.demoteTask = originalDemoteTask;
+		}
+	});
+
+	it("ignores a deferred demotion after the modal closes and reopens for another task", async () => {
+		const container = setupDom();
+		let resolveRequest: (() => void) | undefined;
+		let markStarted: (() => void) | undefined;
+		const requestStarted = new Promise<void>((resolve) => {
+			markStarted = resolve;
+		});
+		const requestRelease = new Promise<void>((resolve) => {
+			resolveRequest = resolve;
+		});
+		let closeCalls = 0;
+		let saveCalls = 0;
+		let draftEvents = 0;
+		const originalDemoteTask = apiClient.demoteTask.bind(apiClient);
+		apiClient.demoteTask = async () => {
+			markStarted?.();
+			await requestRelease;
+		};
+		window.confirm = () => true;
+		const onDraftsUpdated = () => draftEvents++;
+		window.addEventListener("drafts-updated", onDraftsUpdated);
+		const callbacks = {
+			onClose: () => closeCalls++,
+			onSaved: () => {
+				saveCalls += 1;
+			},
+		};
+
+		try {
+			await renderModal(localTask, callbacks);
+			await click(findDemoteButton(container) as HTMLButtonElement);
+			await requestStarted;
+
+			expect(findDemoteButton(container)?.disabled).toBe(true);
+			expect((container.querySelector("button[aria-label='Close modal']") as HTMLButtonElement | null)?.disabled).toBe(
+				true,
+			);
+
+			await renderModal(localTask, { ...callbacks, isOpen: false });
+			const replacement = { ...localTask, id: "DRAFT-420", title: "Replacement task" };
+			await renderModal(replacement, callbacks);
+			expect(findDemoteButton(container)?.disabled).toBe(false);
+
+			resolveRequest?.();
+			await act(async () => {
+				await requestRelease;
+				await new Promise<void>((resolve) => setImmediate(resolve));
+			});
+
+			expect(closeCalls).toBe(0);
+			expect(saveCalls).toBe(0);
+			expect(draftEvents).toBe(0);
+			expect(container.textContent).toContain("DRAFT-420 — Replacement task");
+		} finally {
+			resolveRequest?.();
+			window.removeEventListener("drafts-updated", onDraftsUpdated);
+			apiClient.demoteTask = originalDemoteTask;
+		}
+	});
+});

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -429,6 +429,12 @@ function AppContent() {
     setShowModal(true);
   }, []);
 
+  const openDraftModal = useCallback((draft: Task) => {
+    setEditingTask(draft);
+    setIsDraftMode(true);
+    setShowModal(true);
+  }, []);
+
   const clearTaskModal = useCallback(() => {
     isTaskRouteModalRef.current = false;
     setShowModal(false);
@@ -764,7 +770,7 @@ function AppContent() {
               />
             }
           />
-            <Route path="drafts" element={<DraftsList onEditTask={handleEditTask} onNewDraft={handleNewDraft} dateFormat={config?.dateFormat} />} />
+            <Route path="drafts" element={<DraftsList onEditTask={openDraftModal} onNewDraft={handleNewDraft} dateFormat={config?.dateFormat} />} />
             <Route path="documentation" element={<DocumentationDetail docs={docs} onRefreshData={refreshData} dateFormat={config?.dateFormat} />} />
             <Route path="documentation/:id" element={<DocumentationDetail docs={docs} onRefreshData={refreshData} dateFormat={config?.dateFormat} />} />
             <Route path="documentation/:id/:title" element={<DocumentationDetail docs={docs} onRefreshData={refreshData} dateFormat={config?.dateFormat} />} />

--- a/src/web/components/Modal.tsx
+++ b/src/web/components/Modal.tsx
@@ -121,11 +121,11 @@ const Modal: React.FC<ModalProps> = ({
 				aria-modal="true"
 				aria-labelledby="modal-title"
 			>
-				<div className="sticky top-0 z-10 flex items-center justify-between px-6 pt-4 pb-3 border-b border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur supports-[backdrop-filter]:bg-white/75 supports-[backdrop-filter]:dark:bg-gray-800/75">
-					<h2 id="modal-title" className="text-base font-semibold text-gray-900 dark:text-gray-100">
+				<div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-2 px-6 pt-4 pb-3 border-b border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur supports-[backdrop-filter]:bg-white/75 supports-[backdrop-filter]:dark:bg-gray-800/75">
+					<h2 id="modal-title" className="min-w-0 text-base font-semibold text-gray-900 dark:text-gray-100">
 						{title}
 					</h2>
-					<div className="flex items-center gap-2">
+					<div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
 						{actions}
 						<button
 							type="button"

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -74,13 +74,19 @@ const containsCommentDelimiterLine = (value: string): boolean => /^\s*---\s*$/m.
 
 const areJsonEqual = (first: unknown, second: unknown): boolean => JSON.stringify(first) === JSON.stringify(second);
 
-const isPartialDemotionError = (error: unknown): boolean =>
-	error instanceof ApiError &&
-	error.status !== undefined &&
-	error.status >= 500 &&
-	typeof error.data === "object" &&
-	error.data !== null &&
-	(error.data as { moved?: unknown }).moved === true;
+const getDemotionFailureState = (error: unknown): "moved" | "partial" | null => {
+	if (
+		!(error instanceof ApiError) ||
+		error.status === undefined ||
+		error.status < 500 ||
+		typeof error.data !== "object" ||
+		error.data === null
+	) {
+		return null;
+	}
+	const state = (error.data as { demotionState?: unknown }).demotionState;
+	return state === "moved" || state === "partial" ? state : null;
+};
 
 const isEditableKeyboardTarget = (target: EventTarget | null): boolean =>
   target instanceof Element &&
@@ -977,7 +983,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
 			onClose();
 		} catch (err) {
 			if (!isCurrentRequest()) return;
-			if (isPartialDemotionError(err)) {
+			const demotionFailureState = getDemotionFailureState(err);
+			if (demotionFailureState) {
 				window.dispatchEvent(new window.Event("drafts-updated"));
 				try {
 					if (onSaved) await onSaved();
@@ -986,7 +993,9 @@ export const TaskDetailsModal: React.FC<Props> = ({
 				}
 				if (!isCurrentRequest()) return;
 				const message =
-					"The task was moved to drafts, but recording the Git commit failed. The view was refreshed; verify the draft before retrying.";
+					demotionFailureState === "moved"
+						? "The task was moved to drafts, but recording the Git commit failed. The view was refreshed; verify the draft before retrying."
+						: "The demotion encountered a filesystem failure and may have left both task and draft copies. The view was refreshed; inspect them before retrying.";
 				try {
 					window.alert(message);
 				} catch {

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isLocalEditableTask, type AcceptanceCriterion, type Milestone, type Task, type TaskComment } from "../../types";
 import Modal from "./Modal";
-import { ApiError, apiClient } from "../lib/api";
+import { ApiError, apiClient, NetworkError } from "../lib/api";
 import { useTheme } from "../contexts/ThemeContext";
 import MDEditor from "@uiw/react-md-editor";
 import AcceptanceCriteriaEditor from "./AcceptanceCriteriaEditor";
@@ -1020,6 +1020,12 @@ export const TaskDetailsModal: React.FC<Props> = ({
 						? "The task was moved to drafts, but recording the Git commit failed. The view was refreshed; verify the draft before retrying."
 						: "The demotion encountered a filesystem failure and may have left both task and draft copies. The view was refreshed; inspect them before retrying.";
 				await finishWithRefreshWarning(message);
+				return;
+			}
+			if (err instanceof NetworkError) {
+				await finishWithRefreshWarning(
+					"The demotion request may have succeeded, but its response was lost. Check the task and drafts views before retrying.",
+				);
 				return;
 			}
 			setError(err instanceof Error ? err.message : String(err));

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -632,6 +632,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   };
 
   const handleCancelEdit = () => {
+    if (demoting) return;
     if (isDirty) {
       const confirmDiscard = window.confirm("Discard unsaved changes?");
       if (!confirmDiscard) return;
@@ -749,6 +750,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   };
 
   const handleSave = async () => {
+    if (demoting) return;
     setSaving(true);
     setError(null);
 
@@ -816,6 +818,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   };
 
   const handleToggleCriterion = async (index: number, checked: boolean) => {
+    if (demoting) return;
     if (!task) return; // Can't toggle in create mode
     if (isFromOtherBranch) return; // Can't toggle for cross-branch tasks
     // Optimistic update
@@ -832,6 +835,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   };
 
   const handleToggleDefinitionOfDone = async (index: number, checked: boolean) => {
+    if (demoting) return;
     if (!task) return; // Can't toggle in create mode
     if (isFromOtherBranch) return; // Can't toggle for cross-branch tasks
     const next = (definitionOfDone || []).map((c) => (c.index === index ? { ...c, checked } : c));
@@ -849,6 +853,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   };
 
   const handleInlineMetaUpdate = async (updates: InlineMetaUpdatePayload) => {
+    if (demoting) return;
     // Don't allow updates for cross-branch tasks
     if (isFromOtherBranch) return;
 
@@ -878,6 +883,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   };
 
   const handleTaskTypeChange = async (nextType: string) => {
+    if (demoting) return;
     if (isFromOtherBranch) return;
     if (!task) {
       setTaskType(nextType);
@@ -918,6 +924,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   };
 
   const handleAddComment = async () => {
+    if (demoting) return;
     if (!task || isFromOtherBranch) return;
     const body = commentBody.trim();
     if (!body) return;
@@ -953,6 +960,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   // labels handled via ChipInput; no textarea parsing
 
 	const handleComplete = async () => {
+		if (demoting) return;
 		if (!task) return;
 		if (!window.confirm("Complete this task? It will be moved to the completed folder.")) return;
 		try {
@@ -972,36 +980,46 @@ export const TaskDetailsModal: React.FC<Props> = ({
 		activeDemotionRequest.current = request;
 		const isCurrentRequest = () =>
 			activeDemotionRequest.current === request && demotionIdentityRef.current === request.identity;
+		const finishWithRefreshWarning = async (message: string) => {
+			window.dispatchEvent(new window.Event("drafts-updated"));
+			try {
+				if (onSaved) await onSaved();
+			} catch (refreshError) {
+				console.error("Task was demoted, but refreshing the Web UI failed", refreshError);
+			}
+			if (!isCurrentRequest()) return;
+			try {
+				window.alert(message);
+			} catch {
+				setError(message);
+			}
+			onClose();
+		};
 		setDemoting(true);
 		setError(null);
 		try {
 			await apiClient.demoteTask(task.id);
 			if (!isCurrentRequest()) return;
-			window.dispatchEvent(new window.Event("drafts-updated"));
-			if (onSaved) await onSaved();
+			try {
+				window.dispatchEvent(new window.Event("drafts-updated"));
+				if (onSaved) await onSaved();
+			} catch {
+				await finishWithRefreshWarning(
+					"The task was moved to drafts, but refreshing the view failed. Close this dialog and verify the draft before retrying.",
+				);
+				return;
+			}
 			if (!isCurrentRequest()) return;
 			onClose();
 		} catch (err) {
 			if (!isCurrentRequest()) return;
 			const demotionFailureState = getDemotionFailureState(err);
 			if (demotionFailureState) {
-				window.dispatchEvent(new window.Event("drafts-updated"));
-				try {
-					if (onSaved) await onSaved();
-				} catch (refreshError) {
-					console.error("Task was demoted, but refreshing the Web UI failed", refreshError);
-				}
-				if (!isCurrentRequest()) return;
 				const message =
 					demotionFailureState === "moved"
 						? "The task was moved to drafts, but recording the Git commit failed. The view was refreshed; verify the draft before retrying."
 						: "The demotion encountered a filesystem failure and may have left both task and draft copies. The view was refreshed; inspect them before retrying.";
-				try {
-					window.alert(message);
-				} catch {
-					setError(message);
-				}
-				onClose();
+				await finishWithRefreshWarning(message);
 				return;
 			}
 			setError(err instanceof Error ? err.message : String(err));
@@ -1014,6 +1032,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
 	};
 
   const handleArchive = async () => {
+    if (demoting) return;
     if (!task || !onArchive) return;
     if (!window.confirm(`Are you sure you want to archive "${task.title}"? This will move the task to the archive folder.`)) return;
     await onArchive();
@@ -1023,9 +1042,9 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const totalCount = (criteria || []).length;
   const definitionCheckedCount = (definitionOfDone || []).filter((c) => c.checked).length;
   const definitionTotalCount = (definitionOfDone || []).length;
-  const isDoneStatus = (status || "").toLowerCase().includes("done");
-  const canDemote = Boolean(
-		task && !isOpenDraft && isLocalEditableTask(task) && task.source !== "completed" && !isFromOtherBranch,
+	const isDoneStatus = (status || "").toLowerCase().includes("done");
+	const canDemote = Boolean(
+		task && !isDraftMode && !isOpenDraft && isLocalEditableTask(task) && task.source !== "completed" && !isFromOtherBranch,
 	);
   const comments = displayComments;
 
@@ -1048,10 +1067,11 @@ export const TaskDetailsModal: React.FC<Props> = ({
       maxWidthClass="max-w-5xl"
       disableEscapeClose={mode === "edit" || mode === "create" || demoting}
       actions={
-        <div className="flex items-center gap-2">
+		<div className="flex flex-wrap items-center justify-end gap-2">
 		          {isDoneStatus && mode === "preview" && !isCreateMode && !isFromOtherBranch && (
 		            <button
 		              onClick={handleComplete}
+		              disabled={demoting}
 		              className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-emerald-600 dark:bg-emerald-700 hover:bg-emerald-700 dark:hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200"
 		              title="Move to completed folder (removes from board)"
 		            >
@@ -1071,6 +1091,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
 		          {mode === "preview" && !isCreateMode && !isFromOtherBranch ? (
 		            <button
 		              onClick={() => setMode("edit")}
+		              disabled={demoting}
 		              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200"
 		              title="Edit"
 		            >
@@ -1082,8 +1103,9 @@ export const TaskDetailsModal: React.FC<Props> = ({
             </button>
           ) : (mode === "edit" || mode === "create") ? (
             <div className="flex items-center gap-2">
-		              <button
+	              <button
 		                onClick={handleCancelEdit}
+		                disabled={demoting}
 		                className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200"
 		                title="Cancel"
 		              >
@@ -1092,9 +1114,9 @@ export const TaskDetailsModal: React.FC<Props> = ({
                 </svg>
                 Cancel
               </button>
-		              <button
+	              <button
 		                onClick={() => void handleSave()}
-		                disabled={saving}
+		                disabled={saving || demoting}
 		                className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-blue-600 dark:bg-blue-700 hover:bg-blue-700 dark:hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200 disabled:opacity-50"
 		                title="Save"
 		              >
@@ -1112,6 +1134,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
         <div role="alert" className="mb-3 text-sm text-red-600 dark:text-red-400">{error}</div>
       )}
 
+		<fieldset disabled={demoting} className="contents" aria-busy={demoting}>
       {/* Cross-branch task indicator */}
       {isFromOtherBranch && (
         <div className="mb-4 flex items-center gap-2 px-4 py-3 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg text-amber-800 dark:text-amber-200">
@@ -1701,6 +1724,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
 		            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
 		              <button
 		                onClick={handleArchive}
+		                disabled={demoting}
 		                className="w-full inline-flex items-center justify-center px-4 py-2 bg-red-500 dark:bg-red-600 text-white text-sm font-medium rounded-md hover:bg-red-600 dark:hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 focus:ring-red-400 dark:focus:ring-red-500 transition-colors duration-200"
 		              >
 		                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1711,7 +1735,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
             </div>
           )}
         </div>
-      </div>
+	      </div>
+		</fieldset>
     </Modal>
   );
 };

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -122,7 +122,7 @@ const buildTaskDetailsFormState = ({
   finalSummary: task?.finalSummary || "",
   criteria: task?.acceptanceCriteriaItems || [],
   definitionOfDone: task?.definitionOfDoneItems || (isCreateMode ? defaultDefinitionOfDone : []),
-  status: task?.status || (isDraftMode ? "Draft" : (availableStatuses?.[0] || "To Do")),
+  status: isDraftMode ? "Draft" : (task?.status || (availableStatuses?.[0] || "To Do")),
   assignee: task?.assignee || createModeAssignee,
   labels: task?.labels || [],
   priority: task?.priority || "",
@@ -344,7 +344,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
   }, [milestoneEntities, archivedMilestoneEntities]);
 
   // Sidebar metadata (inline edit)
-  const [status, setStatus] = useState(task?.status || (isDraftMode ? "Draft" : (availableStatuses?.[0] || "To Do")));
+  const [status, setStatus] = useState(isDraftMode ? "Draft" : (task?.status || (availableStatuses?.[0] || "To Do")));
   const [assignee, setAssignee] = useState<string[]>(task?.assignee || createModeAssignee);
   const [labels, setLabels] = useState<string[]>(task?.labels || []);
   const [priority, setPriority] = useState<string>(task?.priority || "");

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { AcceptanceCriterion, Milestone, Task, TaskComment } from "../../types";
+import { isLocalEditableTask, type AcceptanceCriterion, type Milestone, type Task, type TaskComment } from "../../types";
 import Modal from "./Modal";
-import { apiClient } from "../lib/api";
+import { ApiError, apiClient } from "../lib/api";
 import { useTheme } from "../contexts/ThemeContext";
 import MDEditor from "@uiw/react-md-editor";
 import AcceptanceCriteriaEditor from "./AcceptanceCriteriaEditor";
@@ -73,6 +73,14 @@ type TaskDetailsFormState = {
 const containsCommentDelimiterLine = (value: string): boolean => /^\s*---\s*$/m.test(value.replace(/\r\n/g, "\n"));
 
 const areJsonEqual = (first: unknown, second: unknown): boolean => JSON.stringify(first) === JSON.stringify(second);
+
+const isPartialDemotionError = (error: unknown): boolean =>
+	error instanceof ApiError &&
+	error.status !== undefined &&
+	error.status >= 500 &&
+	typeof error.data === "object" &&
+	error.data !== null &&
+	(error.data as { moved?: unknown }).moved === true;
 
 const isEditableKeyboardTarget = (target: EventTarget | null): boolean =>
   target instanceof Element &&
@@ -153,12 +161,17 @@ export const TaskDetailsModal: React.FC<Props> = ({
   // Promoting a draft replaces it with a new task ID, which the Drafts page does through its own
   // Promote action, so the popup shows the draft status without turning the field into a second one.
   const isOpenDraft = (task?.status ?? "").trim().toLowerCase() === "draft";
+  const demotionIdentity = [isOpen ? "open" : "closed", task?.id, task?.source, task?.branch, isOpenDraft ? "draft" : "task"].join("\0");
+  const demotionIdentityRef = useRef(demotionIdentity);
+  demotionIdentityRef.current = demotionIdentity;
   const [mode, setMode] = useState<Mode>(isCreateMode ? "create" : "preview");
   const modeRef = useRef(mode);
   const previousTaskId = useRef(task?.id ?? "");
   const previousIsOpen = useRef(isOpen);
   const formBaselineRef = useRef<TaskDetailsFormState | null>(null);
+  const activeDemotionRequest = useRef<{ identity: string } | null>(null);
   const [saving, setSaving] = useState(false);
+  const [demoting, setDemoting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Title field for create mode
@@ -414,6 +427,18 @@ export const TaskDetailsModal: React.FC<Props> = ({
   useEffect(() => {
     modeRef.current = mode;
   }, [mode]);
+
+  useEffect(
+    () => () => {
+      activeDemotionRequest.current = null;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    activeDemotionRequest.current = null;
+    setDemoting(false);
+  }, [demotionIdentity]);
 
   // Intercept Escape to cancel edit (not close modal) when in edit mode
   useEffect(() => {
@@ -930,8 +955,54 @@ export const TaskDetailsModal: React.FC<Props> = ({
 			onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
-    }
-  };
+		}
+	};
+
+	const handleDemote = async () => {
+		if (!task || !canDemote || activeDemotionRequest.current !== null) return;
+		if (!window.confirm(`Demote "${task.title}" to draft? It will be moved to the drafts folder.`)) return;
+
+		const request = { identity: demotionIdentity };
+		activeDemotionRequest.current = request;
+		const isCurrentRequest = () =>
+			activeDemotionRequest.current === request && demotionIdentityRef.current === request.identity;
+		setDemoting(true);
+		setError(null);
+		try {
+			await apiClient.demoteTask(task.id);
+			if (!isCurrentRequest()) return;
+			window.dispatchEvent(new window.Event("drafts-updated"));
+			if (onSaved) await onSaved();
+			if (!isCurrentRequest()) return;
+			onClose();
+		} catch (err) {
+			if (!isCurrentRequest()) return;
+			if (isPartialDemotionError(err)) {
+				window.dispatchEvent(new window.Event("drafts-updated"));
+				try {
+					if (onSaved) await onSaved();
+				} catch (refreshError) {
+					console.error("Task was demoted, but refreshing the Web UI failed", refreshError);
+				}
+				if (!isCurrentRequest()) return;
+				const message =
+					"The task was moved to drafts, but recording the Git commit failed. The view was refreshed; verify the draft before retrying.";
+				try {
+					window.alert(message);
+				} catch {
+					setError(message);
+				}
+				onClose();
+				return;
+			}
+			setError(err instanceof Error ? err.message : String(err));
+		} finally {
+			if (isCurrentRequest()) {
+				activeDemotionRequest.current = null;
+				setDemoting(false);
+			}
+		}
+	};
 
   const handleArchive = async () => {
     if (!task || !onArchive) return;
@@ -944,6 +1015,9 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const definitionCheckedCount = (definitionOfDone || []).filter((c) => c.checked).length;
   const definitionTotalCount = (definitionOfDone || []).length;
   const isDoneStatus = (status || "").toLowerCase().includes("done");
+  const canDemote = Boolean(
+		task && !isOpenDraft && isLocalEditableTask(task) && task.source !== "completed" && !isFromOtherBranch,
+	);
   const comments = displayComments;
 
   const displayId = task?.id ?? "";
@@ -953,6 +1027,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
     <Modal
       isOpen={isOpen}
       onClose={() => {
+		if (demoting) return;
         // When in edit mode, confirm closing if dirty
         if (mode === "edit" && isDirty) {
           if (!window.confirm("Discard unsaved changes and close?")) return;
@@ -962,7 +1037,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
       }}
       title={isCreateMode ? (isDraftMode ? "Create New Draft" : "Create New Task") : `${displayId} — ${task.title}`}
       maxWidthClass="max-w-5xl"
-      disableEscapeClose={mode === "edit" || mode === "create"}
+      disableEscapeClose={mode === "edit" || mode === "create" || demoting}
       actions={
         <div className="flex items-center gap-2">
 		          {isDoneStatus && mode === "preview" && !isCreateMode && !isFromOtherBranch && (
@@ -972,6 +1047,16 @@ export const TaskDetailsModal: React.FC<Props> = ({
 		              title="Move to completed folder (removes from board)"
 		            >
 		              Mark as completed
+		            </button>
+		          )}
+		          {canDemote && mode === "preview" && (
+		            <button
+		              onClick={() => void handleDemote()}
+		              disabled={demoting}
+		              className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-amber-500 dark:bg-amber-600 hover:bg-amber-600 dark:hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 dark:focus:ring-amber-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50"
+		              title="Move task to drafts"
+		            >
+		              {demoting ? "Demoting…" : "Demote to draft"}
 		            </button>
 		          )}
 		          {mode === "preview" && !isCreateMode && !isFromOtherBranch ? (

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -101,8 +101,9 @@ export class ApiClient {
 	}
 
 	// Enhanced fetch with retry logic and better error handling
-	private async fetchWithRetry(url: string, options: RequestInit = {}): Promise<Response> {
-		const { retries = 3, timeout = 10000 } = this.config;
+	private async fetchWithRetry(url: string, options: RequestInit = {}, retriesOverride?: number): Promise<Response> {
+		const { retries: configuredRetries = 3, timeout = 10000 } = this.config;
+		const retries = retriesOverride ?? configuredRetries;
 		let lastError: Error | undefined;
 
 		for (let attempt = 0; attempt <= retries; attempt++) {
@@ -154,6 +155,10 @@ export class ApiClient {
 			throw lastError;
 		}
 		throw new NetworkError(`Request failed after ${retries + 1} attempts: ${lastError?.message}`);
+	}
+
+	private async fetchWithoutRetry(url: string, options: RequestInit = {}): Promise<Response> {
+		return await this.fetchWithRetry(url, options, 0);
 	}
 
 	// Helper method for JSON responses
@@ -302,6 +307,12 @@ export class ApiClient {
 
 	async completeTask(id: string): Promise<void> {
 		await this.fetchWithRetry(`${API_BASE}/tasks/${id}/complete`, {
+			method: "POST",
+		});
+	}
+
+	async demoteTask(id: string): Promise<void> {
+		await this.fetchWithoutRetry(`${API_BASE}/tasks/${encodeURIComponent(id)}/demote`, {
 			method: "POST",
 		});
 	}


### PR DESCRIPTION
## Summary

- expose a confirmed demote-to-draft action for local active tasks
- delegate to canonical Core demotion through a focused Web endpoint
- publish a versioned cache removal and refresh task/draft views synchronously
- prevent stale modal continuations and disable retries for the non-idempotent mutation

## Testing

- ContentStore: 64 tests passed
- Web modal, API, and route: 37 tests passed
- server endpoint: 3 tests passed
- CLI task-state and draft lifecycle: 19 tests passed
- bunx tsc --noEmit
- bun run check .
- bun run build
- rendered desktop and narrow QA