### PR TITLE
BACK-639 - Add Git-backed live task coordination

### DIFF
--- a/ADVANCED-CONFIG.md
+++ b/ADVANCED-CONFIG.md
@@ -46,6 +46,12 @@ Running `backlog config` with no arguments launches the interactive advanced wiz
 
 > **Note**: Set `remoteOperations: false` to work offline. This disables git fetch operations and loads tasks from local branches only, useful when working without network connectivity.
 
+### Remote task coordination
+
+When remote operations are enabled, Backlog can use blob-backed refs under `refs/backlog/tasks/*` for transient task coordination. These refs provide atomic claims, leases, and a live status/assignee overlay without adding commits to `main` or feature-branch history. Markdown task files remain the durable source of truth.
+
+Use `backlog task start BACK-123` to claim, assign, and move a task to the active status as one workflow. Use `backlog task claim`, `backlog task release`, `backlog task publish`, and `backlog task claims` for the individual operations. Claiming fails closed when the configured Git remote cannot be reached. Set `remoteOperations: false` to disable all remote coordination.
+
 > **Git Control**: By default, `autoCommit` is set to `false`, giving you full control over your git history. Task operations will modify files but won't automatically commit changes. Set `autoCommit: true` if you prefer automatic commits for each task operation.
 
 > **Git Hooks**: If you have pre-commit hooks (like conventional commits or linters) that interfere with backlog.md's automated commits, set `bypassGitHooks: true` to skip them using the `--no-verify` flag.

--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -64,6 +64,12 @@ Humans and agents can run `backlog instructions` for workflow guides and `backlo
 | View (AI mode) | `backlog task 7 --plain`                           |
 | View as JSON | `backlog task 7 --json` |
 | Edit        | `backlog task edit 7 -a @sara -l auth,backend`       |
+| Start work safely | `backlog task start BACK-7 --owner @sara` (atomic remote claim, assignment, and active status) |
+| Claim task | `backlog task claim BACK-7 --owner @sara --lease-hours 8` |
+| Renew claim | `backlog task claim BACK-7 --owner @sara --renew` |
+| Release claim | `backlog task release BACK-7 --owner @sara` |
+| Publish live state | `backlog task publish BACK-7` |
+| List live state | `backlog task claims` |
 | Add plan    | `backlog task edit 7 --plan "Implementation approach"`    |
 | Add AC      | `backlog task edit 7 --ac "New criterion" --ac "Another one"` |
 | Add DoD     | `backlog task edit 7 --dod "Ship notes"` |

--- a/backlog/tasks/back-639 - Add-Git-backed-live-task-coordination.md
+++ b/backlog/tasks/back-639 - Add-Git-backed-live-task-coordination.md
@@ -1,0 +1,58 @@
+---
+id: BACK-639
+title: Add Git-backed live task coordination
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-08-24 07:43'
+updated_date: '2026-08-24 07:59'
+labels: []
+dependencies: []
+priority: high
+type: feature
+ordinal: 274000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent humans and agents from silently duplicating work and make transient task ownership, assignment, and status changes visible across clones without adding coordination commits to normal branch history. Markdown remains the durable task record; Git coordination refs are an optional remote overlay used only when remote operations are enabled.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Two concurrent attempts to claim the same task produce exactly one winner
+- [x] #2 Claims use leases and stale claims can be replaced atomically without deleting a newer owner's claim
+- [x] #3 Status and assignee changes can be published and refreshed as transient coordination state without changing normal branch history
+- [x] #4 The canonical CLI exposes understandable claim, release, start, and coordination-list workflows
+- [x] #5 Remote failures fail closed for exclusive claims and return actionable human-readable errors
+- [x] #6 Projects with remote operations disabled continue to work without coordination
+- [x] #7 Automated tests cover concurrent claims, stale writes, safe release, offline failure, and unchanged normal history
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a small Git coordination model and CAS operations using custom blob-backed refs under refs/backlog/tasks/*. 2. Expose canonical CLI commands for claim, release, start, publish, refresh/list with safe owner and lease handling. 3. Keep Markdown durable by updating it through existing Core mutations while treating remote records as transient overlays. 4. Add local bare-remote integration tests covering concurrent creation, expired replacement, stale release, offline failure, and unchanged branch history. 5. Run focused tests, type-check, lint, build, and the full suite; simplify before finalization.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented blob-backed refs under refs/backlog/tasks/* with explicit force-with-lease CAS for create, update, renewal, replacement, and deletion. Added canonical claim, release, start, publish, and claims CLI workflows plus user documentation.
+
+Verification: 9 focused coordination tests pass (30 assertions), TypeScript passes, modified TypeScript files pass Biome, build passes, and a disposable create/read/delete probe passed against the configured GitHub fork. A repository-wide test run was stopped after unrelated existing Windows failures in Claude-agent fixtures and locked temporary-file tests; bun run check . also reports repository-wide CRLF formatting outside the changed files.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added Git-backed live task coordination with atomic claims, renewable leases, stale-write protection, safe release, transient status/assignee publication, canonical CLI workflows, documentation, local concurrency integration tests, and a successful disposable GitHub compatibility probe.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1717,7 +1717,7 @@ function getTaskReadOutputMode(options: { json?: boolean; plain?: boolean }): Re
 }
 
 taskCmd.hook("preSubcommand", (command, subcommand) => {
-	if (command.opts().json && !["list", "view"].includes(subcommand.name())) {
+	if (command.opts().json && !["list", "view", "claims"].includes(subcommand.name())) {
 		command.error("error: unknown option '--json'", { code: "commander.unknownOption", exitCode: 1 });
 	}
 });
@@ -1932,6 +1932,199 @@ addHelpSchema(taskCmd.command("create [title]"), {
 
 			console.log(`Created task ${task.id}`);
 			console.log(`File: ${filePath}`);
+		} catch (error) {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		}
+	});
+
+async function resolveCoordinationOwner(core: Core, owner?: string): Promise<string> {
+	return owner?.trim() || (await core.git.getUserIdentity());
+}
+
+taskCmd
+	.command("claim <taskId>")
+	.description("atomically claim a task on the Git remote")
+	.option("--owner <owner>", "claim owner; defaults to Git user email or name")
+	.option("--lease-hours <hours>", "claim lease duration", "8")
+	.option("--renew", "renew an active claim owned by the caller")
+	.option("--remote <remote>", "Git remote", "origin")
+	.action(async (taskId: string, options) => {
+		const cwd = await requireProjectRoot();
+		const core = new Core(cwd);
+		const task = await core.loadTaskById(taskId, { includeCrossBranch: false });
+		if (!task) {
+			console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
+			process.exitCode = 1;
+			return;
+		}
+		const leaseHours = Number(options.leaseHours);
+		if (!Number.isFinite(leaseHours) || leaseHours <= 0) {
+			console.error("--lease-hours must be a positive number.");
+			process.exitCode = 1;
+			return;
+		}
+		try {
+			const owner = await resolveCoordinationOwner(core, options.owner);
+			const claim = await core.git.claimTask(task.id, owner, {
+				remote: options.remote,
+				leaseMs: leaseHours * 60 * 60 * 1000,
+				branch: await core.git.getCurrentBranch(),
+				renew: Boolean(options.renew),
+			});
+			console.log(`Claimed ${task.id} for ${owner} until ${claim.state.leaseUntil}.`);
+		} catch (error) {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		}
+	});
+
+taskCmd
+	.command("release <taskId>")
+	.description("release a task claim only when owned by the caller")
+	.option("--owner <owner>", "claim owner; defaults to Git user email or name")
+	.option("--remote <remote>", "Git remote", "origin")
+	.action(async (taskId: string, options) => {
+		const cwd = await requireProjectRoot();
+		const core = new Core(cwd);
+		try {
+			const owner = await resolveCoordinationOwner(core, options.owner);
+			await core.git.releaseTask(taskId, owner, options.remote);
+			console.log(`Released ${taskId}.`);
+		} catch (error) {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		}
+	});
+
+taskCmd
+	.command("start <taskId>")
+	.description("claim, assign, and move a task to the active status")
+	.option("--owner <owner>", "claim owner; defaults to Git user email or name")
+	.option("--status <status>", "active task status", "In Progress")
+	.option("--lease-hours <hours>", "claim lease duration", "8")
+	.option("--remote <remote>", "Git remote", "origin")
+	.action(async (taskId: string, options) => {
+		const cwd = await requireProjectRoot();
+		const core = new Core(cwd);
+		const task = await core.loadTaskById(taskId, { includeCrossBranch: false });
+		if (!task) {
+			console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
+			process.exitCode = 1;
+			return;
+		}
+		const canonicalStatus = await getCanonicalStatus(String(options.status), core);
+		if (!canonicalStatus) {
+			console.error(`Invalid status: ${options.status}.`);
+			process.exitCode = 1;
+			return;
+		}
+		const leaseHours = Number(options.leaseHours);
+		if (!Number.isFinite(leaseHours) || leaseHours <= 0) {
+			console.error("--lease-hours must be a positive number.");
+			process.exitCode = 1;
+			return;
+		}
+		let owner = "";
+		try {
+			owner = await resolveCoordinationOwner(core, options.owner);
+			await core.git.claimTask(task.id, owner, {
+				remote: options.remote,
+				leaseMs: leaseHours * 60 * 60 * 1000,
+				branch: await core.git.getCurrentBranch(),
+			});
+			const updated = await core.updateTaskFromInput(task.id, {
+				status: canonicalStatus,
+				assignee: [owner.startsWith("@") ? owner : `@${owner}`],
+			});
+			const current = await core.git.readTaskCoordination(task.id, options.remote);
+			if (current) {
+				await core.git.publishTaskCoordination(
+					{ ...current.state, status: updated.status, assignee: updated.assignee },
+					current.objectId,
+					options.remote,
+				);
+			}
+			console.log(`Started ${task.id}: claimed by ${owner}, assigned, and moved to ${updated.status}.`);
+		} catch (error) {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		}
+	});
+
+taskCmd
+	.command("publish <taskId>")
+	.description("publish local status and assignees as transient remote coordination state")
+	.option("--remote <remote>", "Git remote", "origin")
+	.action(async (taskId: string, options) => {
+		const cwd = await requireProjectRoot();
+		const core = new Core(cwd);
+		const task = await core.loadTaskById(taskId, { includeCrossBranch: false });
+		if (!task) {
+			console.error(`Task ${taskId} not found. ${LOCAL_TASK_LOOKUP_HINT}`);
+			process.exitCode = 1;
+			return;
+		}
+		try {
+			const current = await core.git.readTaskCoordination(task.id, options.remote);
+			const published = await core.git.publishTaskCoordination(
+				{
+					taskId: task.id,
+					owner: current?.state.owner,
+					branch: current?.state.branch,
+					claimedAt: current?.state.claimedAt,
+					leaseUntil: current?.state.leaseUntil,
+					status: task.status,
+					assignee: task.assignee,
+				},
+				current?.objectId ?? null,
+				options.remote,
+			);
+			console.log(`Published ${task.id} coordination revision ${published.state.revision}.`);
+		} catch (error) {
+			console.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		}
+	});
+
+taskCmd
+	.command("claims")
+	.description("list remote task coordination state")
+	.option("--remote <remote>", "Git remote", "origin")
+	.option("--json", "print JSON output")
+	.action(async (options, command) => {
+		const commandOptions =
+			typeof command?.opts === "function"
+				? command.opts()
+				: typeof options?.opts === "function"
+					? options.opts()
+					: options;
+		const useJson = Boolean(commandOptions.json || taskCmd.opts().json);
+		const cwd = await requireProjectRoot();
+		const core = new Core(cwd);
+		try {
+			const entries = await core.git.listTaskCoordination(commandOptions.remote);
+			if (useJson) {
+				console.log(
+					JSON.stringify(
+						entries.map((entry) => entry.state),
+						null,
+						2,
+					),
+				);
+				return;
+			}
+			if (entries.length === 0) {
+				console.log("No remote task coordination state found.");
+				return;
+			}
+			for (const { state } of entries) {
+				console.log(
+					[state.taskId, state.status, state.owner ? `owner ${state.owner}` : undefined, state.leaseUntil]
+						.filter(Boolean)
+						.join(" | "),
+				);
+			}
 		} catch (error) {
 			console.error(error instanceof Error ? error.message : String(error));
 			process.exitCode = 1;

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -25,6 +25,34 @@ export interface GitIndexEntry {
 	stage: number;
 }
 
+export interface TaskCoordinationState {
+	version: 1;
+	taskId: string;
+	owner?: string;
+	status?: string;
+	assignee?: string[];
+	branch?: string;
+	claimedAt?: string;
+	leaseUntil?: string;
+	updatedAt: string;
+	revision: number;
+}
+
+export interface TaskCoordinationEntry {
+	objectId: string;
+	state: TaskCoordinationState;
+}
+
+export class TaskCoordinationConflictError extends Error {
+	constructor(
+		message: string,
+		readonly current?: TaskCoordinationEntry,
+	) {
+		super(message);
+		this.name = "TaskCoordinationConflictError";
+	}
+}
+
 function indexEntriesEqual(left: readonly GitIndexEntry[], right: readonly GitIndexEntry[]): boolean {
 	return (
 		left.length === right.length &&
@@ -582,6 +610,183 @@ export class GitOperations {
 			if (this.fetches.get(remote) === fetch) {
 				this.fetches.delete(remote);
 			}
+		}
+	}
+
+	async readTaskCoordination(taskId: string, remote = "origin"): Promise<TaskCoordinationEntry | null> {
+		await this.assertTaskCoordinationAvailable(remote);
+		const ref = this.taskCoordinationRef(taskId);
+		const { stdout } = await this.execGit(["ls-remote", "--refs", remote, ref], {
+			readOnly: true,
+			timeoutMs: FETCH_TIMEOUT_MS,
+			env: { GIT_TERMINAL_PROMPT: "0", GCM_INTERACTIVE: "Never" },
+		});
+		const objectId = stdout.trim().split(/\s+/, 1)[0];
+		if (!objectId) return null;
+
+		await this.execGit(["fetch", "--quiet", "--no-write-fetch-head", remote, ref], {
+			timeoutMs: FETCH_TIMEOUT_MS,
+			env: { GIT_TERMINAL_PROMPT: "0", GCM_INTERACTIVE: "Never" },
+		});
+		const { stdout: content } = await this.execGit(["cat-file", "blob", objectId], { readOnly: true });
+		const state = this.parseTaskCoordinationState(content, taskId);
+		return { objectId, state };
+	}
+
+	async claimTask(
+		taskId: string,
+		owner: string,
+		options: { remote?: string; leaseMs?: number; branch?: string; now?: Date; renew?: boolean } = {},
+	): Promise<TaskCoordinationEntry> {
+		const remote = options.remote ?? "origin";
+		const now = options.now ?? new Date();
+		const current = await this.readTaskCoordination(taskId, remote);
+		const activeLease = current?.state.leaseUntil && Date.parse(current.state.leaseUntil) > now.getTime();
+		if (activeLease && (!options.renew || current.state.owner !== owner)) {
+			throw new TaskCoordinationConflictError(
+				`${taskId} is already claimed by ${current.state.owner ?? "another user"} until ${current.state.leaseUntil}.`,
+				current,
+			);
+		}
+
+		const state: TaskCoordinationState = {
+			version: 1,
+			taskId,
+			owner,
+			branch: options.branch,
+			claimedAt: options.renew ? (current?.state.claimedAt ?? now.toISOString()) : now.toISOString(),
+			leaseUntil: new Date(now.getTime() + (options.leaseMs ?? 8 * 60 * 60 * 1000)).toISOString(),
+			updatedAt: now.toISOString(),
+			revision: (current?.state.revision ?? 0) + 1,
+		};
+		return await this.writeTaskCoordination(state, current?.objectId ?? null, remote);
+	}
+
+	async publishTaskCoordination(
+		state: Omit<TaskCoordinationState, "version" | "updatedAt" | "revision">,
+		expectedObjectId: string | null,
+		remote = "origin",
+	): Promise<TaskCoordinationEntry> {
+		const current = expectedObjectId ? await this.readTaskCoordination(state.taskId, remote) : null;
+		const next: TaskCoordinationState = {
+			...state,
+			version: 1,
+			updatedAt: new Date().toISOString(),
+			revision: (current?.state.revision ?? 0) + 1,
+		};
+		return await this.writeTaskCoordination(next, expectedObjectId, remote);
+	}
+
+	async listTaskCoordination(remote = "origin"): Promise<TaskCoordinationEntry[]> {
+		await this.assertTaskCoordinationAvailable(remote);
+		const { stdout } = await this.execGit(["ls-remote", "--refs", remote, "refs/backlog/tasks/*"], {
+			readOnly: true,
+			timeoutMs: FETCH_TIMEOUT_MS,
+			env: { GIT_TERMINAL_PROMPT: "0", GCM_INTERACTIVE: "Never" },
+		});
+		const taskIds = stdout
+			.split("\n")
+			.map((line) => line.trim().split(/\s+/, 2)[1]?.slice("refs/backlog/tasks/".length))
+			.filter((taskId): taskId is string => Boolean(taskId));
+		return (await Promise.all(taskIds.map((taskId) => this.readTaskCoordination(taskId, remote)))).filter(
+			(entry): entry is TaskCoordinationEntry => entry !== null,
+		);
+	}
+
+	async getUserIdentity(): Promise<string> {
+		for (const key of ["user.email", "user.name"]) {
+			const { stdout } = await this.execGit(["config", "--get", key], {
+				readOnly: true,
+				acceptedExitCodes: [1],
+			});
+			if (stdout.trim()) return stdout.trim();
+		}
+		throw new Error("Task coordination needs an owner. Configure git user.email or pass --owner.");
+	}
+
+	async releaseTask(taskId: string, owner: string, remote = "origin"): Promise<void> {
+		const current = await this.readTaskCoordination(taskId, remote);
+		if (!current) return;
+		if (current.state.owner !== owner) {
+			throw new TaskCoordinationConflictError(
+				`${taskId} is claimed by ${current.state.owner ?? "another user"}; ${owner} cannot release it.`,
+				current,
+			);
+		}
+		const ref = this.taskCoordinationRef(taskId);
+		try {
+			await this.execGit(["push", "--quiet", remote, `:${ref}`, `--force-with-lease=${ref}:${current.objectId}`], {
+				timeoutMs: FETCH_TIMEOUT_MS,
+				env: { GIT_TERMINAL_PROMPT: "0", GCM_INTERACTIVE: "Never" },
+			});
+		} catch {
+			throw new TaskCoordinationConflictError(`${taskId} changed remotely and was not released.`, current);
+		}
+	}
+
+	private async writeTaskCoordination(
+		state: TaskCoordinationState,
+		expectedObjectId: string | null,
+		remote: string,
+	): Promise<TaskCoordinationEntry> {
+		await this.assertTaskCoordinationAvailable(remote);
+		const ref = this.taskCoordinationRef(state.taskId);
+		const content = `${JSON.stringify(state)}\n`;
+		const { stdout } = await this.execGit(["hash-object", "-w", "--stdin"], { input: content });
+		const objectId = stdout.trim();
+		try {
+			await this.execGit(
+				["push", "--quiet", remote, `${objectId}:${ref}`, `--force-with-lease=${ref}:${expectedObjectId ?? ""}`],
+				{
+					timeoutMs: FETCH_TIMEOUT_MS,
+					env: { GIT_TERMINAL_PROMPT: "0", GCM_INTERACTIVE: "Never" },
+				},
+			);
+		} catch {
+			const current = await this.readTaskCoordination(state.taskId, remote).catch(() => null);
+			throw new TaskCoordinationConflictError(
+				`${state.taskId} changed remotely; refresh and retry.`,
+				current ?? undefined,
+			);
+		}
+		return { objectId, state };
+	}
+
+	private taskCoordinationRef(taskId: string): string {
+		const normalized = taskId.trim();
+		if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(normalized)) {
+			throw new Error(`Invalid task ID for coordination: ${taskId}`);
+		}
+		return `refs/backlog/tasks/${normalized}`;
+	}
+
+	private parseTaskCoordinationState(content: string, taskId: string): TaskCoordinationState {
+		let value: unknown;
+		try {
+			value = JSON.parse(content);
+		} catch {
+			throw new Error(`Remote coordination state for ${taskId} is not valid JSON.`);
+		}
+		if (
+			typeof value !== "object" ||
+			value === null ||
+			(value as Partial<TaskCoordinationState>).version !== 1 ||
+			(value as Partial<TaskCoordinationState>).taskId !== taskId ||
+			typeof (value as Partial<TaskCoordinationState>).updatedAt !== "string" ||
+			!Number.isInteger((value as Partial<TaskCoordinationState>).revision)
+		) {
+			throw new Error(`Remote coordination state for ${taskId} has an unsupported shape.`);
+		}
+		return value as TaskCoordinationState;
+	}
+
+	private async assertTaskCoordinationAvailable(remote: string): Promise<void> {
+		await this.loadConfigIfNeeded();
+		if (this.config?.remoteOperations === false) {
+			throw new Error("Task coordination requires remoteOperations to be enabled.");
+		}
+		if (!(await this.isRepository()) || !(await this.hasRemote(remote))) {
+			throw new Error(`Task coordination requires a configured Git remote named '${remote}'.`);
 		}
 	}
 

--- a/src/test/git-task-coordination.test.ts
+++ b/src/test/git-task-coordination.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Core } from "../core/backlog.ts";
+import { initializeProject } from "../core/init.ts";
+import { GitOperations, TaskCoordinationConflictError } from "../git/operations.ts";
+import type { BacklogConfig } from "../types/index.ts";
+
+const TEST_CONFIG = {
+	projectName: "Coordination test",
+	statuses: [],
+	labels: [],
+	dateFormat: "YYYY-MM-DD",
+	remoteOperations: true,
+} satisfies BacklogConfig;
+
+const CLI_PATH = join(import.meta.dir, "..", "cli.ts");
+
+async function git(cwd: string, args: string[]): Promise<string> {
+	const process = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+	const [exitCode, stdout, stderr] = await Promise.all([
+		process.exited,
+		new Response(process.stdout).text(),
+		new Response(process.stderr).text(),
+	]);
+	if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+	return stdout.trim();
+}
+
+async function cli(cwd: string, args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const child = Bun.spawn([process.execPath, CLI_PATH, ...args], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [exitCode, stdout, stderr] = await Promise.all([
+		child.exited,
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+	]);
+	return { exitCode, stdout, stderr };
+}
+
+describe("Git task coordination", () => {
+	let root: string;
+	let repo: string;
+	let remote: string;
+	let operations: GitOperations;
+
+	beforeEach(async () => {
+		root = await mkdtemp(join(tmpdir(), "backlog-coordination-"));
+		repo = join(root, "repo");
+		remote = join(root, "remote.git");
+		await git(root, ["init", "--bare", remote]);
+		await git(root, ["init", repo]);
+		await git(repo, ["remote", "add", "origin", remote]);
+		operations = new GitOperations(repo, TEST_CONFIG);
+	});
+
+	afterEach(async () => {
+		await rm(root, { recursive: true, force: true });
+	});
+
+	it("allows exactly one concurrent claimant", async () => {
+		const results = await Promise.allSettled([
+			operations.claimTask("BACK-123", "alice"),
+			new GitOperations(repo, TEST_CONFIG).claimTask("BACK-123", "bob"),
+		]);
+
+		expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+		expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+		expect(results.find((result) => result.status === "rejected")?.reason).toBeInstanceOf(
+			TaskCoordinationConflictError,
+		);
+	});
+
+	it("atomically replaces an expired lease", async () => {
+		await operations.claimTask("BACK-123", "alice", {
+			now: new Date("2026-08-24T00:00:00.000Z"),
+			leaseMs: 1_000,
+		});
+		const replacement = await operations.claimTask("BACK-123", "bob", {
+			now: new Date("2026-08-24T00:00:02.000Z"),
+		});
+
+		expect(replacement.state.owner).toBe("bob");
+		expect(replacement.state.revision).toBe(2);
+	});
+
+	it("renews only the current owner's active claim", async () => {
+		const original = await operations.claimTask("BACK-123", "alice", {
+			now: new Date("2026-08-24T00:00:00.000Z"),
+			leaseMs: 60_000,
+		});
+		const renewed = await operations.claimTask("BACK-123", "alice", {
+			now: new Date("2026-08-24T00:00:30.000Z"),
+			leaseMs: 60_000,
+			renew: true,
+		});
+
+		expect(renewed.state.claimedAt).toBe(original.state.claimedAt);
+		expect(renewed.state.revision).toBe(2);
+		await expect(
+			operations.claimTask("BACK-123", "bob", {
+				now: new Date("2026-08-24T00:00:40.000Z"),
+				renew: true,
+			}),
+		).rejects.toBeInstanceOf(TaskCoordinationConflictError);
+	});
+
+	it("does not let an old owner release a replacement claim", async () => {
+		await operations.claimTask("BACK-123", "alice", {
+			now: new Date("2026-08-24T00:00:00.000Z"),
+			leaseMs: 1_000,
+		});
+		await operations.claimTask("BACK-123", "bob", {
+			now: new Date("2026-08-24T00:00:02.000Z"),
+		});
+
+		await expect(operations.releaseTask("BACK-123", "alice")).rejects.toBeInstanceOf(TaskCoordinationConflictError);
+		expect((await operations.readTaskCoordination("BACK-123"))?.state.owner).toBe("bob");
+	});
+
+	it("fails closed when remote operations are disabled", async () => {
+		const offline = new GitOperations(repo, { ...TEST_CONFIG, remoteOperations: false });
+		await expect(offline.claimTask("BACK-123", "alice")).rejects.toThrow("remoteOperations");
+	});
+
+	it("fails closed with an actionable error when the remote is unavailable", async () => {
+		await expect(operations.claimTask("BACK-123", "alice", { remote: "missing" })).rejects.toThrow(
+			"configured Git remote named 'missing'",
+		);
+	});
+
+	it("rejects a stale live-state publication", async () => {
+		const claim = await operations.claimTask("BACK-123", "alice");
+		await operations.publishTaskCoordination(
+			{ ...claim.state, status: "In Progress", assignee: ["@alice"] },
+			claim.objectId,
+		);
+
+		await expect(
+			operations.publishTaskCoordination({ ...claim.state, status: "Done" }, claim.objectId),
+		).rejects.toBeInstanceOf(TaskCoordinationConflictError);
+		expect((await operations.readTaskCoordination("BACK-123"))?.state.status).toBe("In Progress");
+	});
+
+	it("does not add coordination events to branch history", async () => {
+		const before = await git(repo, ["rev-list", "--all", "--count"]);
+		await operations.claimTask("BACK-123", "alice");
+		await operations.releaseTask("BACK-123", "alice");
+		const after = await git(repo, ["rev-list", "--all", "--count"]);
+
+		expect(after).toBe(before);
+	});
+
+	it("exposes claim, list, and release through the canonical CLI", async () => {
+		const core = new Core(repo);
+		await initializeProject(core, {
+			projectName: "Coordination CLI test",
+			integrationMode: "none",
+			advancedConfig: { remoteOperations: true, autoCommit: false },
+		});
+		const { task } = await core.createTaskFromInput({ title: "Coordinate me" });
+
+		const claimed = await cli(repo, ["task", "claim", task.id, "--owner", "alice"]);
+		expect(claimed.exitCode).toBe(0);
+		expect(claimed.stdout).toContain(`Claimed ${task.id} for alice`);
+
+		const rejected = await cli(repo, ["task", "claim", task.id, "--owner", "bob"]);
+		expect(rejected.exitCode).toBe(1);
+		expect(rejected.stderr).toContain("already claimed by alice");
+
+		const listed = await cli(repo, ["task", "claims", "--json"]);
+		expect(listed.exitCode).toBe(0);
+		expect(JSON.parse(listed.stdout)).toEqual([expect.objectContaining({ taskId: task.id, owner: "alice" })]);
+
+		const released = await cli(repo, ["task", "release", task.id, "--owner", "alice"]);
+		expect(released.exitCode).toBe(0);
+		expect(await operations.readTaskCoordination(task.id)).toBeNull();
+
+		const started = await cli(repo, ["task", "start", task.id, "--owner", "alice"]);
+		expect(started.exitCode).toBe(0);
+		expect(started.stdout).toContain(`Started ${task.id}`);
+		const startedTask = await core.loadTaskById(task.id, { includeCrossBranch: false });
+		expect(startedTask?.status).toBe("In Progress");
+		expect(startedTask?.assignee).toEqual(["@alice"]);
+		expect((await operations.readTaskCoordination(task.id))?.state.status).toBe("In Progress");
+
+		await core.updateTaskFromInput(task.id, { status: "To Do" });
+		const published = await cli(repo, ["task", "publish", task.id]);
+		expect(published.exitCode).toBe(0);
+		expect((await operations.readTaskCoordination(task.id))?.state.status).toBe("To Do");
+	});
+});


### PR DESCRIPTION
Closes #937

## Summary

- add blob-backed task coordination refs with explicit compare-and-swap updates
- add atomic claims, renewable leases, expired replacement, stale-write rejection, and ownership-safe release
- add `task claim`, `release`, `start`, `publish`, and `claims` CLI workflows
- preserve Markdown as the durable task record and keep coordination out of normal branch history
- document the workflow and remote/offline behavior

## Verification

- `bunx tsc --noEmit`
- modified TypeScript files pass Biome
- `bun run build`
- 9 focused coordination tests pass with 30 assertions
- disposable create/read/delete compatibility probe passed against GitHub

## Repository-wide checks

A full suite run progressed through the new tests and many existing suites, but the Windows checkout has unrelated baseline failures involving locked temporary files and the Claude-agent fixture. `bun run check .` likewise reports repository-wide CRLF formatting outside this change, while all modified TypeScript files pass Biome.