### PR TITLE
Fix sidebar quick search hiding real matches on larger projects

### DIFF
--- a/src/web/components/SideNavigation.tsx
+++ b/src/web/components/SideNavigation.tsx
@@ -434,15 +434,20 @@ const SideNavigation = memo(function SideNavigation({
 		if (!searchQuery.trim()) {
 			return [];
 		}
-		const filtered = searchResults
-			.filter((result) => result.score === null || result.score <= 0.45)
-			.sort((a, b) => {
-				const scoreA = a.score ?? Number.POSITIVE_INFINITY;
-				const scoreB = b.score ?? Number.POSITIVE_INFINITY;
-				return scoreA - scoreB;
-			});
+		// No extra score cutoff: Fuse blends several weighted keys (title,
+		// bodyText, id, ...) into one score, so a result that matches well on
+		// one key but poorly on others can score well above any small constant
+		// even for an exact substring hit in the title - on a large,
+		// text-heavy project this hid most real matches. The server's own
+		// Fuse threshold already decided these are matches by returning them
+		// at all; sorting + slicing to 5 is enough to keep the dropdown short.
+		const sorted = [...searchResults].sort((a, b) => {
+			const scoreA = a.score ?? Number.POSITIVE_INFINITY;
+			const scoreB = b.score ?? Number.POSITIVE_INFINITY;
+			return scoreA - scoreB;
+		});
 
-		return filtered.slice(0, 5);
+		return sorted.slice(0, 5);
 	}, [searchQuery, searchResults]);
 
 	// Always show full lists in their sections, search results are separate


### PR DESCRIPTION
Fixes #954.

## Problem

The sidebar's quick search (⌘K) filtered results to `score <= 0.45` before display. Fuse.js computes that `score` as a weighted blend across several keys (`title` 0.35, `bodyText` 0.3, `id` 0.2, `idVariants` 0.1, `modifiedFiles` 0.15) — a result that matches well on one key but has nothing relevant in the others can land well above 0.45 even for an exact substring hit in the title.

On a small demo project this rarely shows up, since short task text keeps blended scores low. On a larger, text-heavy project it hides most real matches. Measured on a ~170-task real project: a single-word search for text that appears verbatim in a task's title scored that task 0.54 — filtered out, never shown — while an unrelated task scored 0.43 and was shown instead.

The server's own Fuse `threshold: 0.35` (`search-service.ts`) is already the relevance gate: a query with no real matches returns zero results from the API at all. The client's extra absolute cutoff could only ever remove results the server had already decided were relevant.

## Fix

Drop the client-side score filter; keep the existing sort-by-score and `slice(0, 5)`, which already bounds the dropdown to a handful of the best matches regardless of their absolute score.

## Verification

Against the real ~170-task project used to find this:
- A single-word title match that was previously hidden (score 0.54) now appears, correctly ranked.
- A previously-hidden multi-field match (score 0.65) now appears first, ahead of weaker matches.
- A genuine no-match query still renders the empty "No matching results" state (the server returns zero results, unaffected by this change).
- Result ordering and the 5-result cap are unchanged.

`bunx tsc --noEmit` and `biome check` pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)