### PR TITLE
BACK-634 - Fix web UI draft editing

### DIFF
--- a/backlog/tasks/back-634 - Fix-web-UI-draft-editing.md
+++ b/backlog/tasks/back-634 - Fix-web-UI-draft-editing.md
@@ -1,0 +1,70 @@
+---
+id: BACK-634
+title: Fix web UI draft editing
+status: Done
+assignee:
+  - '@Claude'
+created_date: '2026-08-15 13:17'
+updated_date: '2026-08-15 13:39'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/915'
+priority: high
+type: bug
+ordinal: 269000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+GitHub issue #915: creating a draft and then editing it from the web Drafts page fails with "Task not found: DRAFT-2"; the underlying PUT /api/tasks/DRAFT-2 returns HTTP 400 and GET returns 404. The web Drafts page has offered a click-to-edit affordance since the drafts UI shipped, but the browser API only ever resolved tasks: handleGetTask and handleUpdateTask go through the task-only content store, which never contains drafts. This is pre-existing, not a v1.50.x regression. The shared core model already implements draft editing (Core.editTaskOrDraft / updateDraftFromInput) and MCP task tools already use it, so the browser server is the only surface with a draft edit UI and no draft handling behind it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Saving an edit to a draft from the web Drafts page writes to the draft file instead of failing with "Task not found"
+- [x] #2 GET /api/tasks/<draft id> returns the draft instead of 404 so the browser resolves drafts and tasks through one path
+- [x] #3 Changing a draft status to a configured non-draft status through the browser API promotes the draft, matching MCP semantics
+- [x] #4 The web Drafts list reflects a saved draft edit without a manual page reload
+- [x] #5 Regression tests cover the reporter's flow (create draft, then PUT /api/tasks/DRAFT-2) and the promote-on-status-change path
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Root cause confirmed: src/server/index.ts handleGetTask (line 934) and handleUpdateTask (line 1065) resolve only tasks through the content store, so a DRAFT id 404s on GET and 400s on PUT with 'Task not found: DRAFT-2' thrown by Core.updateTaskFromInput (src/core/backlog.ts:2337).
+2. Simplify Core.editTaskOrDraft so the non-draft branch delegates straight to updateTaskFromInput instead of pre-loading with fs.loadTask and duplicating the demote branch. This keeps ambiguous-id detection and the task lock on the task path and removes duplicated logic.
+3. Point the browser PUT /api/tasks/:id at Core.editTaskOrDraft so drafts are edited, promoted on a non-draft status, and tasks keep today's behavior.
+4. Make handleGetTask fall back to the draft store when the id is not a task, matching MCP viewTask.
+5. Refresh the web Drafts list on every data refresh by dispatching the existing drafts-updated event from App.refreshData, and drop the now redundant conditional dispatch in handleSubmitTask.
+6. Add regression tests for the reporter's flow (create draft then PUT /api/tasks/DRAFT-2), the GET fallback, and promote-on-status-change.
+7. Gates: bunx tsc --noEmit, bun run check ., bun run test, bun run build.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: the browser task routes only ever resolved tasks. src/server/index.ts handleGetTask went straight to Core.getTask (task content store) and handleUpdateTask to Core.updateTaskFromInput, whose loadTaskForMutation resolves against the same task-only store, so DRAFT-2 fell through to the throw at src/core/backlog.ts:2337 ("Task not found: DRAFT-2") and the handler mapped it to HTTP 400. GET returned 404 for the same reason.
+
+Not a v1.50.x regression. git log -S"loadDraft" -- src/server/index.ts has no hits in the whole history, and the same repro reproduces byte-identically on published v1.49.3 and v1.50.0 (GET 404, PUT 400 "Task not found: DRAFT-2"). The web Drafts page has offered click-to-edit since the drafts UI landed in #225, and saving never worked. backlog task edit DRAFT-2 also fails on 1.49.3, 1.50.0 and 1.50.1, so the canonical CLI never edited drafts either; only the not-found wording changed in 1.50.1.
+
+Changes:
+- Core.editTaskOrDraft now delegates its non-draft branch to updateTaskFromInput instead of pre-loading with fs.loadTask and repeating the demote branch. updateTaskFromInput already demotes on a Draft status, resolves through the mutation index (identical record set to fs.loadTask: working-copy active tasks) and raises AmbiguousTaskIdError, so this removes duplicated logic without changing MCP behavior. It also takes TaskReadOptions so callers can pass read options through.
+- The browser PUT /api/tasks/:id routes DRAFT- ids to editTaskOrDraft and GET /api/tasks/:id serves them from the draft store. Draft ids are recognised by prefix (isDraftId), not by probing the draft store first, so a prefix-less id such as /api/tasks/2 keeps resolving to TASK-2 exactly as before instead of silently retargeting DRAFT-2.
+- App.refreshData dispatches the existing drafts-updated event, so the Drafts page reloads after any save; the conditional dispatch in handleSubmitTask became redundant and was removed.
+- The popup status field lists the status the record actually holds when it is not configured, so a draft reads Draft instead of falling back to the first option. The field is disabled for a draft: promoting changes the ID, and the Drafts page Promote action is the surface that reports the new one.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Made the browser serve drafts on the task routes it already pointed the Drafts page at. GET /api/tasks/DRAFT-x now returns the draft and PUT routes it through Core.editTaskOrDraft, so a draft edit saves (and a non-draft status promotes) instead of failing with HTTP 400 "Task not found: DRAFT-2". Draft ids are matched by prefix so /api/tasks/2 still resolves to TASK-2. Core.editTaskOrDraft lost its duplicated task branch to updateTaskFromInput, the Drafts page now reloads on the shared drafts-updated event after any save, and the popup status field shows a draft as Draft (disabled, because the Drafts page Promote action owns the ID change). Verified with new tests in server-drafts-endpoint (2 of 4 confirmed failing before the fix) and web-draft-editing (1 of 4 confirmed failing before the fix), plus a live browser walkthrough of the reporter flow: created a draft, edited title and acceptance criteria on the Drafts page, saw the draft file rewritten with status Draft, saw the list refresh without reload, and confirmed Promote to Task still works. Regression evidence recorded against published v1.49.3 and v1.50.0. bunx tsc --noEmit, bun run check ., bun run test (2253 pass, 6 skip, 0 fail) and bun run build all clean.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -2402,7 +2402,12 @@ export class Core {
 		return refreshed ?? draft;
 	}
 
-	async editTaskOrDraft(taskId: string, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {
+	async editTaskOrDraft(
+		taskId: string,
+		input: TaskUpdateInput,
+		autoCommit?: boolean,
+		options: TaskReadOptions = {},
+	): Promise<Task> {
 		const draft = await this.fs.loadDraft(taskId);
 		if (draft) {
 			const requestedStatus = input.status?.trim();
@@ -2413,18 +2418,9 @@ export class Core {
 			return await this.updateDraftFromInput(draft.id, input, autoCommit);
 		}
 
-		const task = await this.fs.loadTask(taskId);
-		if (!task) {
-			throw new Error(`Task not found: ${taskId}`);
-		}
-
-		const requestedStatus = input.status?.trim();
-		const wantsDraft = requestedStatus?.toLowerCase() === "draft";
-		if (wantsDraft) {
-			return await this.demoteTaskWithUpdates(task, input, autoCommit);
-		}
-
-		return await this.updateTaskFromInput(task.id, input, autoCommit);
+		// updateTaskFromInput already demotes when the requested status is Draft, resolves the id
+		// against the task store (so ambiguous ids still fail closed) and reports a missing task.
+		return await this.updateTaskFromInput(taskId, input, autoCommit, options);
 	}
 
 	private async promoteDraftWithUpdates(draft: Task, input: TaskUpdateInput, autoCommit?: boolean): Promise<Task> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,6 +22,7 @@ import { launchBrowser } from "../utils/browser-launch.ts";
 import type { BrowserLoadingState } from "../utils/browser-loading-state.ts";
 import { isAmbiguousIdError } from "../utils/entity-id.ts";
 import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
+import { DRAFT_PREFIX, extractAnyPrefix } from "../utils/prefix-config.ts";
 import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import { formatValidStatuses, getCanonicalStatuses, getValidStatuses } from "../utils/status.ts";
 import { isValidTaskId } from "../utils/task-id.ts";
@@ -32,6 +33,14 @@ import { getVersion } from "../utils/version.ts";
 const PREFIX_PATTERN = /^[a-zA-Z]+-/i;
 const DEFAULT_PREFIX = "task-";
 const DOCUMENT_TYPES = new Set<Document["type"]>(DOCUMENT_TYPE_VALUES);
+
+/**
+ * The task routes serve drafts too, so only an explicit DRAFT- id addresses a draft.
+ * A prefix-less id such as "2" keeps naming a task, which is what the task store resolves it to.
+ */
+function isDraftId(taskId: string): boolean {
+	return extractAnyPrefix(taskId) === DRAFT_PREFIX;
+}
 
 class DocumentPayloadValidationError extends Error {
 	constructor(message: string) {
@@ -933,6 +942,10 @@ export class BacklogServer {
 
 	private async handleGetTask(taskId: string): Promise<Response> {
 		if (!isValidTaskId(taskId)) return Response.json({ error: `Invalid task ID: ${taskId}` }, { status: 400 });
+		if (isDraftId(taskId)) {
+			const draft = await this.core.filesystem.loadDraft(taskId);
+			return draft ? Response.json(draft) : Response.json({ error: `Task ${taskId} not found` }, { status: 404 });
+		}
 		let resolvedTask: Task | null;
 		try {
 			resolvedTask = await this.core.getTask(taskId);
@@ -1062,7 +1075,10 @@ export class BacklogServer {
 		}
 
 		try {
-			const updatedTask = await this.core.updateTaskFromInput(taskId, updateInput);
+			// editTaskOrDraft keeps a draft a draft, or promotes it when a real status is requested.
+			const updatedTask = isDraftId(taskId)
+				? await this.core.editTaskOrDraft(taskId, updateInput)
+				: await this.core.updateTaskFromInput(taskId, updateInput);
 			return Response.json(updatedTask);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to update task";

--- a/src/test/server-drafts-endpoint.test.ts
+++ b/src/test/server-drafts-endpoint.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Core } from "../core/backlog.ts";
+import { FileSystem } from "../file-system/operations.ts";
+import { BacklogServer } from "../server/index.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, retry, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+let core: Core;
+let server: BacklogServer | null = null;
+let serverPort = 0;
+
+async function request(path: string, init?: RequestInit): Promise<Response> {
+	return await fetch(`http://127.0.0.1:${serverPort}${path}`, init);
+}
+
+async function put(path: string, body: unknown): Promise<Response> {
+	return await request(path, {
+		method: "PUT",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("BacklogServer draft task endpoints", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("server-drafts");
+		const filesystem = new FileSystem(TEST_DIR);
+		await filesystem.ensureBacklogStructure();
+		await filesystem.saveConfig({
+			projectName: "Server Drafts",
+			statuses: ["To Do", "In Progress", "Done"],
+			labels: [],
+			milestones: [],
+			dateFormat: "YYYY-MM-DD",
+			remoteOperations: false,
+			autoCommit: false,
+		});
+
+		core = new Core(TEST_DIR);
+
+		server = new BacklogServer(TEST_DIR);
+		await server.start(0, false);
+		const port = server.getPort();
+		expect(port).not.toBeNull();
+		serverPort = port ?? 0;
+
+		await retry(async () => {
+			const response = await request("/api/drafts");
+			expect(response.status).toBe(200);
+		});
+	});
+
+	afterEach(async () => {
+		if (server) {
+			await server.stop();
+			server = null;
+		}
+		await safeCleanup(TEST_DIR);
+	});
+
+	// Reporter flow from issue #915: create a draft, then edit it from the web Drafts page.
+	it("saves an edit to the second draft instead of reporting it as a missing task", async () => {
+		await core.createTaskFromInput({ title: "First draft", status: "Draft" });
+		await core.createTaskFromInput({ title: "Second draft", status: "Draft" });
+
+		const read = await request("/api/tasks/DRAFT-2");
+		expect(read.status).toBe(200);
+		expect(((await read.json()) as Task).title).toBe("Second draft");
+
+		const saved = await put("/api/tasks/DRAFT-2", {
+			title: "Second draft edited",
+			description: "Edited from the drafts page",
+			status: "Draft",
+			acceptanceCriteriaItems: [{ text: "Draft edits persist", checked: false }],
+		});
+		expect(saved.status).toBe(200);
+		const updated = (await saved.json()) as Task;
+		expect(updated.id).toBe("DRAFT-2");
+		expect(updated.title).toBe("Second draft edited");
+		expect(updated.status).toBe("Draft");
+
+		const stored = await core.filesystem.loadDraft("DRAFT-2");
+		expect(stored?.title).toBe("Second draft edited");
+		expect(stored?.description).toContain("Edited from the drafts page");
+		expect(stored?.acceptanceCriteriaItems?.[0]?.text).toBe("Draft edits persist");
+
+		// The edit must not move the draft into the task folder.
+		expect(await core.filesystem.loadTask("DRAFT-2")).toBeNull();
+		const drafts = (await (await request("/api/drafts")).json()) as Task[];
+		expect(drafts.map((draft) => draft.title)).toEqual(["First draft", "Second draft edited"]);
+	});
+
+	it("promotes a draft when the request sets a configured status", async () => {
+		await core.createTaskFromInput({ title: "Promote me", status: "Draft" });
+
+		const response = await put("/api/tasks/DRAFT-1", { title: "Promote me", status: "To Do" });
+		expect(response.status).toBe(200);
+		const promoted = (await response.json()) as Task;
+		expect(promoted.id).toBe("TASK-1");
+		expect(promoted.status).toBe("To Do");
+
+		expect(await core.filesystem.loadDraft("DRAFT-1")).toBeNull();
+		expect((await request("/api/tasks/TASK-1")).status).toBe(200);
+	});
+
+	it("keeps a prefix-less id pointing at the task with that number", async () => {
+		await core.createTaskFromInput({ title: "Real task one", status: "To Do" });
+		await core.createTaskFromInput({ title: "Only draft", status: "Draft" });
+
+		const read = await request("/api/tasks/1");
+		expect(read.status).toBe(200);
+		expect(((await read.json()) as Task).id).toBe("TASK-1");
+
+		const response = await put("/api/tasks/1", { title: "Real task one edited" });
+		expect(response.status).toBe(200);
+		expect(((await response.json()) as Task).id).toBe("TASK-1");
+		expect((await core.filesystem.loadDraft("DRAFT-1"))?.title).toBe("Only draft");
+	});
+
+	it("reports an unknown draft id as missing", async () => {
+		const read = await request("/api/tasks/DRAFT-9");
+		expect(read.status).toBe(404);
+
+		const write = await put("/api/tasks/DRAFT-9", { title: "Nope" });
+		expect(write.status).toBe(400);
+	});
+});

--- a/src/test/web-draft-editing.test.tsx
+++ b/src/test/web-draft-editing.test.tsx
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import type { Task } from "../types/index.ts";
+import DraftsList from "../web/components/DraftsList.tsx";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
+import { TaskIdIndexProvider } from "../web/contexts/TaskIdIndexContext.tsx";
+import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
+
+let activeRoot: Root | null = null;
+const originalFetch = globalThis.fetch;
+
+function draft(id: string, title: string): Task {
+	return {
+		id,
+		title,
+		status: "Draft",
+		assignee: [],
+		labels: [],
+		dependencies: [],
+		createdDate: "2026-08-15 10:00",
+	};
+}
+
+function setupDom(): HTMLElement {
+	const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { url: "http://localhost" });
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = dom.window as unknown as Window & typeof globalThis;
+	globalThis.document = dom.window.document as unknown as typeof globalThis.document;
+	globalThis.navigator = dom.window.navigator as unknown as Navigator;
+	globalThis.localStorage = dom.window.localStorage;
+	globalThis.Element = dom.window.Element;
+	globalThis.HTMLElement = dom.window.HTMLElement;
+	globalThis.HTMLInputElement = dom.window.HTMLInputElement;
+	globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+	globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => dom.window.setTimeout(callback, 0);
+	globalThis.cancelAnimationFrame = (handle: number) => dom.window.clearTimeout(handle);
+	window.matchMedia = (() => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} })) as never;
+	const htmlElementPrototype = dom.window.HTMLElement.prototype as unknown as {
+		attachEvent?: () => void;
+		detachEvent?: () => void;
+	};
+	htmlElementPrototype.attachEvent = () => {};
+	htmlElementPrototype.detachEvent = () => {};
+	return dom.window.document.getElementById("root") as unknown as HTMLElement;
+}
+
+function serveJson(body: () => unknown): void {
+	globalThis.fetch = (async () =>
+		new Response(JSON.stringify(body()), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		})) as unknown as typeof globalThis.fetch;
+}
+
+/** Serves /api/drafts from a mutable list so a reload can observe a saved edit. */
+function serveDrafts(current: () => Task[]): void {
+	serveJson(current);
+}
+
+function serveStatuses(): void {
+	serveJson(() => ["To Do", "In Progress", "Done"]);
+}
+
+async function renderDrafts(onEditTask: (task: Task) => void): Promise<HTMLElement> {
+	const container = setupDom();
+	activeRoot = createRoot(container);
+	await act(async () => {
+		activeRoot?.render(
+			<ThemeProvider>
+				<DraftsList onEditTask={onEditTask} onNewDraft={() => {}} />
+			</ThemeProvider>,
+		);
+		await Promise.resolve();
+	});
+	return container;
+}
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => activeRoot?.unmount());
+		activeRoot = null;
+	}
+	globalThis.fetch = originalFetch;
+});
+
+describe("Web drafts list", () => {
+	it("opens the clicked draft for editing", async () => {
+		serveDrafts(() => [draft("DRAFT-1", "First draft"), draft("DRAFT-2", "Second draft")]);
+		const edited: Task[] = [];
+		const container = await renderDrafts((task) => edited.push(task));
+
+		const headings = Array.from(container.querySelectorAll("h3"));
+		const target = headings.find((heading) => heading.textContent === "Second draft");
+		expect(target).toBeTruthy();
+
+		await act(async () => {
+			target?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		expect(edited.map((task) => task.id)).toEqual(["DRAFT-2"]);
+	});
+
+	// App.refreshData fires this event after every save, so a draft edit shows up without a reload.
+	it("reloads the drafts when a drafts-updated event fires", async () => {
+		let drafts = [draft("DRAFT-1", "First draft")];
+		serveDrafts(() => drafts);
+		const container = await renderDrafts(() => {});
+		expect(container.textContent).toContain("First draft");
+
+		drafts = [draft("DRAFT-1", "Reviewed scope")];
+		await act(async () => {
+			window.dispatchEvent(new window.Event("drafts-updated"));
+			await Promise.resolve();
+		});
+
+		expect(container.textContent).toContain("Reviewed scope");
+		expect(container.textContent).not.toContain("First draft");
+	});
+});
+
+describe("Web task popup status field", () => {
+	async function renderModal(task: Task): Promise<HTMLElement> {
+		const container = setupDom();
+		activeRoot = createRoot(container);
+		await act(async () => {
+			activeRoot?.render(
+				<MemoryRouter initialEntries={["/"]}>
+					<ThemeProvider>
+						<TaskIdIndexProvider tasks={[task]}>
+							<TaskDetailsModal task={task} isOpen={true} onClose={() => {}} />
+						</TaskIdIndexProvider>
+					</ThemeProvider>
+				</MemoryRouter>,
+			);
+			await Promise.resolve();
+		});
+		return container;
+	}
+
+	function statusField(container: HTMLElement): { options: string[]; selected?: string; disabled?: boolean } {
+		const select = container.querySelector("select") as HTMLSelectElement | null;
+		expect(select).toBeTruthy();
+		return {
+			options: Array.from(select?.options ?? []).map((option) => option.value),
+			selected: select?.value,
+			disabled: select?.disabled,
+		};
+	}
+
+	it("shows the status a draft actually has instead of the first configured status", async () => {
+		serveStatuses();
+		const container = await renderModal(draft("DRAFT-1", "Draft under review"));
+
+		const { options, selected, disabled } = statusField(container);
+		expect(options).toEqual(["Draft", "To Do", "In Progress", "Done"]);
+		expect(selected).toBe("Draft");
+		// Promotion stays on the Drafts page action, which is the only place that reports the new ID.
+		expect(disabled).toBe(true);
+	});
+
+	it("offers only the configured statuses for a task", async () => {
+		serveStatuses();
+		const container = await renderModal({
+			id: "TASK-1",
+			title: "Ordinary task",
+			status: "To Do",
+			assignee: [],
+			labels: [],
+			dependencies: [],
+			createdDate: "2026-08-15 10:00",
+		});
+
+		const { options, selected, disabled } = statusField(container);
+		expect(options).toEqual(["To Do", "In Progress", "Done"]);
+		expect(selected).toBe("To Do");
+		expect(disabled).toBe(false);
+	});
+});

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -543,6 +543,9 @@ function AppContent() {
 
   const refreshData = useCallback(async () => {
     await loadAllData();
+    // Drafts are loaded by the drafts page, not by loadAllData, and creating, editing, promoting or
+    // demoting a task can change them, so tell that page to reload whenever the rest of the data does.
+    window.dispatchEvent(new Event('drafts-updated'));
   }, [loadAllData]);
 
 	const applyReorderedTasks = useCallback((updatedTasks: Task[], requestTask: Task) => {
@@ -625,12 +628,6 @@ function AppContent() {
     }
     handleCloseModal();
     await refreshData();
-
-    // If we're on the drafts page and created a draft, trigger a refresh
-    if (isDraftMode && window.location.pathname === '/drafts') {
-      // Trigger refresh by updating a timestamp that DraftsList can watch
-      window.dispatchEvent(new Event('drafts-updated'));
-    }
   };
 
   const handleArchiveTask = async (taskId: string) => {

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -148,6 +148,9 @@ export const TaskDetailsModal: React.FC<Props> = ({
   const { theme } = useTheme();
   const isCreateMode = !task;
   const isFromOtherBranch = Boolean(task?.branch);
+  // Promoting a draft replaces it with a new task ID, which the Drafts page does through its own
+  // Promote action, so the popup shows the draft status without turning the field into a second one.
+  const isOpenDraft = (task?.status ?? "").trim().toLowerCase() === "draft";
   const [mode, setMode] = useState<Mode>(isCreateMode ? "create" : "preview");
   const modeRef = useRef(mode);
   const previousTaskId = useRef(task?.id ?? "");
@@ -1394,7 +1397,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
           {/* Status */}
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
             <SectionHeader title="Status" />
-            <StatusSelect current={status} onChange={(val) => handleInlineMetaUpdate({ status: val })} disabled={isFromOtherBranch} />
+            <StatusSelect current={status} onChange={(val) => handleInlineMetaUpdate({ status: val })} disabled={isFromOtherBranch || isOpenDraft} />
           </div>
 
           {/* Type */}
@@ -1545,6 +1548,9 @@ const StatusSelect: React.FC<{ current: string; onChange: (v: string) => void; d
   useEffect(() => {
     apiClient.fetchStatuses().then(setStatuses).catch(() => setStatuses(["To Do", "In Progress", "Done"]));
   }, []);
+  // A draft is on status Draft, and a completed record can hold a historical status, neither of
+  // which is configured. Showing the value the record actually has beats showing the first option.
+  const options = !current || statuses.includes(current) ? statuses : [current, ...statuses];
   return (
     <select
       className={`w-full h-10 px-3 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200 ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
@@ -1552,7 +1558,7 @@ const StatusSelect: React.FC<{ current: string; onChange: (v: string) => void; d
       onChange={(e) => onChange(e.target.value)}
       disabled={disabled}
     >
-      {statuses.map((s) => (
+      {options.map((s) => (
         <option key={s} value={s}>{s}</option>
       ))}
     </select>


### PR DESCRIPTION
Fixes #915

## Symptom

Create a draft in the web UI, click it on the Drafts page, edit it, save:

```
Task not found: DRAFT-2
```

`PUT /api/tasks/DRAFT-2` answers HTTP 400, and `GET /api/tasks/DRAFT-2` answers HTTP 404.

## Root cause

The Drafts page has always opened the task popup for the row you click
(`DraftsList` -> `onEditTask`), and that popup saves through `PUT /api/tasks/:id`.
The browser task routes only ever resolved *tasks*:

- `handleGetTask` (`src/server/index.ts`) calls `Core.getTask`, which resolves against the task content store.
- `handleUpdateTask` calls `Core.updateTaskFromInput`, whose `loadTaskForMutation` resolves against the same task-only store.

Drafts live in `backlog/drafts/` and are never in that store, so `DRAFT-2` fell through
to `throw new Error(\`Task not found: ${taskId}\`)` at `src/core/backlog.ts:2337`, which the
handler maps to HTTP 400. The GET 404 has the same cause.

The shared model already knew how to do this: `Core.editTaskOrDraft` /
`Core.updateDraftFromInput` exist and the MCP task tools already use them. The browser
was the only surface with a draft edit UI and no draft handling behind it.

## Not a v1.50.x regression

| flow | v1.49.3 | v1.50.0 | v1.50.1 | this PR |
| --- | --- | --- | --- | --- |
| `GET /api/tasks/DRAFT-2` | 404 | 404 | 404 | 200, returns the draft |
| `PUT /api/tasks/DRAFT-2` | 400 `Task not found: DRAFT-2` | 400 `Task not found: DRAFT-2` | 400 `Task not found: DRAFT-2` | 200, draft file rewritten |
| `PUT /api/tasks/DRAFT-1` with `status: "To Do"` | 400 | 400 | 400 | 200, promoted to `TASK-n` |
| `GET`/`PUT /api/tasks/2` with `TASK-2` and `DRAFT-2` present | `TASK-2` | `TASK-2` | `TASK-2` | `TASK-2` (unchanged) |
| web Drafts list after a save | stale until reload | stale until reload | stale until reload | reloads |

v1.49.3 and v1.50.0 rows were measured against the published packages
(`bunx backlog.md@1.49.3` / `@1.50.0`) in throwaway projects, not read off the source.
`git log -S"loadDraft" -- src/server/index.ts` has no hits in the entire history: the
browser has never resolved drafts, so this has been broken since the drafts UI landed
in #225.

## Changes

- **`src/server/index.ts`** — `GET /api/tasks/:id` serves `DRAFT-` ids from the draft store, and `PUT /api/tasks/:id` routes them through `Core.editTaskOrDraft` (which keeps a draft a draft, or promotes it when a configured status is requested). Draft ids are recognised by prefix (`isDraftId`) rather than by probing the draft store first, so a prefix-less id such as `/api/tasks/2` keeps resolving to `TASK-2` instead of silently retargeting `DRAFT-2`.
- **`src/core/backlog.ts`** — `editTaskOrDraft` delegates its non-draft branch to `updateTaskFromInput` instead of pre-loading with `fs.loadTask` and repeating the demote branch. `updateTaskFromInput` already demotes on a `Draft` status, resolves through the mutation index (same record set `fs.loadTask` reads: working-copy active tasks) and raises `AmbiguousTaskIdError`, so this deletes duplicated logic without changing MCP behavior. It also accepts `TaskReadOptions`.
- **`src/web/App.tsx`** — `refreshData` dispatches the existing `drafts-updated` event, so the Drafts page reloads after any save; the conditional dispatch in `handleSubmitTask` became redundant and is gone.
- **`src/web/components/TaskDetailsModal.tsx`** — the status field lists the status the record actually holds when it is not a configured status, so a draft reads `Draft` instead of falling back to the first option. The field is disabled for a draft: promoting changes the ID, and the Drafts page **Promote to Task** action is the surface that reports the new one. No new promote/demote affordance is added here (BACK-419 still owns that decision).

## Verification

New tests, each confirmed failing before the fix:

- `src/test/server-drafts-endpoint.test.ts` — the reporter's exact flow (create two drafts, `PUT /api/tasks/DRAFT-2`), promote-on-status-change, the prefix-less-id guard, and unknown draft ids. 2 of 4 fail without the server/core change.
- `src/test/web-draft-editing.test.tsx` — the Drafts page click-to-edit affordance, the `drafts-updated` reload, and the popup status field for a draft vs a task. 1 of 4 fails without the web change.

Live browser walkthrough of the reported flow against a throwaway project: created a
draft, opened it from the Drafts page, edited the title and added an acceptance
criterion, saved with no error, confirmed the draft file was rewritten with
`status: Draft`, confirmed the Drafts list refreshed without a reload, and confirmed
**Promote to Task** still works.

Gates: `bunx tsc --noEmit` clean, `bun run check .` clean, `bun run test` 2253 pass /
6 skip / 0 fail, `bun run build` clean.

## For the maintainer

Two adjacent gaps found while investigating, left alone as product decisions:

1. The canonical CLI still cannot edit a draft — `backlog task edit DRAFT-2` fails on 1.49.3, 1.50.0 and 1.50.1 (only the not-found wording changed in 1.50.1) and `backlog draft` has no `edit` subcommand, while MCP `task_edit` has handled drafts since #430. Worth deciding whether the CLI should adopt it.
2. `DELETE /api/tasks/DRAFT-x` (the popup's Archive button on a draft) still fails, because `Core.archiveTask` resolves tasks only. `Core.archiveDraft` exists and MCP already uses it.
