### PR TITLE
BACK-626 - Make task lifecycle commands local-first

### DIFF
--- a/backlog/tasks/back-626 - Make-task-archive-complete-and-demote-local-first-like-view-and-edit.md
+++ b/backlog/tasks/back-626 - Make-task-archive-complete-and-demote-local-first-like-view-and-edit.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-626
 title: 'Make task archive, complete, and demote local-first like view and edit'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@shixi-li'
 created_date: '2026-08-10 06:10'
+updated_date: '2026-08-10 10:45'
 labels: []
 dependencies: []
 ordinal: 262000
@@ -17,15 +19,36 @@ Follow-up from the PR #898 (BACK-623) review. task archive, task complete, and t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 task archive, task complete, and task demote resolve targets through the shared local resolution used by task view and task edit
-- [ ] #2 None of the three commands triggers a remote fetch or cross-branch corpus load (fetch-tripwire test)
-- [ ] #3 Branch-only targets produce the same local not-found error and hint as task view
-- [ ] #4 Local fail-closed ambiguity (AmbiguousTaskIdError) is preserved for all three commands
+- [x] #1 task archive, task complete, and task demote resolve targets through the shared local resolution used by task view and task edit
+- [x] #2 None of the three commands triggers a remote fetch or cross-branch corpus load (fetch-tripwire test)
+- [x] #3 Branch-only targets produce the same local not-found error and hint as task view
+- [x] #4 Local fail-closed ambiguity (AmbiguousTaskIdError) is preserved for all three commands
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Route task archive, complete, and demote through the working-copy active/completed resolver for both CLI preflight and Core mutation.
+2. Extend local task command tests for fetch tripwires, branch-only not-found hints, and active/completed ID ambiguity across all three lifecycle commands.
+3. Run the focused suite, typecheck, formatting/lint checks, and the relevant full test suite; then finalize BACK-626 with objective evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Kept existing Core callers backward-compatible by adding an optional third TaskReadOptions argument; only the CLI lifecycle handlers request working-copy-only resolution.
+Validation: focused local task test 9/9; lifecycle/Core/MCP scoped suite 142/142; TypeScript, Biome, build, and git diff checks passed. Independent review found P0=0/P1=0.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made task archive, complete, and demote local-first at both CLI preflight and mutation boundaries. Branch-only targets now match view/edit guidance, remote/corpus loading is tripwired out, and local ID ambiguity remains fail-closed.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3372,9 +3372,9 @@ addHelpSchema(taskCmd.command("archive <taskId>"), {
 	.action(async (taskId: string) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
-		const task = await core.loadTaskById(taskId);
+		const task = await core.loadTaskById(taskId, { includeCrossBranch: false });
 		if (!task) {
-			console.error(`Task ${taskId} not found.`);
+			console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 			process.exitCode = 1;
 			return;
 		}
@@ -3396,7 +3396,7 @@ addHelpSchema(taskCmd.command("archive <taskId>"), {
 			return;
 		}
 
-		const success = await core.archiveTask(task.id);
+		const success = await core.archiveTask(task.id, undefined, { includeCrossBranch: false });
 		if (success) {
 			console.log(`Archived task ${task.id}`);
 		} else {
@@ -3427,10 +3427,10 @@ addHelpSchema(taskCmd.command("complete <taskId>"), {
 	.action(async (taskId: string) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
-		const task = await core.loadTaskById(taskId);
+		const task = await core.loadTaskById(taskId, { includeCrossBranch: false });
 
 		if (!task) {
-			console.error(`Task ${taskId} not found.`);
+			console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 			process.exitCode = 1;
 			return;
 		}
@@ -3453,7 +3453,7 @@ addHelpSchema(taskCmd.command("complete <taskId>"), {
 		}
 
 		const completedFilePath = task.filePath ? join(core.filesystem.completedDir, basename(task.filePath)) : undefined;
-		const success = await core.completeTask(task.id);
+		const success = await core.completeTask(task.id, undefined, { includeCrossBranch: false });
 		if (!success) {
 			console.error(`Failed to complete task: ${task.id}`);
 			process.exitCode = 1;
@@ -3473,11 +3473,11 @@ taskCmd
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		try {
-			const task = await core.loadTaskById(taskId);
-			if (task && (await core.demoteTask(task.id))) {
+			const task = await core.loadTaskById(taskId, { includeCrossBranch: false });
+			if (task && (await core.demoteTask(task.id, undefined, { includeCrossBranch: false }))) {
 				console.log(`Demoted task ${task.id}`);
 			} else {
-				console.error(`Task ${taskId} not found.`);
+				console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
 				process.exitCode = 1;
 			}
 		} catch (error) {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2725,8 +2725,8 @@ export class Core {
 		return { updatedTask, changedTasks };
 	}
 
-	async archiveTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const taskToArchive = await this.loadTaskForMutation(taskId);
+	async archiveTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
+		const taskToArchive = await this.loadTaskForMutation(taskId, options);
 		if (!taskToArchive) {
 			return false;
 		}
@@ -2841,8 +2841,8 @@ export class Core {
 		return result;
 	}
 
-	async completeTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const task = await this.loadTaskForMutation(taskId);
+	async completeTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
+		const task = await this.loadTaskForMutation(taskId, options);
 		if (!task) return false;
 		// Get paths before moving the file
 		const completedDir = this.fs.completedDir;
@@ -2959,8 +2959,8 @@ export class Core {
 		return moved !== null;
 	}
 
-	async demoteTask(taskId: string, autoCommit?: boolean): Promise<boolean> {
-		const task = await this.loadTaskForMutation(taskId);
+	async demoteTask(taskId: string, autoCommit?: boolean, options: TaskReadOptions = {}): Promise<boolean> {
+		const task = await this.loadTaskForMutation(taskId, options);
 		if (!task) return false;
 		const movedPaths: Array<{ previousPath: string; savedPath: string }> = [];
 		const success = await this.fs.demoteTask(task.id, (previousPath, savedPath) => {

--- a/src/test/local-task-command-performance.test.ts
+++ b/src/test/local-task-command-performance.test.ts
@@ -132,6 +132,18 @@ describe("local task command performance boundaries", () => {
 		}
 	});
 
+	it("archives, completes, and demotes working-copy tasks without loading branches", async () => {
+		const tripwires = installCrossBranchTripwires(core);
+		try {
+			expect(await core.archiveTask("TASK-1", false, { includeCrossBranch: false })).toBe(true);
+			expect(await core.completeTask("TASK-1.1", false, { includeCrossBranch: false })).toBe(true);
+			expect(await core.demoteTask("TASK-2", false, { includeCrossBranch: false })).toBe(true);
+			tripwires.expectUntouched();
+		} finally {
+			tripwires.restore();
+		}
+	});
+
 	it("keeps CLI reads, parent resolution, and dependency validation scoped to the working copy", async () => {
 		await $`git add .`.cwd(testDir).quiet();
 		await $`git commit -m ${"Commit working copy"}`.cwd(testDir).quiet();
@@ -151,6 +163,9 @@ describe("local task command performance boundaries", () => {
 			.cwd(testDir)
 			.nothrow()
 			.quiet();
+		const archive = await $`bun ${CLI_PATH} task archive TASK-99`.cwd(testDir).nothrow().quiet();
+		const complete = await $`bun ${CLI_PATH} task complete TASK-99`.cwd(testDir).nothrow().quiet();
+		const demote = await $`bun ${CLI_PATH} task demote TASK-99`.cwd(testDir).nothrow().quiet();
 		const parentFilter = await $`bun ${CLI_PATH} task list --parent TASK-99 --plain`.cwd(testDir).nothrow().quiet();
 		const parentCreate = await $`bun ${CLI_PATH} task create ${"Child of a branch task"} --parent TASK-99`
 			.cwd(testDir)
@@ -165,11 +180,21 @@ describe("local task command performance boundaries", () => {
 			`${result.stdout.toString()}${result.stderr.toString()}`;
 		// Every local miss names the working copy as the corpus it searched, so a task parked on
 		// another branch reads as scope rather than as a missing task.
-		for (const result of [view, shorthand, edit, parentFilter, parentCreate, dependencyEdit]) {
+		for (const result of [
+			view,
+			shorthand,
+			edit,
+			archive,
+			complete,
+			demote,
+			parentFilter,
+			parentCreate,
+			dependencyEdit,
+		]) {
 			expect(result.exitCode).not.toBe(0);
 			expect(outputOf(result)).toContain(LOCAL_TASK_LOOKUP_HINT);
 		}
-		for (const result of [view, shorthand, edit]) {
+		for (const result of [view, shorthand, edit, archive, complete, demote]) {
 			expect(outputOf(result)).toContain("Task TASK-99 not found.");
 		}
 		for (const result of [parentFilter, parentCreate]) {
@@ -286,6 +311,15 @@ describe("local task command performance boundaries", () => {
 					includeCrossBranch: false,
 				}),
 			).rejects.toBeInstanceOf(AmbiguousTaskIdError);
+			await expect(core.archiveTask(parentTask.id, false, { includeCrossBranch: false })).rejects.toBeInstanceOf(
+				AmbiguousTaskIdError,
+			);
+			await expect(core.completeTask(parentTask.id, false, { includeCrossBranch: false })).rejects.toBeInstanceOf(
+				AmbiguousTaskIdError,
+			);
+			await expect(core.demoteTask(parentTask.id, false, { includeCrossBranch: false })).rejects.toBeInstanceOf(
+				AmbiguousTaskIdError,
+			);
 			tripwires.expectUntouched();
 		} finally {
 			tripwires.restore();


### PR DESCRIPTION
## Summary

- make `task archive`, `task complete`, and `task demote` resolve their targets from the local working-copy task corpus
- pass the local-only option through the mutation boundary while preserving the existing default behavior for non-CLI Core callers
- align branch-only misses with the same actionable hint used by `task view` and `task edit`
- preserve fail-closed `AmbiguousTaskIdError` behavior for active/completed ID collisions

## Why

These three CLI commands still used the default cross-branch lookup twice: once during command preflight and again inside the Core mutation. That could trigger a remote fetch/full corpus load and produced different errors for tasks that exist only on another branch, despite the owner ruling that CLI task commands are local-only.

The Core methods now accept an optional third `TaskReadOptions` argument. Existing callers retain their current defaults; only the three CLI handlers opt into `includeCrossBranch: false` for both lookup stages.

## Validation

- `bun test --timeout=10000 src/test/local-task-command-performance.test.ts` — 9 passed
- lifecycle/Core/MCP scoped suite — 142 passed
- `bunx tsc --noEmit`
- `bun run check .`
- `bun run build`
- independent diff review: P0=0, P1=0

Closes BACK-626.
