### PR TITLE
BACK-222.1 - Show parent and subtask hierarchy in the web task details modal

### DIFF
--- a/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
+++ b/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
@@ -1,0 +1,72 @@
+---
+id: BACK-222.1
+title: Show parent and subtask hierarchy in the web task details modal
+status: Done
+assignee:
+  - '@yss19850810-crypto'
+created_date: '2026-08-17 07:26'
+updated_date: '2026-08-17 07:27'
+labels: []
+dependencies: []
+parent_task_id: BACK-222
+ordinal: 272000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The task model has carried `parentTaskId` since early on, and the CLI, TUI and MCP surfaces all present the hierarchy it describes: `task-plain-text.ts` prints `Parent:` and `Subtasks (n):`, and the CLI kanban has indented children under their parent since BACK-24. The browser never caught up — a grep for `parentTaskId` or `subtask` across `src/web/` matches nothing but a test file.
+
+Open a parent task in the browser today and the sidebar shows Status, Labels, Milestone and Dependencies, but gives no hint that the task has children at all, nor that a child belongs to anything.
+
+This is the task details slice of BACK-222. It covers that view only; the board and All Tasks views described by the parent task remain open.
+
+Progress counts direct children only, so a parent that is not itself terminal does not inflate its own parent's total; a child that has children of its own carries its nested count on its row. Completion is decided by `isTerminalStatus` against the project's configured statuses rather than substring matching, so custom status sets behave correctly.
+
+Contributed by @yss19850810-crypto.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The task details modal shows a Parent section with the parent task's id, title and status when the task has one
+- [x] #2 The task details modal shows a Subtasks section listing direct children with their id, title and status
+- [x] #3 The Subtasks heading carries a completed/total count derived from the project's configured terminal status, not substring matching
+- [x] #4 A child that has children of its own shows its nested completed/total count on its row
+- [x] #5 Parent and subtask rows navigate to canonical task routes and preserve existing close and back behaviour
+- [x] #6 Tasks with no children render no Subtasks section, and tasks with no parent render no Parent section
+- [x] #7 The derivation lives in shared pure functions so the board, All Tasks and the TUI can reuse it without a second implementation
+- [x] #8 Tests cover the no-child case, progress counting, nested counts, canonical navigation and the parent section
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Derived in the browser from the corpus the modal already receives as `availableTasks`, rather than extending the server payload. `GET /api/tasks` already carries `parentTaskId` and each task's status, so no server change was needed; `GET /api/task/:id` carries neither, which is why the single-task payload is not the source here.
+
+`attachSubtaskSummaries` was deliberately left untouched. Its return type is `Task` and `subtaskSummaries` is already part of the JSON contract, so adding status to it would widen a frozen public surface for a browser-only need. The three new functions sit beside it as plain derivations instead:
+
+- `summarizeSubtaskProgress(task, tasks, statuses)` returns `{ total, completed }` or `null` when there are no children, so callers render nothing rather than an empty state
+- `findDirectSubtasks(task, tasks)` returns direct children only, ordered by `sortByTaskId`
+- `findParentTask(task, tasks)` resolves the parent, or `null` when it is outside the corpus
+
+Completion uses `isTerminalStatus`. The two existing `isDoneStatus` helpers in `core/milestones.ts` and `ui/board.ts` hardcode "done"/"complete" substrings, disagree with each other, and would misreport any project whose terminal status is named differently — neither was reused.
+
+Navigation goes through the existing `handleEditTask` in `App.tsx`, passed down as `onNavigateToTask`. That path already builds canonical `/tasks/:id/:title` routes and threads `taskModalFrom`, so close and back behave exactly as they did before; the modal itself stays free of routing concerns.
+
+Two notes for reviewers:
+
+`taskIdsEqual` is imported from `utils/task-id.ts` rather than the `utils/task-path.ts` re-export. `task-path.ts` pulls in `node:path` and `core/backlog.ts`, which breaks the browser bundle with `graceful-fs` requiring `fs`, `util` and `assert`. This was verified by building clean `main` first to confirm the failure was introduced here.
+
+The status dot uses the project's `rounded-circle` utility, not `rounded-full` — `src/web/styles/source.css` explicitly disables the latter via `@source not inline("{rounded-full}")`, so it silently renders square.
+
+Verification: `bunx tsc --noEmit` clean; `bun run lint` 375 files with no fixes applied; `bun run build` clean; new tests 10 + 8 pass; the existing `web-task-details-modal-modified-files` suite still 5 pass. Browser QA against two real projects — a six-child parent reading 6/6, and a three-level tree reading 5/6 with its `To Do` child annotated 1/4 — with parent and child navigation checked in both directions.
+
+`bun run check .` is not reported as passing: on Windows the repo's `* text=auto` gitattribute produces CRLF worktree files that biome's formatter rejects wholesale, independently of this change. Committed blobs are LF, and `bun run lint` is clean. A maintainer on Linux or macOS, or CI, should see the formatter pass.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
+++ b/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-222.1
 title: Show parent and subtask hierarchy in the web task details modal
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-17 07:26'
-updated_date: '2026-08-19 21:34'
+updated_date: '2026-08-19 21:46'
 labels: []
 dependencies: []
 parent_task_id: BACK-222
@@ -83,3 +83,9 @@ Maintainer follow-up: responsive modal-header and hierarchy-title polish request
 
 Rendered QA after maintainer polish (in-app Browser): board and All Tasks parent-to-child and child-parent routes checked at 1280x720 and 390x844. The shared modal header has no title/action overlap at 390px, no horizontal overflow, and hierarchy rows remain keyboard-semantic buttons with status sr-only labels and canonical route metadata. Parent subtasks row is readable across two lines; child Parent row is readable across two lines. Empty BACK-633 modal renders no Parent/Subtasks section. Dark and light theme hierarchy states were checked; no framework overlays or console warnings/errors observed. Screenshots: /private/tmp/pr917-after-parent-desktop-visible.png, /private/tmp/pr917-after-child-desktop.png, /private/tmp/pr917-after-parent-mobile.png, /private/tmp/pr917-after-child-mobile.png, /private/tmp/pr917-after-parent-light-desktop.png.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Implemented and verified BACK-222.1. The shared Modal header now gives long titles a dedicated mobile row and keeps actions clear at 390px; parent/subtask rows reuse the existing two-line task-card treatment and retain canonical navigation, status semantics, accessibility labels, and theme classes. In-app Browser QA covered Board and All Tasks parent/child navigation at 1280x720 and 390x844, dark/light themes, the empty BACK-633 state, no horizontal overflow, no framework overlay, and no console warnings/errors. Screenshots: /private/tmp/pr917-after-parent-desktop-visible.png, /private/tmp/pr917-after-child-desktop.png, /private/tmp/pr917-after-parent-mobile.png, /private/tmp/pr917-after-child-mobile.png, /private/tmp/pr917-after-parent-light-desktop.png. GitHub Actions run 32304774065 passed all seven current-head jobs; current-head Codex approval is review 4977021284. The exact bun run check . DoD item remains unchecked because that separate local command was not run.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
+++ b/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-222.1
 title: Show parent and subtask hierarchy in the web task details modal
-status: Done
+status: In Progress
 assignee:
-  - '@yss19850810-crypto'
+  - '@codex'
 created_date: '2026-08-17 07:26'
-updated_date: '2026-08-17 07:27'
+updated_date: '2026-08-19 21:34'
 labels: []
 dependencies: []
 parent_task_id: BACK-222
@@ -45,6 +45,15 @@ Contributed by @yss19850810-crypto.
 - [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Keep the accepted parent/subtask hierarchy and preserve existing routes, clients, accessibility, and theme classes.
+2. Use one shared responsive Modal header layout so long task titles and actions do not overlap at 390px.
+3. Make hierarchy row titles readable with the existing task-card wrapping pattern, without new controls or data fetching.
+4. Verify board and All Tasks navigation in the in-app Browser at desktop and mobile sizes, then record evidence and finalize after PR review and CI.
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
@@ -69,4 +78,8 @@ The status dot uses the project's `rounded-circle` utility, not `rounded-full` �
 Verification: `bunx tsc --noEmit` clean; `bun run lint` 375 files with no fixes applied; `bun run build` clean; new tests 10 + 8 pass; the existing `web-task-details-modal-modified-files` suite still 5 pass. Browser QA against two real projects — a six-child parent reading 6/6, and a three-level tree reading 5/6 with its `To Do` child annotated 1/4 — with parent and child navigation checked in both directions.
 
 `bun run check .` is not reported as passing: on Windows the repo's `* text=auto` gitattribute produces CRLF worktree files that biome's formatter rejects wholesale, independently of this change. Committed blobs are LF, and `bun run lint` is clean. A maintainer on Linux or macOS, or CI, should see the formatter pass.
+
+Maintainer follow-up: responsive modal-header and hierarchy-title polish requested after rendered mobile QA. No product semantics or data flow changes.
+
+Rendered QA after maintainer polish (in-app Browser): board and All Tasks parent-to-child and child-parent routes checked at 1280x720 and 390x844. The shared modal header has no title/action overlap at 390px, no horizontal overflow, and hierarchy rows remain keyboard-semantic buttons with status sr-only labels and canonical route metadata. Parent subtasks row is readable across two lines; child Parent row is readable across two lines. Empty BACK-633 modal renders no Parent/Subtasks section. Dark and light theme hierarchy states were checked; no framework overlays or console warnings/errors observed. Screenshots: /private/tmp/pr917-after-parent-desktop-visible.png, /private/tmp/pr917-after-child-desktop.png, /private/tmp/pr917-after-parent-mobile.png, /private/tmp/pr917-after-child-mobile.png, /private/tmp/pr917-after-parent-light-desktop.png.
 <!-- SECTION:NOTES:END -->

--- a/src/test/subtask-progress.test.ts
+++ b/src/test/subtask-progress.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "../types/index.ts";
+import { findDirectSubtasks, findParentTask, summarizeSubtaskProgress } from "../utils/task-subtasks.ts";
+
+const STATUSES = ["To Do", "In Progress", "Done"] as const;
+
+function makeTask(id: string, status: string, parentTaskId?: string): Task {
+	return {
+		id,
+		title: `Task ${id}`,
+		status,
+		assignee: [],
+		createdDate: "2026-08-17",
+		labels: [],
+		dependencies: [],
+		rawContent: "",
+		...(parentTaskId ? { parentTaskId } : {}),
+	} as Task;
+}
+
+describe("summarizeSubtaskProgress", () => {
+	it("returns null when the task has no subtasks", () => {
+		const tasks = [makeTask("TASK-1", "To Do"), makeTask("TASK-2", "Done")];
+		expect(summarizeSubtaskProgress(tasks[0] as Task, tasks, STATUSES)).toBeNull();
+	});
+
+	it("counts only direct children, not grandchildren", () => {
+		const tasks = [
+			makeTask("TASK-2", "In Progress"),
+			makeTask("TASK-2.1", "Done", "TASK-2"),
+			makeTask("TASK-2.2", "Done", "TASK-2"),
+			makeTask("TASK-2.3", "Done", "TASK-2"),
+			makeTask("TASK-2.4", "Done", "TASK-2"),
+			makeTask("TASK-2.5", "Done", "TASK-2"),
+			makeTask("TASK-2.6", "To Do", "TASK-2"),
+			makeTask("TASK-2.6.1", "Done", "TASK-2.6"),
+			makeTask("TASK-2.6.2", "To Do", "TASK-2.6"),
+			makeTask("TASK-2.6.3", "To Do", "TASK-2.6"),
+			makeTask("TASK-2.6.4", "To Do", "TASK-2.6"),
+		];
+		expect(summarizeSubtaskProgress(tasks[0] as Task, tasks, STATUSES)).toEqual({ total: 6, completed: 5 });
+		expect(summarizeSubtaskProgress(tasks[6] as Task, tasks, STATUSES)).toEqual({ total: 4, completed: 1 });
+	});
+
+	it("treats only the configured terminal status as complete", () => {
+		const tasks = [
+			makeTask("TASK-1", "To Do"),
+			makeTask("TASK-1.1", "Done", "TASK-1"),
+			makeTask("TASK-1.2", "In Progress", "TASK-1"),
+			makeTask("TASK-1.3", "To Do", "TASK-1"),
+		];
+		expect(summarizeSubtaskProgress(tasks[0] as Task, tasks, STATUSES)).toEqual({ total: 3, completed: 1 });
+	});
+
+	it("honours a custom terminal status from project config", () => {
+		const customStatuses = ["Backlog", "Doing", "Shipped"] as const;
+		const tasks = [
+			makeTask("TASK-1", "Doing"),
+			makeTask("TASK-1.1", "Shipped", "TASK-1"),
+			makeTask("TASK-1.2", "Done", "TASK-1"),
+		];
+		expect(summarizeSubtaskProgress(tasks[0] as Task, tasks, customStatuses)).toEqual({ total: 2, completed: 1 });
+	});
+
+	it("matches parent ids that differ only by zero padding or case", () => {
+		const tasks = [
+			makeTask("TASK-7", "To Do"),
+			makeTask("TASK-7.1", "Done", "task-007"),
+			makeTask("TASK-7.2", "To Do", "TASK-7"),
+		];
+		expect(summarizeSubtaskProgress(tasks[0] as Task, tasks, STATUSES)).toEqual({ total: 2, completed: 1 });
+	});
+});
+
+describe("findDirectSubtasks", () => {
+	it("returns only direct children, sorted hierarchically", () => {
+		const tasks = [
+			makeTask("TASK-5", "To Do"),
+			makeTask("TASK-5.10", "To Do", "TASK-5"),
+			makeTask("TASK-5.2", "Done", "TASK-5"),
+			makeTask("TASK-5.2.1", "Done", "TASK-5.2"),
+			makeTask("TASK-6", "To Do"),
+		];
+		expect(findDirectSubtasks(tasks[0] as Task, tasks).map((t) => t.id)).toEqual(["TASK-5.2", "TASK-5.10"]);
+	});
+
+	it("returns an empty array when there are no children", () => {
+		const tasks = [makeTask("TASK-1", "To Do")];
+		expect(findDirectSubtasks(tasks[0] as Task, tasks)).toEqual([]);
+	});
+});
+
+describe("findParentTask", () => {
+	it("resolves the parent task", () => {
+		const tasks = [makeTask("TASK-3", "To Do"), makeTask("TASK-3.1", "To Do", "TASK-3")];
+		expect(findParentTask(tasks[1] as Task, tasks)?.id).toBe("TASK-3");
+	});
+
+	it("returns null when the task has no parent", () => {
+		const tasks = [makeTask("TASK-3", "To Do")];
+		expect(findParentTask(tasks[0] as Task, tasks)).toBeNull();
+	});
+
+	it("returns null when the parent is missing from the corpus", () => {
+		const tasks = [makeTask("TASK-3.1", "To Do", "TASK-3")];
+		expect(findParentTask(tasks[0] as Task, tasks)).toBeNull();
+	});
+});

--- a/src/test/web-task-details-modal-subtasks.test.tsx
+++ b/src/test/web-task-details-modal-subtasks.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { renderToString } from "react-dom/server";
+import type { Task } from "../types/index.ts";
+import { TaskDetailsModal } from "../web/components/TaskDetailsModal";
+import { ThemeProvider } from "../web/contexts/ThemeContext";
+
+const STATUSES = ["To Do", "In Progress", "Done"];
+
+const setupDom = () => {
+	const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost" });
+	globalThis.window = dom.window as unknown as Window & typeof globalThis;
+	globalThis.document = dom.window.document as Document;
+	globalThis.navigator = dom.window.navigator as Navigator;
+	globalThis.localStorage = dom.window.localStorage;
+
+	if (!window.matchMedia) {
+		window.matchMedia = () =>
+			({
+				matches: false,
+				media: "",
+				onchange: null,
+				addListener: () => {},
+				removeListener: () => {},
+				addEventListener: () => {},
+				removeEventListener: () => {},
+				dispatchEvent: () => false,
+			}) as MediaQueryList;
+	}
+};
+
+const makeTask = (id: string, status: string, parentTaskId?: string, title?: string): Task =>
+	({
+		id,
+		title: title ?? `Task ${id}`,
+		status,
+		assignee: [],
+		createdDate: "2026-08-17",
+		labels: [],
+		dependencies: [],
+		...(parentTaskId ? { parentTaskId } : {}),
+	}) as Task;
+
+const renderModal = (task: Task, availableTasks: Task[]) => {
+	setupDom();
+	return renderToString(
+		<ThemeProvider>
+			<TaskDetailsModal
+				task={task}
+				isOpen={true}
+				onClose={() => {}}
+				availableTasks={availableTasks}
+				availableStatuses={STATUSES}
+				onNavigateToTask={() => {}}
+			/>
+		</ThemeProvider>,
+	);
+};
+
+// Mirrors the real corpus shape this feature was built for: a parent whose children are spread
+// across statuses, one of which has children of its own.
+const nestedCorpus = (): Task[] => [
+	makeTask("TASK-2", "In Progress", undefined, "Parent with six children"),
+	makeTask("TASK-2.1", "Done", "TASK-2"),
+	makeTask("TASK-2.2", "Done", "TASK-2"),
+	makeTask("TASK-2.3", "Done", "TASK-2"),
+	makeTask("TASK-2.4", "Done", "TASK-2"),
+	makeTask("TASK-2.5", "Done", "TASK-2"),
+	makeTask("TASK-2.6", "To Do", "TASK-2", "Child that has children"),
+	makeTask("TASK-2.6.1", "Done", "TASK-2.6"),
+	makeTask("TASK-2.6.2", "To Do", "TASK-2.6"),
+	makeTask("TASK-2.6.3", "To Do", "TASK-2.6"),
+	makeTask("TASK-2.6.4", "To Do", "TASK-2.6"),
+];
+
+describe("Web task details modal subtask hierarchy", () => {
+	it("omits both sections for a task with no parent and no children", () => {
+		const tasks = [makeTask("TASK-1", "To Do"), makeTask("TASK-9", "Done")];
+		const html = renderModal(tasks[0] as Task, tasks);
+
+		expect(html).not.toContain("data-subtask-list");
+		expect(html).not.toContain("data-parent-task-id");
+		expect(html).not.toContain("Subtasks");
+	});
+
+	it("lists direct children with their ids and titles", () => {
+		const tasks = nestedCorpus();
+		const html = renderModal(tasks[0] as Task, tasks);
+
+		expect(html).toContain("data-subtask-list");
+		expect(html).toContain('data-subtask-id="TASK-2.1"');
+		expect(html).toContain('data-subtask-id="TASK-2.6"');
+		expect(html).toContain("Child that has children");
+		// Grandchildren are not flattened into the parent's list.
+		expect(html).not.toContain('data-subtask-id="TASK-2.6.1"');
+	});
+
+	it("summarises progress over direct children only", () => {
+		const tasks = nestedCorpus();
+		const html = renderModal(tasks[0] as Task, tasks);
+
+		// Five of six direct children are Done; the sixth has its own children but is not itself Done.
+		expect(html).toContain("Subtasks 5/6");
+		expect(html).not.toContain("Subtasks 6/10");
+	});
+
+	it("marks a child that has children of its own with its nested progress", () => {
+		const tasks = nestedCorpus();
+		const html = renderModal(tasks[0] as Task, tasks);
+
+		expect(html).toContain('data-nested-progress="1/4"');
+	});
+
+	it("counts only the configured terminal status as complete", () => {
+		const tasks = [
+			makeTask("TASK-3", "To Do"),
+			makeTask("TASK-3.1", "Done", "TASK-3"),
+			makeTask("TASK-3.2", "In Progress", "TASK-3"),
+			makeTask("TASK-3.3", "To Do", "TASK-3"),
+		];
+		const html = renderModal(tasks[0] as Task, tasks);
+
+		// In Progress must not be counted as complete.
+		expect(html).toContain("Subtasks 1/3");
+	});
+
+	it("links each child to its canonical task route", () => {
+		const tasks = nestedCorpus();
+		const html = renderModal(tasks[0] as Task, tasks);
+
+		expect(html).toContain('data-subtask-href="/tasks/TASK-2.1/task-task-21"');
+	});
+
+	it("shows the parent task on a child, linked to its canonical route", () => {
+		const tasks = nestedCorpus();
+		const child = tasks.find((task) => task.id === "TASK-2.6") as Task;
+		const html = renderModal(child, tasks);
+
+		expect(html).toContain('data-parent-task-id="TASK-2"');
+		expect(html).toContain("Parent with six children");
+		expect(html).toContain('data-parent-task-href="/tasks/TASK-2/parent-with-six-children"');
+	});
+
+	it("omits the parent section when the parent is absent from the corpus", () => {
+		const tasks = [makeTask("TASK-4.1", "To Do", "TASK-4")];
+		const html = renderModal(tasks[0] as Task, tasks);
+
+		expect(html).not.toContain("data-parent-task-id");
+	});
+});

--- a/src/utils/task-subtasks.ts
+++ b/src/utils/task-subtasks.ts
@@ -1,6 +1,7 @@
 import type { Task } from "../types/index.ts";
-import { taskIdsEqual } from "./task-path.ts";
+import { taskIdsEqual } from "./task-id.ts";
 import { sortByTaskId } from "./task-sorting.ts";
+import { isTerminalStatus } from "./terminal-status.ts";
 
 export function attachSubtaskSummaries(task: Task, tasks: Task[]): Task {
 	let parentTitle: string | undefined;
@@ -35,4 +36,38 @@ export function attachSubtaskSummaries(task: Task, tasks: Task[]): Task {
 		subtasks: sortedSummaries.map((summary) => summary.id),
 		subtaskSummaries: sortedSummaries,
 	};
+}
+
+export interface SubtaskProgress {
+	total: number;
+	completed: number;
+}
+
+export function summarizeSubtaskProgress(
+	task: Pick<Task, "id">,
+	tasks: readonly Task[],
+	statuses: readonly string[],
+): SubtaskProgress | null {
+	let total = 0;
+	let completed = 0;
+	for (const candidate of tasks) {
+		if (!candidate.parentTaskId) continue;
+		if (!taskIdsEqual(candidate.parentTaskId, task.id)) continue;
+		total += 1;
+		if (isTerminalStatus(candidate.status, statuses)) {
+			completed += 1;
+		}
+	}
+	return total === 0 ? null : { total, completed };
+}
+
+export function findDirectSubtasks(task: Pick<Task, "id">, tasks: readonly Task[]): Task[] {
+	const children = tasks.filter((candidate) => candidate.parentTaskId && taskIdsEqual(candidate.parentTaskId, task.id));
+	return sortByTaskId(children);
+}
+
+export function findParentTask(task: Pick<Task, "parentTaskId">, tasks: readonly Task[]): Task | null {
+	if (!task.parentTaskId) return null;
+	const parentId = task.parentTaskId;
+	return tasks.find((candidate) => taskIdsEqual(parentId, candidate.id)) ?? null;
 }

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -810,6 +810,7 @@ function AppContent() {
         onArchive={editingTask ? () => handleArchiveTask(editingTask.id) : undefined}
         availableStatuses={isDraftMode ? ['Draft', ...statuses] : statuses}
         availableTasks={tasks}
+        onNavigateToTask={handleEditTask}
         availableMilestones={milestones}
         availablePriorities={config?.priorities}
         availableTypes={availableTypes}

--- a/src/web/components/Modal.tsx
+++ b/src/web/components/Modal.tsx
@@ -121,11 +121,11 @@ const Modal: React.FC<ModalProps> = ({
 				aria-modal="true"
 				aria-labelledby="modal-title"
 			>
-				<div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-2 px-6 pt-4 pb-3 border-b border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur supports-[backdrop-filter]:bg-white/75 supports-[backdrop-filter]:dark:bg-gray-800/75">
-					<h2 id="modal-title" className="min-w-0 text-base font-semibold text-gray-900 dark:text-gray-100">
+				<div className="sticky top-0 z-10 flex flex-wrap items-start gap-3 px-6 pt-4 pb-3 border-b border-gray-200 dark:border-gray-700 bg-white/95 dark:bg-gray-800/95 backdrop-blur supports-[backdrop-filter]:bg-white/75 supports-[backdrop-filter]:dark:bg-gray-800/75">
+					<h2 id="modal-title" className="min-w-0 flex-1 basis-full break-words text-base font-semibold text-gray-900 dark:text-gray-100 sm:basis-auto">
 						{title}
 					</h2>
-					<div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+					<div className="ml-auto flex min-w-0 max-w-full flex-wrap items-center justify-end gap-2">
 						{actions}
 						<button
 							type="button"

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -13,6 +13,9 @@ import { getPriorityOptions } from "../../utils/priority-config";
 import { getTaskTypeValues, resolveTaskTypeValue } from "../../utils/task-type-config";
 import { createReadinessGraph, formatReadinessBlockers, getTaskReadiness } from "../../utils/readiness";
 import { canonicalTaskId } from "../../utils/task-id.ts";
+import { findDirectSubtasks, findParentTask, summarizeSubtaskProgress } from "../../utils/task-subtasks.ts";
+import { isTerminalStatus } from "../../utils/terminal-status.ts";
+import { createUrlPath } from "../utils/urlHelpers";
 
 interface Props {
   task?: Task; // Optional for create mode
@@ -23,6 +26,7 @@ interface Props {
   onArchive?: () => Promise<void> | void; // For archiving tasks
   availableStatuses?: string[]; // Available statuses for new tasks
   availableTasks?: Task[]; // Shared task corpus for dependency selection
+  onNavigateToTask?: (task: Task) => void; // Opens another task, preserving close/back context
   isDraftMode?: boolean; // Whether creating a draft
   availableMilestones?: string[];
   availablePriorities?: string[];
@@ -145,6 +149,23 @@ const SectionHeader: React.FC<{ title: string; right?: React.ReactNode }> = ({ t
   </div>
 );
 
+// Status is conveyed by colour on the dot; the title attribute carries it for pointer users and
+// the sr-only span for assistive technology, so no visible label competes with the task title.
+const StatusDot: React.FC<{ status: string; statuses: string[] }> = ({ status, statuses }) => {
+  const normalized = (status ?? '').toLowerCase();
+  const tone = isTerminalStatus(status, statuses)
+    ? 'bg-emerald-500 dark:bg-emerald-400'
+    : normalized.includes('progress')
+      ? 'bg-blue-500 dark:bg-blue-400'
+      : 'bg-gray-300 dark:bg-gray-600';
+  return (
+    <span className="flex-shrink-0 leading-none" title={status}>
+      <span className={`inline-block h-2 w-2 rounded-circle ${tone}`} aria-hidden="true" />
+      <span className="sr-only">{status}</span>
+    </span>
+  );
+};
+
 export const TaskDetailsModal: React.FC<Props> = ({
   task,
   isOpen,
@@ -152,8 +173,9 @@ export const TaskDetailsModal: React.FC<Props> = ({
   onSaved,
   onSubmit,
   onArchive,
-  availableStatuses,
+  availableStatuses = [],
   availableTasks = [],
+  onNavigateToTask,
   availableMilestones: _availableMilestones,
   availablePriorities,
   availableTypes,
@@ -410,6 +432,23 @@ export const TaskDetailsModal: React.FC<Props> = ({
     const result = getTaskReadiness({ ...task, dependencies, status }, graph);
     return result.isReady || result.isBlocked ? result : null;
   }, [task, dependencies, status, availableTasks, offBoardDependencies, availableStatuses]);
+
+  // Hierarchy is derived from the shared corpus rather than the task payload: the single-task
+  // API does not carry parent/subtask fields, while the list the modal already receives does.
+  const parentTask = useMemo(
+    () => (task ? findParentTask(task, availableTasks) : null),
+    [task, availableTasks],
+  );
+
+  const subtasks = useMemo(
+    () => (task ? findDirectSubtasks(task, availableTasks) : []),
+    [task, availableTasks],
+  );
+
+  const subtaskProgress = useMemo(
+    () => (task ? summarizeSubtaskProgress(task, availableTasks, availableStatuses) : null),
+    [task, availableTasks, availableStatuses],
+  );
 
   // Keep a baseline for dirty-check
   const baseline = useMemo(() => ({
@@ -1724,6 +1763,85 @@ export const TaskDetailsModal: React.FC<Props> = ({
               ))}
             </select>
           </div>
+
+          {/* Parent task */}
+          {parentTask && (
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+              <SectionHeader title="Parent" />
+              <button
+                type="button"
+                onClick={() => onNavigateToTask?.(parentTask)}
+                disabled={!onNavigateToTask}
+                data-parent-task-id={parentTask.id}
+                data-parent-task-href={createUrlPath('/tasks', parentTask.id, parentTask.title)}
+                className="w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:cursor-default disabled:hover:bg-transparent"
+              >
+                <StatusDot status={parentTask.status} statuses={availableStatuses} />
+                <span className="text-xs font-mono text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {parentTask.id}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm text-gray-900 dark:text-gray-100">
+                  {parentTask.title}
+                </span>
+              </button>
+            </div>
+          )}
+
+          {/* Subtasks */}
+          {subtasks.length > 0 && (
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+              <SectionHeader
+                title={
+                  subtaskProgress
+                    ? `Subtasks ${subtaskProgress.completed}/${subtaskProgress.total}`
+                    : 'Subtasks'
+                }
+              />
+              <div className="flex flex-col gap-0.5" data-subtask-list>
+                {subtasks.map((subtask) => {
+                  const nested = summarizeSubtaskProgress(subtask, availableTasks, availableStatuses);
+                  const isComplete = isTerminalStatus(subtask.status, availableStatuses);
+                  return (
+                    <button
+                      key={subtask.id}
+                      type="button"
+                      onClick={() => onNavigateToTask?.(subtask)}
+                      disabled={!onNavigateToTask}
+                      data-subtask-id={subtask.id}
+                      data-subtask-href={createUrlPath('/tasks', subtask.id, subtask.title)}
+                      className="w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:cursor-default disabled:hover:bg-transparent"
+                    >
+                      <StatusDot status={subtask.status} statuses={availableStatuses} />
+                      <span
+                        className={`text-xs font-mono whitespace-nowrap ${
+                          isComplete ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'
+                        }`}
+                      >
+                        {subtask.id}
+                      </span>
+                      <span
+                        className={`min-w-0 flex-1 truncate text-sm ${
+                          isComplete
+                            ? 'text-gray-400 dark:text-gray-500 line-through'
+                            : 'text-gray-900 dark:text-gray-100'
+                        }`}
+                      >
+                        {subtask.title}
+                      </span>
+                      {nested && (
+                        <span
+                          className="text-[11px] font-mono text-gray-400 dark:text-gray-500 whitespace-nowrap"
+                          data-nested-progress={`${nested.completed}/${nested.total}`}
+                        >
+                          {nested.completed}/{nested.total}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
 
           {/* Dependencies */}
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -1780,13 +1780,15 @@ export const TaskDetailsModal: React.FC<Props> = ({
                 disabled={!onNavigateToTask}
                 data-parent-task-id={parentTask.id}
                 data-parent-task-href={createUrlPath('/tasks', parentTask.id, parentTask.title)}
-                className="w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:cursor-default disabled:hover:bg-transparent"
+                className="w-full flex items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:cursor-default disabled:hover:bg-transparent"
               >
-                <StatusDot status={parentTask.status} statuses={availableStatuses} />
+                <span className="mt-1">
+                  <StatusDot status={parentTask.status} statuses={availableStatuses} />
+                </span>
                 <span className="text-xs font-mono text-gray-500 dark:text-gray-400 whitespace-nowrap">
                   {parentTask.id}
                 </span>
-                <span className="min-w-0 flex-1 truncate text-sm text-gray-900 dark:text-gray-100">
+                <span className="min-w-0 flex-1 line-clamp-2 break-words text-sm text-gray-900 dark:text-gray-100" title={parentTask.title}>
                   {parentTask.title}
                 </span>
               </button>
@@ -1815,9 +1817,11 @@ export const TaskDetailsModal: React.FC<Props> = ({
                       disabled={!onNavigateToTask}
                       data-subtask-id={subtask.id}
                       data-subtask-href={createUrlPath('/tasks', subtask.id, subtask.title)}
-                      className="w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:cursor-default disabled:hover:bg-transparent"
+                      className="w-full flex items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:cursor-default disabled:hover:bg-transparent"
                     >
-                      <StatusDot status={subtask.status} statuses={availableStatuses} />
+                      <span className="mt-1">
+                        <StatusDot status={subtask.status} statuses={availableStatuses} />
+                      </span>
                       <span
                         className={`text-xs font-mono whitespace-nowrap ${
                           isComplete ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'
@@ -1826,11 +1830,12 @@ export const TaskDetailsModal: React.FC<Props> = ({
                         {subtask.id}
                       </span>
                       <span
-                        className={`min-w-0 flex-1 truncate text-sm ${
+                        className={`min-w-0 flex-1 line-clamp-2 break-words text-sm ${
                           isComplete
                             ? 'text-gray-400 dark:text-gray-500 line-through'
                             : 'text-gray-900 dark:text-gray-100'
                         }`}
+                        title={subtask.title}
                       >
                         {subtask.title}
                       </span>

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -76,6 +76,12 @@ type TaskDetailsFormState = {
   dueDate: string;
 };
 
+// Shared empty defaults. A `= []` default parameter allocates a fresh array on every render, so
+// every memo and effect keyed on it re-runs each time; combined with a state update in that chain
+// the modal spins until React aborts with "Maximum update depth exceeded".
+const EMPTY_STATUSES: string[] = [];
+const EMPTY_TASKS: Task[] = [];
+
 const containsCommentDelimiterLine = (value: string): boolean => /^\s*---\s*$/m.test(value.replace(/\r\n/g, "\n"));
 
 const areJsonEqual = (first: unknown, second: unknown): boolean => JSON.stringify(first) === JSON.stringify(second);
@@ -173,8 +179,8 @@ export const TaskDetailsModal: React.FC<Props> = ({
   onSaved,
   onSubmit,
   onArchive,
-  availableStatuses = [],
-  availableTasks = [],
+  availableStatuses = EMPTY_STATUSES,
+  availableTasks = EMPTY_TASKS,
   onNavigateToTask,
   availableMilestones: _availableMilestones,
   availablePriorities,


### PR DESCRIPTION
## Summary

`parentTaskId` has been part of the task model for a long time, and the CLI, TUI and MCP surfaces all present the hierarchy it describes — `task-plain-text.ts` prints `Parent:` and `Subtasks (n):`, and the CLI kanban has indented children under their parent since BACK-24. The browser never caught up: grepping `parentTaskId` or `subtask` across `src/web/` matches nothing but a test file.

The gap is easy to see. Open a parent task in the browser and the sidebar shows Status, Labels, Milestone and Dependencies, but gives no hint that the task has children at all — and opening a child gives no hint that it belongs to anything.

This adds two sections to `TaskDetailsModal`, modelled on the Dependencies card directly below them:

- **Parent** — the parent's id, title and status, when the task has one.
- **Subtasks** — direct children with a `completed/total` count in the heading, each row carrying a status dot and, where a child has children of its own, its own nested count.

Progress counts direct children only, so a child that is not itself terminal does not inflate its parent's total while still showing its own progress on its row. Completion is decided by `isTerminalStatus` against the project's configured statuses, so a project whose terminal status is not named "Done" behaves correctly.

Both sections navigate through the existing `handleEditTask` path in `App.tsx`, which already builds canonical `/tasks/:id/:title` routes and threads `taskModalFrom`, so close and back behave exactly as before.

No server changes were needed. `GET /api/tasks` already carries `parentTaskId` and each task's status, and the modal already receives the full corpus as `availableTasks`. (`GET /api/task/:id` carries neither, which is why the single-task payload is not the source here.)

### Design notes

The derivation lives in `src/utils/task-subtasks.ts` as three pure functions beside `attachSubtaskSummaries`, rather than inside the component, so the board, All Tasks and the TUI (BACK-549) can reuse it without a second implementation.

`attachSubtaskSummaries` itself is deliberately untouched: its return type is `Task` and `subtaskSummaries` is already part of the JSON contract, so adding status there would widen a frozen public surface for a browser-only need.

Two things worth flagging for review:

- `taskIdsEqual` is imported from `utils/task-id.ts` rather than the `utils/task-path.ts` re-export. `task-path.ts` pulls in `node:path` and `core/backlog.ts`, which breaks the browser bundle (`graceful-fs` requiring `fs`, `util`, `assert`). Verified by building clean `main` first to confirm the failure was introduced here.
- The status dot uses `rounded-circle`, not `rounded-full` — `src/web/styles/source.css` disables the latter via `@source not inline("{rounded-full}")`, so it silently renders square.

## Related Issue or Task

Closes BACK-222.1, a child of BACK-222 created with `backlog task create --parent BACK-222`.

BACK-222 spans the board, All Tasks and task details views. This PR implements the **task details slice only**, so the parent task stays open for the two views it still describes. Splitting it that way keeps this reviewable as one unit rather than one PR defining scope across three surfaces.

On the "discuss in an issue first" guidance: there was no issue for BACK-222, and the task itself already carries maintainer-authored acceptance criteria from its 2026-07-16 revision, so this follows that existing scope rather than proposing new behaviour. Happy to open an issue and hold, or narrow the scope further, if you would prefer that.

## Task Checklist

- [x] I have created a corresponding task in `backlog/tasks/`
- [x] The task has clear acceptance criteria
- [x] I have added an implementation plan to the task
- [x] All acceptance criteria in the task are marked as completed

## Testing

- `bunx tsc --noEmit` — clean
- `bun run lint` — 375 files, no fixes applied
- `bun run build` — clean
- `bun test src/test/subtask-progress.test.ts` — 10 pass
- `bun test src/test/web-task-details-modal-subtasks.test.tsx` — 8 pass
- `bun test src/test/web-task-details-modal-modified-files.test.tsx` — 5 pass, unaffected

Browser QA against two real projects: a six-child parent reading `6/6`, and a three-level tree reading `5/6` with its `To Do` child annotated `1/4`. Parent-to-child and child-to-parent navigation verified in both directions, along with browser back returning to the previous task rather than dismissing the modal. Checked in light and dark themes — no new colours were introduced; the sections reuse the existing card classes and their `dark:` variants.

`bun run check .` is not reported as passing. On Windows the repo's `* text=auto` gitattribute produces CRLF worktree files that biome's formatter rejects wholesale, independently of this change — committed blobs are LF and `bun run lint` is clean, so CI or a maintainer on Linux/macOS should see the formatter pass. Flagging it rather than claiming a check I could not run.
