### PR TITLE
BACK-635 - Reserve draft, doc, and decision prefixes at init

### DIFF
--- a/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
+++ b/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-635
 title: 'Reserve draft, doc, and decision prefixes at init'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-15 14:00'
+updated_date: '2026-08-20 22:44'
 labels: []
 dependencies: []
 priority: medium
@@ -18,13 +20,44 @@ From the PR #916 (BACK-634) review and a matching Codex finding. backlog init --
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 backlog init rejects draft, doc, and decision (case-insensitive) as --task-prefix and wizard values with a clear error
-- [ ] #2 Existing projects with a reserved prefix are unaffected at runtime (no new failures beyond current behavior); doctor mentions the misconfiguration
+- [x] #1 backlog init rejects draft, doc, and decision (case-insensitive) as --task-prefix and wizard values with a clear error
+- [x] #2 Existing projects with a reserved prefix are unaffected at runtime (no new failures beyond current behavior); doctor mentions the misconfiguration
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add RESERVED_TASK_PREFIXES (draft, doc, decision) and isReservedTaskPrefix() to src/utils/prefix-config.ts; extract DOC_PREFIX/DECISION_PREFIX constants used by getPrefixForType.
+2. Reject reserved prefixes (case-insensitive) in src/cli.ts: the --task-prefix flag validation and the interactive init wizard's clack.text validate callback, with a clear error message.
+3. Add a doctor check: load config.prefixes.task and warn (clear message, exitCode 1) when it collides with a reserved prefix, without altering any other runtime behavior for existing projects.
+4. Add regression tests: CLI test for init rejecting draft/doc/decision (case-insensitive) via --task-prefix, and a cli-doctor test asserting the new warning for an existing reserved-prefix project.
+5. Run bunx tsc --noEmit, bun run check ., and the scoped/full test suite; finalize the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC1: added isReservedTaskPrefix()/RESERVED_TASK_PREFIXES to src/utils/prefix-config.ts (also extracted DOC_PREFIX/DECISION_PREFIX constants, reused by getPrefixForType). Applied the check case-insensitively in both --task-prefix flag validation and the interactive init wizard's clack.text validate callback in src/cli.ts, with a clear error naming the reserved-for reason. No dedicated PTY test exists for the pre-existing letters-only wizard validation either, so wizard coverage relies on the shared, unit-tested isReservedTaskPrefix() helper plus code inspection rather than a new PTY harness - consistent with existing test-suite scope for this interactive prompt.
+
+AC2: doctor now loads config.prefixes.task and, if it collides with a reserved prefix, prints a clear warning and sets exitCode 1 (independent of duplicate-ID findings); "No duplicate task, document, or decision IDs found." is suppressed in that case so the warning isn't masked. No other runtime behavior was touched for existing reserved-prefix projects - misrouting stays exactly as before, per AC2's "no new failures beyond current behavior."
+
+Verification:
+- New tests: src/test/prefix-config.test.ts (isReservedTaskPrefix unit tests), src/test/cli-init-create.test.ts (6 cases: draft/DRAFT/doc/Doc/decision/DECISION rejected via --task-prefix, config.yml not created), src/test/cli-doctor.test.ts (doctor mentions the reserved-prefix collision).
+- git-stash fail/pass: stashing src/cli.ts + src/utils/prefix-config.ts reproduces the exact pre-fix failure (8 fail, including a module-load error for the missing isReservedTaskPrefix export); popping the stash makes all pass again.
+- bunx tsc --noEmit: clean.
+- bunx biome check on all touched files: clean. bun run check . reports 6 pre-existing errors in unrelated files (src/server/index.ts, src/ui/board.ts, src/ui/components/task-composer.ts) - confirmed present on unmodified main via git stash, untouched.
+- Full suite: bun test --timeout=10000 -> 2348 pass / 6 skip / 1 fail / 243 files. The sole fail (Config commands > reads the config key at column 0...) is the same pre-existing, unrelated YAML-parsing flake in config-commands.test.ts confirmed in the prior BACK-630 session.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+backlog init now rejects draft, doc, and decision (case-insensitive) as --task-prefix, both via the CLI flag and the interactive wizard prompt, using a new shared isReservedTaskPrefix() helper in src/utils/prefix-config.ts. Existing projects that already have a reserved prefix are untouched at runtime; backlog doctor now detects and clearly reports the misconfiguration (exitCode 1) instead of staying silent. Verified with new unit/CLI tests (prefix-config.test.ts, cli-init-create.test.ts, cli-doctor.test.ts), git-stash fail/pass confirmation, clean tsc/biome on touched files, and a full suite run (2348 pass, 1 pre-existing unrelated flake in config-commands.test.ts).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
+++ b/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
@@ -1,11 +1,12 @@
 ---
 id: BACK-635
 title: 'Reserve draft, doc, and decision prefixes at init'
-status: In Progress
+status: Done
 assignee:
   - '@grok'
+  - '@claude'
 created_date: '2026-08-15 14:00'
-updated_date: '2026-08-26 21:39'
+updated_date: '2026-08-29 18:07'
 labels: []
 dependencies: []
 priority: medium
@@ -20,15 +21,15 @@ From the PR #916 (BACK-634) review and a matching Codex finding. backlog init --
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 backlog init rejects draft, doc, and decision (case-insensitive) as --task-prefix and wizard values with a clear error
-- [ ] #2 Existing projects with a reserved prefix are unaffected at runtime (no new failures beyond current behavior); doctor mentions the misconfiguration
+- [x] #1 backlog init rejects draft, doc, and decision (case-insensitive) as --task-prefix and wizard values with a clear error
+- [x] #2 Existing projects with a reserved prefix are unaffected at runtime (no new failures beyond current behavior); doctor mentions the misconfiguration
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -62,4 +63,42 @@ Follow-up on PR #928 after rebase onto current main:
 - Documented reserved names in the init help schema as well as the commander option.
 - Doctor copy no longer suggests re-init; doctor --fix --yes returns without renaming files. task list still succeeds on an existing reserved-prefix project.
 - Scoped tests: prefix-config, cli-init-create, cli-doctor, enhanced-init, server-init. bunx tsc --noEmit and biome on touched files passed.
+
+Maintainer takeover of PR #928 (contributor jafigueroam94), rebase check + review pass on top of main @ 40482ca0:
+- prefix-config.ts: kept isReservedTaskPrefix/getTaskPrefixError as the single source of truth, but un-exported RESERVED_TASK_PREFIXES, DOC_PREFIX, and DECISION_PREFIX (no external consumers) and trimmed the JSDoc, per the minimal-API rule.
+- init.ts: dropped the '!isReInitialization' guard so an explicitly requested taskPrefix is always validated. Previously a project whose config predates the prefixes field could be re-initialized with --task-prefix draft and have the reserved prefix written; existing prefixes are still preserved untouched because re-init never feeds them back through advancedConfig.
+- server/index.ts: reserved prefixes now fail the browser init endpoint with 400 in the input-validation block instead of falling through to a 500 from the initializeProject throw. Web wizard surfaces the message either way.
+- InitializationScreen.tsx: existing task-prefix hint now names the reserved values, matching 'init --help'.
+- cli.ts: simplified the redundant flag-validation ternary and split the doctor warning into two readable lines.
+- Tests: fixed a doctor assertion that checked a stale message string ('No duplicate task, document, or decision IDs found.' -> the current '... decision, or draft IDs found.'), tightened the server test to assert 400, and added re-init rejection coverage in enhanced-init.
+
+End-to-end verification in a temp git project (bun src/cli.ts):
+- init --defaults --task-prefix draft/doc/DECISION -> exit 1, clear error, no backlog/config.yml written.
+- init --task-prefix JIRA -> succeeds, task_prefix: "JIRA", tasks created as jira-1.
+- Re-init without the flag preserves JIRA; re-init with --task-prefix draft exits 1 and leaves the config untouched.
+- Legacy project simulated with task_prefix: "draft": task list and task create still succeed (exit 0), doctor prints the collision warning and exits 1, doctor --fix --yes refuses without renaming files, re-init preserves the reserved prefix.
+- init --help lists 'draft, doc, and decision are reserved' in both the commander option and the help schema.
+
+Full-suite result on the final head (bun test): 2427 pass / 7 skip / 1 fail across 247 files.
+
+The single failure is 'Config commands > reads the config key at column 0, not an indented look-alike inside another key's value'. It is NOT caused by this PR and is NOT a flake (the earlier note calling it an intermittent YAML flake was wrong - it reproduces deterministically when the file is run alone). Proof it is unrelated:
+- Both the test (src/test/config-commands.test.ts) and the code it exercises (src/file-system/operations.ts, parseConfigListValue/parseConfig) are byte-identical to origin/main; 'git diff origin/main' on those two paths is empty.
+- Nothing in this PR touches config parsing.
+- Root cause is a Bun version difference, not a code regression: operations.ts parses config with Bun.YAML.parse, CI pins BUN_VERSION 1.3.14, and this machine runs bun 1.4.0. Bun 1.4 rejects tab-indented YAML ('Tab characters cannot be used as indentation'), so the test's tab-indentation control assertion fails. CI on main is green.
+
+Separately, 'bun run check .' reports one formatter-only error in src/ui/components/task-composer.ts. That file is also byte-identical to origin/main and is outside CI's gate (CI runs 'bun run lint' = biome lint, not biome check). Left untouched to keep the diff scoped. Biome is clean on every file this PR touches, and 'bun run lint' is clean repo-wide.
+
+Verification on the final head: bunx tsc --noEmit clean; bun run lint clean; scoped suites green (prefix-config, enhanced-init, server-init, cli-doctor, cli-init-create = 170 tests, 0 fail).
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+backlog init now rejects draft, doc, and decision (case-insensitive) as a task prefix, so a project can no longer be created in the state where regular tasks are stored as DRAFT-/doc-/decision- IDs and are then misrouted by the web server and MCP as drafts, documents, or decisions.
+
+One validator, getTaskPrefixError() in src/utils/prefix-config.ts, backs every entry point: the --task-prefix flag, the interactive init wizard prompt, the browser init endpoint (400), and initializeProject() itself, which enforces it for any caller. Reserved names are documented in both the commander option and the init help schema, and in the web wizard's task-prefix hint.
+
+Existing projects that already carry a reserved prefix are left working exactly as before - task list, task create, and re-init all still succeed - because the prefix is only validated when it is explicitly requested and existing config prefixes are preserved untouched. backlog doctor reports the collision with a human-readable explanation and no false promise of an automated migration, exits 1, and refuses --fix so duplicate-ID repair cannot allocate an ID into the colliding draft/doc/decision store.
+
+Verified end to end in a temp git project: reserved values rejected at exit 1 with no config.yml written; JIRA accepted and tasks created as jira-1; re-init preserves the prefix and rejects a reserved one; a simulated legacy task_prefix draft project still lists and creates tasks at exit 0 while doctor warns, exits 1, and --fix --yes renames nothing. Backed by unit and integration tests across prefix-config, enhanced-init, server-init, cli-doctor, and cli-init-create.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
+++ b/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-635
 title: 'Reserve draft, doc, and decision prefixes at init'
-status: Done
+status: In Progress
 assignee:
-  - '@claude'
+  - '@grok'
 created_date: '2026-08-15 14:00'
-updated_date: '2026-08-24 21:25'
+updated_date: '2026-08-26 21:39'
 labels: []
 dependencies: []
 priority: medium
@@ -20,25 +20,25 @@ From the PR #916 (BACK-634) review and a matching Codex finding. backlog init --
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 backlog init rejects draft, doc, and decision (case-insensitive) as --task-prefix and wizard values with a clear error
-- [x] #2 Existing projects with a reserved prefix are unaffected at runtime (no new failures beyond current behavior); doctor mentions the misconfiguration
+- [ ] #1 backlog init rejects draft, doc, and decision (case-insensitive) as --task-prefix and wizard values with a clear error
+- [ ] #2 Existing projects with a reserved prefix are unaffected at runtime (no new failures beyond current behavior); doctor mentions the misconfiguration
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [x] #1 bunx tsc --noEmit passes when TypeScript touched
-- [x] #2 bun run check . passes when formatting/linting touched
-- [x] #3 bun test (or scoped test) passes
+- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Add RESERVED_TASK_PREFIXES (draft, doc, decision) and isReservedTaskPrefix() to src/utils/prefix-config.ts; extract DOC_PREFIX/DECISION_PREFIX constants used by getPrefixForType.
-2. Reject reserved prefixes (case-insensitive) in src/cli.ts: the --task-prefix flag validation and the interactive init wizard's clack.text validate callback, with a clear error message.
-3. Add a doctor check: load config.prefixes.task and warn (clear message, exitCode 1) when it collides with a reserved prefix, without altering any other runtime behavior for existing projects.
-4. Add regression tests: CLI test for init rejecting draft/doc/decision (case-insensitive) via --task-prefix, and a cli-doctor test asserting the new warning for an existing reserved-prefix project.
-5. Run bunx tsc --noEmit, bun run check ., and the scoped/full test suite; finalize the task.
+1. Keep a single reserved-prefix check in src/utils/prefix-config.ts (draft, doc, decision; case-insensitive) and reuse it from the init wizard, --task-prefix flag, and initializeProject so CLI and browser init fail the same way.
+2. Do not fail existing reserved-prefix projects at runtime. Re-init keeps existing prefixes. Doctor reports the collision and refuses --fix so duplicate repair cannot allocate into the colliding draft/doc/decision store.
+3. Document reserved names in public init help (commander option plus input schema). Replace doctor copy that tells users to re-init or otherwise do something that cannot work.
+4. Add/keep tests for: flag rejection (case-insensitive), shared initializeProject rejection, doctor mention, doctor --fix no-op, runtime commands still working on a reserved-prefix project, init --help listing reserved names.
+5. Rebase onto current main so cli.ts picks up BACK-626/BACK-638 without changing reserved-prefix behavior. Run tsc, biome on touched files, and scoped tests.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -56,10 +56,10 @@ Verification:
 - Full suite: bun test --timeout=10000 -> 2348 pass / 6 skip / 1 fail / 243 files. The sole fail (Config commands > reads the config key at column 0...) is the same pre-existing, unrelated YAML-parsing flake in config-commands.test.ts confirmed in the prior BACK-630 session.
 
 Addressed Codex PR review (PR #928): moved reserved-prefix validation into initializeProject so the browser init path is covered too; documented reserved names in --task-prefix help; fixed doctor's impossible re-init recovery text; blocked 'doctor --fix --yes' automatic repair when the prefix is reserved.
+
+Follow-up on PR #928 after rebase onto current main:
+- Shared getTaskPrefixError() across the init wizard, --task-prefix flag, and initializeProject (CLI + browser).
+- Documented reserved names in the init help schema as well as the commander option.
+- Doctor copy no longer suggests re-init; doctor --fix --yes returns without renaming files. task list still succeeds on an existing reserved-prefix project.
+- Scoped tests: prefix-config, cli-init-create, cli-doctor, enhanced-init, server-init. bunx tsc --noEmit and biome on touched files passed.
 <!-- SECTION:NOTES:END -->
-
-## Final Summary
-
-<!-- SECTION:FINAL_SUMMARY:BEGIN -->
-backlog init now rejects draft, doc, and decision (case-insensitive) as --task-prefix, both via the CLI flag and the interactive wizard prompt, using a new shared isReservedTaskPrefix() helper in src/utils/prefix-config.ts. Existing projects that already have a reserved prefix are untouched at runtime; backlog doctor now detects and clearly reports the misconfiguration (exitCode 1) instead of staying silent. Verified with new unit/CLI tests (prefix-config.test.ts, cli-init-create.test.ts, cli-doctor.test.ts), git-stash fail/pass confirmation, clean tsc/biome on touched files, and a full suite run (2348 pass, 1 pre-existing unrelated flake in config-commands.test.ts).
-<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
+++ b/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-15 14:00'
-updated_date: '2026-08-20 22:44'
+updated_date: '2026-08-24 21:25'
 labels: []
 dependencies: []
 priority: medium
@@ -54,6 +54,8 @@ Verification:
 - bunx tsc --noEmit: clean.
 - bunx biome check on all touched files: clean. bun run check . reports 6 pre-existing errors in unrelated files (src/server/index.ts, src/ui/board.ts, src/ui/components/task-composer.ts) - confirmed present on unmodified main via git stash, untouched.
 - Full suite: bun test --timeout=10000 -> 2348 pass / 6 skip / 1 fail / 243 files. The sole fail (Config commands > reads the config key at column 0...) is the same pre-existing, unrelated YAML-parsing flake in config-commands.test.ts confirmed in the prior BACK-630 session.
+
+Addressed Codex PR review (PR #928): moved reserved-prefix validation into initializeProject so the browser init path is covered too; documented reserved names in --task-prefix help; fixed doctor's impossible re-init recovery text; blocked 'doctor --fix --yes' automatic repair when the prefix is reserved.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
+++ b/backlog/tasks/back-635 - Reserve-draft-doc-and-decision-prefixes-at-init.md
@@ -6,7 +6,7 @@ assignee:
   - '@grok'
   - '@claude'
 created_date: '2026-08-15 14:00'
-updated_date: '2026-08-29 18:07'
+updated_date: '2026-08-29 18:36'
 labels: []
 dependencies: []
 priority: medium
@@ -89,6 +89,18 @@ The single failure is 'Config commands > reads the config key at column 0, not a
 Separately, 'bun run check .' reports one formatter-only error in src/ui/components/task-composer.ts. That file is also byte-identical to origin/main and is outside CI's gate (CI runs 'bun run lint' = biome lint, not biome check). Left untouched to keep the diff scoped. Biome is clean on every file this PR touches, and 'bun run lint' is clean repo-wide.
 
 Verification on the final head: bunx tsc --noEmit clean; bun run lint clean; scoped suites green (prefix-config, enhanced-init, server-init, cli-doctor, cli-init-create = 170 tests, 0 fail).
+
+Codex-thread triage fixes on head 1fe43a7d:
+
+1. Whitespace-prefix regression (real regression vs old main). getTaskPrefixError() trimmed before validating while initializeProject persists advancedConfig.taskPrefix verbatim, so 'init --task-prefix " JIRA "' wrote task_prefix: " JIRA " and produced task files literally named ' jira -jira -1 - Title.md'. Whitespace-only '   ' persisted the same way. Old main rejected the raw value because its check was untrimmed.
+   Fix keeps one owner for the rule: getTaskPrefixError() now judges the value exactly as given, since init stores it verbatim. The init wizard trims before calling (it already trimmed what it assigned), so blank input still means 'use the default' and typing a padded value in the prompt is still accepted and trimmed - wizard behavior is unchanged. The --task-prefix flag, initializeProject, and the browser endpoint now all reject padding instead of persisting it.
+   Regression coverage: unit cases for ' JIRA ', 'JIRA ', '   ', and ' draft ' in prefix-config.test.ts, plus a CLI end-to-end case in cli-init-create.test.ts asserting exit 1 and no config.yml.
+
+2. Doctor guidance named a nonexistent config key. The message said 'set prefixes.task in the project config file', but the on-disk YAML key is task_prefix (src/file-system/operations.ts serializes prefixes.task as task_prefix). prefixes.task is the in-memory shape only, so the advice could not be followed as written. Copy now names task_prefix.
+
+Verified end to end: padded, whitespace-only, and padded-reserved values all exit 1 with no config.yml written; clean 'JIRA' still initializes and creates jira-1; doctor now prints the task_prefix key name. bunx tsc --noEmit clean, bun run lint clean, scoped suites green (prefix-config, enhanced-init, server-init, cli-doctor, cli-init-create).
+
+Deferred per triage, not touched: git-init-before-validation ordering, and the non-string taskPrefix 500 on the browser endpoint (both pre-existing/edge).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1225,7 +1225,8 @@ addHelpSchema(program.command("init [projectName]"), {
 				if (!taskPrefix && !isNonInteractive && !isReInitialization) {
 					const enteredPrefix = await clack.text({
 						message: "Task prefix (default: task):",
-						validate: (value) => getTaskPrefixError(String(value ?? "")),
+						// The prompt trims what it accepts below, so judge the trimmed value here too.
+						validate: (value) => getTaskPrefixError(String(value ?? "").trim()),
 					});
 					if (clack.isCancel(enteredPrefix)) {
 						abortInitialization();
@@ -5178,7 +5179,7 @@ addHelpSchema(program.command("doctor"), {
 					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type.`,
 				);
 				console.error(
-					"There is no automated migration. Rename the affected task files and IDs to a non-reserved prefix, then set prefixes.task in the project config file to match.",
+					"There is no automated migration. Rename the affected task files and IDs to a non-reserved prefix, then set task_prefix in the project config file to match.",
 				);
 				process.exitCode = 1;
 				if (options.fix) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,7 +81,7 @@ import {
 	runMcpClientSetupCommand,
 } from "./utils/mcp-client-setup.ts";
 import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
-import { DRAFT_PREFIX, hasAnyPrefix, normalizeId } from "./utils/prefix-config.ts";
+import { DRAFT_PREFIX, hasAnyPrefix, isReservedTaskPrefix, normalizeId } from "./utils/prefix-config.ts";
 import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
 import { type ReadOutputMode, resolveReadOutputMode } from "./utils/read-output-mode.ts";
 import { getTaskReadiness, loadReadinessGraph } from "./utils/readiness.ts";
@@ -1191,6 +1191,9 @@ addHelpSchema(program.command("init [projectName]"), {
 							if (!/^[a-zA-Z]+$/.test(normalized)) {
 								return "Task prefix must contain only letters (a-z, A-Z).";
 							}
+							if (isReservedTaskPrefix(normalized)) {
+								return `Task prefix "${normalized}" is reserved for drafts, docs, or decisions. Choose a different prefix.`;
+							}
 							return undefined;
 						},
 					});
@@ -1203,6 +1206,12 @@ addHelpSchema(program.command("init [projectName]"), {
 				// Validate task prefix if provided
 				if (taskPrefix && !/^[a-zA-Z]+$/.test(taskPrefix)) {
 					console.error("Task prefix must contain only letters (a-z, A-Z).");
+					process.exit(1);
+				}
+				if (taskPrefix && isReservedTaskPrefix(taskPrefix)) {
+					console.error(
+						`Task prefix "${taskPrefix}" is reserved for drafts, docs, or decisions. Choose a different prefix.`,
+					);
 					process.exit(1);
 				}
 
@@ -5005,11 +5014,23 @@ addHelpSchema(program.command("doctor"), {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		try {
+			const config = await core.filesystem.loadConfig();
+			const taskPrefix = config?.prefixes?.task;
+			const reservedTaskPrefix = taskPrefix && isReservedTaskPrefix(taskPrefix) ? taskPrefix : null;
+			if (reservedTaskPrefix) {
+				console.error(
+					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type. Task prefix cannot be changed after initialization; re-initialize the project with a different prefix instead.`,
+				);
+				process.exitCode = 1;
+			}
+
 			const plan = await core.previewDuplicateTaskIdRepair({ includeBranches: true });
 			const contentIdentity = await core.diagnoseContentIdentity();
 			const contentIdentityBroken = hasContentIdentityIssues(contentIdentity);
 			if (plan.groups.length === 0 && plan.crossBranchFindings.length === 0 && !contentIdentityBroken) {
-				console.log("No duplicate task, document, or decision IDs found.");
+				if (!reservedTaskPrefix) {
+					console.log("No duplicate task, document, or decision IDs found.");
+				}
 				return;
 			}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,7 +84,7 @@ import {
 	runMcpClientSetupCommand,
 } from "./utils/mcp-client-setup.ts";
 import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
-import { DRAFT_PREFIX, hasAnyPrefix, normalizeId } from "./utils/prefix-config.ts";
+import { DRAFT_PREFIX, hasAnyPrefix, isReservedTaskPrefix, normalizeId } from "./utils/prefix-config.ts";
 import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
 import { type ReadOutputMode, resolveReadOutputMode } from "./utils/read-output-mode.ts";
 import { getTaskReadiness, loadReadinessGraph } from "./utils/readiness.ts";
@@ -1219,6 +1219,9 @@ addHelpSchema(program.command("init [projectName]"), {
 							if (!/^[a-zA-Z]+$/.test(normalized)) {
 								return "Task prefix must contain only letters (a-z, A-Z).";
 							}
+							if (isReservedTaskPrefix(normalized)) {
+								return `Task prefix "${normalized}" is reserved for drafts, docs, or decisions. Choose a different prefix.`;
+							}
 							return undefined;
 						},
 					});
@@ -1231,6 +1234,12 @@ addHelpSchema(program.command("init [projectName]"), {
 				// Validate task prefix if provided
 				if (taskPrefix && !/^[a-zA-Z]+$/.test(taskPrefix)) {
 					console.error("Task prefix must contain only letters (a-z, A-Z).");
+					process.exit(1);
+				}
+				if (taskPrefix && isReservedTaskPrefix(taskPrefix)) {
+					console.error(
+						`Task prefix "${taskPrefix}" is reserved for drafts, docs, or decisions. Choose a different prefix.`,
+					);
 					process.exit(1);
 				}
 
@@ -5165,6 +5174,16 @@ addHelpSchema(program.command("doctor"), {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);
 		try {
+			const config = await core.filesystem.loadConfig();
+			const taskPrefix = config?.prefixes?.task;
+			const reservedTaskPrefix = taskPrefix && isReservedTaskPrefix(taskPrefix) ? taskPrefix : null;
+			if (reservedTaskPrefix) {
+				console.error(
+					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type. Task prefix cannot be changed after initialization; re-initialize the project with a different prefix instead.`,
+				);
+				process.exitCode = 1;
+			}
+
 			const plan = await core.previewDuplicateTaskIdRepair({ includeBranches: true });
 			const contentIdentity = await core.diagnoseContentIdentity();
 			const contentIdentityBroken = hasContentIdentityIssues(contentIdentity);
@@ -5176,7 +5195,9 @@ addHelpSchema(program.command("doctor"), {
 				!contentIdentityBroken &&
 				!draftIdentityBroken
 			) {
-				console.log("No duplicate task, document, decision, or draft IDs found.");
+				if (!reservedTaskPrefix) {
+					console.log("No duplicate task, document, decision, or draft IDs found.");
+				}
 				return;
 			}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -930,7 +930,10 @@ addHelpSchema(program.command("init [projectName]"), {
 	)
 	.option("--backlog-dir <path>", "backlog folder for init: backlog, .backlog, or a custom project-relative path")
 	.option("--config-location <location>", "config location for init: folder or root")
-	.option("--task-prefix <prefix>", "custom task prefix, letters only (default: task)")
+	.option(
+		"--task-prefix <prefix>",
+		"custom task prefix, letters only (default: task); draft, doc, and decision are reserved",
+	)
 	.option("--no-git", "initialize without Git integration")
 	.option("--defaults", "use default values for all prompts")
 	.action(
@@ -5179,9 +5182,13 @@ addHelpSchema(program.command("doctor"), {
 			const reservedTaskPrefix = taskPrefix && isReservedTaskPrefix(taskPrefix) ? taskPrefix : null;
 			if (reservedTaskPrefix) {
 				console.error(
-					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type. Task prefix cannot be changed after initialization; re-initialize the project with a different prefix instead.`,
+					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type. Task prefix cannot be changed after initialization; there is no automated migration. Manually rename the affected task files and update the prefix in the project config file.`,
 				);
 				process.exitCode = 1;
+				if (options.fix) {
+					console.error("Resolve the reserved task prefix before running --fix.");
+					return;
+				}
 			}
 
 			const plan = await core.previewDuplicateTaskIdRepair({ includeBranches: true });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1233,7 +1233,7 @@ addHelpSchema(program.command("init [projectName]"), {
 					}
 					taskPrefix = String(enteredPrefix ?? "").trim();
 				}
-				const taskPrefixError = taskPrefix ? getTaskPrefixError(taskPrefix) : undefined;
+				const taskPrefixError = getTaskPrefixError(taskPrefix ?? "");
 				if (taskPrefixError) {
 					console.error(taskPrefixError);
 					process.exit(1);
@@ -5175,7 +5175,10 @@ addHelpSchema(program.command("doctor"), {
 			const reservedTaskPrefix = taskPrefix && isReservedTaskPrefix(taskPrefix) ? taskPrefix : null;
 			if (reservedTaskPrefix) {
 				console.error(
-					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type. There is no automated migration. Rename the affected task files and IDs to a non-reserved prefix, then set prefixes.task in the project config file to match.`,
+					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type.`,
+				);
+				console.error(
+					"There is no automated migration. Rename the affected task files and IDs to a non-reserved prefix, then set prefixes.task in the project config file to match.",
 				);
 				process.exitCode = 1;
 				if (options.fix) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,7 +84,13 @@ import {
 	runMcpClientSetupCommand,
 } from "./utils/mcp-client-setup.ts";
 import { resolveMilestoneInputForStorage } from "./utils/milestone-storage.ts";
-import { DRAFT_PREFIX, hasAnyPrefix, isReservedTaskPrefix, normalizeId } from "./utils/prefix-config.ts";
+import {
+	DRAFT_PREFIX,
+	getTaskPrefixError,
+	hasAnyPrefix,
+	isReservedTaskPrefix,
+	normalizeId,
+} from "./utils/prefix-config.ts";
 import { formatValidPriorityValues, getPriorityOptions, resolvePriorityValue } from "./utils/priority-config.ts";
 import { type ReadOutputMode, resolveReadOutputMode } from "./utils/read-output-mode.ts";
 import { getTaskReadiness, loadReadinessGraph } from "./utils/readiness.ts";
@@ -900,6 +906,11 @@ addHelpSchema(program.command("init [projectName]"), {
 			description: "Instruction files to create; cursor writes AGENTS.md; comma-separated",
 		},
 		{ name: "--backlog-dir", type: "Project-relative path", description: "backlog, .backlog, or custom path" },
+		{
+			name: "--task-prefix",
+			type: "String (letters only; default: task)",
+			description: "Task ID prefix; draft, doc, and decision are reserved",
+		},
 		{ name: "--no-git", type: "Boolean", description: "Initialize without Git integration" },
 	],
 	writes: "Backlog directory, config file, optional agent instruction files, and optional git commit",
@@ -1214,19 +1225,7 @@ addHelpSchema(program.command("init [projectName]"), {
 				if (!taskPrefix && !isNonInteractive && !isReInitialization) {
 					const enteredPrefix = await clack.text({
 						message: "Task prefix (default: task):",
-						validate: (value) => {
-							const normalized = String(value ?? "").trim();
-							if (!normalized) {
-								return undefined;
-							}
-							if (!/^[a-zA-Z]+$/.test(normalized)) {
-								return "Task prefix must contain only letters (a-z, A-Z).";
-							}
-							if (isReservedTaskPrefix(normalized)) {
-								return `Task prefix "${normalized}" is reserved for drafts, docs, or decisions. Choose a different prefix.`;
-							}
-							return undefined;
-						},
+						validate: (value) => getTaskPrefixError(String(value ?? "")),
 					});
 					if (clack.isCancel(enteredPrefix)) {
 						abortInitialization();
@@ -1234,15 +1233,9 @@ addHelpSchema(program.command("init [projectName]"), {
 					}
 					taskPrefix = String(enteredPrefix ?? "").trim();
 				}
-				// Validate task prefix if provided
-				if (taskPrefix && !/^[a-zA-Z]+$/.test(taskPrefix)) {
-					console.error("Task prefix must contain only letters (a-z, A-Z).");
-					process.exit(1);
-				}
-				if (taskPrefix && isReservedTaskPrefix(taskPrefix)) {
-					console.error(
-						`Task prefix "${taskPrefix}" is reserved for drafts, docs, or decisions. Choose a different prefix.`,
-					);
+				const taskPrefixError = taskPrefix ? getTaskPrefixError(taskPrefix) : undefined;
+				if (taskPrefixError) {
+					console.error(taskPrefixError);
 					process.exit(1);
 				}
 
@@ -5182,7 +5175,7 @@ addHelpSchema(program.command("doctor"), {
 			const reservedTaskPrefix = taskPrefix && isReservedTaskPrefix(taskPrefix) ? taskPrefix : null;
 			if (reservedTaskPrefix) {
 				console.error(
-					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type. Task prefix cannot be changed after initialization; there is no automated migration. Manually rename the affected task files and update the prefix in the project config file.`,
+					`Task prefix "${reservedTaskPrefix}" collides with a reserved prefix (draft, doc, decision); tasks are misrouted as that entity type. There is no automated migration. Rename the affected task files and IDs to a non-reserved prefix, then set prefixes.task in the project config file to match.`,
 				);
 				process.exitCode = 1;
 				if (options.fix) {

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -15,6 +15,7 @@ import {
 	type McpClientSetupKey,
 	runMcpClientSetupCommand,
 } from "../utils/mcp-client-setup.ts";
+import { isReservedTaskPrefix } from "../utils/prefix-config.ts";
 import type { Core } from "./backlog.ts";
 
 export const MCP_SERVER_NAME = "backlog";
@@ -115,6 +116,11 @@ export async function initializeProject(
 	} = options;
 
 	const isReInitialization = !!existingConfig;
+	if (!isReInitialization && advancedConfig.taskPrefix && isReservedTaskPrefix(advancedConfig.taskPrefix)) {
+		throw new Error(
+			`Task prefix "${advancedConfig.taskPrefix}" is reserved for drafts, docs, or decisions. Choose a different prefix.`,
+		);
+	}
 	const projectRoot = core.filesystem.rootDir;
 	const effectiveFilesystemOnly = filesystemOnly || existingConfig?.filesystemOnly === true;
 	const normalizedAdvancedConfig = effectiveFilesystemOnly

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -15,7 +15,7 @@ import {
 	type McpClientSetupKey,
 	runMcpClientSetupCommand,
 } from "../utils/mcp-client-setup.ts";
-import { isReservedTaskPrefix } from "../utils/prefix-config.ts";
+import { getTaskPrefixError } from "../utils/prefix-config.ts";
 import type { Core } from "./backlog.ts";
 
 export const MCP_SERVER_NAME = "backlog";
@@ -116,10 +116,11 @@ export async function initializeProject(
 	} = options;
 
 	const isReInitialization = !!existingConfig;
-	if (!isReInitialization && advancedConfig.taskPrefix && isReservedTaskPrefix(advancedConfig.taskPrefix)) {
-		throw new Error(
-			`Task prefix "${advancedConfig.taskPrefix}" is reserved for drafts, docs, or decisions. Choose a different prefix.`,
-		);
+	if (!isReInitialization && advancedConfig.taskPrefix) {
+		const taskPrefixError = getTaskPrefixError(advancedConfig.taskPrefix);
+		if (taskPrefixError) {
+			throw new Error(taskPrefixError);
+		}
 	}
 	const projectRoot = core.filesystem.rootDir;
 	const effectiveFilesystemOnly = filesystemOnly || existingConfig?.filesystemOnly === true;

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -116,11 +116,10 @@ export async function initializeProject(
 	} = options;
 
 	const isReInitialization = !!existingConfig;
-	if (!isReInitialization && advancedConfig.taskPrefix) {
-		const taskPrefixError = getTaskPrefixError(advancedConfig.taskPrefix);
-		if (taskPrefixError) {
-			throw new Error(taskPrefixError);
-		}
+	// An explicitly requested prefix is always validated; existing prefixes are preserved below untouched.
+	const taskPrefixError = getTaskPrefixError(advancedConfig.taskPrefix ?? "");
+	if (taskPrefixError) {
+		throw new Error(taskPrefixError);
 	}
 	const projectRoot = core.filesystem.rootDir;
 	const effectiveFilesystemOnly = filesystemOnly || existingConfig?.filesystemOnly === true;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,7 +22,7 @@ import { launchBrowser } from "../utils/browser-launch.ts";
 import type { BrowserLoadingState } from "../utils/browser-loading-state.ts";
 import { isAmbiguousIdError } from "../utils/entity-id.ts";
 import { resolveMilestoneInputForStorage } from "../utils/milestone-storage.ts";
-import { DRAFT_PREFIX, extractAnyPrefix } from "../utils/prefix-config.ts";
+import { DRAFT_PREFIX, extractAnyPrefix, getTaskPrefixError } from "../utils/prefix-config.ts";
 import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import { formatValidStatuses, getCanonicalStatuses, getValidStatuses } from "../utils/status.ts";
 import { isValidTaskId } from "../utils/task-id.ts";
@@ -1924,6 +1924,12 @@ export class BacklogServer {
 			// Input validation (browser layer responsibility)
 			if (!projectName) {
 				return Response.json({ error: "Project name is required" }, { status: 400 });
+			}
+			const taskPrefixError = getTaskPrefixError(
+				typeof advancedConfig.taskPrefix === "string" ? advancedConfig.taskPrefix : "",
+			);
+			if (taskPrefixError) {
+				return Response.json({ error: taskPrefixError }, { status: 400 });
 			}
 
 			// Check if already initialized (for browser, we don't allow re-init)

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -231,6 +231,20 @@ describe("backlog doctor", () => {
 			expect(output).not.toContain("backlog doctor --fix");
 		},
 	);
+
+	it("mentions a task prefix that collides with a reserved system prefix", async () => {
+		await removeDuplicateTasks();
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Missing test config");
+		config.prefixes = { task: "draft" };
+		await core.filesystem.saveConfig(config);
+
+		const result = await $`bun ${cliPath} doctor`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).toContain('Task prefix "draft" collides with a reserved prefix');
+		expect(output).not.toContain("No duplicate task, document, or decision IDs found.");
+	});
 });
 
 describe("CLI collision safety", () => {

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -245,7 +245,7 @@ describe("backlog doctor", () => {
 		expect(output).toContain('Task prefix "draft" collides with a reserved prefix');
 		expect(output).toContain("There is no automated migration");
 		expect(output.toLowerCase()).not.toContain("re-initialize");
-		expect(output).not.toContain("No duplicate task, document, or decision IDs found.");
+		expect(output).not.toContain("No duplicate task, document, decision, or draft IDs found.");
 	});
 
 	it("does not auto-repair duplicates when the task prefix is reserved", async () => {

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -174,6 +174,20 @@ describe("backlog doctor", () => {
 			expect(output).not.toContain("backlog doctor --fix");
 		},
 	);
+
+	it("mentions a task prefix that collides with a reserved system prefix", async () => {
+		await removeDuplicateTasks();
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Missing test config");
+		config.prefixes = { task: "draft" };
+		await core.filesystem.saveConfig(config);
+
+		const result = await $`bun ${cliPath} doctor`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).toContain('Task prefix "draft" collides with a reserved prefix');
+		expect(output).not.toContain("No duplicate task, document, or decision IDs found.");
+	});
 });
 
 describe("CLI collision safety", () => {

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -243,7 +243,55 @@ describe("backlog doctor", () => {
 		const output = `${result.stdout}${result.stderr}`;
 		expect(result.exitCode).toBe(1);
 		expect(output).toContain('Task prefix "draft" collides with a reserved prefix');
+		expect(output).toContain("There is no automated migration");
+		expect(output.toLowerCase()).not.toContain("re-initialize");
 		expect(output).not.toContain("No duplicate task, document, or decision IDs found.");
+	});
+
+	it("does not auto-repair duplicates when the task prefix is reserved", async () => {
+		await unlink(join(core.filesystem.tasksDir, "task-1 - Alpha.md"));
+		await unlink(join(core.filesystem.tasksDir, "task-01 - Beta.md"));
+		await unlink(join(core.filesystem.completedDir, "task-001 - Gamma.md"));
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Missing test config");
+		config.prefixes = { task: "draft" };
+		await core.filesystem.saveConfig(config);
+
+		const draftTaskAlpha = join(core.filesystem.tasksDir, "draft-1 - Alpha.md");
+		const draftTaskBeta = join(core.filesystem.tasksDir, "draft-01 - Beta.md");
+		const realDraft = join(await core.filesystem.getDraftsDir(), "draft-2 - Real draft.md");
+		await Bun.write(draftTaskAlpha, serializeTask(makeTask("DRAFT-1", "Alpha")));
+		await Bun.write(draftTaskBeta, serializeTask(makeTask("DRAFT-01", "Beta")));
+		await Bun.write(realDraft, serializeTask(makeTask("DRAFT-2", "Real draft")));
+		const alphaBefore = await Bun.file(draftTaskAlpha).text();
+		const betaBefore = await Bun.file(draftTaskBeta).text();
+		const draftBefore = await Bun.file(realDraft).text();
+
+		const result = await $`bun ${cliPath} doctor --fix --yes`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).toContain('Task prefix "draft" collides with a reserved prefix');
+		expect(output).toContain("Resolve the reserved task prefix before running --fix.");
+		expect(output).not.toContain("Repaired");
+		expect(await Bun.file(draftTaskAlpha).text()).toBe(alphaBefore);
+		expect(await Bun.file(draftTaskBeta).text()).toBe(betaBefore);
+		expect(await Bun.file(realDraft).text()).toBe(draftBefore);
+	});
+
+	it("does not fail task list solely because the task prefix is reserved", async () => {
+		await unlink(join(core.filesystem.tasksDir, "task-1 - Alpha.md"));
+		await unlink(join(core.filesystem.tasksDir, "task-01 - Beta.md"));
+		await unlink(join(core.filesystem.completedDir, "task-001 - Gamma.md"));
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Missing test config");
+		config.prefixes = { task: "draft" };
+		await core.filesystem.saveConfig(config);
+		await Bun.write(join(core.filesystem.tasksDir, "draft-1 - Hello.md"), serializeTask(makeTask("DRAFT-1", "Hello")));
+
+		const result = await $`bun ${cliPath} task list --plain`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(0);
+		expect(output).toContain("Hello");
 	});
 });
 

--- a/src/test/cli-init-create.test.ts
+++ b/src/test/cli-init-create.test.ts
@@ -271,6 +271,13 @@ describe("CLI Integration", () => {
 			expect(help).toContain("cursor writes AGENTS.md");
 		});
 
+		it("documents reserved task prefixes in init help", async () => {
+			const help = await $`bun ${CLI_PATH} init --help`.cwd(TEST_DIR).text();
+
+			expect(help).toContain("--task-prefix");
+			expect(help).toContain("draft, doc, and decision are reserved");
+		});
+
 		it("should label created and updated agent instruction files separately", async () => {
 			await $`git init -b main`.cwd(TEST_DIR).quiet();
 			await Bun.write(join(TEST_DIR, "AGENTS.md"), "Existing instructions\n");

--- a/src/test/cli-init-create.test.ts
+++ b/src/test/cli-init-create.test.ts
@@ -475,6 +475,21 @@ describe("CLI Integration", () => {
 				expect(await Bun.file(join(TEST_DIR, "backlog", "config.yml")).exists()).toBe(false);
 			});
 		}
+
+		it("should reject a padded --task-prefix instead of persisting the padding", async () => {
+			// init writes --task-prefix into task_prefix verbatim, so accepting " JIRA " produced
+			// a config of task_prefix: " JIRA " and task files named ' jira -jira -1 - Title.md'.
+			await $`git init -b main`.cwd(TEST_DIR).quiet();
+
+			const result = await $`bun ${CLI_PATH} init PaddedPrefixProj --defaults --task-prefix ${" JIRA "}`
+				.cwd(TEST_DIR)
+				.nothrow();
+			const output = result.stdout.toString() + result.stderr.toString();
+
+			expect(result.exitCode).toBe(1);
+			expect(output).toContain("Task prefix must contain only letters (a-z, A-Z).");
+			expect(await Bun.file(join(TEST_DIR, "backlog", "config.yml")).exists()).toBe(false);
+		});
 	});
 
 	describe("git integration", () => {

--- a/src/test/cli-init-create.test.ts
+++ b/src/test/cli-init-create.test.ts
@@ -453,6 +453,21 @@ describe("CLI Integration", () => {
 
 			expect(failed).toBe(true);
 		});
+
+		for (const reservedPrefix of ["draft", "DRAFT", "doc", "Doc", "decision", "DECISION"]) {
+			it(`should reject reserved --task-prefix value ${reservedPrefix}`, async () => {
+				await $`git init -b main`.cwd(TEST_DIR).quiet();
+
+				const result = await $`bun ${CLI_PATH} init ReservedPrefixProj --defaults --task-prefix ${reservedPrefix}`
+					.cwd(TEST_DIR)
+					.nothrow();
+				const output = result.stdout.toString() + result.stderr.toString();
+
+				expect(result.exitCode).toBe(1);
+				expect(output).toContain("is reserved for drafts, docs, or decisions");
+				expect(await Bun.file(join(TEST_DIR, "backlog", "config.yml")).exists()).toBe(false);
+			});
+		}
 	});
 
 	describe("git integration", () => {

--- a/src/test/enhanced-init.test.ts
+++ b/src/test/enhanced-init.test.ts
@@ -413,6 +413,16 @@ describe("Enhanced init command", () => {
 		expect(result.config.prefixes?.task).toBe("draft");
 		const loadedConfig = await core.filesystem.loadConfig();
 		expect(loadedConfig?.prefixes?.task).toBe("draft");
+
+		// Re-init cannot introduce a reserved prefix either.
+		await expect(
+			initializeProject(core, {
+				projectName: "Legacy Reserved Prefix",
+				integrationMode: "none",
+				existingConfig,
+				advancedConfig: { taskPrefix: "doc" },
+			}),
+		).rejects.toThrow(/reserved for drafts, docs, or decisions/);
 	});
 
 	test("initializeProject should use custom taskPrefix from advancedConfig", async () => {

--- a/src/test/enhanced-init.test.ts
+++ b/src/test/enhanced-init.test.ts
@@ -377,6 +377,44 @@ describe("Enhanced init command", () => {
 		expect(existingConfig?.prefixes?.task).toBe("BUG");
 	});
 
+	test("initializeProject should reject reserved task prefixes", async () => {
+		for (const taskPrefix of ["draft", "DOC", "Decision"]) {
+			const core = new Core(tmpDir);
+			await expect(
+				initializeProject(core, {
+					projectName: "Reserved Prefix Init",
+					integrationMode: "none",
+					advancedConfig: { taskPrefix },
+				}),
+			).rejects.toThrow(/reserved for drafts, docs, or decisions/);
+			expect(await Bun.file(join(tmpDir, "backlog", "config.yml")).exists()).toBe(false);
+		}
+	});
+
+	test("initializeProject should preserve an existing reserved prefix on re-init", async () => {
+		const core = new Core(tmpDir);
+		await initializeProject(core, {
+			projectName: "Legacy Reserved Prefix",
+			integrationMode: "none",
+			advancedConfig: { taskPrefix: "JIRA" },
+		});
+		const existingConfig = await core.filesystem.loadConfig();
+		if (!existingConfig) throw new Error("Missing test config");
+		existingConfig.prefixes = { task: "draft" };
+		await core.filesystem.saveConfig(existingConfig);
+
+		const result = await initializeProject(core, {
+			projectName: "Legacy Reserved Prefix",
+			integrationMode: "none",
+			existingConfig,
+			advancedConfig: { taskPrefix: "task" },
+		});
+
+		expect(result.config.prefixes?.task).toBe("draft");
+		const loadedConfig = await core.filesystem.loadConfig();
+		expect(loadedConfig?.prefixes?.task).toBe("draft");
+	});
+
 	test("initializeProject should use custom taskPrefix from advancedConfig", async () => {
 		const core = new Core(tmpDir);
 

--- a/src/test/prefix-config.test.ts
+++ b/src/test/prefix-config.test.ts
@@ -12,6 +12,7 @@ import {
 	generateNextSubtaskId,
 	getDefaultPrefixConfig,
 	getPrefixForType,
+	getTaskPrefixError,
 	hasPrefix,
 	idsEqual,
 	isReservedTaskPrefix,
@@ -360,6 +361,30 @@ describe("prefix-config", () => {
 			expect(isReservedTaskPrefix("task")).toBe(false);
 			expect(isReservedTaskPrefix("JIRA")).toBe(false);
 			expect(isReservedTaskPrefix("documents")).toBe(false);
+		});
+	});
+
+	describe("getTaskPrefixError", () => {
+		test("rejects reserved prefixes with the init error used by the wizard and flag", () => {
+			expect(getTaskPrefixError("draft")).toBe(
+				'Task prefix "draft" is reserved for drafts, docs, or decisions. Choose a different prefix.',
+			);
+			expect(getTaskPrefixError("DOC")).toBe(
+				'Task prefix "DOC" is reserved for drafts, docs, or decisions. Choose a different prefix.',
+			);
+			expect(getTaskPrefixError("Decision")).toBe(
+				'Task prefix "Decision" is reserved for drafts, docs, or decisions. Choose a different prefix.',
+			);
+		});
+
+		test("rejects non-letter prefixes", () => {
+			expect(getTaskPrefixError("task-1")).toBe("Task prefix must contain only letters (a-z, A-Z).");
+		});
+
+		test("allows empty input and non-reserved prefixes", () => {
+			expect(getTaskPrefixError("")).toBeUndefined();
+			expect(getTaskPrefixError("   ")).toBeUndefined();
+			expect(getTaskPrefixError("JIRA")).toBeUndefined();
 		});
 	});
 

--- a/src/test/prefix-config.test.ts
+++ b/src/test/prefix-config.test.ts
@@ -14,6 +14,7 @@ import {
 	getPrefixForType,
 	hasPrefix,
 	idsEqual,
+	isReservedTaskPrefix,
 	mergePrefixConfig,
 	normalizeId,
 } from "../utils/prefix-config.ts";
@@ -339,6 +340,26 @@ describe("prefix-config", () => {
 
 		test("returns decision prefix for Decision type", () => {
 			expect(getPrefixForType(EntityType.Decision)).toBe("decision");
+		});
+	});
+
+	describe("isReservedTaskPrefix", () => {
+		test("rejects prefixes matching the draft, doc, and decision system prefixes", () => {
+			expect(isReservedTaskPrefix("draft")).toBe(true);
+			expect(isReservedTaskPrefix("doc")).toBe(true);
+			expect(isReservedTaskPrefix("decision")).toBe(true);
+		});
+
+		test("is case-insensitive", () => {
+			expect(isReservedTaskPrefix("DRAFT")).toBe(true);
+			expect(isReservedTaskPrefix("Doc")).toBe(true);
+			expect(isReservedTaskPrefix("DECISION")).toBe(true);
+		});
+
+		test("allows non-reserved prefixes", () => {
+			expect(isReservedTaskPrefix("task")).toBe(false);
+			expect(isReservedTaskPrefix("JIRA")).toBe(false);
+			expect(isReservedTaskPrefix("documents")).toBe(false);
 		});
 	});
 

--- a/src/test/prefix-config.test.ts
+++ b/src/test/prefix-config.test.ts
@@ -383,8 +383,18 @@ describe("prefix-config", () => {
 
 		test("allows empty input and non-reserved prefixes", () => {
 			expect(getTaskPrefixError("")).toBeUndefined();
-			expect(getTaskPrefixError("   ")).toBeUndefined();
 			expect(getTaskPrefixError("JIRA")).toBeUndefined();
+		});
+
+		test("rejects surrounding whitespace, which init would otherwise persist verbatim", () => {
+			// init writes the value straight into task_prefix, so padding would leak into IDs and filenames.
+			expect(getTaskPrefixError(" JIRA ")).toBe("Task prefix must contain only letters (a-z, A-Z).");
+			expect(getTaskPrefixError("JIRA ")).toBe("Task prefix must contain only letters (a-z, A-Z).");
+			expect(getTaskPrefixError("   ")).toBe("Task prefix must contain only letters (a-z, A-Z).");
+		});
+
+		test("still rejects a reserved prefix that is padded", () => {
+			expect(getTaskPrefixError(" draft ")).toBe("Task prefix must contain only letters (a-z, A-Z).");
 		});
 	});
 

--- a/src/test/server-init.test.ts
+++ b/src/test/server-init.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { join } from "node:path";
 import { Core } from "../core/backlog.ts";
 import { BacklogServer } from "../server/index.ts";
 import { createUniqueTestDir, safeCleanup } from "./test-utils.ts";
@@ -40,6 +41,20 @@ describe("BacklogServer init endpoint", () => {
 		expect(config?.filesystemOnly).toBe(false);
 		expect(config?.remoteOperations).toBe(true);
 		expect(config?.checkActiveBranches).toBe(true);
+	});
+
+	it("rejects reserved task prefixes before writing config", async () => {
+		const server = new BacklogServer(TEST_DIR) as unknown as InitHandler;
+		const response = await server.handleInit(
+			initRequest({
+				advancedConfig: { taskPrefix: "draft" },
+			}),
+		);
+		const body = (await response.json()) as { error?: string };
+
+		expect(response.status).not.toBe(200);
+		expect(body.error).toContain("reserved for drafts, docs, or decisions");
+		expect(await Bun.file(join(TEST_DIR, "backlog", "config.yml")).exists()).toBe(false);
 	});
 
 	it("accepts string true filesystemOnly for loose init callers", async () => {

--- a/src/test/server-init.test.ts
+++ b/src/test/server-init.test.ts
@@ -52,7 +52,7 @@ describe("BacklogServer init endpoint", () => {
 		);
 		const body = (await response.json()) as { error?: string };
 
-		expect(response.status).not.toBe(200);
+		expect(response.status).toBe(400);
 		expect(body.error).toContain("reserved for drafts, docs, or decisions");
 		expect(await Bun.file(join(TEST_DIR, "backlog", "config.yml")).exists()).toBe(false);
 	});

--- a/src/utils/prefix-config.ts
+++ b/src/utils/prefix-config.ts
@@ -13,6 +13,39 @@ export const DEFAULT_PREFIX_CONFIG: PrefixConfig = {
 export const DRAFT_PREFIX = "draft";
 
 /**
+ * Hardcoded document prefix. Not configurable - always "doc".
+ */
+export const DOC_PREFIX = "doc";
+
+/**
+ * Hardcoded decision prefix. Not configurable - always "decision".
+ */
+export const DECISION_PREFIX = "decision";
+
+/**
+ * Prefixes reserved for system entity types. A configurable --task-prefix
+ * matching one of these (case-insensitively) collides with drafts, documents,
+ * or decisions and misroutes their IDs.
+ */
+export const RESERVED_TASK_PREFIXES: readonly string[] = [DRAFT_PREFIX, DOC_PREFIX, DECISION_PREFIX];
+
+/**
+ * Checks whether a candidate task prefix collides with a reserved system prefix
+ * (case-insensitive).
+ *
+ * @param prefix - The candidate task prefix
+ * @returns true if the prefix matches a reserved system prefix
+ *
+ * @example
+ * isReservedTaskPrefix("draft") // => true
+ * isReservedTaskPrefix("DOC") // => true
+ * isReservedTaskPrefix("task") // => false
+ */
+export function isReservedTaskPrefix(prefix: string): boolean {
+	return RESERVED_TASK_PREFIXES.includes(prefix.trim().toLowerCase());
+}
+
+/**
  * Returns the default prefix configuration.
  * Use this when no custom config is specified.
  */
@@ -414,9 +447,9 @@ export function getPrefixForType(type: EntityType, config?: BacklogConfig): stri
 		case EntityType.Draft:
 			return DRAFT_PREFIX;
 		case EntityType.Document:
-			return "doc";
+			return DOC_PREFIX;
 		case EntityType.Decision:
-			return "decision";
+			return DECISION_PREFIX;
 		default:
 			return type;
 	}

--- a/src/utils/prefix-config.ts
+++ b/src/utils/prefix-config.ts
@@ -37,17 +37,19 @@ export function isReservedTaskPrefix(prefix: string): boolean {
 
 /**
  * Init-time task prefix validation. Empty input is allowed (the default prefix is used).
+ * The value is judged exactly as given, because init persists it verbatim: padding that
+ * passed validation but survived into the config would end up inside task IDs and filenames.
+ * Callers that mean to accept surrounding whitespace must trim before calling.
  */
 export function getTaskPrefixError(prefix: string): string | undefined {
-	const normalized = prefix.trim();
-	if (!normalized) {
+	if (!prefix) {
 		return undefined;
 	}
-	if (!/^[a-zA-Z]+$/.test(normalized)) {
+	if (!/^[a-zA-Z]+$/.test(prefix)) {
 		return "Task prefix must contain only letters (a-z, A-Z).";
 	}
-	if (isReservedTaskPrefix(normalized)) {
-		return `Task prefix "${normalized}" is reserved for drafts, docs, or decisions. Choose a different prefix.`;
+	if (isReservedTaskPrefix(prefix)) {
+		return `Task prefix "${prefix}" is reserved for drafts, docs, or decisions. Choose a different prefix.`;
 	}
 	return undefined;
 }

--- a/src/utils/prefix-config.ts
+++ b/src/utils/prefix-config.ts
@@ -15,31 +15,21 @@ export const DRAFT_PREFIX = "draft";
 /**
  * Hardcoded document prefix. Not configurable - always "doc".
  */
-export const DOC_PREFIX = "doc";
+const DOC_PREFIX = "doc";
 
 /**
  * Hardcoded decision prefix. Not configurable - always "decision".
  */
-export const DECISION_PREFIX = "decision";
+const DECISION_PREFIX = "decision";
 
 /**
- * Prefixes reserved for system entity types. A configurable --task-prefix
- * matching one of these (case-insensitively) collides with drafts, documents,
- * or decisions and misroutes their IDs.
+ * Prefixes owned by system entity types. A configurable task prefix matching one
+ * of these collides with drafts, documents, or decisions and misroutes their IDs.
  */
-export const RESERVED_TASK_PREFIXES: readonly string[] = [DRAFT_PREFIX, DOC_PREFIX, DECISION_PREFIX];
+const RESERVED_TASK_PREFIXES = [DRAFT_PREFIX, DOC_PREFIX, DECISION_PREFIX];
 
 /**
- * Checks whether a candidate task prefix collides with a reserved system prefix
- * (case-insensitive).
- *
- * @param prefix - The candidate task prefix
- * @returns true if the prefix matches a reserved system prefix
- *
- * @example
- * isReservedTaskPrefix("draft") // => true
- * isReservedTaskPrefix("DOC") // => true
- * isReservedTaskPrefix("task") // => false
+ * Checks whether a candidate task prefix collides with a reserved system prefix (case-insensitive).
  */
 export function isReservedTaskPrefix(prefix: string): boolean {
 	return RESERVED_TASK_PREFIXES.includes(prefix.trim().toLowerCase());

--- a/src/utils/prefix-config.ts
+++ b/src/utils/prefix-config.ts
@@ -13,6 +13,39 @@ export const DEFAULT_PREFIX_CONFIG: PrefixConfig = {
 export const DRAFT_PREFIX = "draft";
 
 /**
+ * Hardcoded document prefix. Not configurable - always "doc".
+ */
+export const DOC_PREFIX = "doc";
+
+/**
+ * Hardcoded decision prefix. Not configurable - always "decision".
+ */
+export const DECISION_PREFIX = "decision";
+
+/**
+ * Prefixes reserved for system entity types. A configurable --task-prefix
+ * matching one of these (case-insensitively) collides with drafts, documents,
+ * or decisions and misroutes their IDs.
+ */
+export const RESERVED_TASK_PREFIXES: readonly string[] = [DRAFT_PREFIX, DOC_PREFIX, DECISION_PREFIX];
+
+/**
+ * Checks whether a candidate task prefix collides with a reserved system prefix
+ * (case-insensitive).
+ *
+ * @param prefix - The candidate task prefix
+ * @returns true if the prefix matches a reserved system prefix
+ *
+ * @example
+ * isReservedTaskPrefix("draft") // => true
+ * isReservedTaskPrefix("DOC") // => true
+ * isReservedTaskPrefix("task") // => false
+ */
+export function isReservedTaskPrefix(prefix: string): boolean {
+	return RESERVED_TASK_PREFIXES.includes(prefix.trim().toLowerCase());
+}
+
+/**
  * Returns the default prefix configuration.
  * Use this when no custom config is specified.
  */
@@ -399,9 +432,9 @@ export function getPrefixForType(type: EntityType, config?: BacklogConfig): stri
 		case EntityType.Draft:
 			return DRAFT_PREFIX;
 		case EntityType.Document:
-			return "doc";
+			return DOC_PREFIX;
 		case EntityType.Decision:
-			return "decision";
+			return DECISION_PREFIX;
 		default:
 			return type;
 	}

--- a/src/utils/prefix-config.ts
+++ b/src/utils/prefix-config.ts
@@ -46,6 +46,23 @@ export function isReservedTaskPrefix(prefix: string): boolean {
 }
 
 /**
+ * Init-time task prefix validation. Empty input is allowed (the default prefix is used).
+ */
+export function getTaskPrefixError(prefix: string): string | undefined {
+	const normalized = prefix.trim();
+	if (!normalized) {
+		return undefined;
+	}
+	if (!/^[a-zA-Z]+$/.test(normalized)) {
+		return "Task prefix must contain only letters (a-z, A-Z).";
+	}
+	if (isReservedTaskPrefix(normalized)) {
+		return `Task prefix "${normalized}" is reserved for drafts, docs, or decisions. Choose a different prefix.`;
+	}
+	return undefined;
+}
+
+/**
  * Returns the default prefix configuration.
  * Use this when no custom config is specified.
  */

--- a/src/web/components/InitializationScreen.tsx
+++ b/src/web/components/InitializationScreen.tsx
@@ -747,7 +747,8 @@ const InitializationScreen: React.FC<InitializationScreenProps> = ({ onInitializ
 								className="w-32 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700"
 							/>
 							<p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-								Letters only. Cannot be changed later. Examples: JIRA, BUG, ISSUE
+								Letters only; draft, doc, and decision are reserved. Cannot be changed later. Examples: JIRA,
+								BUG, ISSUE
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary
- From the PR #916 (BACK-634) review and a matching Codex finding: `backlog init --task-prefix` accepted `draft`, `doc`, and `decision` (letters-only check had no reserved-word exclusion), which collide with the hard-coded system prefixes for drafts (`DRAFT-`), documents (`doc-`), and decisions (`decision-`). A project initialized with one of these prefixes silently misroutes regular tasks (web prefix-routed draft handling, MCP `task_edit`'s DRAFT- preference) and guarantees ID collisions.
- `backlog init` now rejects `draft`/`doc`/`decision` (case-insensitive) as `--task-prefix`, both via the CLI flag and the interactive wizard prompt, with a clear error.
- Task prefix is init-only (cannot be changed afterwards), so existing projects with a reserved prefix are left untouched at runtime - no new failures beyond current behavior. `backlog doctor` now detects and reports this misconfiguration instead of staying silent.

## Test plan
- New tests: `src/test/prefix-config.test.ts` (`isReservedTaskPrefix` unit coverage), `src/test/cli-init-create.test.ts` (rejects `draft`/`DRAFT`/`doc`/`Doc`/`decision`/`DECISION` via `--task-prefix`, config.yml not created), `src/test/cli-doctor.test.ts` (doctor reports the reserved-prefix collision).
- Verified fail-before/pass-after via `git stash` on the source changes.
- `bunx tsc --noEmit` clean; `bunx biome check` clean on all touched files (`bun run check .` reports 6 pre-existing, unrelated errors in other files, confirmed present on unmodified `main`).
- Full suite: `bun test --timeout=10000` -> 2348 pass / 6 skip / 1 fail (243 files). The one fail is a pre-existing, unrelated `config-commands.test.ts` YAML-parsing flake, reproducible on unmodified `main`.