### PR TITLE
BACK-627 - Prevent forced allocation refresh from joining an in-flight stale fetch

### DIFF
--- a/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
+++ b/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-10 06:37'
-updated_date: '2026-08-29 18:00'
+updated_date: '2026-08-29 18:27'
 labels: []
 dependencies: []
 priority: medium
@@ -67,6 +67,8 @@ Maintainer review (takeover of PR #925): the contributor's diagnosis and fix wer
 Residual race (inherent, not introduced here): a push that lands during the second, post-request fetch is still invisible to that allocation. Closing that would need server-side reservation, not a client fetch.
 
 Residual hole found during maintainer review, deliberately left out of scope (needs a product decision): GitOperations.fetch has its own coalescing layer (this.fetches, keyed by remote, in src/git/operations.ts). Core's forced pre-wait guarantees Core's own remoteRefRefreshPromise slot is empty, and because GitOperations deletes its map entry in a finally before fetch() returns, the forced path does start a genuinely new git fetch in the common case. But generateNextDocId and generateNextDecisionId (src/utils/id-generators.ts) call core.gitOps.fetch() directly, bypassing Core's slot. If one of those is in flight when a forced task-ID refresh runs, Core sees an empty slot, calls git.fetch(), and joins the older git-level fetch -- reintroducing exactly the staleness this task closes. Narrow: it needs a concurrent doc/decision ID allocation in the same process (TUI or web server, not separate CLI invocations). Not fixed here because the obvious fix (a force flag that skips the git-level dedup) can put two concurrent git fetches on the same remote and risk ref lock contention, which is a bigger decision than this task's scope.
+
+Correction to the verification above: the two src/test/core.test.ts failures seen during review ('fails closed when an archive snapshot...' and 'keeps an ID occupied when equal-time branch records...') were not environmental and not caused by this branch. They were a time-bomb in main's own tests -- hardcoded commit dates that aged out of the activeBranchDays window -- and upstream fixed them in main commit 6c6f1843 'Fix expired hardcoded commit dates in core branch-record tests'. Rebased this branch onto that new main; src/test/core.test.ts is now 66 pass / 0 fail locally.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
+++ b/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-10 06:37'
-updated_date: '2026-08-27 17:05'
+updated_date: '2026-08-29 18:00'
 labels: []
 dependencies: []
 priority: medium
@@ -35,13 +35,12 @@ Follow-up from the PR #899 (BACK-624) verification round. The task-ID allocation
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add a `remoteRefRefreshStartedAt` timestamp field next to `remoteRefRefreshPromise` in Core (src/core/backlog.ts), recording when the currently in-flight refresh's git.fetch() call actually started.
-2. In `refreshRemoteRefsForTaskRead`, capture `requestedAt = Date.now()` up front (used for both the existing non-forced interval short-circuit and the new forced-freshness check).
-3. Replace the single join-or-start block with a loop: join (or start) the in-flight refresh, record/read its start timestamp, await it. If not forced, or the joined refresh started at/after requestedAt, return. Otherwise loop to trigger one more fetch, since the joined refresh may have started (and captured refs) before this force request arrived.
-4. Reset the new `remoteRefRefreshStartedAt` field in `disposeContentStore()` alongside the existing `remoteRefRefreshPromise`/`lastRemoteRefRefreshAt` reset.
-5. Add a regression test in src/test/core-task-corpus-regressions.test.ts: gate a mocked git.fetch so a non-forced read-triggered fetch is in flight, push a new task from a contributor clone while it's in flight, then concurrently call the forced `generateNextId()`; assert it joins the in-flight fetch, issues exactly one more fetch, and allocates past the newly pushed task (no duplicate/stale ID).
-6. Verify the existing "allocates past a remote task pushed inside the read refresh window" test (push completes before allocation starts) still asserts exactly 1 fetch, confirming AC #3 (no extra fetch when nothing is in flight).
-7. Run bunx tsc --noEmit, bun run check ., and the scoped test file, then the full suite.
+1. In Core.refreshRemoteRefsForTaskRead (src/core/backlog.ts), keep the existing non-forced interval short-circuit and the single-slot remoteRefRefreshPromise join-or-start coalescing unchanged.
+2. Before the join-or-start, add a forced-only pre-wait: if a refresh is already in flight when a forced request arrives, await it first. Anything in the slot at that moment started before the request, so its captured refs may predate a push the caller must see.
+3. Rely on the slot's existing clear handler (registered synchronously at creation, so it runs ahead of any later awaiter) to empty the slot, which makes the subsequent join-or-start always begin a fetch that starts after the request arrived.
+4. Add a regression test in src/test/core-task-corpus-regressions.test.ts: gate a mocked git.fetch so the real fetch captures remote state before a contributor push but withholds resolution, push a task from a clone while that fetch is in flight, then run a concurrent forced generateNextId(); assert it allocates past the pushed task using exactly 2 fetches.
+5. Confirm the pre-existing 'allocates past a remote task pushed inside the read refresh window' test still asserts exactly 1 fetch, covering AC #3.
+6. Verify the test fails on pre-fix code, then run bunx tsc --noEmit and the full test suite.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -58,14 +57,24 @@ Addressed Codex PR review (PR #925): replaced the Date.now()-based remoteRefRefr
 Rebased onto the newly conflict-free BACK-637 branch tip after that branch was rebased onto upstream main; no additional conflicts.
 
 Rebased again (BACK-641) onto BACK-637's new post-BACK-639 tip after that branch was itself rebased onto upstream main -- the previous note here about 'the conflict-free BACK-637 tip' referred to a tip that no longer exists (BACK-637's rebase rewrote every commit SHA). This rebase (via 'git rebase --onto' against the old BACK-637 tip 6753c4d) replayed cleanly with zero conflicts. Verified refreshRemoteRefsForTaskRead and the remoteRefRefreshGeneration field are byte-identical to the pre-rebase version (isolated function-body diff, not just a whole-file diff, since the whole file shifted substantially due to BACK-639's unrelated draft-editing changes). bunx tsc --noEmit clean; the scoped core-task-corpus-regressions.test.ts (7 tests) passes.
+
+Maintainer review (takeover of PR #925): the contributor's diagnosis and fix were correct, and the regression test reproducibly fails on pre-fix code. Two changes on review:
+
+1. Simplified the implementation. The submitted fix tracked fetch ordering with a monotonic remoteRefRefreshGeneration field and re-entered a while(true) loop until the joined fetch's generation exceeded the one captured at entry. That is equivalent to simply waiting out whatever refresh was already in flight: any promise present in the single remoteRefRefreshPromise slot when the request arrives started before the request by construction, and the slot's clear handler is registered at creation, so it runs before any later awaiter's continuation. Replaced the counter and loop with a single guarded pre-wait, dropping one class field and the loop. The loop version also had a latent hazard the linear version does not: if the slot were ever not cleared before the awaiter resumed, it would spin on an already-resolved promise instead of returning.
+
+2. Rebased off the unmerged BACK-637/BACK-641 stack onto origin/main (post BACK-639 draft-editing merge). The PR previously carried the whole BACK-637 project-attribute branch in its diff; replayed the five BACK-627 commits with git rebase --onto and got zero conflicts. The branch now touches only src/core/backlog.ts, src/test/core-task-corpus-regressions.test.ts, and this task file.
+
+Residual race (inherent, not introduced here): a push that lands during the second, post-request fetch is still invisible to that allocation. Closing that would need server-side reservation, not a client fetch.
+
+Residual hole found during maintainer review, deliberately left out of scope (needs a product decision): GitOperations.fetch has its own coalescing layer (this.fetches, keyed by remote, in src/git/operations.ts). Core's forced pre-wait guarantees Core's own remoteRefRefreshPromise slot is empty, and because GitOperations deletes its map entry in a finally before fetch() returns, the forced path does start a genuinely new git fetch in the common case. But generateNextDocId and generateNextDecisionId (src/utils/id-generators.ts) call core.gitOps.fetch() directly, bypassing Core's slot. If one of those is in flight when a forced task-ID refresh runs, Core sees an empty slot, calls git.fetch(), and joins the older git-level fetch -- reintroducing exactly the staleness this task closes. Narrow: it needs a concurrent doc/decision ID allocation in the same process (TUI or web server, not separate CLI invocations). Not fixed here because the obvious fix (a force flag that skips the git-level dedup) can put two concurrent git fetches on the same remote and risk ref lock contention, which is a bigger decision than this task's scope.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Fixed the force-fetch join race in Core.refreshRemoteRefsForTaskRead (src/core/backlog.ts): a forced allocation refresh that arrived while a non-forced fetch was already in flight simply joined that fetch and returned, so a push landing during that in-flight fetch's remaining duration was invisible to allocation, risking a duplicate ID. The force path now tracks when the joined refresh actually started (new remoteRefRefreshStartedAt field) and, if that predates the force request, loops to issue one more fetch after the joined one resolves.
+Fixed the force-fetch join race in Core.refreshRemoteRefsForTaskRead (src/core/backlog.ts). A forced allocation refresh that arrived while a non-forced fetch was already in flight simply joined that fetch and returned; because that fetch captured remote state before the force request arrived, a push landing during its remaining duration was invisible to allocation and could hand out an already-published numeric ID. The forced path now waits out any refresh that was already in flight before joining or starting one, so the fetch it ultimately observes always starts after the request arrived. Non-forced reads keep the previous join-or-start coalescing, and a forced request with nothing in flight still issues exactly one fetch.
 
-Added a regression test in src/test/core-task-corpus-regressions.test.ts that reproduces the race with a gated git.fetch mock (data captured before the push, resolution withheld until released) driving a concurrent forced generateNextId() call. Confirmed it fails on pre-fix code (allocates a colliding TASK-2) and passes post-fix (allocates TASK-3 via exactly 2 fetches). The pre-existing "allocates past a remote task pushed inside the read refresh window" test still asserts a single fetch when nothing is in flight, covering AC #3.
+Added a regression test in src/test/core-task-corpus-regressions.test.ts that gates a mocked git.fetch (remote state captured before the push, resolution withheld until released) so a contributor push lands while a non-forced fetch is in flight, then drives a concurrent forced generateNextId(). Verified it fails deterministically on pre-fix code (allocates a colliding TASK-2, reproduced across repeated runs) and passes post-fix (allocates TASK-3 via exactly 2 fetches). The pre-existing single-fetch assertion still holds, covering AC #3.
 
-Verified: bunx tsc --noEmit clean, bun run check . clean (391 files), full bun run test suite passes -- 2395 pass / 6 pre-existing skips / 0 fail across 250 files.
+Verified: bunx tsc --noEmit clean; full bun run test suite green. Note that bun run check . is red on main for an unrelated pre-existing formatting error in src/ui/components/task-composer.ts (untouched by this task).
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
+++ b/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-10 06:37'
-updated_date: '2026-08-29 18:27'
+updated_date: '2026-08-29 18:52'
 labels: []
 dependencies: []
 priority: medium
@@ -69,6 +69,12 @@ Residual race (inherent, not introduced here): a push that lands during the seco
 Residual hole found during maintainer review, deliberately left out of scope (needs a product decision): GitOperations.fetch has its own coalescing layer (this.fetches, keyed by remote, in src/git/operations.ts). Core's forced pre-wait guarantees Core's own remoteRefRefreshPromise slot is empty, and because GitOperations deletes its map entry in a finally before fetch() returns, the forced path does start a genuinely new git fetch in the common case. But generateNextDocId and generateNextDecisionId (src/utils/id-generators.ts) call core.gitOps.fetch() directly, bypassing Core's slot. If one of those is in flight when a forced task-ID refresh runs, Core sees an empty slot, calls git.fetch(), and joins the older git-level fetch -- reintroducing exactly the staleness this task closes. Narrow: it needs a concurrent doc/decision ID allocation in the same process (TUI or web server, not separate CLI invocations). Not fixed here because the obvious fix (a force flag that skips the git-level dedup) can put two concurrent git fetches on the same remote and risk ref lock contention, which is a bigger decision than this task's scope.
 
 Correction to the verification above: the two src/test/core.test.ts failures seen during review ('fails closed when an archive snapshot...' and 'keeps an ID occupied when equal-time branch records...') were not environmental and not caused by this branch. They were a time-bomb in main's own tests -- hardcoded commit dates that aged out of the activeBranchDays window -- and upstream fixed them in main commit 6c6f1843 'Fix expired hardcoded commit dates in core branch-record tests'. Rebased this branch onto that new main; src/test/core.test.ts is now 66 pass / 0 fail locally.
+
+Pre-merge fix from Codex-thread triage at head 74e672a8. The forced pre-wait introduced a new interleaving window that the original synchronous join-or-start did not have: the entry guard 'if (git !== this.git) return' runs before the pre-wait, so if reinitializeProjectRoot() fires during that await it synchronously calls disposeContentStore() (nulling remoteRefRefreshPromise) and swaps this.git and this.fs. The forced continuation then resumes holding the captured old git and config, sees an empty slot, and starts an old-project fetch that it installs into the new project's slot. A new-project read entering afterwards passes its own entry guard, finds that slot occupied, joins it, and proceeds as though its remote refs were refreshed. Note the new-project caller does not self-heal via projectChanged(), because from its perspective nothing changed -- it started after the swap.
+
+Fixed by re-checking 'if (git !== this.git) return' immediately after the pre-wait, mirroring the entry guard and the existing 'if (this.git === git)' guard already used around lastRemoteRefRefreshAt. Returning early is safe for the old-project caller: loadTasksWithStableBranchSnapshot re-checks projectChanged() right after the refresh call and retries.
+
+Added a regression test 'does not start an old-root fetch when the project moves during a forced refresh' in src/test/shared-branch-task-loader.test.ts, next to its sibling 'does not let an old-root fetch lease suppress the new root' and reusing that file's existing lightweight scaffolding (fake roots, stubbed git.fetch, internals cast) rather than the heavier real-git setup in core-task-corpus-regressions.test.ts. The test is deterministic because the function body runs synchronously into the pre-wait, so the forced call is guaranteed parked there when reinitializeProjectRoot() is invoked. Verified it discriminates: 2 old-root fetches without the guard, 1 with it.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
+++ b/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-10 06:37'
-updated_date: '2026-08-24 22:12'
+updated_date: '2026-08-24 22:35'
 labels: []
 dependencies: []
 priority: medium
@@ -54,6 +54,8 @@ Added a regression test that gates a mocked git.fetch so the real fetch data-cap
 Verified: bunx tsc --noEmit clean, bun run check . clean (391 files), full bun run test suite: 2395 pass / 6 pre-existing skips / 0 fail across 250 files (was 2394 pass before the new test).
 
 Addressed Codex PR review (PR #925): replaced the Date.now()-based remoteRefRefreshStartedAt/requestedAt comparison with a monotonic remoteRefRefreshGeneration counter, avoiding a same-millisecond edge case where a stale in-flight fetch could look sufficiently fresh; disposeContentStore no longer resets the counter.
+
+Rebased onto the newly conflict-free BACK-637 branch tip after that branch was rebased onto upstream main; no additional conflicts.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
+++ b/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-627
 title: Prevent forced allocation refresh from joining an in-flight stale fetch
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-10 06:37'
+updated_date: '2026-08-20 21:32'
 labels: []
 dependencies: []
 priority: medium
@@ -18,14 +20,46 @@ Follow-up from the PR #899 (BACK-624) verification round. The task-ID allocation
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A forced allocation refresh that arrives during an in-flight non-forced fetch observes refs at least as fresh as the moment the force was requested
-- [ ] #2 A regression test covers the push-during-in-flight-fetch allocation race and fails on the current code
-- [ ] #3 No extra fetch is issued when no refresh is in flight (existing single-fetch assertion still passes)
+- [x] #1 A forced allocation refresh that arrives during an in-flight non-forced fetch observes refs at least as fresh as the moment the force was requested
+- [x] #2 A regression test covers the push-during-in-flight-fetch allocation race and fails on the current code
+- [x] #3 No extra fetch is issued when no refresh is in flight (existing single-fetch assertion still passes)
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a `remoteRefRefreshStartedAt` timestamp field next to `remoteRefRefreshPromise` in Core (src/core/backlog.ts), recording when the currently in-flight refresh's git.fetch() call actually started.
+2. In `refreshRemoteRefsForTaskRead`, capture `requestedAt = Date.now()` up front (used for both the existing non-forced interval short-circuit and the new forced-freshness check).
+3. Replace the single join-or-start block with a loop: join (or start) the in-flight refresh, record/read its start timestamp, await it. If not forced, or the joined refresh started at/after requestedAt, return. Otherwise loop to trigger one more fetch, since the joined refresh may have started (and captured refs) before this force request arrived.
+4. Reset the new `remoteRefRefreshStartedAt` field in `disposeContentStore()` alongside the existing `remoteRefRefreshPromise`/`lastRemoteRefRefreshAt` reset.
+5. Add a regression test in src/test/core-task-corpus-regressions.test.ts: gate a mocked git.fetch so a non-forced read-triggered fetch is in flight, push a new task from a contributor clone while it's in flight, then concurrently call the forced `generateNextId()`; assert it joins the in-flight fetch, issues exactly one more fetch, and allocates past the newly pushed task (no duplicate/stale ID).
+6. Verify the existing "allocates past a remote task pushed inside the read refresh window" test (push completes before allocation starts) still asserts exactly 1 fetch, confirming AC #3 (no extra fetch when nothing is in flight).
+7. Run bunx tsc --noEmit, bun run check ., and the scoped test file, then the full suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the reviewer-validated fix: refreshRemoteRefsForTaskRead now captures requestedAt up front and, when forced, loops after joining an in-flight refresh -- if the joined refresh's tracked start time (new remoteRefRefreshStartedAt field) predates requestedAt, it triggers one more fetch instead of returning immediately. Reset remoteRefRefreshStartedAt in disposeContentStore alongside the existing fields.
+
+Added a regression test that gates a mocked git.fetch so the real fetch data-capture happens before a contributor push (to make the race realistic) but resolution is withheld until released, simulating a genuinely in-flight non-forced fetch while the push lands and a forced generateNextId() call joins it. Verified the test fails on pre-fix code (allocates TASK-2, colliding with the pushed task) and passes post-fix (allocates TASK-3, exactly 2 fetches).
+
+Verified: bunx tsc --noEmit clean, bun run check . clean (391 files), full bun run test suite: 2395 pass / 6 pre-existing skips / 0 fail across 250 files (was 2394 pass before the new test).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the force-fetch join race in Core.refreshRemoteRefsForTaskRead (src/core/backlog.ts): a forced allocation refresh that arrived while a non-forced fetch was already in flight simply joined that fetch and returned, so a push landing during that in-flight fetch's remaining duration was invisible to allocation, risking a duplicate ID. The force path now tracks when the joined refresh actually started (new remoteRefRefreshStartedAt field) and, if that predates the force request, loops to issue one more fetch after the joined one resolves.
+
+Added a regression test in src/test/core-task-corpus-regressions.test.ts that reproduces the race with a gated git.fetch mock (data captured before the push, resolution withheld until released) driving a concurrent forced generateNextId() call. Confirmed it fails on pre-fix code (allocates a colliding TASK-2) and passes post-fix (allocates TASK-3 via exactly 2 fetches). The pre-existing "allocates past a remote task pushed inside the read refresh window" test still asserts a single fetch when nothing is in flight, covering AC #3.
+
+Verified: bunx tsc --noEmit clean, bun run check . clean (391 files), full bun run test suite passes -- 2395 pass / 6 pre-existing skips / 0 fail across 250 files.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
+++ b/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-10 06:37'
-updated_date: '2026-08-20 21:32'
+updated_date: '2026-08-24 22:12'
 labels: []
 dependencies: []
 priority: medium
@@ -52,6 +52,8 @@ Implemented the reviewer-validated fix: refreshRemoteRefsForTaskRead now capture
 Added a regression test that gates a mocked git.fetch so the real fetch data-capture happens before a contributor push (to make the race realistic) but resolution is withheld until released, simulating a genuinely in-flight non-forced fetch while the push lands and a forced generateNextId() call joins it. Verified the test fails on pre-fix code (allocates TASK-2, colliding with the pushed task) and passes post-fix (allocates TASK-3, exactly 2 fetches).
 
 Verified: bunx tsc --noEmit clean, bun run check . clean (391 files), full bun run test suite: 2395 pass / 6 pre-existing skips / 0 fail across 250 files (was 2394 pass before the new test).
+
+Addressed Codex PR review (PR #925): replaced the Date.now()-based remoteRefRefreshStartedAt/requestedAt comparison with a monotonic remoteRefRefreshGeneration counter, avoiding a same-millisecond edge case where a stale in-flight fetch could look sufficiently fresh; disposeContentStore no longer resets the counter.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
+++ b/backlog/tasks/back-627 - Prevent-forced-allocation-refresh-from-joining-an-in-flight-stale-fetch.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-10 06:37'
-updated_date: '2026-08-24 22:35'
+updated_date: '2026-08-27 17:05'
 labels: []
 dependencies: []
 priority: medium
@@ -56,6 +56,8 @@ Verified: bunx tsc --noEmit clean, bun run check . clean (391 files), full bun r
 Addressed Codex PR review (PR #925): replaced the Date.now()-based remoteRefRefreshStartedAt/requestedAt comparison with a monotonic remoteRefRefreshGeneration counter, avoiding a same-millisecond edge case where a stale in-flight fetch could look sufficiently fresh; disposeContentStore no longer resets the counter.
 
 Rebased onto the newly conflict-free BACK-637 branch tip after that branch was rebased onto upstream main; no additional conflicts.
+
+Rebased again (BACK-641) onto BACK-637's new post-BACK-639 tip after that branch was itself rebased onto upstream main -- the previous note here about 'the conflict-free BACK-637 tip' referred to a tip that no longer exists (BACK-637's rebase rewrote every commit SHA). This rebase (via 'git rebase --onto' against the old BACK-637 tip 6753c4d) replayed cleanly with zero conflicts. Verified refreshRemoteRefsForTaskRead and the remoteRefRefreshGeneration field are byte-identical to the pre-rebase version (isolated function-body diff, not just a whole-file diff, since the whole file shifted substantially due to BACK-639's unrelated draft-editing changes). bunx tsc --noEmit clean; the scoped core-task-corpus-regressions.test.ts (7 tests) passes.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -285,7 +285,7 @@ export class Core {
 	} | null = null;
 	private activeBranchRefreshPromise: Promise<void> | null = null;
 	private remoteRefRefreshPromise: Promise<void> | null = null;
-	private remoteRefRefreshStartedAt = 0;
+	private remoteRefRefreshGeneration = 0;
 	private lastRemoteRefRefreshAt = 0;
 
 	constructor(projectRoot: string, options?: { enableWatchers?: boolean }) {
@@ -618,13 +618,16 @@ export class Core {
 			return;
 		}
 
-		// A forced request must observe refs at least as fresh as requestedAt. Joining
-		// an in-flight non-forced fetch that started before requestedAt isn't enough --
-		// a push landing while that fetch is in flight would be invisible to it -- so
-		// loop once more to trigger a fetch that starts at/after requestedAt.
+		// A forced request must observe refs from a fetch that started at/after this request
+		// arrived. Joining an in-flight non-forced fetch that started earlier isn't enough --
+		// a push landing while that fetch is in flight would be invisible to it -- so loop once
+		// more to trigger a fetch that starts after this point. Ordering is tracked with a
+		// monotonic generation counter rather than Date.now(): two requests can otherwise land
+		// in the same millisecond, which would make a stale fetch look sufficiently fresh.
+		const requestedGeneration = this.remoteRefRefreshGeneration;
 		while (true) {
 			if (!this.remoteRefRefreshPromise) {
-				this.remoteRefRefreshStartedAt = Date.now();
+				this.remoteRefRefreshGeneration += 1;
 				const refreshPromise = (async () => {
 					git.setConfig(config);
 					try {
@@ -642,10 +645,10 @@ export class Core {
 				void refreshPromise.then(clearRefreshPromise, clearRefreshPromise);
 			}
 
-			const joinedRefreshStartedAt = this.remoteRefRefreshStartedAt;
+			const joinedRefreshGeneration = this.remoteRefRefreshGeneration;
 			await this.remoteRefRefreshPromise;
 
-			if (options?.force !== true || joinedRefreshStartedAt >= requestedAt) return;
+			if (options?.force !== true || joinedRefreshGeneration > requestedGeneration) return;
 		}
 	}
 
@@ -1087,7 +1090,6 @@ export class Core {
 		this.activeBranchSnapshotPromise = null;
 		this.activeBranchRefreshPromise = null;
 		this.remoteRefRefreshPromise = null;
-		this.remoteRefRefreshStartedAt = 0;
 		this.lastRemoteRefRefreshAt = 0;
 	}
 

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -625,6 +625,11 @@ export class Core {
 		// afterwards. A non-forced request keeps the plain join-or-start behavior.
 		if (force && this.remoteRefRefreshPromise) {
 			await this.remoteRefRefreshPromise;
+			// The project may have been re-pointed while we waited: reinitializeProjectRoot
+			// clears this slot and installs a new GitOperations. Starting a fetch for the old
+			// project now would publish it into the new project's slot, where a new-project
+			// read could join it and skip the refresh it actually needs.
+			if (git !== this.git) return;
 		}
 
 		if (!this.remoteRefRefreshPromise) {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -285,6 +285,7 @@ export class Core {
 	} | null = null;
 	private activeBranchRefreshPromise: Promise<void> | null = null;
 	private remoteRefRefreshPromise: Promise<void> | null = null;
+	private remoteRefRefreshStartedAt = 0;
 	private lastRemoteRefRefreshAt = 0;
 
 	constructor(projectRoot: string, options?: { enableWatchers?: boolean }) {
@@ -612,29 +613,40 @@ export class Core {
 		// Reads may reuse a recent fetch, but task ID allocation may not: an ID that
 		// looks free only because remote refs are up to a minute old is an ID another
 		// clone has already published.
-		if (options?.force !== true && Date.now() - this.lastRemoteRefRefreshAt < REMOTE_REF_REFRESH_INTERVAL_MS) {
+		const requestedAt = Date.now();
+		if (options?.force !== true && requestedAt - this.lastRemoteRefRefreshAt < REMOTE_REF_REFRESH_INTERVAL_MS) {
 			return;
 		}
 
-		if (!this.remoteRefRefreshPromise) {
-			const refreshPromise = (async () => {
-				git.setConfig(config);
-				try {
-					await git.fetch();
-				} catch (error) {
-					console.error("Failed to refresh remote refs:", error);
-				} finally {
-					if (this.git === git) this.lastRemoteRefRefreshAt = Date.now();
-				}
-			})();
-			this.remoteRefRefreshPromise = refreshPromise;
-			const clearRefreshPromise = () => {
-				if (this.remoteRefRefreshPromise === refreshPromise) this.remoteRefRefreshPromise = null;
-			};
-			void refreshPromise.then(clearRefreshPromise, clearRefreshPromise);
-		}
+		// A forced request must observe refs at least as fresh as requestedAt. Joining
+		// an in-flight non-forced fetch that started before requestedAt isn't enough --
+		// a push landing while that fetch is in flight would be invisible to it -- so
+		// loop once more to trigger a fetch that starts at/after requestedAt.
+		while (true) {
+			if (!this.remoteRefRefreshPromise) {
+				this.remoteRefRefreshStartedAt = Date.now();
+				const refreshPromise = (async () => {
+					git.setConfig(config);
+					try {
+						await git.fetch();
+					} catch (error) {
+						console.error("Failed to refresh remote refs:", error);
+					} finally {
+						if (this.git === git) this.lastRemoteRefRefreshAt = Date.now();
+					}
+				})();
+				this.remoteRefRefreshPromise = refreshPromise;
+				const clearRefreshPromise = () => {
+					if (this.remoteRefRefreshPromise === refreshPromise) this.remoteRefRefreshPromise = null;
+				};
+				void refreshPromise.then(clearRefreshPromise, clearRefreshPromise);
+			}
 
-		await this.remoteRefRefreshPromise;
+			const joinedRefreshStartedAt = this.remoteRefRefreshStartedAt;
+			await this.remoteRefRefreshPromise;
+
+			if (options?.force !== true || joinedRefreshStartedAt >= requestedAt) return;
+		}
 	}
 
 	/** Refresh the existing cross-branch store only when relevant config or refs changed. */
@@ -1075,6 +1087,7 @@ export class Core {
 		this.activeBranchSnapshotPromise = null;
 		this.activeBranchRefreshPromise = null;
 		this.remoteRefRefreshPromise = null;
+		this.remoteRefRefreshStartedAt = 0;
 		this.lastRemoteRefRefreshAt = 0;
 	}
 

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -285,7 +285,6 @@ export class Core {
 	} | null = null;
 	private activeBranchRefreshPromise: Promise<void> | null = null;
 	private remoteRefRefreshPromise: Promise<void> | null = null;
-	private remoteRefRefreshGeneration = 0;
 	private lastRemoteRefRefreshAt = 0;
 
 	constructor(projectRoot: string, options?: { enableWatchers?: boolean }) {
@@ -613,43 +612,40 @@ export class Core {
 		// Reads may reuse a recent fetch, but task ID allocation may not: an ID that
 		// looks free only because remote refs are up to a minute old is an ID another
 		// clone has already published.
-		const requestedAt = Date.now();
-		if (options?.force !== true && requestedAt - this.lastRemoteRefRefreshAt < REMOTE_REF_REFRESH_INTERVAL_MS) {
+		const force = options?.force === true;
+		if (!force && Date.now() - this.lastRemoteRefRefreshAt < REMOTE_REF_REFRESH_INTERVAL_MS) {
 			return;
 		}
 
-		// A forced request must observe refs from a fetch that started at/after this request
-		// arrived. Joining an in-flight non-forced fetch that started earlier isn't enough --
-		// a push landing while that fetch is in flight would be invisible to it -- so loop once
-		// more to trigger a fetch that starts after this point. Ordering is tracked with a
-		// monotonic generation counter rather than Date.now(): two requests can otherwise land
-		// in the same millisecond, which would make a stale fetch look sufficiently fresh.
-		const requestedGeneration = this.remoteRefRefreshGeneration;
-		while (true) {
-			if (!this.remoteRefRefreshPromise) {
-				this.remoteRefRefreshGeneration += 1;
-				const refreshPromise = (async () => {
-					git.setConfig(config);
-					try {
-						await git.fetch();
-					} catch (error) {
-						console.error("Failed to refresh remote refs:", error);
-					} finally {
-						if (this.git === git) this.lastRemoteRefRefreshAt = Date.now();
-					}
-				})();
-				this.remoteRefRefreshPromise = refreshPromise;
-				const clearRefreshPromise = () => {
-					if (this.remoteRefRefreshPromise === refreshPromise) this.remoteRefRefreshPromise = null;
-				};
-				void refreshPromise.then(clearRefreshPromise, clearRefreshPromise);
-			}
-
-			const joinedRefreshGeneration = this.remoteRefRefreshGeneration;
+		// A forced request must observe refs from a fetch that started after the request
+		// arrived. Joining a refresh that was already in flight is not enough: it captured
+		// remote state before this request, so a push landing while it runs stays invisible
+		// and allocation can hand out an ID another clone already published. Waiting that
+		// refresh out first leaves the slot empty, so the fetch joined below always starts
+		// afterwards. A non-forced request keeps the plain join-or-start behavior.
+		if (force && this.remoteRefRefreshPromise) {
 			await this.remoteRefRefreshPromise;
-
-			if (options?.force !== true || joinedRefreshGeneration > requestedGeneration) return;
 		}
+
+		if (!this.remoteRefRefreshPromise) {
+			const refreshPromise = (async () => {
+				git.setConfig(config);
+				try {
+					await git.fetch();
+				} catch (error) {
+					console.error("Failed to refresh remote refs:", error);
+				} finally {
+					if (this.git === git) this.lastRemoteRefRefreshAt = Date.now();
+				}
+			})();
+			this.remoteRefRefreshPromise = refreshPromise;
+			const clearRefreshPromise = () => {
+				if (this.remoteRefRefreshPromise === refreshPromise) this.remoteRefRefreshPromise = null;
+			};
+			void refreshPromise.then(clearRefreshPromise, clearRefreshPromise);
+		}
+
+		await this.remoteRefRefreshPromise;
 	}
 
 	/** Refresh the existing cross-branch store only when relevant config or refs changed. */

--- a/src/test/core-task-corpus-regressions.test.ts
+++ b/src/test/core-task-corpus-regressions.test.ts
@@ -323,6 +323,72 @@ describe("Core shared task corpus regressions", () => {
 		expect(fetches).toBe(1);
 	});
 
+	it("allocates past a remote task pushed while a non-forced fetch is in flight", async () => {
+		await saveRemoteEnabledConfig("Core allocation in-flight freshness");
+		const originDir = trackDir("origin");
+		await mkdir(originDir, { recursive: true });
+		await $`git init --bare -b main`.cwd(originDir).quiet();
+		await writeTask(core.filesystem.tasksDir, "task-1 - Local.md", task("TASK-1", "Local task"));
+		await commit("Add local task", recentCommitDate(2));
+		await $`git remote add origin ${originDir}`.cwd(testDir).quiet();
+		await $`git push -u origin main`.cwd(testDir).quiet();
+
+		const git = core.gitOps;
+		const originalFetch = git.fetch.bind(git);
+		let fetches = 0;
+		let releaseFirstFetch: () => void = () => {};
+		const firstFetchStarted = new Promise<void>((resolve) => {
+			git.fetch = async (...args) => {
+				fetches += 1;
+				const isFirstFetch = fetches === 1;
+				// Capture the remote state now (before any later push), but withhold
+				// resolution until released, so the caller is still "in flight" per the
+				// remoteRefRefreshPromise coalescing while the push below lands.
+				const result = await originalFetch(...args);
+				if (isFirstFetch) {
+					resolve();
+					await new Promise<void>((releaseResolve) => {
+						releaseFirstFetch = releaseResolve;
+					});
+				}
+				return result;
+			};
+		});
+
+		try {
+			// A read starts a non-forced fetch and blocks in flight.
+			const readPromise = core.loadTasks();
+			await firstFetchStarted;
+
+			// A contributor pushes a new task while that fetch is still running, so it
+			// is invisible to the fetch already in flight.
+			const contributorDir = trackDir("contributor");
+			await $`git clone ${originDir} ${contributorDir}`.quiet();
+			await $`git switch -c contributed`.cwd(contributorDir).quiet();
+			await writeTask(
+				join(contributorDir, "backlog", "tasks"),
+				"task-2 - Contributed.md",
+				task("TASK-2", "Contributed"),
+			);
+			await $`git add -A`.cwd(contributorDir).quiet();
+			await $`git -c user.name="Backlog Test" -c user.email="test@example.com" commit -m "Contribute task"`
+				.cwd(contributorDir)
+				.quiet();
+			await $`git push -u origin contributed`.cwd(contributorDir).quiet();
+
+			// A forced allocation joins the in-flight fetch; it must not treat that
+			// stale-at-start fetch as sufficient once it observes the push above.
+			const allocationPromise = core.generateNextId();
+			releaseFirstFetch();
+
+			const [nextId] = await Promise.all([allocationPromise, readPromise]);
+			expect(nextId).toBe("TASK-3");
+		} finally {
+			git.fetch = originalFetch;
+		}
+		expect(fetches).toBe(2);
+	});
+
 	it("cancels a load before it starts a remote refresh", async () => {
 		await saveRemoteEnabledConfig("Core cancellation before fetch");
 		const git = core.gitOps;

--- a/src/test/shared-branch-task-loader.test.ts
+++ b/src/test/shared-branch-task-loader.test.ts
@@ -582,6 +582,45 @@ describe("shared immutable branch task loading", () => {
 		expect(newFetches).toBe(1);
 	});
 
+	it("does not start an old-root fetch when the project moves during a forced refresh", async () => {
+		const core = new Core("/tmp/forced-refresh-old-root");
+		let oldFetches = 0;
+		let releaseOldFetch: () => void = () => {};
+		const oldFetchGate = new Promise<void>((resolve) => {
+			releaseOldFetch = resolve;
+		});
+		const oldFetchStarted = new Promise<void>((resolve) => {
+			core.git.fetch = async () => {
+				oldFetches += 1;
+				resolve();
+				await oldFetchGate;
+			};
+		});
+		const internals = core as unknown as {
+			refreshRemoteRefsForTaskRead: (
+				loadedConfig: BacklogConfig,
+				git?: GitOperations,
+				options?: { force?: boolean },
+			) => Promise<void>;
+		};
+		const loadedConfig = { ...config, checkActiveBranches: true, remoteOperations: true };
+		const oldGit = core.git;
+
+		const readRefresh = internals.refreshRemoteRefsForTaskRead(loadedConfig);
+		await oldFetchStarted;
+
+		// Runs synchronously into its wait on the in-flight fetch, so the root moves
+		// while the forced refresh is parked there.
+		const forcedRefresh = internals.refreshRemoteRefsForTaskRead(loadedConfig, oldGit, { force: true });
+		core.reinitializeProjectRoot("/tmp/forced-refresh-new-root");
+		releaseOldFetch();
+		await Promise.all([readRefresh, forcedRefresh]);
+
+		// A second old-root fetch here would land in the new root's refresh slot, where a
+		// new-root read could join it and skip the refresh it actually needs.
+		expect(oldFetches).toBe(1);
+	});
+
 	it("retries a working-copy task snapshot after the project root changes", async () => {
 		const core = new Core("/tmp/working-copy-root-a");
 		const oldFilesystem = core.fs;


### PR DESCRIPTION
## Summary

Follow-up from the PR #899 (BACK-624) verification round. The task-ID allocation path forces a remote-ref refresh past the normal 60s lease, but a forced refresh arriving while a non-forced fetch is already in flight simply joined that fetch and returned — a push landing during the remaining fetch duration was invisible to the allocation, allowing a duplicate numeric ID (window typically under 2s, capped at 10s).

- `Core.refreshRemoteRefsForTaskRead` (`src/core/backlog.ts`) now tracks when the in-flight refresh it joins actually started (`remoteRefRefreshStartedAt`).
- On a forced call, if the joined refresh started before the request, it loops to trigger one more fetch after that refresh resolves, instead of returning immediately.
- No extra fetch is issued when no refresh is in flight — the existing single-fetch behavior is unchanged.

Closes BACK-627.

## Test plan

- [x] New regression test in `src/test/core-task-corpus-regressions.test.ts` reproduces the push-during-in-flight-fetch race with a gated `git.fetch` mock (real fetch data capture happens before the push, resolution withheld until released) driving a concurrent forced `generateNextId()` call
- [x] Confirmed the new test fails on pre-fix code (allocates a colliding `TASK-2`) and passes post-fix (allocates `TASK-3` via exactly 2 fetches)
- [x] Existing "allocates past a remote task pushed inside the read refresh window" test still asserts exactly 1 fetch when nothing is in flight
- [x] `bunx tsc --noEmit` clean
- [x] `bun run check .` clean (391 files)
- [x] `bun run test` — 2395 pass / 6 pre-existing skips / 0 fail across 250 files