### PR TITLE
BACK-644 - Keep the board task popup in sync with live task state

### DIFF
--- a/backlog/tasks/back-644 - Keep-the-board-task-popup-in-sync-with-live-task-state.md
+++ b/backlog/tasks/back-644 - Keep-the-board-task-popup-in-sync-with-live-task-state.md
@@ -69,6 +69,16 @@ Verification: new src/test/board-popup-sync.test.ts drives renderBoardTui with a
 bunx tsc --noEmit clean. Biome clean on all files this task touched. Two repo-level conditions are pre-existing on the branch and unrelated: 'bun run check .' fails formatting on the untouched src/ui/components/task-composer.ts (CI runs check:types only, not Biome), and 'bun test' has 2 pre-existing failures in src/test/core.test.ts (archive-snapshot / equal-time branch record ID occupancy) that also fail with this change stashed. Full suite otherwise 2411 pass / 7 skip.
 <!-- SECTION:NOTES:END -->
 
+## Comments
+
+<!-- COMMENTS:BEGIN -->
+author: @claude
+created: 2026-08-29 18:28
+---
+Implementation is complete, committed locally as 4f727552 on branch fix/board-popup-refresh (on top of bjohas's 6f714d88). Pushing the maintainer edit to the PR branch is blocked by GitHub: the head fork OpenDevEd/Backlog.md is organization-owned, and 'allow edits by maintainers' does not apply to org-owned forks. The API reports maintainerCanModify: true, but 'git push' returns 403 'Permission to OpenDevEd/Backlog.md.git denied to MrLesk' and repos/OpenDevEd/Backlog.md reports push: false for this account. Auth is fine (repo scope present). Needs a decision from Alex: ask OpenDevEd to grant push access on the fork branch, ask bjohas to apply the patch, or supersede PR #952 with a maintainer branch on origin.
+---
+<!-- COMMENTS:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/back-644 - Keep-the-board-task-popup-in-sync-with-live-task-state.md
+++ b/backlog/tasks/back-644 - Keep-the-board-task-popup-in-sync-with-live-task-state.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-29 17:59'
-updated_date: '2026-08-29 18:28'
+updated_date: '2026-08-29 21:30'
 labels:
   - tui
   - bug
@@ -67,6 +67,14 @@ Changed vs the contributor's version:
 Verification: new src/test/board-popup-sync.test.ts drives renderBoardTui with an injected screen, a stub core.editTaskInTui and a captured subscribeUpdates updater; 4 tests cover the editor path, the external-edit path, the external-removal path (asserting the footer notice) and the watcher echo (asserting the popup widget identity is preserved, so no rebuild). Stashing the board change makes the external-edit and external-removal tests fail, confirming they are not vacuous.
 
 bunx tsc --noEmit clean. Biome clean on all files this task touched. Two repo-level conditions are pre-existing on the branch and unrelated: 'bun run check .' fails formatting on the untouched src/ui/components/task-composer.ts (CI runs check:types only, not Biome), and 'bun test' has 2 pre-existing failures in src/test/core.test.ts (archive-snapshot / equal-time branch record ID occupancy) that also fail with this change stashed. Full suite otherwise 2411 pass / 7 skip.
+
+Review follow-up on maintainer PR #957 (Codex findings). Both confirmed real and fixed:
+
+1. Rebuild vs confirmation dialog - REAL. The popup's c/a handlers open a confirm dialog through runWithModalGuard while the task popup stays alive underneath. A watcher update arriving mid-confirmation ran syncOpenPopup, which destroyed and recreated the popup; createTaskPopup's setImmediate(contentArea.focus()) then stole focus from the dialog. Because openConfirmPopup binds its keys to its own widget and only resolves when answered, the dialog became unanswerable and modalOpen stayed true, wedging the board. Fix mirrors the taskCreationOpen guard: syncOpenPopup sets popupSyncPending and returns while modalOpen is true, and runWithModalGuard's finally flushes the deferred sync once the dialog closes. Proven by a test asserting the dialog keeps focus across an external edit and that the deferred refresh lands after it is answered; the test fails without the guard.
+
+2. Unclamped column index on focus restore - REAL, and reachable through the removal path rather than only Escape. focusColumn ignores an out-of-range index, so the failure mode is silent: no column is focused and the board stops responding to navigation. With hideEmptyColumns, a lane disappears when its last task goes, so currentCol can exceed columns.length - 1 exactly when the popup closes because its task was removed. Added restoreColumnFocus(), which clamps into range, and routed both the Escape path and the removal path through it. Proven by a test that opens the popup on the only Done task with hideEmptyColumns enabled, removes it externally, and asserts focus lands on a surviving column list; it fails without the clamp.
+
+Not rebasing onto the moved origin/main: the push must stay fast-forward. CI runs on the pull_request merge result, which already carries main's formatting fix for the untouched src/ui/components/task-composer.ts, so the repo-wide 'bun run check' failure noted earlier does not apply to this PR.
 <!-- SECTION:NOTES:END -->
 
 ## Comments

--- a/backlog/tasks/back-644 - Keep-the-board-task-popup-in-sync-with-live-task-state.md
+++ b/backlog/tasks/back-644 - Keep-the-board-task-popup-in-sync-with-live-task-state.md
@@ -1,0 +1,76 @@
+---
+id: BACK-644
+title: Keep the board task popup in sync with live task state
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-08-29 17:59'
+updated_date: '2026-08-29 18:28'
+labels:
+  - tui
+  - bug
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/pull/952'
+  - 'https://github.com/MrLesk/Backlog.md/issues/951'
+ordinal: 278000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The board task popup renders from a Task object captured when it opens, so edits made after opening (external editor via E, or any out-of-process agent/CLI edit picked up by the task watcher) leave the popup stale; confirmations can even target a ghost title. Contributor PR #952 (bjohas) correctly extracts a rebuildable openTaskPopup(task) but triggers refresh only from the editor-return path. Take over that PR in place and drive popup rebuild/close from the board's existing watcher-fed updateBoard funnel instead, mirroring the TUI list view's pattern, so every change path refreshes the popup with one mechanism.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 After editing a task via E from the board popup, the reopened/refreshed popup shows the updated content and its key handlers act on the updated task
+- [x] #2 An out-of-process edit to the open popup's task (external CLI edit while the board is running) refreshes the popup content without user action
+- [x] #3 If the popup's task is completed, archived, or deleted externally while open, the popup closes with a visible notice instead of offering actions on a missing task
+- [x] #4 Popup refresh uses the board's existing update funnel; no parallel refresh channel or editor return-value plumbing remains
+- [x] #5 Watcher echo after an in-popup edit does not cause visible double-rebuild or flicker
+- [x] #6 Automated TUI tests cover the editor path, the external-edit path, and the external-removal path
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Take over PR #952 in place: keep bjohas's openTaskPopup(task) extraction, revert openTaskEditor to Promise<void> (drop the Task | null return-value plumbing and the E-handler's manual close/reopen).
+2. Export the watcher's content signature helper (taskSignature -> taskContentSignature in src/utils/task-watcher.ts) so board and watcher share one definition; it already excludes branch/filePath/lastModified/source.
+3. Track the open popup as board state: openPopup = { taskId, signature, close }, set inside openTaskPopup and cleared on every close path (Escape/q, complete, archive).
+4. Add syncOpenPopup(): resolve the popup's task in currentTasks; if gone -> close popup, restore column focus, showTransientFooter notice; if content signature changed -> close and rebuild via openTaskPopup(nextTask); otherwise no-op (this is what swallows the watcher echo, AC #5).
+5. Drive syncOpenPopup from the board's existing updateBoard funnel, next to the taskCreationOpen guard, so watcher-fed updates refresh the popup.
+6. Route the editor result through updateBoard instead of openTaskEditor's local currentTasks mutation, so the E path refreshes the popup through the same funnel with no second channel.
+7. Add automated TUI tests driving renderBoardTui with an injected screen + subscribeUpdates for: editor path, external-edit path, external-removal path.
+8. Verify bunx tsc --noEmit, bun run check ., bun test; report the pre-existing Escape-focus quirk if it is not naturally fixed here.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Took over contributor PR #952 (bjohas) in place; his openTaskPopup(task) extraction is kept as the rebuild primitive.
+
+Changed vs the contributor's version:
+- Reverted openTaskEditor to Promise<void>; the Task | null return-value plumbing and the E handler's manual close/reopen are gone. openTaskEditor now feeds its reconciled task list into updateBoard(nextTasks, []) instead of assigning currentTasks directly, so the editor and the watcher share one update path.
+- Board state tracks the open popup as openPopup = { taskId, signature, close }, with one closeOpenPopup() used by Escape/q, complete, archive and the sync helper (previously two separate close+popupOpen=false pairs).
+- syncOpenPopup() runs from updateBoard next to the taskCreationOpen guard: task gone -> close + focus the board + transient notice; content signature changed -> close and rebuild via openTaskPopup; otherwise no-op. It re-checks itself after a rebuild in case the board advanced again mid-rebuild.
+- taskSignature in src/utils/task-watcher.ts is exported as taskContentSignature and reused by the board, so one definition decides what counts as a content change (it excludes branch/filePath/lastModified/source, which is what makes the post-edit watcher echo a no-op for the popup).
+- Escape from the popup now focuses the column that currently holds the task instead of the column it was opened from. This pre-existing quirk became reachable once an external status change refreshes the popup rather than leaving it stale, so it is fixed here rather than reported.
+
+Verification: new src/test/board-popup-sync.test.ts drives renderBoardTui with an injected screen, a stub core.editTaskInTui and a captured subscribeUpdates updater; 4 tests cover the editor path, the external-edit path, the external-removal path (asserting the footer notice) and the watcher echo (asserting the popup widget identity is preserved, so no rebuild). Stashing the board change makes the external-edit and external-removal tests fail, confirming they are not vacuous.
+
+bunx tsc --noEmit clean. Biome clean on all files this task touched. Two repo-level conditions are pre-existing on the branch and unrelated: 'bun run check .' fails formatting on the untouched src/ui/components/task-composer.ts (CI runs check:types only, not Biome), and 'bun test' has 2 pre-existing failures in src/test/core.test.ts (archive-snapshot / equal-time branch record ID occupancy) that also fail with this change stashed. Full suite otherwise 2411 pass / 7 skip.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+The board popup now tracks live task state through the board's own update funnel. renderBoardTui remembers the open popup as { taskId, contentSignature, close }; updateBoard (the watcher-fed entry point) calls syncOpenPopup, which rebuilds the popup via bjohas's openTaskPopup when the task's content signature changed, closes it with a transient footer notice when the task left the board, and does nothing when only read metadata moved - which is what makes the watcher echo after an in-popup edit invisible. The editor path routes its result through the same updateBoard call, so the Task | null return-value plumbing through openTaskEditor is gone and there is one refresh mechanism. taskContentSignature is now exported from the task watcher and shared by both. Escape from the popup follows the task to its current column. Verified by src/test/board-popup-sync.test.ts (4 tests: editor path, external edit, external removal, watcher echo) driving the real board with an injected screen and subscribeUpdates; the external-edit and external-removal tests fail with the board change stashed. bunx tsc --noEmit clean, Biome clean on touched files, full suite at the branch's pre-existing baseline.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/board-popup-sync.test.ts
+++ b/src/test/board-popup-sync.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "bun:test";
+import type { ScreenInterface } from "neo-neo-bblessed";
+import type { Core, TuiTaskEditResult } from "../core/backlog.ts";
+import type { Task } from "../types/index.ts";
+import { renderBoardTui } from "../ui/board.ts";
+import { createScreen } from "../ui/tui.ts";
+import { withTimeout } from "./test-utils.ts";
+
+type EmittingWidget = {
+	emit: (event: string, ch?: string, key?: { name: string; full: string; shift?: boolean }) => boolean;
+};
+type TestWidget = {
+	type?: string;
+	children?: TestWidget[];
+	getContent?: () => string;
+} & EmittingWidget;
+
+const BOARD_STATUSES = ["To Do", "In Progress", "Done"];
+const OPEN_TASK_ID = "TASK-1";
+
+function createTask(overrides: Partial<Task> = {}): Task {
+	return {
+		id: OPEN_TASK_ID,
+		title: "Popup task",
+		status: "To Do",
+		assignee: [],
+		createdDate: "2025-01-01",
+		labels: [],
+		dependencies: [],
+		description: "ORIGINAL-BODY",
+		...overrides,
+	};
+}
+
+const OTHER_TASK = createTask({ id: "TASK-2", title: "Other task", status: "Done", description: "OTHER-BODY" });
+
+function pressKey(widget: EmittingWidget | undefined, full: string, name = full.replace(/^S-/, "")): void {
+	if (!widget) throw new Error(`No widget to receive key ${full}`);
+	const key = { name, full, shift: full.startsWith("S-") };
+	widget.emit("keypress", "", key);
+	widget.emit(`key ${full}`, "", key);
+}
+
+function collectWidgets(root: TestWidget): TestWidget[] {
+	const widgets: TestWidget[] = [];
+	const visit = (node: TestWidget) => {
+		for (const child of node.children ?? []) {
+			widgets.push(child);
+			visit(child);
+		}
+	};
+	visit(root);
+	return widgets;
+}
+
+/**
+ * The popup body is the only widget rendering a task's checklists, so its presence says the
+ * popup is open and its identity says whether the board rebuilt it.
+ */
+function findPopupBody(screen: ScreenInterface): TestWidget | undefined {
+	return collectWidgets(screen as unknown as TestWidget).find((widget) =>
+		widget.getContent?.().includes("Acceptance Criteria"),
+	);
+}
+
+function screenText(screen: ScreenInterface): string {
+	return collectWidgets(screen as unknown as TestWidget)
+		.map((widget) => widget.getContent?.() ?? "")
+		.join("\n");
+}
+
+async function withBoardPopup(
+	options: { editTaskInTui?: () => Promise<TuiTaskEditResult> },
+	run: (context: {
+		screen: ScreenInterface & EmittingWidget;
+		/** Push a new task list through the board's update funnel, exactly as the watcher does. */
+		publishTasks: (tasks: Task[]) => Promise<void>;
+		popupBody: () => TestWidget | undefined;
+		text: () => string;
+	}) => Promise<void>,
+): Promise<void> {
+	const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+	Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+	const screen = createScreen({ smartCSR: false }) as ScreenInterface & EmittingWidget;
+	let subscriber: ((nextTasks: Task[], nextStatuses: string[]) => void) | undefined;
+	try {
+		const core = { editTaskInTui: options.editTaskInTui ?? (async () => ({ changed: false })) } as unknown as Core;
+		const boardPromise = renderBoardTui([createTask(), OTHER_TASK], BOARD_STATUSES, "horizontal", 20, {
+			screen,
+			core,
+			subscribeUpdates: (update) => {
+				subscriber = update;
+			},
+		});
+		await Bun.sleep(20);
+
+		// Open the popup on the selected task in the first column.
+		pressKey(screen, "enter");
+		await Bun.sleep(30);
+		expect(findPopupBody(screen)?.getContent?.()).toContain("ORIGINAL-BODY");
+
+		await run({
+			screen,
+			publishTasks: async (tasks) => {
+				expect(subscriber).toBeDefined();
+				subscriber?.(tasks, BOARD_STATUSES);
+				await Bun.sleep(30);
+			},
+			popupBody: () => findPopupBody(screen),
+			text: () => screenText(screen),
+		});
+
+		// The board ignores q while a popup is open, so dismiss it first.
+		if (findPopupBody(screen)) {
+			pressKey((screen as unknown as { focused?: EmittingWidget }).focused, "escape");
+			await Bun.sleep(20);
+		}
+		pressKey(screen, "q");
+		await withTimeout(boardPromise, "board close", 5000);
+	} finally {
+		screen.destroy();
+		if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
+		else Reflect.deleteProperty(process.stdout, "isTTY");
+	}
+}
+
+describe("board task popup stays in sync with live task state", () => {
+	it("rebuilds the popup after an in-popup editor edit", async () => {
+		const edited = createTask({ title: "Edited title", description: "UPDATED-BODY" });
+		await withBoardPopup(
+			{ editTaskInTui: async () => ({ changed: true, task: edited }) },
+			async ({ screen, popupBody, text }) => {
+				const original = popupBody();
+
+				pressKey((screen as unknown as { focused?: EmittingWidget }).focused, "e");
+				await Bun.sleep(40);
+
+				const refreshed = popupBody();
+				expect(refreshed).toBeDefined();
+				expect(refreshed).not.toBe(original);
+				expect(refreshed?.getContent?.()).toContain("UPDATED-BODY");
+				expect(refreshed?.getContent?.()).not.toContain("ORIGINAL-BODY");
+				expect(text()).toContain("Edited title");
+			},
+		);
+	});
+
+	it("rebuilds the popup when the task changes outside the board", async () => {
+		await withBoardPopup({}, async ({ publishTasks, popupBody, text }) => {
+			const original = popupBody();
+
+			await publishTasks([createTask({ title: "Renamed by CLI", description: "UPDATED-BODY" }), OTHER_TASK]);
+
+			const refreshed = popupBody();
+			expect(refreshed).toBeDefined();
+			expect(refreshed).not.toBe(original);
+			expect(refreshed?.getContent?.()).toContain("UPDATED-BODY");
+			expect(refreshed?.getContent?.()).not.toContain("ORIGINAL-BODY");
+			expect(text()).toContain("Renamed by CLI");
+		});
+	});
+
+	it("closes the popup with a notice when the task leaves the board", async () => {
+		await withBoardPopup({}, async ({ publishTasks, popupBody, text }) => {
+			await publishTasks([OTHER_TASK]);
+
+			expect(popupBody()).toBeUndefined();
+			expect(text()).toContain(`${OPEN_TASK_ID} is no longer on the board`);
+		});
+	});
+
+	it("leaves the popup untouched when an update carries no content change", async () => {
+		await withBoardPopup({}, async ({ publishTasks, popupBody }) => {
+			const original = popupBody();
+			expect(original).toBeDefined();
+
+			// The watcher echo of a just-saved task differs only in read metadata.
+			await publishTasks([
+				createTask({ lastModified: new Date("2030-01-01"), filePath: "/elsewhere/task-1.md" }),
+				OTHER_TASK,
+			]);
+
+			expect(popupBody()).toBe(original);
+		});
+	});
+});

--- a/src/test/board-popup-sync.test.ts
+++ b/src/test/board-popup-sync.test.ts
@@ -70,13 +70,20 @@ function screenText(screen: ScreenInterface): string {
 }
 
 async function withBoardPopup(
-	options: { editTaskInTui?: () => Promise<TuiTaskEditResult> },
+	options: {
+		editTaskInTui?: () => Promise<TuiTaskEditResult>;
+		tasks?: Task[];
+		hideEmptyColumns?: boolean;
+		/** Columns to step right through before opening the popup. */
+		startColumn?: number;
+	},
 	run: (context: {
 		screen: ScreenInterface & EmittingWidget;
 		/** Push a new task list through the board's update funnel, exactly as the watcher does. */
 		publishTasks: (tasks: Task[]) => Promise<void>;
 		popupBody: () => TestWidget | undefined;
 		text: () => string;
+		focused: () => EmittingWidget | undefined;
 	}) => Promise<void>,
 ): Promise<void> {
 	const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
@@ -85,19 +92,25 @@ async function withBoardPopup(
 	let subscriber: ((nextTasks: Task[], nextStatuses: string[]) => void) | undefined;
 	try {
 		const core = { editTaskInTui: options.editTaskInTui ?? (async () => ({ changed: false })) } as unknown as Core;
-		const boardPromise = renderBoardTui([createTask(), OTHER_TASK], BOARD_STATUSES, "horizontal", 20, {
+		const boardPromise = renderBoardTui(options.tasks ?? [createTask(), OTHER_TASK], BOARD_STATUSES, "horizontal", 20, {
 			screen,
 			core,
+			hideEmptyColumns: options.hideEmptyColumns,
 			subscribeUpdates: (update) => {
 				subscriber = update;
 			},
 		});
 		await Bun.sleep(20);
 
-		// Open the popup on the selected task in the first column.
+		for (let step = 0; step < (options.startColumn ?? 0); step++) {
+			pressKey(screen, "right");
+			await Bun.sleep(10);
+		}
+
+		// Open the popup on the selected task in the focused column.
 		pressKey(screen, "enter");
 		await Bun.sleep(30);
-		expect(findPopupBody(screen)?.getContent?.()).toContain("ORIGINAL-BODY");
+		expect(findPopupBody(screen)).toBeDefined();
 
 		await run({
 			screen,
@@ -108,10 +121,11 @@ async function withBoardPopup(
 			},
 			popupBody: () => findPopupBody(screen),
 			text: () => screenText(screen),
+			focused: () => (screen as unknown as { focused?: EmittingWidget }).focused,
 		});
 
-		// The board ignores q while a popup is open, so dismiss it first.
-		if (findPopupBody(screen)) {
+		// The board ignores q while a popup or modal is open, so dismiss them first.
+		for (let attempt = 0; attempt < 2 && findPopupBody(screen); attempt++) {
 			pressKey((screen as unknown as { focused?: EmittingWidget }).focused, "escape");
 			await Bun.sleep(20);
 		}
@@ -129,10 +143,10 @@ describe("board task popup stays in sync with live task state", () => {
 		const edited = createTask({ title: "Edited title", description: "UPDATED-BODY" });
 		await withBoardPopup(
 			{ editTaskInTui: async () => ({ changed: true, task: edited }) },
-			async ({ screen, popupBody, text }) => {
+			async ({ popupBody, text, focused }) => {
 				const original = popupBody();
 
-				pressKey((screen as unknown as { focused?: EmittingWidget }).focused, "e");
+				pressKey(focused(), "e");
 				await Bun.sleep(40);
 
 				const refreshed = popupBody();
@@ -167,6 +181,47 @@ describe("board task popup stays in sync with live task state", () => {
 			expect(popupBody()).toBeUndefined();
 			expect(text()).toContain(`${OPEN_TASK_ID} is no longer on the board`);
 		});
+	});
+
+	it("defers the rebuild while a confirmation dialog is stacked on the popup", async () => {
+		await withBoardPopup({}, async ({ publishTasks, popupBody, text, focused }) => {
+			pressKey(focused(), "c");
+			await Bun.sleep(30);
+			const dialog = focused();
+			expect(text()).toContain("as completed?");
+
+			// An external edit lands while the user is still answering the dialog.
+			await publishTasks([createTask({ title: "Renamed by CLI", description: "UPDATED-BODY" }), OTHER_TASK]);
+
+			// The dialog must keep both the screen and the keyboard until it is answered.
+			expect(text()).toContain("as completed?");
+			expect(focused()).toBe(dialog);
+
+			// Answering it still works, and the deferred refresh lands afterwards.
+			pressKey(focused(), "escape");
+			await Bun.sleep(40);
+			expect(text()).not.toContain("as completed?");
+			expect(popupBody()?.getContent?.()).toContain("UPDATED-BODY");
+		});
+	});
+
+	it("restores focus to a real column when the board loses columns as the task disappears", async () => {
+		// hideEmptyColumns drops the Done lane once its only task is gone, so the column the
+		// popup was opened from no longer exists when focus has to go somewhere.
+		const todo = createTask({ id: "TASK-A", status: "To Do" });
+		const inProgress = createTask({ id: "TASK-B", status: "In Progress" });
+		const done = createTask({ id: "TASK-C", status: "Done" });
+		await withBoardPopup(
+			{ tasks: [todo, inProgress, done], hideEmptyColumns: true, startColumn: 2 },
+			async ({ publishTasks, popupBody, text, focused }) => {
+				await publishTasks([todo, inProgress]);
+
+				expect(popupBody()).toBeUndefined();
+				expect(text()).toContain("TASK-C is no longer on the board");
+				// Focus must land on a surviving column list, not nowhere.
+				expect((focused() as TestWidget | undefined)?.type).toBe("list");
+			},
+		);
 	});
 
 	it("leaves the popup untouched when an update carries no content change", async () => {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -1275,38 +1275,38 @@ export async function renderBoardTui(
 			screen.render();
 		});
 
-		const openTaskEditor = async (task: Task) => {
+		const openTaskEditor = async (task: Task): Promise<Task | null> => {
 			try {
 				const core = await getCore();
 				const result = await core.editTaskInTui(task.id, screen, task);
 				if (result.reason === "read_only") {
 					const branchInfo = result.task?.branch ? ` from branch "${result.task.branch}"` : "";
 					showTransientFooter(` {red-fg}Cannot edit task${branchInfo}.{/}`);
-					return;
+					return null;
 				}
 				if (result.reason === "editor_failed") {
 					showTransientFooter(" {red-fg}Editor exited with an error; task was not modified.{/}");
-					return;
+					return null;
 				}
 				if (result.reason === "not_found") {
 					showTransientFooter(` {red-fg}Task ${task.id} not found on this branch.{/}`);
-					return;
+					return null;
 				}
 				if (result.reason === "identity_conflict") {
 					showTransientFooter(
 						" {red-fg}File identity is inconsistent; make the frontmatter id match the filename, then retry.{/}",
 					);
-					return;
+					return null;
 				}
 				if (result.reason === "unreadable") {
 					showTransientFooter(" {red-fg}Could not read the saved file; fix its YAML/markdown syntax.{/}");
-					return;
+					return null;
 				}
 				if (result.reason === "ambiguous") {
 					showTransientFooter(
 						" {red-fg}Numeric draft id is shared by multiple files; rename or fix their ids, then retry.{/}",
 					);
-					return;
+					return null;
 				}
 
 				if (result.task) {
@@ -1324,7 +1324,7 @@ export async function renderBoardTui(
 				if (result.changed) {
 					renderView();
 					showTransientFooter(` {green-fg}Task ${result.task?.id ?? task.id} marked modified.{/}`);
-					return;
+					return result.task ?? null;
 				}
 
 				renderView();
@@ -1332,23 +1332,10 @@ export async function renderBoardTui(
 			} catch (_error) {
 				showTransientFooter(" {red-fg}Failed to open editor.{/}");
 			}
+			return null;
 		};
 
-		screen.key(["enter"], async () => {
-			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
-
-			// In move mode, Enter confirms the move
-			if (moveOp) {
-				await performTaskMove();
-				return;
-			}
-
-			const column = columns[currentCol];
-			if (!column) return;
-			const idx = column.list.selected ?? 0;
-			if (idx < 0 || idx >= column.tasks.length) return;
-			const task = column.tasks[idx];
-			if (!task) return;
+		const openTaskPopup = async (task: Task): Promise<void> => {
 			popupOpen = true;
 
 			const popup = await createTaskPopup(screen, task, resolveMilestoneLabel, options?.dateFormat);
@@ -1365,7 +1352,13 @@ export async function renderBoardTui(
 			});
 
 			contentArea.key(["e", "E", "S-e"], async () => {
-				await openTaskEditor(task);
+				const updatedTask = await openTaskEditor(task);
+				if (updatedTask) {
+					// Rebuild the popup so its content and key handlers reflect the edit.
+					popupOpen = false;
+					close();
+					await openTaskPopup(updatedTask);
+				}
 			});
 
 			contentArea.key(["y", "Y"], async () => {
@@ -1453,6 +1446,24 @@ export async function renderBoardTui(
 			});
 
 			screen.render();
+		};
+
+		screen.key(["enter"], async () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
+
+			// In move mode, Enter confirms the move
+			if (moveOp) {
+				await performTaskMove();
+				return;
+			}
+
+			const column = columns[currentCol];
+			if (!column) return;
+			const idx = column.list.selected ?? 0;
+			if (idx < 0 || idx >= column.tasks.length) return;
+			const task = column.tasks[idx];
+			if (!task) return;
+			await openTaskPopup(task);
 		});
 
 		screen.key(["e", "E", "S-e"], async () => {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -19,6 +19,7 @@ import { getPriorityOptions } from "../utils/priority-config.ts";
 import { applySharedTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
 import { compareTaskIds } from "../utils/task-sorting.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
+import { taskContentSignature } from "../utils/task-watcher.ts";
 import { formatUtcDateForDisplay } from "../utils/utc-date-display.ts";
 import { formatAcceptanceCriteriaProgress } from "./acceptance-criteria-progress.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
@@ -362,6 +363,14 @@ export async function renderBoardTui(
 		let pendingSettingWrite: Promise<void> | null = null;
 		let currentCol = 0;
 		let popupOpen = false;
+		// The task popup renders a snapshot, so the board remembers which task it shows and
+		// what that task's content looked like to keep it in step with later updates.
+		let openPopup: { taskId: string; signature: string; close: () => void } | null = null;
+		const closeOpenPopup = () => {
+			openPopup?.close();
+			openPopup = null;
+			popupOpen = false;
+		};
 		let currentFocus: "board" | "filters" = "board";
 		let filterPopupOpen = false;
 		let modalOpen = false;
@@ -1042,6 +1051,7 @@ export async function renderBoardTui(
 				return;
 			}
 			renderView();
+			if (openPopup) void syncOpenPopup();
 		};
 
 		options?.subscribeUpdates?.(updateBoard);
@@ -1275,64 +1285,66 @@ export async function renderBoardTui(
 			screen.render();
 		});
 
-		const openTaskEditor = async (task: Task): Promise<Task | null> => {
+		const openTaskEditor = async (task: Task) => {
 			try {
 				const core = await getCore();
 				const result = await core.editTaskInTui(task.id, screen, task);
 				if (result.reason === "read_only") {
 					const branchInfo = result.task?.branch ? ` from branch "${result.task.branch}"` : "";
 					showTransientFooter(` {red-fg}Cannot edit task${branchInfo}.{/}`);
-					return null;
+					return;
 				}
 				if (result.reason === "editor_failed") {
 					showTransientFooter(" {red-fg}Editor exited with an error; task was not modified.{/}");
-					return null;
+					return;
 				}
 				if (result.reason === "not_found") {
 					showTransientFooter(` {red-fg}Task ${task.id} not found on this branch.{/}`);
-					return null;
+					return;
 				}
 				if (result.reason === "identity_conflict") {
 					showTransientFooter(
 						" {red-fg}File identity is inconsistent; make the frontmatter id match the filename, then retry.{/}",
 					);
-					return null;
+					return;
 				}
 				if (result.reason === "unreadable") {
 					showTransientFooter(" {red-fg}Could not read the saved file; fix its YAML/markdown syntax.{/}");
-					return null;
+					return;
 				}
 				if (result.reason === "ambiguous") {
 					showTransientFooter(
 						" {red-fg}Numeric draft id is shared by multiple files; rename or fix their ids, then retry.{/}",
 					);
-					return null;
+					return;
 				}
 
 				if (result.task) {
 					// Reconcile by file identity first: with task_prefix="draft" a task and a draft
 					// can share one id, so an id match alone may target the wrong record.
-					currentTasks = currentTasks.map((existingTask) => {
+					const editedTask = result.task;
+					const nextTasks = currentTasks.map((existingTask) => {
 						const matchesByFile =
-							result.task?.filePath !== undefined &&
+							editedTask.filePath !== undefined &&
 							existingTask.filePath !== undefined &&
-							existingTask.filePath === result.task.filePath;
-						return existingTask.id === task.id || matchesByFile ? result.task || existingTask : existingTask;
+							existingTask.filePath === editedTask.filePath;
+						return existingTask.id === task.id || matchesByFile ? editedTask : existingTask;
 					});
+					// Feed the edit through the shared update funnel so the board and any open
+					// popup refresh the same way a watcher update would.
+					updateBoard(nextTasks, []);
 				}
 
-				if (result.changed) {
-					renderView();
-					showTransientFooter(` {green-fg}Task ${result.task?.id ?? task.id} marked modified.{/}`);
-					return result.task ?? null;
-				}
-
+				// The editor owned the terminal; repaint even when nothing changed.
 				renderView();
-				showTransientFooter(` {gray-fg}No changes detected for ${result.task?.id ?? task.id}.{/}`);
+				showTransientFooter(
+					result.changed
+						? ` {green-fg}Task ${result.task?.id ?? task.id} marked modified.{/}`
+						: ` {gray-fg}No changes detected for ${result.task?.id ?? task.id}.{/}`,
+				);
 			} catch (_error) {
 				showTransientFooter(" {red-fg}Failed to open editor.{/}");
 			}
-			return null;
 		};
 
 		const openTaskPopup = async (task: Task): Promise<void> => {
@@ -1341,24 +1353,26 @@ export async function renderBoardTui(
 			const popup = await createTaskPopup(screen, task, resolveMilestoneLabel, options?.dateFormat);
 			if (!popup) {
 				popupOpen = false;
+				openPopup = null;
 				return;
 			}
 
 			const { contentArea, close } = popup;
+			openPopup = { taskId: task.id, signature: taskContentSignature(task), close };
+
 			contentArea.key(["escape", "q"], () => {
-				popupOpen = false;
-				close();
-				focusColumn(currentCol);
+				closeOpenPopup();
+				// A status change while the popup was open moves the task to another column,
+				// so follow it instead of returning to the column it was opened from.
+				const columnIndex = columns.findIndex((column) => column.tasks.some((candidate) => candidate.id === task.id));
+				focusColumn(
+					columnIndex === -1 ? currentCol : columnIndex,
+					columns[columnIndex]?.tasks.findIndex((candidate) => candidate.id === task.id),
+				);
 			});
 
 			contentArea.key(["e", "E", "S-e"], async () => {
-				const updatedTask = await openTaskEditor(task);
-				if (updatedTask) {
-					// Rebuild the popup so its content and key handlers reflect the edit.
-					popupOpen = false;
-					close();
-					await openTaskPopup(updatedTask);
-				}
+				await openTaskEditor(task);
 			});
 
 			contentArea.key(["y", "Y"], async () => {
@@ -1392,8 +1406,7 @@ export async function renderBoardTui(
 						if (result.success) {
 							currentTasks = currentTasks.filter((t) => t.id !== task.id);
 							showTransientFooter(` {green-fg}Completed ${task.id}{/}`);
-							close();
-							popupOpen = false;
+							closeOpenPopup();
 							renderView();
 						} else if (result.reason === "not-terminal") {
 							showTransientFooter(` {red-fg}${formatTaskCompletionBlockedMessage(task.id, result.terminalStatus)}{/}`);
@@ -1431,8 +1444,7 @@ export async function renderBoardTui(
 						if (success) {
 							currentTasks = currentTasks.filter((t) => t.id !== task.id);
 							showTransientFooter(` {green-fg}Archived ${task.id}{/}`);
-							close();
-							popupOpen = false;
+							closeOpenPopup();
 							renderView();
 						} else {
 							showTransientFooter(` {red-fg}Failed to archive ${task.id}{/}`);
@@ -1446,6 +1458,28 @@ export async function renderBoardTui(
 			});
 
 			screen.render();
+		};
+
+		/**
+		 * Bring an open task popup back in step with the board's tasks: rebuild it when its
+		 * task changed, close it with a notice when the task left the board.
+		 */
+		const syncOpenPopup = async (): Promise<void> => {
+			const current = openPopup;
+			if (!current) return;
+			const nextTask = currentTasks.find((candidate) => candidate.id === current.taskId);
+			if (!nextTask) {
+				closeOpenPopup();
+				focusColumn(currentCol);
+				showTransientFooter(` {yellow-fg}${current.taskId} is no longer on the board; its details closed.{/}`, 6000);
+				return;
+			}
+			// Rebuilding only on a content change keeps the watcher echo of an in-popup edit invisible.
+			if (taskContentSignature(nextTask) === current.signature) return;
+			closeOpenPopup();
+			await openTaskPopup(nextTask);
+			// The board may have moved on again while the popup was rebuilding.
+			await syncOpenPopup();
 		};
 
 		screen.key(["enter"], async () => {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -371,6 +371,11 @@ export async function renderBoardTui(
 			openPopup = null;
 			popupOpen = false;
 		};
+		let popupSyncPending = false;
+		/** Focus a column after a popup closes; the board may have lost columns while it was open. */
+		const restoreColumnFocus = (preferredIndex: number, preferredRow?: number) => {
+			focusColumn(Math.max(0, Math.min(preferredIndex, columns.length - 1)), preferredRow);
+		};
 		let currentFocus: "board" | "filters" = "board";
 		let filterPopupOpen = false;
 		let modalOpen = false;
@@ -403,6 +408,11 @@ export async function renderBoardTui(
 				return await operation();
 			} finally {
 				modalOpen = false;
+				// A task update that arrived while the dialog held the screen was deferred.
+				if (popupSyncPending) {
+					popupSyncPending = false;
+					void syncOpenPopup();
+				}
 			}
 		};
 		let configuredLabels = collectAvailableLabels(initialTasks, options?.availableLabels ?? []);
@@ -1365,7 +1375,7 @@ export async function renderBoardTui(
 				// A status change while the popup was open moves the task to another column,
 				// so follow it instead of returning to the column it was opened from.
 				const columnIndex = columns.findIndex((column) => column.tasks.some((candidate) => candidate.id === task.id));
-				focusColumn(
+				restoreColumnFocus(
 					columnIndex === -1 ? currentCol : columnIndex,
 					columns[columnIndex]?.tasks.findIndex((candidate) => candidate.id === task.id),
 				);
@@ -1467,10 +1477,16 @@ export async function renderBoardTui(
 		const syncOpenPopup = async (): Promise<void> => {
 			const current = openPopup;
 			if (!current) return;
+			// A confirmation dialog is stacked on the popup and owns the keyboard; rebuilding
+			// underneath it would steal focus and leave the dialog unanswerable.
+			if (modalOpen) {
+				popupSyncPending = true;
+				return;
+			}
 			const nextTask = currentTasks.find((candidate) => candidate.id === current.taskId);
 			if (!nextTask) {
 				closeOpenPopup();
-				focusColumn(currentCol);
+				restoreColumnFocus(currentCol);
 				showTransientFooter(` {yellow-fg}${current.taskId} is no longer on the board; its details closed.{/}`, 6000);
 				return;
 			}

--- a/src/utils/task-watcher.ts
+++ b/src/utils/task-watcher.ts
@@ -36,7 +36,12 @@ function isUsableTask(task: Task | null, taskId: string): task is Task {
 	return Boolean(task && taskIdsEqual(task.id, taskId) && task.title.trim() && task.status.trim());
 }
 
-function taskSignature(task: Task): string {
+/**
+ * Identity of a task's content, ignoring where it was read from and when.
+ * Re-reading the same task after a write yields the same signature, so consumers can
+ * tell a real edit from a watcher echo.
+ */
+export function taskContentSignature(task: Task): string {
 	const { branch: _branch, filePath: _filePath, lastModified: _lastModified, source: _source, ...content } = task;
 	return JSON.stringify(content);
 }
@@ -47,7 +52,7 @@ function createReconciliation(initialTask?: Task): TaskReconciliation {
 		processing: false,
 		pending: false,
 		hasPublishedState: initialTask !== undefined,
-		lastPublishedSignature: initialTask ? taskSignature(initialTask) : null,
+		lastPublishedSignature: initialTask ? taskContentSignature(initialTask) : null,
 	};
 }
 
@@ -118,7 +123,7 @@ export function watchTasks(
 				return;
 			}
 
-			const signature = taskSignature(task);
+			const signature = taskContentSignature(task);
 			if (signature !== previousCandidateSignature) {
 				previousCandidateSignature = signature;
 				continue;
@@ -186,7 +191,8 @@ export function watchTasks(
 					const taskId = normalizeTaskId(task.id);
 					visibleTaskIds.add(taskId);
 					const state = reconciliations.get(taskId);
-					if (!state?.hasPublishedState || state.lastPublishedSignature !== taskSignature(task)) schedule(taskId);
+					if (!state?.hasPublishedState || state.lastPublishedSignature !== taskContentSignature(task))
+						schedule(taskId);
 				}
 			}
 


### PR DESCRIPTION
Supersedes #952, whose fork is organization-owned and cannot receive maintainer edits. The original commit by @bjohas is preserved with their authorship.

Builds on their openTaskPopup extraction, but drives popup rebuild/close from the board's existing watcher-fed updateBoard funnel instead of editor return-value plumbing, so external and agent edits refresh the popup too, and a task completed/archived/deleted externally closes it with a footer notice. Content-signature comparison (shared with the task watcher) prevents echo double-rebuilds. Also fixes Escape refocusing the stale column after a status change.

Closes #951.