### PR TITLE
BACK-222.1 - Polish parent and subtask hierarchy

### DIFF
--- a/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
+++ b/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-222.1
 title: Show parent and subtask hierarchy in the web task details modal
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-08-17 07:26'
-updated_date: '2026-08-19 21:46'
+updated_date: '2026-08-20 06:30'
 labels: []
 dependencies: []
 parent_task_id: BACK-222
@@ -48,44 +48,21 @@ Contributed by @yss19850810-crypto.
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Keep the accepted parent/subtask hierarchy and preserve existing routes, clients, accessibility, and theme classes.
-2. Use one shared responsive Modal header layout so long task titles and actions do not overlap at 390px.
-3. Make hierarchy row titles readable with the existing task-card wrapping pattern, without new controls or data fetching.
-4. Verify board and All Tasks navigation in the in-app Browser at desktop and mobile sizes, then record evidence and finalize after PR review and CI.
+1. Preserve the existing shared hierarchy derivation and canonical navigation.
+2. Present the parent as compact task navigation above the details grid.
+3. Present subtasks in the main content column with shared readable rows, visible status text, full titles, and explicit completion wording.
+4. Keep mobile modal actions on one compact row without adding a menu or another interaction model.
+5. Update focused render assertions, then rely on PR Codex review and CI for verification.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Derived in the browser from the corpus the modal already receives as `availableTasks`, rather than extending the server payload. `GET /api/tasks` already carries `parentTaskId` and each task's status, so no server change was needed; `GET /api/task/:id` carries neither, which is why the single-task payload is not the source here.
+Hierarchy data stays derived from the `availableTasks` corpus through `findParentTask`, `findDirectSubtasks`, and `summarizeSubtaskProgress`; the single-task API remains unchanged. Completion continues to use `isTerminalStatus` and configured statuses.
 
-`attachSubtaskSummaries` was deliberately left untouched. Its return type is `Task` and `subtaskSummaries` is already part of the JSON contract, so adding status to it would widen a frozen public surface for a browser-only need. The three new functions sit beside it as plain derivations instead:
+The parent is task navigation, not editable metadata: it appears above the details grid as a compact hierarchy path with ID, full title, visible status, and the current task ID. Subtasks live in the main content column immediately after Description. Every row shows ID, visible status, full title, optional nested progress, and a navigation chevron; completed titles remain readable instead of using strikethrough.
 
-- `summarizeSubtaskProgress(task, tasks, statuses)` returns `{ total, completed }` or `null` when there are no children, so callers render nothing rather than an empty state
-- `findDirectSubtasks(task, tasks)` returns direct children only, ordered by `sortByTaskId`
-- `findParentTask(task, tasks)` resolves the parent, or `null` when it is outside the corpus
+Parent and subtask navigation still use the existing `onNavigateToTask` path and canonical route metadata, preserving close/back behavior without adding routing or fetch logic to the modal. Mobile action labels shorten at the supported mobile breakpoint so the existing actions remain on one row without a new menu.
 
-Completion uses `isTerminalStatus`. The two existing `isDoneStatus` helpers in `core/milestones.ts` and `ui/board.ts` hardcode "done"/"complete" substrings, disagree with each other, and would misreport any project whose terminal status is named differently — neither was reused.
-
-Navigation goes through the existing `handleEditTask` in `App.tsx`, passed down as `onNavigateToTask`. That path already builds canonical `/tasks/:id/:title` routes and threads `taskModalFrom`, so close and back behave exactly as they did before; the modal itself stays free of routing concerns.
-
-Two notes for reviewers:
-
-`taskIdsEqual` is imported from `utils/task-id.ts` rather than the `utils/task-path.ts` re-export. `task-path.ts` pulls in `node:path` and `core/backlog.ts`, which breaks the browser bundle with `graceful-fs` requiring `fs`, `util` and `assert`. This was verified by building clean `main` first to confirm the failure was introduced here.
-
-The status dot uses the project's `rounded-circle` utility, not `rounded-full` — `src/web/styles/source.css` explicitly disables the latter via `@source not inline("{rounded-full}")`, so it silently renders square.
-
-Verification: `bunx tsc --noEmit` clean; `bun run lint` 375 files with no fixes applied; `bun run build` clean; new tests 10 + 8 pass; the existing `web-task-details-modal-modified-files` suite still 5 pass. Browser QA against two real projects — a six-child parent reading 6/6, and a three-level tree reading 5/6 with its `To Do` child annotated 1/4 — with parent and child navigation checked in both directions.
-
-`bun run check .` is not reported as passing: on Windows the repo's `* text=auto` gitattribute produces CRLF worktree files that biome's formatter rejects wholesale, independently of this change. Committed blobs are LF, and `bun run lint` is clean. A maintainer on Linux or macOS, or CI, should see the formatter pass.
-
-Maintainer follow-up: responsive modal-header and hierarchy-title polish requested after rendered mobile QA. No product semantics or data flow changes.
-
-Rendered QA after maintainer polish (in-app Browser): board and All Tasks parent-to-child and child-parent routes checked at 1280x720 and 390x844. The shared modal header has no title/action overlap at 390px, no horizontal overflow, and hierarchy rows remain keyboard-semantic buttons with status sr-only labels and canonical route metadata. Parent subtasks row is readable across two lines; child Parent row is readable across two lines. Empty BACK-633 modal renders no Parent/Subtasks section. Dark and light theme hierarchy states were checked; no framework overlays or console warnings/errors observed. Screenshots: /private/tmp/pr917-after-parent-desktop-visible.png, /private/tmp/pr917-after-child-desktop.png, /private/tmp/pr917-after-parent-mobile.png, /private/tmp/pr917-after-child-mobile.png, /private/tmp/pr917-after-parent-light-desktop.png.
+Per maintainer workflow, no local test, lint, or build gate is used for this follow-up. Verification is delegated to PR Codex review and CI.
 <!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Implemented and verified BACK-222.1. The shared Modal header now gives long titles a dedicated mobile row and keeps actions clear at 390px; parent/subtask rows reuse the existing two-line task-card treatment and retain canonical navigation, status semantics, accessibility labels, and theme classes. In-app Browser QA covered Board and All Tasks parent/child navigation at 1280x720 and 390x844, dark/light themes, the empty BACK-633 state, no horizontal overflow, no framework overlay, and no console warnings/errors. Screenshots: /private/tmp/pr917-after-parent-desktop-visible.png, /private/tmp/pr917-after-child-desktop.png, /private/tmp/pr917-after-parent-mobile.png, /private/tmp/pr917-after-child-mobile.png, /private/tmp/pr917-after-parent-light-desktop.png. GitHub Actions run 32304774065 passed all seven current-head jobs; current-head Codex approval is review 4977021284. The exact bun run check . DoD item remains unchecked because that separate local command was not run.
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
+++ b/backlog/tasks/back-222.1 - Show-parent-and-subtask-hierarchy-in-the-web-task-details-modal.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-222.1
 title: Show parent and subtask hierarchy in the web task details modal
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-17 07:26'
-updated_date: '2026-08-20 06:30'
+updated_date: '2026-08-20 06:48'
 labels: []
 dependencies: []
 parent_task_id: BACK-222
@@ -65,4 +65,12 @@ The parent is task navigation, not editable metadata: it appears above the detai
 Parent and subtask navigation still use the existing `onNavigateToTask` path and canonical route metadata, preserving close/back behavior without adding routing or fetch logic to the modal. Mobile action labels shorten at the supported mobile breakpoint so the existing actions remain on one row without a new menu.
 
 Per maintainer workflow, no local test, lint, or build gate is used for this follow-up. Verification is delegated to PR Codex review and CI.
+
+Verification for the code-bearing head `72fdffbb0ec4bf8632e750f619eeda769b5eb0df`: GitHub Actions run 32340551392 passed the full Linux/macOS/Windows test, lint, type, build/smoke, Nix, and CodeQL matrix. PR Codex review reported no major issues on that exact commit.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Polished the task hierarchy presentation without changing its data flow or routing: parent context is now compact navigation above the details grid, subtasks are readable main-column rows with visible status and explicit progress, completed titles are no longer struck through, and supported mobile actions remain on one compact row. Verified on the code-bearing commit `72fdffbb0ec4bf8632e750f619eeda769b5eb0df` by green GitHub Actions run 32340551392 and a clean PR Codex review on the same commit. The final task-record commit is metadata-only and must clear the same remote gates before merge.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/web-task-details-modal-subtasks.test.tsx
+++ b/src/test/web-task-details-modal-subtasks.test.tsx
@@ -90,6 +90,7 @@ describe("Web task details modal subtask hierarchy", () => {
 		expect(html).toContain("data-subtask-list");
 		expect(html).toContain('data-subtask-id="TASK-2.1"');
 		expect(html).toContain('data-subtask-id="TASK-2.6"');
+		expect(html).toContain('aria-label="Open subtask TASK-2.1: Task TASK-2.1 (Done)"');
 		expect(html).toContain("Child that has children");
 		// Grandchildren are not flattened into the parent's list.
 		expect(html).not.toContain('data-subtask-id="TASK-2.6.1"');
@@ -100,8 +101,8 @@ describe("Web task details modal subtask hierarchy", () => {
 		const html = renderModal(tasks[0] as Task, tasks);
 
 		// Five of six direct children are Done; the sixth has its own children but is not itself Done.
-		expect(html).toContain("Subtasks 5/6");
-		expect(html).not.toContain("Subtasks 6/10");
+		expect(html).toContain("5 of 6 complete");
+		expect(html).not.toContain("6 of 10 complete");
 	});
 
 	it("marks a child that has children of its own with its nested progress", () => {
@@ -109,6 +110,7 @@ describe("Web task details modal subtask hierarchy", () => {
 		const html = renderModal(tasks[0] as Task, tasks);
 
 		expect(html).toContain('data-nested-progress="1/4"');
+		expect(html).toContain("1 of 4 complete");
 	});
 
 	it("counts only the configured terminal status as complete", () => {
@@ -121,7 +123,7 @@ describe("Web task details modal subtask hierarchy", () => {
 		const html = renderModal(tasks[0] as Task, tasks);
 
 		// In Progress must not be counted as complete.
-		expect(html).toContain("Subtasks 1/3");
+		expect(html).toContain("1 of 3 complete");
 	});
 
 	it("links each child to its canonical task route", () => {
@@ -136,8 +138,10 @@ describe("Web task details modal subtask hierarchy", () => {
 		const child = tasks.find((task) => task.id === "TASK-2.6") as Task;
 		const html = renderModal(child, tasks);
 
+		expect(html).toContain("data-task-hierarchy");
 		expect(html).toContain('data-parent-task-id="TASK-2"');
 		expect(html).toContain("Parent with six children");
+		expect(html).toContain('aria-label="Open parent task TASK-2: Parent with six children (In Progress)"');
 		expect(html).toContain('data-parent-task-href="/tasks/TASK-2/parent-with-six-children"');
 	});
 

--- a/src/test/web-task-details-modal-subtasks.test.tsx
+++ b/src/test/web-task-details-modal-subtasks.test.tsx
@@ -108,9 +108,10 @@ describe("Web task details modal subtask hierarchy", () => {
 	it("marks a child that has children of its own with its nested progress", () => {
 		const tasks = nestedCorpus();
 		const html = renderModal(tasks[0] as Task, tasks);
+		const document = new JSDOM(html).window.document;
 
 		expect(html).toContain('data-nested-progress="1/4"');
-		expect(html).toContain("1 of 4 complete");
+		expect(document.querySelector('[data-nested-progress="1/4"]')?.textContent).toBe("1 of 4 complete");
 	});
 
 	it("counts only the configured terminal status as complete", () => {

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -155,22 +155,31 @@ const SectionHeader: React.FC<{ title: string; right?: React.ReactNode }> = ({ t
   </div>
 );
 
-// Status is conveyed by colour on the dot; the title attribute carries it for pointer users and
-// the sr-only span for assistive technology, so no visible label competes with the task title.
-const StatusDot: React.FC<{ status: string; statuses: string[] }> = ({ status, statuses }) => {
+const HierarchyStatusBadge: React.FC<{ status: string; statuses: string[] }> = ({ status, statuses }) => {
   const normalized = (status ?? '').toLowerCase();
   const tone = isTerminalStatus(status, statuses)
-    ? 'bg-emerald-500 dark:bg-emerald-400'
+    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
     : normalized.includes('progress')
-      ? 'bg-blue-500 dark:bg-blue-400'
-      : 'bg-gray-300 dark:bg-gray-600';
+      ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300'
+      : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300';
   return (
-    <span className="flex-shrink-0 leading-none" title={status}>
-      <span className={`inline-block h-2 w-2 rounded-circle ${tone}`} aria-hidden="true" />
-      <span className="sr-only">{status}</span>
+    <span className={`shrink-0 rounded-md px-1.5 py-0.5 text-[11px] font-medium ${tone}`}>
+      {status}
     </span>
   );
 };
+
+const HierarchyChevron: React.FC = () => (
+  <svg
+    className="h-4 w-4 shrink-0 text-gray-400 transition-transform duration-200 group-hover:translate-x-0.5 dark:text-gray-500"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+  </svg>
+);
 
 export const TaskDetailsModal: React.FC<Props> = ({
   task,
@@ -670,7 +679,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
 
   // Links inside the modal (dependency chips, auto-linked task IDs in markdown) leave this
   // task behind, so they ask the same question closing does before the navigation happens.
-  const confirmNavigationAwayFromEdits = (event: React.MouseEvent<HTMLDivElement>) => {
+  const confirmNavigationAwayFromEdits = (event: React.MouseEvent<HTMLElement>) => {
     if (!hasUnsavedEdits || event.defaultPrevented || event.button !== 0) return;
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
     const link = (event.target as Element | null)?.closest?.("a[href]") as HTMLAnchorElement | null;
@@ -1129,35 +1138,41 @@ export const TaskDetailsModal: React.FC<Props> = ({
       maxWidthClass="max-w-5xl"
       disableEscapeClose={mode === "edit" || mode === "create" || demoting}
       actions={
-		<div className="flex flex-wrap items-center justify-end gap-2">
+		<div className="flex flex-nowrap items-center justify-end gap-2">
 		          {isDoneStatus && mode === "preview" && !isCreateMode && !isFromOtherBranch && (
 		            <button
 		              onClick={handleComplete}
 		              disabled={demoting}
-		              className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-emerald-600 dark:bg-emerald-700 hover:bg-emerald-700 dark:hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200"
+		              className="inline-flex items-center px-3 py-2 sm:px-4 rounded-lg text-sm font-medium text-white bg-emerald-600 dark:bg-emerald-700 hover:bg-emerald-700 dark:hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:focus:ring-emerald-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200"
 		              title="Move to completed folder (removes from board)"
 		            >
-		              Mark as completed
+		              <span className="sm:hidden">Complete</span>
+		              <span className="hidden sm:inline">Mark as completed</span>
 		            </button>
 		          )}
 		          {canDemote && mode === "preview" && (
 		            <button
 		              onClick={() => void handleDemote()}
 		              disabled={demoting}
-		              className="inline-flex items-center px-4 py-2 rounded-lg text-sm font-medium text-white bg-amber-500 dark:bg-amber-600 hover:bg-amber-600 dark:hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 dark:focus:ring-amber-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50"
+		              className="inline-flex items-center px-3 py-2 sm:px-4 rounded-lg text-sm font-medium text-white bg-amber-500 dark:bg-amber-600 hover:bg-amber-600 dark:hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 dark:focus:ring-amber-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50"
 		              title="Move task to drafts"
 		            >
-		              {demoting ? "Demoting…" : "Demote to draft"}
+		              {demoting ? "Demoting…" : (
+		                <>
+		                  <span className="sm:hidden">Demote</span>
+		                  <span className="hidden sm:inline">Demote to draft</span>
+		                </>
+		              )}
 		            </button>
 		          )}
 		          {mode === "preview" && !isCreateMode && !isFromOtherBranch ? (
 		            <button
 		              onClick={() => setMode("edit")}
 		              disabled={demoting}
-		              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200"
+		              className="inline-flex items-center px-3 py-2 sm:px-4 border border-gray-300 dark:border-gray-600 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors duration-200"
 		              title="Edit"
 		            >
-              <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                       d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
               </svg>
@@ -1209,6 +1224,44 @@ export const TaskDetailsModal: React.FC<Props> = ({
         </div>
       )}
 
+      {parentTask && task && (
+        <nav
+          aria-label="Task hierarchy"
+          className="mb-4"
+          data-task-hierarchy
+          onClickCapture={confirmNavigationAwayFromEdits}
+        >
+          <ol className="flex flex-wrap items-center gap-x-2 gap-y-1.5 text-sm">
+            <li className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Parent
+            </li>
+            <li className="min-w-0 max-w-full">
+              <button
+                type="button"
+                onClick={() => onNavigateToTask?.(parentTask)}
+                disabled={!onNavigateToTask}
+                data-parent-task-id={parentTask.id}
+                data-parent-task-href={createUrlPath('/tasks', parentTask.id, parentTask.title)}
+                className="group inline-flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 rounded-md px-2 py-1 text-left text-gray-700 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-950 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-default disabled:hover:bg-transparent dark:text-gray-200 dark:hover:bg-gray-700 dark:hover:text-white"
+                aria-label={`Open parent task ${parentTask.id}: ${parentTask.title} (${parentTask.status})`}
+              >
+                <span className="shrink-0 font-mono text-xs text-gray-500 dark:text-gray-400">
+                  {parentTask.id}
+                </span>
+                <span className="min-w-0 break-words font-medium">{parentTask.title}</span>
+                <HierarchyStatusBadge status={parentTask.status} statuses={availableStatuses} />
+              </button>
+            </li>
+            <li aria-hidden="true">
+              <HierarchyChevron />
+            </li>
+            <li aria-current="page" className="font-mono text-xs text-gray-500 dark:text-gray-400">
+              {task.id}
+            </li>
+          </ol>
+        </nav>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6" onClickCapture={confirmNavigationAwayFromEdits}>
         {/* Main content */}
         <div className="md:col-span-2 space-y-6">
@@ -1248,6 +1301,57 @@ export const TaskDetailsModal: React.FC<Props> = ({
               </div>
             )}
           </div>
+
+          {subtasks.length > 0 && (
+            <section className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+              <SectionHeader
+                title="Subtasks"
+                right={
+                  subtaskProgress
+                    ? `${subtaskProgress.completed} of ${subtaskProgress.total} complete`
+                    : undefined
+                }
+              />
+              <div className="divide-y divide-gray-100 dark:divide-gray-700" data-subtask-list>
+                {subtasks.map((subtask) => {
+                  const nested = summarizeSubtaskProgress(subtask, availableTasks, availableStatuses);
+                  return (
+                    <button
+                      key={subtask.id}
+                      type="button"
+                      onClick={() => onNavigateToTask?.(subtask)}
+                      disabled={!onNavigateToTask}
+                      data-subtask-id={subtask.id}
+                      data-subtask-href={createUrlPath('/tasks', subtask.id, subtask.title)}
+                      className="group flex w-full items-center gap-3 rounded-md px-2 py-3 text-left transition-colors duration-200 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-default disabled:hover:bg-transparent dark:hover:bg-gray-700/50"
+                      aria-label={`Open subtask ${subtask.id}: ${subtask.title} (${subtask.status})`}
+                    >
+                      <span className="min-w-0 flex-1">
+                        <span className="flex flex-wrap items-center gap-2">
+                          <span className="shrink-0 font-mono text-xs text-gray-500 dark:text-gray-400">
+                            {subtask.id}
+                          </span>
+                          <HierarchyStatusBadge status={subtask.status} statuses={availableStatuses} />
+                          {nested && (
+                            <span
+                              className="text-xs text-gray-500 dark:text-gray-400"
+                              data-nested-progress={`${nested.completed}/${nested.total}`}
+                            >
+                              {nested.completed} of {nested.total} complete
+                            </span>
+                          )}
+                        </span>
+                        <span className="mt-1 block break-words text-sm font-medium text-gray-900 dark:text-gray-100">
+                          {subtask.title}
+                        </span>
+                      </span>
+                      <HierarchyChevron />
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          )}
 
           {/* References */}
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
@@ -1769,90 +1873,6 @@ export const TaskDetailsModal: React.FC<Props> = ({
               ))}
             </select>
           </div>
-
-          {/* Parent task */}
-          {parentTask && (
-            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
-              <SectionHeader title="Parent" />
-              <button
-                type="button"
-                onClick={() => onNavigateToTask?.(parentTask)}
-                disabled={!onNavigateToTask}
-                data-parent-task-id={parentTask.id}
-                data-parent-task-href={createUrlPath('/tasks', parentTask.id, parentTask.title)}
-                className="w-full flex items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:cursor-default disabled:hover:bg-transparent"
-              >
-                <span className="mt-1">
-                  <StatusDot status={parentTask.status} statuses={availableStatuses} />
-                </span>
-                <span className="text-xs font-mono text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                  {parentTask.id}
-                </span>
-                <span className="min-w-0 flex-1 line-clamp-2 break-words text-sm text-gray-900 dark:text-gray-100" title={parentTask.title}>
-                  {parentTask.title}
-                </span>
-              </button>
-            </div>
-          )}
-
-          {/* Subtasks */}
-          {subtasks.length > 0 && (
-            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
-              <SectionHeader
-                title={
-                  subtaskProgress
-                    ? `Subtasks ${subtaskProgress.completed}/${subtaskProgress.total}`
-                    : 'Subtasks'
-                }
-              />
-              <div className="flex flex-col gap-0.5" data-subtask-list>
-                {subtasks.map((subtask) => {
-                  const nested = summarizeSubtaskProgress(subtask, availableTasks, availableStatuses);
-                  const isComplete = isTerminalStatus(subtask.status, availableStatuses);
-                  return (
-                    <button
-                      key={subtask.id}
-                      type="button"
-                      onClick={() => onNavigateToTask?.(subtask)}
-                      disabled={!onNavigateToTask}
-                      data-subtask-id={subtask.id}
-                      data-subtask-href={createUrlPath('/tasks', subtask.id, subtask.title)}
-                      className="w-full flex items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:cursor-default disabled:hover:bg-transparent"
-                    >
-                      <span className="mt-1">
-                        <StatusDot status={subtask.status} statuses={availableStatuses} />
-                      </span>
-                      <span
-                        className={`text-xs font-mono whitespace-nowrap ${
-                          isComplete ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'
-                        }`}
-                      >
-                        {subtask.id}
-                      </span>
-                      <span
-                        className={`min-w-0 flex-1 line-clamp-2 break-words text-sm ${
-                          isComplete
-                            ? 'text-gray-400 dark:text-gray-500 line-through'
-                            : 'text-gray-900 dark:text-gray-100'
-                        }`}
-                        title={subtask.title}
-                      >
-                        {subtask.title}
-                      </span>
-                      {nested && (
-                        <span
-                          className="text-[11px] font-mono text-gray-400 dark:text-gray-500 whitespace-nowrap"
-                          data-nested-progress={`${nested.completed}/${nested.total}`}
-                        >
-                          {nested.completed}/{nested.total}
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          )}
 
           {/* Dependencies */}
           <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">


### PR DESCRIPTION
## Task

BACK-222.1 - Show parent and subtask hierarchy in the web task details modal

Follow-up to #917 after maintainer visual review.

## What changed

- treats the parent relationship as navigation above the details grid instead of sidebar metadata
- moves subtasks into the main content column with full titles, visible status badges, explicit completion wording, and clear navigation affordance
- removes completed-title strikethrough and ambiguous `x/y` display
- keeps supported mobile actions on one compact row without adding a menu
- updates focused render assertions for the final hierarchy structure

## Validation

No local test, lint, or build gate was run per maintainer workflow. PR Codex review and CI are the required verification gates.