### PR TITLE
BACK-638 - Allow task list --status to accept several statuses

### DIFF
--- a/backlog/tasks/back-638 - Allow-task-list-status-to-accept-several-statuses.md
+++ b/backlog/tasks/back-638 - Allow-task-list-status-to-accept-several-statuses.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@MrLesk'
 created_date: '2026-08-22 12:22'
-updated_date: '2026-08-22 12:50'
+updated_date: '2026-08-23 12:27'
 labels: []
 dependencies: []
 references:
@@ -34,10 +34,18 @@ Make the task list --status flag accept repeated values and comma-separated valu
 - [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add shared src/utils/status-filter.ts (normalizeStatusSet + statusMatchesSet) for multi-status normalization/case-insensitive matching. 2. Use it in Core.applyTaskFilters, ContentStore.getTasks, FileSystem.listTasks (include + exclude blocks). 3. Carry structured multi-status through the interactive path: UnifiedViewFilters.statusFilter becomes string[], TUI status popup becomes multi-select like type/labels, filter-header shows joined selection, task-search matches any selected status. 4. CLI: search --status becomes repeatable like task list --status; filter description renders lists; initialUnifiedFilter receives parsed selection. 5. Tests: helper unit tests, unified-view filter-state arrays, plain-path regressions incl. JSON and search. Finding 3 (comma-containing status names) declined by maintainer decision - parsing untouched.
+<!-- SECTION:PLAN:END -->
+
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Verification: contributor PR #929 branch checked out locally (worktree). tsc --noEmit passes; new test file 5/5 pass; full suite 2350 pass / 0 fail; TUI suite 109 pass / 0 fail; manual CLI checks for repeated flag, comma-separated, case-insensitive, and exclude-status composition all match PR claims. All 7 CI jobs green on approved run. Biome: only PR-introduced format issue (one line in new test) fixed locally as maintainer edit.
+
+Review round (PR #929 takeover): fixed Codex findings 1/2/4. Finding 1+4: interactive paths now receive the structured multi-status selection - UnifiedViewFilters.statusFilter became string[], the TUI status popup is multi-select like type/labels, task-search matches any selected status via the shared helper, and search --status is repeatable like task list --status so repeated flags accumulate instead of last-wins. Finding 2: one shared helper src/utils/status-filter.ts (normalizeStatusSet + statusMatchesSet) now backs Core.applyTaskFilters, ContentStore.getTasks, FileSystem.listTasks, and utils/task-search include/exclude blocks with identical trim/lowercase/blank-drop semantics. Finding 3 (status names containing commas) declined by maintainer decision; comma-splitting untouched. Verified: tsc clean; biome clean on changed files; cli-status-filtering 9/9, status-filter 6/6 + unified-view-filters 17/17, full suite 2357 pass / 0 fail; tui-test manual check of task list and search with repeated and comma forms shows only matching tasks ('Status: 2 selected') with no crash.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-638 - Allow-task-list-status-to-accept-several-statuses.md
+++ b/backlog/tasks/back-638 - Allow-task-list-status-to-accept-several-statuses.md
@@ -1,0 +1,47 @@
+---
+id: BACK-638
+title: Allow task list --status to accept several statuses
+status: Done
+assignee:
+  - '@MrLesk'
+created_date: '2026-08-22 12:22'
+updated_date: '2026-08-22 12:50'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/pull/929'
+ordinal: 273000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the task list --status flag accept repeated values and comma-separated values (OR semantics), matching --exclude-status and --type. Introduced by contributor PR #929. Regression: repeating the flag previously overwrote instead of accumulating, so listing tasks in several statuses silently matched only the last one.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 --status can be repeated and matches tasks in any given status
+- [x] #2 --status accepts comma-separated values
+- [x] #3 a single --status behaves as before and remains case-insensitive
+- [x] #4 repeated/inline statuses compose with --exclude-status
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Verification: contributor PR #929 branch checked out locally (worktree). tsc --noEmit passes; new test file 5/5 pass; full suite 2350 pass / 0 fail; TUI suite 109 pass / 0 fail; manual CLI checks for repeated flag, comma-separated, case-insensitive, and exclude-status composition all match PR claims. All 7 CI jobs green on approved run. Biome: only PR-introduced format issue (one line in new test) fixed locally as maintainer edit.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Merged contributor PR #929 which lets task list --status accept repeated and comma-separated status values with OR semantics, matching --exclude-status/--type. Verified with new regression tests, full suite (2350 pass), TUI suite (109 pass), manual CLI checks, and green CI across ubuntu/macos/windows + build + nix.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-638 - Allow-task-list-status-to-accept-several-statuses.md
+++ b/backlog/tasks/back-638 - Allow-task-list-status-to-accept-several-statuses.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@MrLesk'
 created_date: '2026-08-22 12:22'
-updated_date: '2026-08-23 12:27'
+updated_date: '2026-08-23 12:44'
 labels: []
 dependencies: []
 references:
@@ -46,6 +46,8 @@ Make the task list --status flag accept repeated values and comma-separated valu
 Verification: contributor PR #929 branch checked out locally (worktree). tsc --noEmit passes; new test file 5/5 pass; full suite 2350 pass / 0 fail; TUI suite 109 pass / 0 fail; manual CLI checks for repeated flag, comma-separated, case-insensitive, and exclude-status composition all match PR claims. All 7 CI jobs green on approved run. Biome: only PR-introduced format issue (one line in new test) fixed locally as maintainer edit.
 
 Review round (PR #929 takeover): fixed Codex findings 1/2/4. Finding 1+4: interactive paths now receive the structured multi-status selection - UnifiedViewFilters.statusFilter became string[], the TUI status popup is multi-select like type/labels, task-search matches any selected status via the shared helper, and search --status is repeatable like task list --status so repeated flags accumulate instead of last-wins. Finding 2: one shared helper src/utils/status-filter.ts (normalizeStatusSet + statusMatchesSet) now backs Core.applyTaskFilters, ContentStore.getTasks, FileSystem.listTasks, and utils/task-search include/exclude blocks with identical trim/lowercase/blank-drop semantics. Finding 3 (status names containing commas) declined by maintainer decision; comma-splitting untouched. Verified: tsc clean; biome clean on changed files; cli-status-filtering 9/9, status-filter 6/6 + unified-view-filters 17/17, full suite 2357 pass / 0 fail; tui-test manual check of task list and search with repeated and comma forms shows only matching tasks ('Status: 2 selected') with no crash.
+
+Help-schema follow-up (P2): statusType gained a multiple option and the task list / search help schemas now advertise 'one or more of configured statuses' with repeat/comma-separate, case-insensitive descriptions; cli-guidance expectations updated. Help text only.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1953,7 +1953,11 @@ addHelpSchema(program.command("search [query]"), {
 			type: () => taskType({ multiple: true }),
 			description: "Filter task results by one or more configured task types; repeat or comma-separate values",
 		},
-		{ name: "status", type: statusType, description: "Filter task results by status; case-insensitive" },
+		{
+			name: "status",
+			type: () => statusType({ multiple: true }),
+			description: "Filter task results by one or more statuses; repeat or comma-separate values; case-insensitive",
+		},
 		{
 			name: "exclude-status",
 			type: statusType,
@@ -2325,7 +2329,11 @@ addHelpSchema(taskCmd.command("list"), {
 	reads: "Local editable tasks from the configured backlog directory",
 	required: [],
 	optional: [
-		{ name: "status", type: statusType, description: "Filter by task status; case-insensitive" },
+		{
+			name: "status",
+			type: () => statusType({ multiple: true }),
+			description: "Filter tasks by one or more statuses; repeat or comma-separate values; case-insensitive",
+		},
 		{
 			name: "exclude-status",
 			type: statusType,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2048,7 +2048,7 @@ addHelpSchema(program.command("search [query]"), {
 			modifiedFiles?: string[];
 		} = {};
 		if (options.status) {
-			filters.status = options.status;
+			filters.status = parseDelimitedStringList(options.status) ?? options.status;
 		}
 		const excludeStatuses = parseDelimitedStringList(options.excludeStatus) ?? [];
 		if (excludeStatuses.length > 0) {
@@ -2363,7 +2363,11 @@ addHelpSchema(taskCmd.command("list"), {
 	],
 })
 	.description("list tasks grouped by status")
-	.option("-s, --status <status>", "filter tasks by status (case-insensitive)")
+	.option(
+		"-s, --status <status>",
+		"filter tasks by status (case-insensitive, repeatable or comma-separated)",
+		createMultiValueAccumulator(),
+	)
 	.option(
 		"--exclude-status <status>",
 		"exclude tasks by status (repeatable or comma-separated)",
@@ -2412,7 +2416,7 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 		const baseFilters: TaskListFilter = {};
 		if (options.status) {
-			baseFilters.status = options.status;
+			baseFilters.status = parseDelimitedStringList(options.status) ?? options.status;
 		}
 		const excludeStatuses = parseDelimitedStringList(options.excludeStatus) ?? [];
 		if (excludeStatuses.length > 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1984,7 +1984,11 @@ addHelpSchema(program.command("search [query]"), {
 		"filter task results by configured task type (repeatable or comma-separated)",
 		createMultiValueAccumulator(),
 	)
-	.option("--status <status>", "filter task results by status")
+	.option(
+		"--status <status>",
+		"filter task results by status (repeatable or comma-separated)",
+		createMultiValueAccumulator(),
+	)
 	.option(
 		"--exclude-status <status>",
 		"exclude task results by status (repeatable or comma-separated)",
@@ -2041,7 +2045,7 @@ addHelpSchema(program.command("search [query]"), {
 		}
 
 		const filters: {
-			status?: string;
+			status?: string | string[];
 			excludeStatus?: string[];
 			type?: string[];
 			priority?: SearchPriorityFilter;
@@ -2162,7 +2166,7 @@ addHelpSchema(program.command("search [query]"), {
 	});
 
 function buildSearchFilterDescription(filters: {
-	status?: string;
+	status?: string | string[];
 	excludeStatus?: string[];
 	type?: string[];
 	priority?: SearchPriorityFilter;
@@ -2174,7 +2178,8 @@ function buildSearchFilterDescription(filters: {
 		parts.push(`Query: ${filters.query}`);
 	}
 	if (filters.status) {
-		parts.push(`Status: ${filters.status}`);
+		const statusText = Array.isArray(filters.status) ? filters.status.join(", ") : filters.status;
+		parts.push(`Status: ${statusText}`);
 	}
 	if (filters.excludeStatus?.length) {
 		parts.push(`Exclude status: ${filters.excludeStatus.join(", ")}`);
@@ -2636,7 +2641,7 @@ addHelpSchema(taskCmd.command("list"), {
 			title = `Tasks (${activeFilters.join(" • ")})`;
 		}
 		const initialUnifiedFilter: {
-			status?: string;
+			status?: string | string[];
 			excludeStatus?: string[];
 			assignee?: string;
 			milestone?: string;
@@ -2652,7 +2657,7 @@ addHelpSchema(taskCmd.command("list"), {
 			limit?: number;
 			ready?: boolean;
 		} = {
-			status: options.status,
+			status: baseFilters.status,
 			excludeStatus: Array.isArray(baseFilters.excludeStatus) ? baseFilters.excludeStatus : undefined,
 			assignee: options.assignee,
 			milestone: options.milestone,

--- a/src/commands/help-schema.ts
+++ b/src/commands/help-schema.ts
@@ -269,8 +269,9 @@ export function choiceType(values: readonly string[], options?: { multiple?: boo
 	return `${options?.multiple ? "one or more of" : "one of"}: ${values.join(", ")}`;
 }
 
-export function statusType(options?: { includeDraft?: boolean }): string {
-	return `one of configured statuses: ${getCliStatusValues(options).join(", ")}`;
+export function statusType(options?: { includeDraft?: boolean; multiple?: boolean }): string {
+	const cardinality = options?.multiple ? "one or more of" : "one of";
+	return `${cardinality} configured statuses: ${getCliStatusValues(options).join(", ")}`;
 }
 
 export function priorityType(): string {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -668,8 +668,15 @@ export class Core {
 		}
 		let result = tasks;
 		if (filters.status) {
-			const statusLower = filters.status.toLowerCase();
-			result = result.filter((task) => (task.status ?? "").toLowerCase() === statusLower);
+			// Any of the given statuses, matching the content store.
+			const wanted = new Set(
+				(Array.isArray(filters.status) ? filters.status : [filters.status])
+					.map((status) => status.trim().toLowerCase())
+					.filter((status) => status.length > 0),
+			);
+			if (wanted.size > 0) {
+				result = result.filter((task) => wanted.has((task.status ?? "").toLowerCase()));
+			}
 		}
 		if (filters.excludeStatus) {
 			const excludedStatuses = Array.isArray(filters.excludeStatus) ? filters.excludeStatus : [filters.excludeStatus];

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -56,6 +56,7 @@ import {
 	getValidStatuses as resolveValidStatuses,
 } from "../utils/status.ts";
 import { executeStatusCallback } from "../utils/status-callback.ts";
+import { normalizeStatusSet, statusMatchesSet } from "../utils/status-filter.ts";
 import {
 	buildDefinitionOfDoneItems,
 	normalizeStringList,
@@ -668,23 +669,15 @@ export class Core {
 		}
 		let result = tasks;
 		if (filters.status) {
-			// Any of the given statuses, matching the content store.
-			const wanted = new Set(
-				(Array.isArray(filters.status) ? filters.status : [filters.status])
-					.map((status) => status.trim().toLowerCase())
-					.filter((status) => status.length > 0),
-			);
+			const wanted = normalizeStatusSet(filters.status);
 			if (wanted.size > 0) {
-				result = result.filter((task) => wanted.has((task.status ?? "").toLowerCase()));
+				result = result.filter((task) => statusMatchesSet(wanted, task.status));
 			}
 		}
 		if (filters.excludeStatus) {
-			const excludedStatuses = Array.isArray(filters.excludeStatus) ? filters.excludeStatus : [filters.excludeStatus];
-			const excluded = new Set(
-				excludedStatuses.map((status) => status.trim().toLowerCase()).filter((status) => status.length > 0),
-			);
+			const excluded = normalizeStatusSet(filters.excludeStatus);
 			if (excluded.size > 0) {
-				result = result.filter((task) => !excluded.has((task.status ?? "").toLowerCase()));
+				result = result.filter((task) => !statusMatchesSet(excluded, task.status));
 			}
 		}
 		if (filters.type) {
@@ -2775,8 +2768,7 @@ export class Core {
 			}
 			this.contentStore?.transitionTask(normalizedTaskId);
 
-			const sanitizedPaths =
-				sanitizedTasks.length > 0 ? await this.writeTasksBulk(sanitizedTasks) : [];
+			const sanitizedPaths = sanitizedTasks.length > 0 ? await this.writeTasksBulk(sanitizedTasks) : [];
 
 			if (await this.shouldAutoCommit(autoCommit)) {
 				// Stage the file move for proper Git tracking

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -8,6 +8,7 @@ import { watchConfigFile } from "../utils/config-watcher.ts";
 import { documentIdKey, documentIdsEqual } from "../utils/document-id.ts";
 import { normalizeDocumentRelativePath } from "../utils/document-path.ts";
 import { normalizePriorityValue } from "../utils/priority-config.ts";
+import { normalizeStatusSet, statusMatchesSet } from "../utils/status-filter.ts";
 import { canonicalTaskId, normalizeTaskId, normalizeTaskIdentity, taskIdsEqual } from "../utils/task-path.ts";
 import { sortByTaskId } from "../utils/task-sorting.ts";
 import { matchesTaskTypeFilter } from "../utils/task-type-config.ts";
@@ -296,22 +297,15 @@ export class ContentStore {
 		if (filter?.status) {
 			// Any of the given statuses. Repeating -s used to overwrite rather than accumulate, so
 			// "list everything unfinished" silently returned whatever matched the last one alone.
-			const wanted = new Set(
-				(Array.isArray(filter.status) ? filter.status : [filter.status])
-					.map((status) => status.trim().toLowerCase())
-					.filter((status) => status.length > 0),
-			);
+			const wanted = normalizeStatusSet(filter.status);
 			if (wanted.size > 0) {
-				tasks = tasks.filter((task) => wanted.has(task.status.toLowerCase()));
+				tasks = tasks.filter((task) => statusMatchesSet(wanted, task.status));
 			}
 		}
 		if (filter?.excludeStatus) {
-			const excludedStatuses = Array.isArray(filter.excludeStatus) ? filter.excludeStatus : [filter.excludeStatus];
-			const excluded = new Set(
-				excludedStatuses.map((status) => status.trim().toLowerCase()).filter((status) => status.length > 0),
-			);
+			const excluded = normalizeStatusSet(filter.excludeStatus);
 			if (excluded.size > 0) {
-				tasks = tasks.filter((task) => !excluded.has(task.status.toLowerCase()));
+				tasks = tasks.filter((task) => !statusMatchesSet(excluded, task.status));
 			}
 		}
 		if (filter?.type) {
@@ -872,11 +866,7 @@ export class ContentStore {
 			return false;
 		}
 
-		const reconciledTaskCorpus = this.mergeConcurrentWorkingCopyCorpus(
-			taskCorpus,
-			itemVersions.tasks,
-			targetRoot,
-		);
+		const reconciledTaskCorpus = this.mergeConcurrentWorkingCopyCorpus(taskCorpus, itemVersions.tasks, targetRoot);
 		const mergedTasks = this.mergeConcurrentChanges(
 			reconciledTaskCorpus.tasks,
 			before.tasks,
@@ -1587,11 +1577,7 @@ export class ContentStore {
 				!this.isContentRefreshCurrent("tasks", generation)
 			)
 				return false;
-			const reconciledCorpus = this.mergeConcurrentWorkingCopyCorpus(
-				corpus,
-				before.versions,
-				targetRoot,
-			);
+			const reconciledCorpus = this.mergeConcurrentWorkingCopyCorpus(corpus, before.versions, targetRoot);
 			const merged = this.mergeConcurrentChanges(
 				reconciledCorpus.tasks,
 				before.items,
@@ -1737,12 +1723,7 @@ export class ContentStore {
 		beforeVersions: ReadonlyMap<string, number>,
 		targetRoot: string,
 	): { activeTasks: Task[]; completedTasks: Task[] } {
-		const activeTasks = this.mergeConcurrentTaskCorpus(
-			loadedActiveTasks,
-			this.activeTasks,
-			beforeVersions,
-			targetRoot,
-		);
+		const activeTasks = this.mergeConcurrentTaskCorpus(loadedActiveTasks, this.activeTasks, beforeVersions, targetRoot);
 		const completedTasks = this.mergeConcurrentTaskCorpus(
 			loadedCompletedTasks,
 			this.completedTasks,

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -294,8 +294,16 @@ export class ContentStore {
 
 		let tasks = this.cachedTasks;
 		if (filter?.status) {
-			const statusLower = filter.status.toLowerCase();
-			tasks = tasks.filter((task) => task.status.toLowerCase() === statusLower);
+			// Any of the given statuses. Repeating -s used to overwrite rather than accumulate, so
+			// "list everything unfinished" silently returned whatever matched the last one alone.
+			const wanted = new Set(
+				(Array.isArray(filter.status) ? filter.status : [filter.status])
+					.map((status) => status.trim().toLowerCase())
+					.filter((status) => status.length > 0),
+			);
+			if (wanted.size > 0) {
+				tasks = tasks.filter((task) => wanted.has(task.status.toLowerCase()));
+			}
 		}
 		if (filter?.excludeStatus) {
 			const excludedStatuses = Array.isArray(filter.excludeStatus) ? filter.excludeStatus : [filter.excludeStatus];

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -22,6 +22,7 @@ import {
 	idForFilename,
 	normalizeId,
 } from "../utils/prefix-config.ts";
+import { normalizeStatusSet, statusMatchesSet } from "../utils/status-filter.ts";
 import {
 	AmbiguousTaskIdError,
 	getTaskFilename,
@@ -638,9 +639,9 @@ export class FileSystem {
 	 * orders and deadlocking each other.
 	 */
 	async withTaskLocks<T>(tasks: Array<Pick<Task, "id" | "filePath">>, fn: () => Promise<T>): Promise<T> {
-		const uniqueTasks = Array.from(
-			new Map(tasks.map((task) => [task.id.trim().toLowerCase(), task])).values(),
-		).sort((left, right) => left.id.localeCompare(right.id));
+		const uniqueTasks = Array.from(new Map(tasks.map((task) => [task.id.trim().toLowerCase(), task])).values()).sort(
+			(left, right) => left.id.localeCompare(right.id),
+		);
 
 		const acquire = async (index: number): Promise<T> => {
 			const task = uniqueTasks[index];
@@ -912,22 +913,15 @@ export class FileSystem {
 
 		if (filter?.status) {
 			// Any of the given statuses, matching the content store.
-			const wanted = new Set(
-				(Array.isArray(filter.status) ? filter.status : [filter.status])
-					.map((status) => status.trim().toLowerCase())
-					.filter((status) => status.length > 0),
-			);
+			const wanted = normalizeStatusSet(filter.status);
 			if (wanted.size > 0) {
-				tasks = tasks.filter((t) => wanted.has(t.status.toLowerCase()));
+				tasks = tasks.filter((t) => statusMatchesSet(wanted, t.status));
 			}
 		}
 		if (filter?.excludeStatus) {
-			const excludedStatuses = Array.isArray(filter.excludeStatus) ? filter.excludeStatus : [filter.excludeStatus];
-			const excluded = new Set(
-				excludedStatuses.map((status) => status.trim().toLowerCase()).filter((status) => status.length > 0),
-			);
+			const excluded = normalizeStatusSet(filter.excludeStatus);
 			if (excluded.size > 0) {
-				tasks = tasks.filter((t) => !excluded.has(t.status.toLowerCase()));
+				tasks = tasks.filter((t) => !statusMatchesSet(excluded, t.status));
 			}
 		}
 		if (filter?.type) {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -911,8 +911,15 @@ export class FileSystem {
 		);
 
 		if (filter?.status) {
-			const statusLower = filter.status.toLowerCase();
-			tasks = tasks.filter((t) => t.status.toLowerCase() === statusLower);
+			// Any of the given statuses, matching the content store.
+			const wanted = new Set(
+				(Array.isArray(filter.status) ? filter.status : [filter.status])
+					.map((status) => status.trim().toLowerCase())
+					.filter((status) => status.length > 0),
+			);
+			if (wanted.size > 0) {
+				tasks = tasks.filter((t) => wanted.has(t.status.toLowerCase()));
+			}
 		}
 		if (filter?.excludeStatus) {
 			const excludedStatuses = Array.isArray(filter.excludeStatus) ? filter.excludeStatus : [filter.excludeStatus];

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -331,7 +331,7 @@ describe("CLI Integration", () => {
 			expect(createHelp).toContain(
 				"plan: Markdown - Only for already-started work created directly in a configured active status (for example, In Progress)",
 			);
-			expect(listHelp).toContain("status: one of configured statuses: To Do, In Progress, Done");
+			expect(listHelp).toContain("status: one or more of configured statuses: To Do, In Progress, Done");
 			expect(listHelp).not.toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
 			expect(listHelp).toContain("priority: one of configured priorities: High, Medium, Low");
 			expect(listHelp).toContain("labels: Comma-separated strings");
@@ -437,8 +437,8 @@ describe("CLI Integration", () => {
 			const editHelp = await $`bun ${CLI_PATH} task edit --help`.cwd(TEST_DIR).text();
 
 			expect(createHelp).toContain("status: one of configured statuses: Draft, Ready, Review, Closed");
-			expect(listHelp).toContain("status: one of configured statuses: Ready, Review, Closed");
-			expect(searchHelp).toContain("status: one of configured statuses: Ready, Review, Closed");
+			expect(listHelp).toContain("status: one or more of configured statuses: Ready, Review, Closed");
+			expect(searchHelp).toContain("status: one or more of configured statuses: Ready, Review, Closed");
 			expect(editHelp).toContain("status: one of configured statuses: Ready, Review, Closed");
 			for (const output of [listHelp, searchHelp, editHelp]) {
 				expect(output).not.toContain("status: one of configured statuses: Draft, Ready, Review, Closed");
@@ -457,7 +457,7 @@ describe("CLI Integration", () => {
 			expect(configHelp).toContain("key: one of: defaultEditor, projectName, defaultAssignee, defaultStatus");
 			expect(configHelp).toContain("value: String");
 			expect(searchHelp).toContain("type: one or more of: task, document, decision");
-			expect(searchHelp).toContain("status: one of configured statuses: To Do, In Progress, Done");
+			expect(searchHelp).toContain("status: one or more of configured statuses: To Do, In Progress, Done");
 			expect(searchHelp).not.toContain("status: one of configured statuses: Draft, To Do, In Progress, Done");
 			expect(searchHelp).toContain("priority: one of configured priorities: High, Medium, Low");
 			expect(searchHelp).toContain("modified-file: Project-root-relative path");

--- a/src/test/cli-status-filtering.test.ts
+++ b/src/test/cli-status-filtering.test.ts
@@ -83,10 +83,9 @@ describe("CLI status filtering", () => {
 	});
 
 	it("still honours exclude-status alongside several included statuses", async () => {
-		const result =
-			await $`bun ${cliPath} task list --status "To Do" --status "Done" --exclude-status Done --plain`
-				.cwd(TEST_DIR)
-				.quiet();
+		const result = await $`bun ${cliPath} task list --status "To Do" --status "Done" --exclude-status Done --plain`
+			.cwd(TEST_DIR)
+			.quiet();
 
 		expect(result.exitCode).toBe(0);
 		const stdout = result.stdout.toString();

--- a/src/test/cli-status-filtering.test.ts
+++ b/src/test/cli-status-filtering.test.ts
@@ -92,4 +92,47 @@ describe("CLI status filtering", () => {
 		expect(stdout).toContain("TASK-1 - Todo one");
 		expect(stdout).not.toContain("TASK-3 - Done one");
 	});
+
+	it("returns tasks matching any repeated status in JSON output", async () => {
+		const result = await $`bun ${cliPath} task list --status "To Do" --status "Done" --json`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr.toString()).toBe("");
+		const ids = JSON.parse(result.stdout.toString()).tasks.map((t: { id: string }) => t.id);
+		expect(ids).toContain("TASK-1");
+		expect(ids).toContain("TASK-3");
+		expect(ids).not.toContain("TASK-2");
+	});
+
+	it("accepts comma-separated statuses in JSON output", async () => {
+		const result = await $`bun ${cliPath} task list --status "To Do,Done" --json`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		const ids = JSON.parse(result.stdout.toString()).tasks.map((t: { id: string }) => t.id);
+		expect(ids).toContain("TASK-1");
+		expect(ids).toContain("TASK-3");
+		expect(ids).not.toContain("TASK-2");
+	});
+
+	it("search keeps every selected status in plain output when the flag is repeated", async () => {
+		const result = await $`bun ${cliPath} search work --type task --status "To Do" --status "Done" --plain`
+			.cwd(TEST_DIR)
+			.quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("TASK-1 - Todo one");
+		expect(stdout).toContain("TASK-3 - Done one");
+		expect(stdout).not.toContain("TASK-2 - Progress one");
+	});
+
+	it("search accepts comma-separated statuses in plain output", async () => {
+		const result = await $`bun ${cliPath} search work --type task --status "to do,DONE" --plain`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("TASK-1 - Todo one");
+		expect(stdout).toContain("TASK-3 - Done one");
+		expect(stdout).not.toContain("TASK-2 - Progress one");
+	});
 });

--- a/src/test/cli-status-filtering.test.ts
+++ b/src/test/cli-status-filtering.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+
+const task = (id: string, title: string, status: string) => ({
+	id,
+	title,
+	status,
+	assignee: [],
+	createdDate: "2026-01-01",
+	labels: [],
+	dependencies: [],
+	description: "work",
+	rawContent: "work",
+});
+
+describe("CLI status filtering", () => {
+	const cliPath = getTestCliPath();
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("cli-status");
+		await mkdir(TEST_DIR, { recursive: true });
+
+		const core = new Core(TEST_DIR);
+		await initializeFilesystemTestProject(core, "Status Project");
+
+		await core.createTask(task("task-1", "Todo one", "To Do"), false);
+		await core.createTask(task("task-2", "Progress one", "In Progress"), false);
+		await core.createTask(task("task-3", "Done one", "Done"), false);
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("filters by a single status", async () => {
+		const result = await $`bun ${cliPath} task list --status "To Do" --plain`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("TASK-1 - Todo one");
+		expect(stdout).not.toContain("TASK-2 - Progress one");
+		expect(stdout).not.toContain("TASK-3 - Done one");
+	});
+
+	// Repeating the flag used to overwrite rather than accumulate, so asking for everything
+	// unfinished returned only whatever matched the last status — and silently, since an empty
+	// list looks exactly like having no such tasks.
+	it("returns tasks matching any status when the flag is repeated", async () => {
+		const result = await $`bun ${cliPath} task list --status "To Do" --status "In Progress" --plain`
+			.cwd(TEST_DIR)
+			.quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("TASK-1 - Todo one");
+		expect(stdout).toContain("TASK-2 - Progress one");
+		expect(stdout).not.toContain("TASK-3 - Done one");
+	});
+
+	it("accepts several statuses separated by commas", async () => {
+		const result = await $`bun ${cliPath} task list --status "To Do,Done" --plain`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("TASK-1 - Todo one");
+		expect(stdout).toContain("TASK-3 - Done one");
+		expect(stdout).not.toContain("TASK-2 - Progress one");
+	});
+
+	it("matches statuses case-insensitively when several are given", async () => {
+		const result = await $`bun ${cliPath} task list --status "to do" --status "DONE" --plain`.cwd(TEST_DIR).quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("TASK-1 - Todo one");
+		expect(stdout).toContain("TASK-3 - Done one");
+	});
+
+	it("still honours exclude-status alongside several included statuses", async () => {
+		const result =
+			await $`bun ${cliPath} task list --status "To Do" --status "Done" --exclude-status Done --plain`
+				.cwd(TEST_DIR)
+				.quiet();
+
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("TASK-1 - Todo one");
+		expect(stdout).not.toContain("TASK-3 - Done one");
+	});
+});

--- a/src/test/status-filter.test.ts
+++ b/src/test/status-filter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeStatusSet, statusMatchesSet } from "../utils/status-filter.ts";
+
+describe("normalizeStatusSet", () => {
+	it("lowercases and trims each status", () => {
+		expect([...normalizeStatusSet(["To Do", "  DONE "])]).toEqual(["to do", "done"]);
+	});
+
+	it("accepts a single status string", () => {
+		expect([...normalizeStatusSet("In Progress")]).toEqual(["in progress"]);
+	});
+
+	it("drops blank entries and deduplicates case-insensitively", () => {
+		const set = normalizeStatusSet(["To Do", "", "   ", "TO DO"]);
+		expect(set.size).toBe(1);
+		expect(set.has("to do")).toBe(true);
+	});
+
+	it("returns an empty set for missing values", () => {
+		expect(normalizeStatusSet(undefined).size).toBe(0);
+	});
+});
+
+describe("statusMatchesSet", () => {
+	it("matches task statuses case-insensitively", () => {
+		const wanted = normalizeStatusSet(["to do", "done"]);
+		expect(statusMatchesSet(wanted, "To Do")).toBe(true);
+		expect(statusMatchesSet(wanted, "DONE")).toBe(true);
+		expect(statusMatchesSet(wanted, "In Progress")).toBe(false);
+	});
+
+	it("treats missing task statuses as no match", () => {
+		const wanted = normalizeStatusSet(["done"]);
+		expect(statusMatchesSet(wanted, undefined)).toBe(false);
+		expect(statusMatchesSet(wanted, null)).toBe(false);
+	});
+
+	it("matches nothing when the selection is empty", () => {
+		const wanted = normalizeStatusSet([]);
+		expect(statusMatchesSet(wanted, "Done")).toBe(false);
+	});
+});

--- a/src/test/unified-view-filters.test.ts
+++ b/src/test/unified-view-filters.test.ts
@@ -66,7 +66,7 @@ describe("unified view filter state", () => {
 		});
 
 		expect(filters.searchQuery).toBe("sync");
-		expect(filters.statusFilter).toBe("In Progress");
+		expect(filters.statusFilter).toEqual(["In Progress"]);
 		expect(filters.excludeStatus).toEqual(["Done"]);
 		expect(filters.priorityFilter).toBe("high");
 		expect(filters.labelFilter).toEqual(["backend"]);
@@ -74,6 +74,13 @@ describe("unified view filter state", () => {
 		expect(filters.milestoneFilter).toBe("Release 1");
 		expect(filters.limit).toBe(2);
 		expect(filters.labelFilter).not.toBe(labels);
+	});
+
+	it("seeds several selected statuses without sharing the caller's array", () => {
+		const status = ["To Do", "Done"];
+		const filters = createUnifiedViewFilters({ status });
+		expect(filters.statusFilter).toEqual(["To Do", "Done"]);
+		expect(filters.statusFilter).not.toBe(status);
 	});
 
 	it("preserves milestone filter when merging filter updates", () => {
@@ -86,7 +93,7 @@ describe("unified view filter state", () => {
 
 		const updated: UnifiedViewFilters = {
 			searchQuery: "api",
-			statusFilter: "To Do",
+			statusFilter: ["To Do"],
 			excludeStatus: [],
 			typeFilter: [],
 			priorityFilter: "",
@@ -111,7 +118,7 @@ describe("unified view filter state", () => {
 
 		const updated: UnifiedViewFilters = {
 			searchQuery: "api auth",
-			statusFilter: "",
+			statusFilter: [],
 			excludeStatus: [],
 			typeFilter: [],
 			priorityFilter: "high",
@@ -131,7 +138,7 @@ describe("unified view filter state", () => {
 
 		const updated = {
 			searchQuery: "api auth",
-			statusFilter: "",
+			statusFilter: [],
 			priorityFilter: "",
 			labelFilter: [],
 			milestoneFilter: "",
@@ -149,7 +156,7 @@ describe("unified view filter state", () => {
 
 		const updated: UnifiedViewFilters = {
 			searchQuery: "api",
-			statusFilter: "",
+			statusFilter: [],
 			excludeStatus: [],
 			typeFilter: [],
 			priorityFilter: "",
@@ -170,7 +177,7 @@ describe("unified view filter state", () => {
 
 		const updated: UnifiedViewFilters = {
 			searchQuery: "auth",
-			statusFilter: "",
+			statusFilter: [],
 			excludeStatus: [],
 			typeFilter: [],
 			priorityFilter: "",
@@ -190,7 +197,7 @@ describe("unified view filter state", () => {
 
 		const updated: UnifiedViewFilters = {
 			searchQuery: "",
-			statusFilter: "",
+			statusFilter: [],
 			excludeStatus: [],
 			typeFilter: [],
 			priorityFilter: "",
@@ -372,6 +379,44 @@ describe("unified view filter state", () => {
 		}).map((task) => task.id);
 
 		expect(results).toEqual(["task-1"]);
+	});
+
+	it("matches any selected status case-insensitively in the task list", () => {
+		const tasks: Task[] = [
+			{
+				id: "task-1",
+				title: "Todo one",
+				status: "To Do",
+				labels: [],
+				assignee: [],
+				createdDate: "2026-01-01",
+				dependencies: [],
+			},
+			{
+				id: "task-2",
+				title: "Progress one",
+				status: "In Progress",
+				labels: [],
+				assignee: [],
+				createdDate: "2026-01-02",
+				dependencies: [],
+			},
+			{
+				id: "task-3",
+				title: "Done one",
+				status: "Done",
+				labels: [],
+				assignee: [],
+				createdDate: "2026-01-03",
+				dependencies: [],
+			},
+		];
+
+		const results = applyTaskFilters(tasks, { status: ["to do", "DONE"] }).map((task) => task.id);
+		expect(results).toEqual(["task-1", "task-3"]);
+
+		const singleStringResults = applyTaskFilters(tasks, { status: "done" }).map((task) => task.id);
+		expect(singleStringResults).toEqual(["task-3"]);
 	});
 
 	it("keeps shared filter results consistent between task list and kanban", () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -174,7 +174,8 @@ export interface TaskUpdateInput {
 }
 
 export interface TaskListFilter {
-	status?: string;
+	/** Matches any of these when several are given, mirroring `excludeStatus`. */
+	status?: string | string[];
 	excludeStatus?: string | string[];
 	type?: string | string[];
 	assignee?: string;

--- a/src/ui/components/filter-header.ts
+++ b/src/ui/components/filter-header.ts
@@ -12,7 +12,7 @@ export type FilterControlId = "search" | "status" | "type" | "priority" | "label
 
 export interface FilterState {
 	search: string;
-	status: string;
+	status: string[];
 	taskTypes: string[];
 	priority: string;
 	labels: string[];
@@ -150,7 +150,7 @@ export class FilterHeader {
 		this.visibleFilterIds = normalizeVisibleFilters(options.visibleFilters);
 		this.state = {
 			search: options.initialFilters?.search ?? "",
-			status: options.initialFilters?.status ?? "",
+			status: options.initialFilters?.status ?? [],
 			taskTypes: options.initialFilters?.taskTypes ?? [],
 			priority: options.initialFilters?.priority ?? "",
 			labels: options.initialFilters?.labels ?? [],
@@ -198,7 +198,7 @@ export class FilterHeader {
 			this.searchInput?.setValue(filters.search);
 		}
 		if (filters.status !== undefined) {
-			this.state.status = filters.status;
+			this.state.status = [...filters.status];
 			this.updateStatusButton();
 		}
 		if (filters.taskTypes !== undefined) {
@@ -618,7 +618,9 @@ export class FilterHeader {
 	private getPopupButtonContent(field: Exclude<FilterControlId, "search">): string {
 		switch (field) {
 			case "status":
-				return this.state.status ? `${this.state.status} ▼` : "All ▼";
+				if (this.state.status.length === 0) return "All ▼";
+				if (this.state.status.length === 1) return `${this.state.status[0]} ▼`;
+				return `${this.state.status.length} selected ▼`;
 			case "type":
 				if (this.state.taskTypes.length === 0) return "All ▼";
 				if (this.state.taskTypes.length === 1) return `${this.state.taskTypes[0]} ▼`;

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -212,7 +212,7 @@ export async function viewTaskEnhanced(
 		title?: string;
 		filterDescription?: string;
 		searchQuery?: string;
-		statusFilter?: string;
+		statusFilter?: string | string[];
 		excludeStatus?: string[];
 		typeFilter?: string[];
 		priorityFilter?: string;
@@ -234,7 +234,7 @@ export async function viewTaskEnhanced(
 		onTabPress?: () => Promise<void>;
 		onFilterChange?: (filters: {
 			searchQuery: string;
-			statusFilter: string;
+			statusFilter: string[];
 			excludeStatus: string[];
 			typeFilter: string[];
 			priorityFilter: string;
@@ -336,12 +336,15 @@ export async function viewTaskEnhanced(
 	// State for filtering - normalize filters to match configured values
 	let searchQuery = options.searchQuery || "";
 
-	// Find the canonical status value from configured statuses (case-insensitive)
-	let statusFilter = "";
-	if (options.statusFilter) {
-		const lowerFilter = options.statusFilter.toLowerCase();
-		const matchedStatus = statuses.find((s) => s.toLowerCase() === lowerFilter);
-		statusFilter = matchedStatus || "";
+	// Keep the requested statuses that match configured ones (case-insensitive), in config order
+	let statusFilter: string[] = [];
+	if (options.statusFilter && options.statusFilter.length > 0) {
+		const requested = new Set(
+			(Array.isArray(options.statusFilter) ? options.statusFilter : [options.statusFilter]).map((status) =>
+				status.trim().toLowerCase(),
+			),
+		);
+		statusFilter = statuses.filter((status) => requested.has(status.toLowerCase()));
 	}
 	const excludeStatusFilter = [...(options.excludeStatus ?? [])];
 
@@ -363,7 +366,7 @@ export async function viewTaskEnhanced(
 	// else triggers a refilter.
 	const filtersActive = Boolean(
 		searchQuery ||
-			statusFilter ||
+			statusFilter.length > 0 ||
 			excludeStatusFilter.length > 0 ||
 			taskTypeFilter.length > 0 ||
 			priorityFilter ||
@@ -468,15 +471,15 @@ export async function viewTaskEnhanced(
 			}
 
 			if (filterId === "status") {
-				const selected = await openSingleSelectFilterPopup({
+				const nextStatuses = await openMultiSelectFilterPopup({
 					screen,
 					title: "Status Filter",
-					selectedValue: statusFilter,
-					choices: [{ label: "All", value: "" }, ...statuses.map((status) => ({ label: status, value: status }))],
+					items: statuses,
+					selectedItems: statusFilter,
 				});
-				if (selected !== null) {
-					statusFilter = selected;
-					filterHeader.setFilters({ status: selected });
+				if (nextStatuses !== null) {
+					statusFilter = nextStatuses;
+					filterHeader.setFilters({ status: nextStatuses });
 					applyFilters();
 					notifyFilterChange();
 				}
@@ -729,7 +732,7 @@ export async function viewTaskEnhanced(
 	function applyFilters() {
 		const hasActiveFilters = Boolean(
 			searchQuery.trim() ||
-				statusFilter ||
+				statusFilter.length > 0 ||
 				excludeStatusFilter.length > 0 ||
 				taskTypeFilter.length > 0 ||
 				priorityFilter ||
@@ -745,7 +748,7 @@ export async function viewTaskEnhanced(
 				allTasks,
 				{
 					query: searchQuery,
-					status: statusFilter || undefined,
+					status: statusFilter.length > 0 ? [...statusFilter] : undefined,
 					excludeStatus: excludeStatusFilter,
 					type: taskTypeFilter,
 					priority: priorityFilter || undefined,
@@ -761,7 +764,7 @@ export async function viewTaskEnhanced(
 			const searchResults = searchService.search({
 				query: searchQuery,
 				filters: {
-					status: statusFilter || undefined,
+					status: statusFilter.length > 0 ? [...statusFilter] : undefined,
 					excludeStatus: excludeStatusFilter,
 					type: taskTypeFilter,
 					priority: priorityFilter || undefined,
@@ -811,8 +814,8 @@ export async function viewTaskEnhanced(
 			if (trimmedQuery) {
 				activeFilters.push(`Search: {cyan-fg}${trimmedQuery}{/}`);
 			}
-			if (statusFilter) {
-				activeFilters.push(`Status: {cyan-fg}${statusFilter}{/}`);
+			if (statusFilter.length > 0) {
+				activeFilters.push(`Status: {cyan-fg}${statusFilter.join(", ")}{/}`);
 			}
 			if (excludeStatusFilter.length > 0) {
 				activeFilters.push(`Exclude status: {cyan-fg}${excludeStatusFilter.join(", ")}{/}`);

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -27,7 +27,7 @@ export interface UnifiedViewOptions {
 	loadingScreenFactory?: (initialMessage: string) => Promise<LoadingScreen | null>;
 	title?: string;
 	filter?: {
-		status?: string;
+		status?: string | string[];
 		assignee?: string;
 		type?: string[];
 		priority?: string;
@@ -109,7 +109,7 @@ export function createUnifiedTaskUpdateCallbacks(
 
 export interface UnifiedViewFilters {
 	searchQuery: string;
-	statusFilter: string;
+	statusFilter: string[];
 	excludeStatus: string[];
 	typeFilter: string[];
 	priorityFilter: string;
@@ -181,9 +181,10 @@ export function filterTasksForKanban(
 }
 
 export function createUnifiedViewFilters(filter: UnifiedViewOptions["filter"] | undefined): UnifiedViewFilters {
+	const status = filter?.status;
 	return {
 		searchQuery: filter?.searchQuery || "",
-		statusFilter: filter?.status || "",
+		statusFilter: Array.isArray(status) ? [...status] : status ? [status] : [],
 		excludeStatus: [...(filter?.excludeStatus || [])],
 		typeFilter: [...(filter?.type || [])],
 		priorityFilter: filter?.priority || "",

--- a/src/ui/view-switcher.ts
+++ b/src/ui/view-switcher.ts
@@ -13,7 +13,7 @@ export interface ViewState {
 	selectedTask?: Task;
 	tasks?: Task[];
 	filter?: {
-		status?: string;
+		status?: string | string[];
 		assignee?: string;
 		priority?: string;
 		sort?: string;

--- a/src/utils/status-filter.ts
+++ b/src/utils/status-filter.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared multi-status matching for task filters, used by Core.applyTaskFilters,
+ * ContentStore.getTasks, FileSystem.listTasks, and the interactive task views so every
+ * surface agrees on how a status selection is compared.
+ *
+ * Status names are matched case-insensitively after trimming. Blank names are dropped,
+ * and an empty selection matches nothing by design: callers skip filtering when the set
+ * is empty instead of treating it as "match every task".
+ */
+export function normalizeStatusSet(values: string | string[] | undefined): Set<string> {
+	const list = Array.isArray(values) ? values : values ? [values] : [];
+	return new Set(list.map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0));
+}
+
+/** Case-insensitive check of one task's status against a set from `normalizeStatusSet`. */
+export function statusMatchesSet(wanted: Set<string>, status: string | null | undefined): boolean {
+	return wanted.has((status ?? "").toLowerCase());
+}

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -14,6 +14,7 @@ import {
 import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "./modified-files.ts";
 import { normalizePriorityValue } from "./priority-config.ts";
 import { getTaskReadiness, type ReadinessGraph } from "./readiness.ts";
+import { normalizeStatusSet, statusMatchesSet } from "./status-filter.ts";
 import { createTaskIdSearchVariants } from "./task-id-search.ts";
 import { matchesTaskTypeFilter } from "./task-type-config.ts";
 
@@ -21,7 +22,7 @@ export type LabelMatchMode = "any" | "all";
 
 export interface TaskSearchOptions {
 	query?: string;
-	status?: string;
+	status?: string | string[];
 	excludeStatus?: string | string[];
 	type?: string | string[];
 	priority?: string;
@@ -43,7 +44,7 @@ export interface SharedTaskFilterOptions {
 }
 
 export interface TaskFilterOptions extends SharedTaskFilterOptions {
-	status?: string;
+	status?: string | string[];
 	excludeStatus?: string | string[];
 	/**
 	 * When set, keep only tasks that are ready according to this graph. The graph carries the full
@@ -135,18 +136,15 @@ export function createTaskSearchIndex(tasks: Task[]): TaskSearchIndex {
 				results = [...searchableTasks];
 			}
 
-			// Apply status filter
-			if (options.status) {
-				const statusLower = options.status.toLowerCase();
-				results = results.filter((t) => t.statusLower === statusLower);
+			// Apply status filter: any of the given statuses, matching the stores.
+			const wantedStatuses = options.status ? normalizeStatusSet(options.status) : null;
+			if (wantedStatuses && wantedStatuses.size > 0) {
+				results = results.filter((t) => statusMatchesSet(wantedStatuses, t.statusLower));
 			}
 			if (options.excludeStatus) {
-				const excludedStatuses = Array.isArray(options.excludeStatus) ? options.excludeStatus : [options.excludeStatus];
-				const excluded = new Set(
-					excludedStatuses.map((status) => status.trim().toLowerCase()).filter((status) => status.length > 0),
-				);
+				const excluded = normalizeStatusSet(options.excludeStatus);
 				if (excluded.size > 0) {
-					results = results.filter((t) => !excluded.has(t.statusLower));
+					results = results.filter((t) => !statusMatchesSet(excluded, t.statusLower));
 				}
 			}
 			if (options.type) {


### PR DESCRIPTION
`--status` is the only list filter that does not accept several values. `--exclude-status` (#745) and `--type` both do; `--status` has kept the single-value form it was given in #82 / #112.

## Symptom

```console
$ backlog task list --status "To Do" --plain
TASK-1 - ...        # 4 tasks

$ backlog task list --status "In Progress" --plain
TASK-2 - ...        # 2 tasks

$ backlog task list --status "To Do" --status "In Progress" --plain
No tasks found.     # expected 6
```

Asking for everything unfinished returns nothing. There is no error — an empty list is indistinguishable from genuinely having no such tasks, which is why this is easy to miss.

## Cause

The option has no accumulator, so repeating the flag overwrites the earlier value rather than collecting it. The filter then runs against whichever status came last. It is not an intersection; it is the first value being discarded.

## Change

`--status` now accumulates and splits on commas, exactly as `--exclude-status` does. Both forms work:

```console
backlog task list --status "To Do" --status "In Progress"
backlog task list --status "To Do,In Progress"
```

A single `--status` behaves as before.

## Why three core files

`TaskListFilter.status` widens from `string` to `string | string[]`, mirroring `excludeStatus`. That change made the compiler point out that the same status comparison is implemented separately in three places:

- `src/core/content-store.ts`
- `src/core/backlog.ts`
- `src/file-system/operations.ts`

Changing only the first would have left two paths on the old behaviour. The three copies are left as they are otherwise — deduplicating them is a separate concern and would make this change harder to review.

## Tests

`src/test/cli-status-filtering.test.ts` covers a single status, a repeated flag, comma-separated values, case-insensitivity across several values, and the combination with `--exclude-status`.

Reverting the accumulator makes three of the five fail, so they exercise the fix rather than following it.

## Verification

`bunx tsc --noEmit`, `bun run lint`, and the new plus existing status-filter tests all pass.

`bun run check .` is not included: on Windows the repository's `* text=auto` gives the working tree CRLF endings, which biome rejects wholesale, so the command fails regardless of the change.
