### PR TITLE
BACK-649 - Single-source task search config and filters in core

### DIFF
--- a/backlog/tasks/back-649 - Single-source-task-search-config-and-filters-in-core.md
+++ b/backlog/tasks/back-649 - Single-source-task-search-config-and-filters-in-core.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-649
 title: Single-source task search config and filters in core
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-29 21:04'
+updated_date: '2026-08-29 22:15'
 labels:
   - cli
   - mcp
@@ -20,15 +22,58 @@ Task search is implemented three times with real behavior drift: core SearchServ
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One module owns the Fuse config and searchable-text builder; SearchService imports it and its duplicated config is deleted
-- [ ] #2 A query matching a label or assignee finds the task identically via backlog search, task list --search, MCP, and the web API
-- [ ] #3 One shared filter implementation with explicitly resolved labelMatch semantics; divergent copies deleted
-- [ ] #4 Tests pin the cross-surface parity, including the labels and assignees cases
+- [x] #1 One module owns the Fuse config and searchable-text builder; SearchService imports it and its duplicated config is deleted
+- [x] #2 A query matching a label or assignee finds the task identically via backlog search, task list --search, MCP, and the web API
+- [x] #3 One shared filter implementation with explicitly resolved labelMatch semantics; divergent copies deleted
+- [x] #4 Tests pin the cross-surface parity, including the labels and assignees cases
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Make src/utils/task-search.ts the single owner of the search corpus shape: export buildTaskSearchFields(task) (title, bodyText, id, idVariants, dependencyIds, modifiedFiles) and TASK_SEARCH_FUSE_OPTIONS (threshold/ignoreLocation/minMatchCharLength/keys), so the indexed keys and the text behind them can never drift apart. bodyText keeps labels and assignees (maintainer-approved).
+2. Extend the shared filter options in task-search.ts to the union of all three copies (status, excludeStatus, type, priority, assignee, unassigned, labels+labelMatch, modifiedFiles, parentTaskId, milestone, ready) and export createTaskFilterMatcher(options, corpus) + applyTaskFilters over Task, so one predicate set serves every surface.
+3. src/core/search-service.ts: import buildTaskSearchFields and TASK_SEARCH_FUSE_OPTIONS; delete its buildTaskBodyText, its inline Fuse config, and BOTH of its filter copies (applyTaskFilters and matchesTaskFilters) in favour of the shared matcher over entity.task.
+4. src/core/backlog.ts: delete Core.applyTaskFilters and call the shared applyTaskFilters instead.
+5. src/cli.ts: delete taskMatchesAllLabels; the plain/JSON task list passes labels + labelMatch 'all' through baseFilters like every other filter.
+6. src/mcp/tools/tasks/handlers.ts: delete the two hand-rolled every() label loops (task path and draft path) and use the shared filters; this also makes MCP label matching case-insensitive like the other surfaces.
+7. src/types/index.ts: add labelMatch to TaskListFilter and SearchFilters so the choice is explicit at every boundary.
+8. labelMatch resolution: default 'any'; callers that pass an explicitly typed label list (CLI task list --labels in all output modes, MCP task_list labels) pass 'all'. Rationale: the CLI help is the only place the product documents the semantics ('require every comma-separated label') and MCP already required every label, while every remaining consumer is an interactive multi-select picker (TUI board and unified view, web label dropdown) where adding a label must widen the result set. The undocumented HTTP label params keep the 'any' default they have today.
+9. Do not touch the local vs cross-branch corpus split, the TUI viewer fallback, or MilestonesPage (BACK-650).
+10. Add src/test/task-search-parity.test.ts pinning that a label query and an assignee query return the same task through createTaskSearchIndex and SearchService, and pinning the labelMatch any/all split; then run bunx tsc --noEmit, bun run check ., bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+labelMatch resolution: the shared predicate defaults to 'any', and callers that pass an explicitly typed label list pass 'all'. Only one surface documents the semantics -- the 'backlog task list --labels' help text says 'require every comma-separated label' -- and the MCP task_list labels argument already required every label, so both now pass labelMatch: 'all'. Every remaining consumer is an interactive multi-select picker (TUI board and unified view, web label dropdown) where adding a label must widen the result set, so those keep 'any'. The undocumented HTTP label parameters keep the 'any' default they already had; verified /api/tasks?label=backend&label=infrastructure still returns both tasks.
+
+Two pre-existing bugs fell out of the consolidation. The plain and JSON 'task list --labels' path filtered with a local taskMatchesAllLabels helper applied after the query, while Core.applyTaskFilters matched any label; both now run one predicate. MCP label matching compared raw strings, so a task labelled 'Backend' did not match 'backend'; it is case-insensitive now like every other surface.
+
+MCP drafts: the hand-rolled filter chain became one applyTaskFilters call. Draft assignee matching is now trimmed and case-insensitive (it was an exact Array.includes). The 'search narrows drafts to the literal Draft status, listing them does not' quirk was preserved deliberately rather than silently changed.
+
+Kept out of scope per the task: the local vs cross-branch corpus split, the TUI viewer fallback, and MilestonesPage (BACK-650).
+
+Simplification pass: applySharedTaskFilters and SharedTaskFilterOptions were left as a pure alias after the merge, so both were deleted and the board and unified view now call applyTaskFilters directly.
+
+Rebased onto origin/main after BACK-643 (PR #924) added the project task attribute. That feature had added project filtering to every filter copy this task deletes, so a conflict resolution taking either side wholesale would have silently dropped project filtering. Resolution folds project into the shared predicate: TaskFilterOptions gains 'project', createTaskFilterMatcher calls matchesProjectFilter (OR across the list, a task with no project never matches a non-empty filter), and every former call site keeps threading it -- Core.queryTasks searchFilters pass-through, the MCP task and draft paths including the draft status condition, the board, and the unified view. Core.applyTaskFilters no longer imports matchesProjectFilter since the predicate owns it.
+
+Added a 'filter wiring across surfaces' test block that drives the real CLI and MCP surfaces rather than the predicate alone, because an argument dropped at a call site is invisible to a predicate-level test. Each pin was mutation-verified: removing labelMatch 'all' from the MCP handler fails two tests, removing it from the CLI baseFilters fails one, and removing the project check from the shared predicate fails the project parity test and the OR-semantics test. All mutations were reverted after checking.
+
+Three emoji-width test failures seen mid-rebase were stale node_modules after BACK-646 bumped neo-neo-bblessed; bun i fixed them and bun.lock is unchanged, so no update-nix run is needed.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+src/utils/task-search.ts is now the single owner of task search and task filtering. It exports buildTaskSearchFields (title, bodyText, id, idVariants, dependencyIds, modifiedFiles) and TASK_SEARCH_FUSE_OPTIONS, and SearchService imports both instead of keeping its own copies, so the indexed keys and the text behind them cannot drift. Labels and assignees are now in the searchable text on every surface. The four non-query filter implementations (Core.applyTaskFilters, SearchService's applyTaskFilters and matchesTaskFilters, the CLI's taskMatchesAllLabels, and the MCP adapter's two label loops) collapsed into one createTaskFilterMatcher predicate set; labelMatch defaults to 'any' with the CLI --labels flag and the MCP labels argument passing 'all' to match the documented CLI contract.
+
+Verified end to end against a scratch project: 'backlog search infrastructure', 'task list --search infrastructure', and GET /api/search?query=infrastructure all return the same task, as do the same three surfaces for the assignee query 'morgan'; 'task list --labels backend,infrastructure' returns only the task carrying both, 'task list --labels BACKEND' matches case-insensitively, and GET /api/tasks?label=backend&label=infrastructure still returns both tasks so the interactive picker keeps widening. Automated: bunx tsc --noEmit clean, bun run check . clean, bun test 2471 pass / 0 fail, including nine new cross-surface parity tests in src/test/task-search-parity.test.ts. Net -300 lines of production code.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,7 +76,6 @@ import {
 import { AmbiguousIdError, isAmbiguousIdError } from "./utils/entity-id.ts";
 import { findBacklogRoot } from "./utils/find-backlog-root.ts";
 import { generateNextDecisionId } from "./utils/id-generators.ts";
-import { labelsToLower } from "./utils/label-filter.ts";
 import {
 	formatMcpClientSetupCommand,
 	getMcpClientSetupCommand,
@@ -300,15 +299,6 @@ function formatTaskEditError(error: unknown, taskId: string, commandKind = "task
 		return `${message}\nRun 'backlog ${commandKind} view ${taskId} --plain' to inspect indexes, or 'backlog ${commandKind} edit ${taskId} --help' for edit options.`;
 	}
 	return message;
-}
-
-function taskMatchesAllLabels(task: Task, labels: string[]): boolean {
-	const requiredLabels = labelsToLower(labels);
-	if (requiredLabels.length === 0) {
-		return true;
-	}
-	const taskLabels = new Set(labelsToLower(task.labels ?? []));
-	return requiredLabels.every((label) => taskLabels.has(label));
 }
 
 function formatPlainTaskListRow(task: Task, options: { includeStatus?: boolean } = {}): string {
@@ -2589,6 +2579,11 @@ addHelpSchema(taskCmd.command("list"), {
 		}
 
 		const labelFilters = parseDelimitedStringList(options.labels) ?? [];
+		if (labelFilters.length > 0) {
+			// `--labels` is documented as requiring every listed label.
+			baseFilters.labels = labelFilters;
+			baseFilters.labelMatch = "all";
+		}
 		const searchQuery = typeof options.search === "string" ? options.search.trim() : "";
 		let taskLimit: number | undefined;
 		if (options.limit !== undefined) {
@@ -2674,10 +2669,6 @@ addHelpSchema(taskCmd.command("list"), {
 				const parent = resolvedParentId;
 				filtered = filtered.filter((task) => task.parentTaskId && taskIdsEqual(parent, task.parentTaskId));
 			}
-			if (labelFilters.length > 0) {
-				filtered = filtered.filter((task) => taskMatchesAllLabels(task, labelFilters));
-			}
-
 			const displayTasks = taskLimit !== undefined ? filtered.slice(0, taskLimit) : filtered;
 
 			if (outputMode === "json") {

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -49,11 +49,7 @@ import { openInEditor } from "../utils/editor.ts";
 import { isAmbiguousIdError } from "../utils/entity-id.ts";
 import { findBacklogRoot } from "../utils/find-backlog-root.ts";
 import { generateNextDecisionId, generateNextDocId } from "../utils/id-generators.ts";
-import {
-	createMilestoneFilterMatcher,
-	createMilestoneFilterValueResolver,
-	type MilestoneFilterValueResolver,
-} from "../utils/milestone-filter.ts";
+import { createMilestoneFilterValueResolver } from "../utils/milestone-filter.ts";
 import {
 	buildGlobPattern,
 	buildIdRegex,
@@ -63,11 +59,10 @@ import {
 	getPrefixForType,
 	normalizeId,
 } from "../utils/prefix-config.ts";
-import { formatValidPriorityValues, normalizePriorityValue, resolvePriorityValue } from "../utils/priority-config.ts";
+import { formatValidPriorityValues, resolvePriorityValue } from "../utils/priority-config.ts";
 import {
 	formatValidProjectValues,
 	getProjectValues,
-	matchesProjectFilter,
 	noProjectsConfiguredMessage,
 	resolveProjectValue,
 } from "../utils/project-config.ts";
@@ -77,7 +72,6 @@ import {
 	getValidStatuses as resolveValidStatuses,
 } from "../utils/status.ts";
 import { executeStatusCallback } from "../utils/status-callback.ts";
-import { normalizeStatusSet, statusMatchesSet } from "../utils/status-filter.ts";
 import {
 	buildDefinitionOfDoneItems,
 	normalizeStringList,
@@ -96,9 +90,9 @@ import {
 	normalizeTaskIdentity,
 	taskIdsEqual,
 } from "../utils/task-path.ts";
-import { createTaskSearchIndex } from "../utils/task-search.ts";
+import { applyTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
-import { formatValidTaskTypeValues, matchesTaskTypeFilter, resolveTaskTypeValue } from "../utils/task-type-config.ts";
+import { formatValidTaskTypeValues, resolveTaskTypeValue } from "../utils/task-type-config.ts";
 import { upsertTaskUpdatedDate } from "../utils/task-updated-date.ts";
 import { isTerminalStatus } from "../utils/terminal-status.ts";
 import { normalizeUtcDateTime } from "../utils/utc-datetime.ts";
@@ -714,68 +708,6 @@ export class Core {
 		}
 	}
 
-	private applyTaskFilters(
-		tasks: Task[],
-		filters?: TaskListFilter,
-		resolveMilestoneFilterValue?: MilestoneFilterValueResolver,
-	): Task[] {
-		if (!filters) {
-			return tasks;
-		}
-		let result = tasks;
-		if (filters.status) {
-			const wanted = normalizeStatusSet(filters.status);
-			if (wanted.size > 0) {
-				result = result.filter((task) => statusMatchesSet(wanted, task.status));
-			}
-		}
-		if (filters.excludeStatus) {
-			const excluded = normalizeStatusSet(filters.excludeStatus);
-			if (excluded.size > 0) {
-				result = result.filter((task) => !statusMatchesSet(excluded, task.status));
-			}
-		}
-		if (filters.type) {
-			result = result.filter((task) => matchesTaskTypeFilter(task.type, filters.type));
-		}
-		if (filters.project) {
-			result = result.filter((task) => matchesProjectFilter(task.project, filters.project));
-		}
-		if (filters.assignee) {
-			const assigneeLower = filters.assignee.toLowerCase();
-			result = result.filter((task) => (task.assignee ?? []).some((value) => value.toLowerCase() === assigneeLower));
-		}
-		if (filters.unassigned) {
-			result = result.filter((task) => !(task.assignee ?? []).some((value) => value.trim().length > 0));
-		}
-		if (filters.priority) {
-			const priorityLower = normalizePriorityValue(String(filters.priority));
-			result = result.filter((task) => normalizePriorityValue(task.priority) === priorityLower);
-		}
-		if (filters.milestone) {
-			const resolveValue = resolveMilestoneFilterValue ?? createMilestoneFilterValueResolver([]);
-			const milestoneValues = tasks.map((task) => task.milestone ?? "");
-			const matchesMilestone = createMilestoneFilterMatcher(filters.milestone, milestoneValues, resolveValue);
-			result = result.filter((task) => matchesMilestone(task.milestone ?? ""));
-		}
-		if (filters.parentTaskId) {
-			const parentFilter = filters.parentTaskId;
-			result = result.filter((task) => task.parentTaskId && taskIdsEqual(parentFilter, task.parentTaskId));
-		}
-		if (filters.labels && filters.labels.length > 0) {
-			const requiredLabels = filters.labels.map((label) => label.toLowerCase()).filter(Boolean);
-			if (requiredLabels.length > 0) {
-				result = result.filter((task) => {
-					const taskLabels = task.labels?.map((label) => label.toLowerCase()) || [];
-					if (taskLabels.length === 0) return false;
-					const labelSet = new Set(taskLabels);
-					return requiredLabels.some((label) => labelSet.has(label));
-				});
-			}
-		}
-		return result;
-	}
-
 	private filterLocalEditableTasks(tasks: Task[]): Task[] {
 		return tasks.filter(isLocalEditableTask);
 	}
@@ -891,8 +823,8 @@ export class Core {
 				: undefined;
 
 			const applyFiltersAndLimit = async (collection: Task[]): Promise<Task[]> => {
-				const resolveMilestoneFilterValue = milestoneResolverPromise ? await milestoneResolverPromise : undefined;
-				let filtered = this.applyTaskFilters(collection, filters, resolveMilestoneFilterValue);
+				const resolveMilestoneLabel = milestoneResolverPromise ? await milestoneResolverPromise : undefined;
+				let filtered = filters ? applyTaskFilters(collection, { ...filters, resolveMilestoneLabel }) : [...collection];
 				if (!includeCrossBranch) {
 					filtered = this.filterLocalEditableTasks(filtered);
 				}
@@ -949,6 +881,7 @@ export class Core {
 			}
 			if (filters?.labels) {
 				searchFilters.labels = filters.labels;
+				searchFilters.labelMatch = filters.labelMatch;
 			}
 
 			const searchResults = searchService.search({

--- a/src/core/search-service.ts
+++ b/src/core/search-service.ts
@@ -2,38 +2,37 @@ import Fuse, { type FuseResult, type FuseResultMatch } from "fuse.js";
 import type {
 	Decision,
 	Document,
-	SearchFilters,
 	SearchMatch,
 	SearchOptions,
-	SearchPriorityFilter,
 	SearchResult,
 	SearchResultType,
 	Task,
 } from "../types/index.ts";
-import { matchesModifiedFileFilters, normalizeModifiedFileFilters } from "../utils/modified-files.ts";
-import { normalizePriorityValue } from "../utils/priority-config.ts";
-import { matchesProjectFilter } from "../utils/project-config.ts";
-import { createTaskIdSearchVariants } from "../utils/task-id-search.ts";
-import { matchesTaskTypeFilter } from "../utils/task-type-config.ts";
+import {
+	buildTaskSearchFields,
+	createTaskFilterMatcher,
+	TASK_SEARCH_FUSE_OPTIONS,
+	type TaskSearchFields,
+} from "../utils/task-search.ts";
 import type { ContentStore, ContentStoreEvent } from "./content-store.ts";
 
-interface BaseSearchEntity {
-	readonly id: string;
+/**
+ * Documents and decisions are indexed with the same Fuse keys as tasks, so they expose the task
+ * search fields with empty values for the task-only ones.
+ */
+const EMPTY_TASK_SEARCH_FIELDS: Omit<TaskSearchFields, "title" | "bodyText" | "id"> = {
+	idVariants: [],
+	dependencyIds: [],
+	modifiedFiles: [],
+};
+
+interface BaseSearchEntity extends TaskSearchFields {
 	readonly type: SearchResultType;
-	readonly title: string;
-	readonly bodyText: string;
 }
 
 interface TaskSearchEntity extends BaseSearchEntity {
 	readonly type: "task";
 	readonly task: Task;
-	readonly statusLower: string;
-	readonly priorityLower?: SearchPriorityFilter;
-	readonly assigneesLower: string[];
-	readonly labelsLower: string[];
-	readonly idVariants: string[];
-	readonly dependencyIds: string[];
-	readonly modifiedFiles: string[];
 }
 
 interface DocumentSearchEntity extends BaseSearchEntity {
@@ -47,17 +46,6 @@ interface DecisionSearchEntity extends BaseSearchEntity {
 }
 
 type SearchEntity = TaskSearchEntity | DocumentSearchEntity | DecisionSearchEntity;
-
-type NormalizedFilters = {
-	statuses?: string[];
-	excludedStatuses?: string[];
-	taskTypes?: string[];
-	projects?: string[];
-	priorities?: SearchPriorityFilter[];
-	assignees?: string[];
-	labels?: string[];
-	modifiedFiles?: string[];
-};
 
 export class SearchService {
 	private initialized = false;
@@ -112,10 +100,10 @@ export class SearchService {
 		const allowedTypes = new Set<SearchResultType>(
 			types && types.length > 0 ? types : ["task", "document", "decision"],
 		);
-		const normalizedFilters = this.normalizeFilters(filters);
+		const matchesTaskFilters = createTaskFilterMatcher(filters ?? {});
 
 		if (trimmedQuery === "") {
-			return this.collectWithoutQuery(allowedTypes, normalizedFilters, limit);
+			return this.collectWithoutQuery(allowedTypes, matchesTaskFilters, limit);
 		}
 
 		const fuse = this.fuse;
@@ -132,7 +120,7 @@ export class SearchService {
 				continue;
 			}
 
-			if (entity.type === "task" && !this.matchesTaskFilters(entity, normalizedFilters)) {
+			if (entity.type === "task" && !matchesTaskFilters(entity.task)) {
 				continue;
 			}
 
@@ -169,21 +157,13 @@ export class SearchService {
 
 	private applySnapshot(tasks: Task[], documents: Document[], decisions: Decision[]): void {
 		this.tasks = tasks.map((task) => ({
-			id: task.id,
+			...buildTaskSearchFields(task),
 			type: "task",
-			title: task.title,
-			bodyText: buildTaskBodyText(task),
 			task,
-			statusLower: task.status.toLowerCase(),
-			priorityLower: normalizePriorityValue(task.priority),
-			assigneesLower: (task.assignee ?? []).map((assignee) => assignee.toLowerCase()),
-			labelsLower: (task.labels || []).map((label) => label.toLowerCase()),
-			idVariants: createTaskIdSearchVariants(task.id),
-			dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdSearchVariants(dependency)),
-			modifiedFiles: task.modifiedFiles ?? [],
 		}));
 
 		this.documents = documents.map((document) => ({
+			...EMPTY_TASK_SEARCH_FIELDS,
 			id: document.id,
 			type: "document",
 			title: document.title,
@@ -192,6 +172,7 @@ export class SearchService {
 		}));
 
 		this.decisions = decisions.map((decision) => ({
+			...EMPTY_TASK_SEARCH_FIELDS,
 			id: decision.id,
 			type: "decision",
 			title: decision.title,
@@ -209,32 +190,20 @@ export class SearchService {
 			return;
 		}
 
-		this.fuse = new Fuse(this.collection, {
-			includeScore: true,
-			includeMatches: true,
-			threshold: 0.35,
-			ignoreLocation: true,
-			minMatchCharLength: 2,
-			keys: [
-				{ name: "title", weight: 0.35 },
-				{ name: "bodyText", weight: 0.3 },
-				{ name: "id", weight: 0.2 },
-				{ name: "idVariants", weight: 0.1 },
-				{ name: "dependencyIds", weight: 0.05 },
-				{ name: "modifiedFiles", weight: 0.15 },
-			],
-		});
+		// Same keys, weights, and threshold as every other task search; only the highlight ranges
+		// this surface reports back to callers are extra.
+		this.fuse = new Fuse(this.collection, { ...TASK_SEARCH_FUSE_OPTIONS, includeMatches: true });
 	}
 
 	private collectWithoutQuery(
 		allowedTypes: Set<SearchResultType>,
-		filters: NormalizedFilters,
+		matchesTaskFilters: (task: Task) => boolean,
 		limit?: number,
 	): SearchResult[] {
 		const results: SearchResult[] = [];
 
 		if (allowedTypes.has("task")) {
-			const tasks = this.applyTaskFilters(this.tasks, filters);
+			const tasks = this.tasks.filter((entity) => matchesTaskFilters(entity.task));
 			for (const entity of tasks) {
 				results.push(this.mapEntityToResult(entity));
 				if (limit && results.length >= limit) {
@@ -262,170 +231,6 @@ export class SearchService {
 		}
 
 		return results;
-	}
-
-	private applyTaskFilters(tasks: TaskSearchEntity[], filters: NormalizedFilters): TaskSearchEntity[] {
-		let filtered = tasks;
-		if (filters.statuses && filters.statuses.length > 0) {
-			const allowedStatuses = new Set(filters.statuses);
-			filtered = filtered.filter((task) => allowedStatuses.has(task.statusLower));
-		}
-		if (filters.excludedStatuses && filters.excludedStatuses.length > 0) {
-			const excludedStatuses = new Set(filters.excludedStatuses);
-			filtered = filtered.filter((task) => !excludedStatuses.has(task.statusLower));
-		}
-		if (filters.taskTypes && filters.taskTypes.length > 0) {
-			filtered = filtered.filter((task) => matchesTaskTypeFilter(task.task.type, filters.taskTypes));
-		}
-		if (filters.projects && filters.projects.length > 0) {
-			filtered = filtered.filter((task) => matchesProjectFilter(task.task.project, filters.projects));
-		}
-		if (filters.priorities && filters.priorities.length > 0) {
-			const allowedPriorities = new Set(filters.priorities);
-			filtered = filtered.filter((task) => {
-				if (!task.priorityLower) {
-					return false;
-				}
-				return allowedPriorities.has(task.priorityLower);
-			});
-		}
-		if (filters.assignees && filters.assignees.length > 0) {
-			const requiredAssignees = new Set(filters.assignees);
-			filtered = filtered.filter((task) => {
-				if (!task.assigneesLower || task.assigneesLower.length === 0) {
-					return false;
-				}
-				return task.assigneesLower.some((assignee) => requiredAssignees.has(assignee));
-			});
-		}
-		if (filters.labels && filters.labels.length > 0) {
-			const requiredLabels = new Set(filters.labels);
-			filtered = filtered.filter((task) => {
-				if (!task.labelsLower || task.labelsLower.length === 0) {
-					return false;
-				}
-				return task.labelsLower.some((label) => requiredLabels.has(label));
-			});
-		}
-		if (filters.modifiedFiles && filters.modifiedFiles.length > 0) {
-			filtered = filtered.filter((task) => matchesModifiedFileFilters(task.modifiedFiles, filters.modifiedFiles));
-		}
-		return filtered;
-	}
-
-	private matchesTaskFilters(task: TaskSearchEntity, filters: NormalizedFilters): boolean {
-		if (filters.statuses && filters.statuses.length > 0) {
-			if (!filters.statuses.includes(task.statusLower)) {
-				return false;
-			}
-		}
-		if (filters.excludedStatuses?.includes(task.statusLower)) {
-			return false;
-		}
-		if (filters.taskTypes && !matchesTaskTypeFilter(task.task.type, filters.taskTypes)) {
-			return false;
-		}
-
-		if (filters.projects && !matchesProjectFilter(task.task.project, filters.projects)) {
-			return false;
-		}
-
-		if (filters.priorities && filters.priorities.length > 0) {
-			if (!task.priorityLower || !filters.priorities.includes(task.priorityLower)) {
-				return false;
-			}
-		}
-
-		if (filters.assignees && filters.assignees.length > 0) {
-			if (!task.assigneesLower || task.assigneesLower.length === 0) {
-				return false;
-			}
-			const assigneeSet = new Set(task.assigneesLower);
-			const anyMatch = filters.assignees.some((assignee) => assigneeSet.has(assignee));
-			if (!anyMatch) {
-				return false;
-			}
-		}
-
-		if (filters.labels && filters.labels.length > 0) {
-			if (!task.labelsLower || task.labelsLower.length === 0) {
-				return false;
-			}
-			const labelSet = new Set(task.labelsLower);
-			const anyMatch = filters.labels.some((label) => labelSet.has(label));
-			if (!anyMatch) {
-				return false;
-			}
-		}
-
-		if (filters.modifiedFiles && !matchesModifiedFileFilters(task.modifiedFiles, filters.modifiedFiles)) {
-			return false;
-		}
-
-		return true;
-	}
-
-	private normalizeFilters(filters?: SearchFilters): NormalizedFilters {
-		if (!filters) {
-			return {};
-		}
-
-		const statuses = this.normalizeStringArray(filters.status);
-		const excludedStatuses = this.normalizeStringArray(filters.excludeStatus);
-		const taskTypes = this.normalizeStringArray(filters.type);
-		const projects = this.normalizeStringArray(filters.project);
-		const priorities = this.normalizePriorityArray(filters.priority);
-		const assignees = this.normalizeStringArray(filters.assignee);
-		const labels = this.normalizeLabelsArray(filters.labels);
-		const modifiedFiles = normalizeModifiedFileFilters(filters.modifiedFiles);
-
-		return {
-			statuses,
-			excludedStatuses,
-			taskTypes,
-			projects,
-			priorities,
-			assignees,
-			labels,
-			modifiedFiles,
-		};
-	}
-
-	private normalizeStringArray(value?: string | string[]): string[] | undefined {
-		if (!value) {
-			return undefined;
-		}
-
-		const values = Array.isArray(value) ? value : [value];
-		const normalized = values.map((item) => item.trim().toLowerCase()).filter((item) => item.length > 0);
-
-		return normalized.length > 0 ? normalized : undefined;
-	}
-
-	private normalizeLabelsArray(value?: string | string[]): string[] | undefined {
-		if (!value) {
-			return undefined;
-		}
-
-		const values = Array.isArray(value) ? value : [value];
-		const normalized = values.map((item) => item.trim().toLowerCase()).filter((item) => item.length > 0);
-
-		return normalized.length > 0 ? normalized : undefined;
-	}
-
-	private normalizePriorityArray(
-		value?: SearchPriorityFilter | SearchPriorityFilter[],
-	): SearchPriorityFilter[] | undefined {
-		if (!value) {
-			return undefined;
-		}
-
-		const values = Array.isArray(value) ? value : [value];
-		const normalized = values
-			.map((item) => normalizePriorityValue(item))
-			.filter((item): item is SearchPriorityFilter => Boolean(item));
-
-		return normalized.length > 0 ? normalized : undefined;
 	}
 
 	private mapEntityToResult(entity: SearchEntity, result?: FuseResult<SearchEntity>): SearchResult {
@@ -469,36 +274,4 @@ export class SearchService {
 			value: match.value,
 		}));
 	}
-}
-function buildTaskBodyText(task: Task): string {
-	const parts: string[] = [];
-
-	if (task.description) {
-		parts.push(task.description);
-	}
-
-	if (Array.isArray(task.acceptanceCriteriaItems) && task.acceptanceCriteriaItems.length > 0) {
-		const lines = [...task.acceptanceCriteriaItems]
-			.sort((a, b) => a.index - b.index)
-			.map((criterion) => `- [${criterion.checked ? "x" : " "}] ${criterion.text}`);
-		parts.push(lines.join("\n"));
-	}
-
-	if (task.implementationPlan) {
-		parts.push(task.implementationPlan);
-	}
-
-	if (task.implementationNotes) {
-		parts.push(task.implementationNotes);
-	}
-
-	if (Array.isArray(task.comments) && task.comments.length > 0) {
-		parts.push(task.comments.map((comment) => comment.body).join("\n\n"));
-	}
-
-	if (task.modifiedFiles?.length) {
-		parts.push(task.modifiedFiles.join("\n"));
-	}
-
-	return parts.join("\n\n");
 }

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -10,11 +10,14 @@ import {
 } from "../../../types/index.ts";
 import type { TaskEditArgs, TaskEditRequest } from "../../../types/task-edit-args.ts";
 import { formatDuplicateTaskIdWarning } from "../../../utils/duplicate-detection.ts";
-import { createMilestoneFilterMatcher, createMilestoneFilterValueResolver } from "../../../utils/milestone-filter.ts";
+import {
+	createMilestoneFilterValueResolver,
+	type MilestoneFilterValueResolver,
+} from "../../../utils/milestone-filter.ts";
 import { resolveMilestoneInputForStorage } from "../../../utils/milestone-storage.ts";
 import { getTaskReadiness, loadReadinessGraph } from "../../../utils/readiness.ts";
 import { buildTaskUpdateInput } from "../../../utils/task-edit-builder.ts";
-import { createTaskSearchIndex } from "../../../utils/task-search.ts";
+import { applyTaskFilters, createTaskSearchIndex } from "../../../utils/task-search.ts";
 import { sortByOrdinalAndPriority } from "../../../utils/task-sorting.ts";
 import { getTerminalStatus, isTerminalStatus } from "../../../utils/terminal-status.ts";
 import { formatUtcDateForDisplay } from "../../../utils/utc-date-display.ts";
@@ -78,6 +81,14 @@ export class TaskHandlers {
 			this.core.filesystem.listArchivedMilestones(),
 		]);
 		return resolveMilestoneInputForStorage(milestone, activeMilestones, archivedMilestones);
+	}
+
+	private async createMilestoneFilterValueResolver(): Promise<MilestoneFilterValueResolver> {
+		const [activeMilestones, archivedMilestones] = await Promise.all([
+			this.core.filesystem.listMilestones(),
+			this.core.filesystem.listArchivedMilestones(),
+		]);
+		return createMilestoneFilterValueResolver([...activeMilestones, ...archivedMilestones]);
 	}
 
 	private async getConfiguredStatuses(): Promise<string[]> {
@@ -165,49 +176,20 @@ export class TaskHandlers {
 		const config = await this.core.filesystem.loadConfig();
 		const priorities = config?.priorities;
 		if (this.isDraftStatus(args.status)) {
-			let drafts = await this.core.filesystem.listDrafts();
-			const milestoneCandidates = drafts;
-			if (args.search || args.type?.length || args.project?.length) {
-				const draftSearch = createTaskSearchIndex(drafts);
-				drafts = draftSearch.search({ query: args.search, status: "Draft", type: args.type, project: args.project });
-			}
-
-			if (args.assignee) {
-				drafts = drafts.filter((draft) => (draft.assignee ?? []).includes(args.assignee ?? ""));
-			}
-			if (args.unassigned) {
-				drafts = drafts.filter((draft) => !(draft.assignee ?? []).some((value) => value.trim().length > 0));
-			}
-			if (args.milestone) {
-				const [activeMilestones, archivedMilestones] = await Promise.all([
-					this.core.filesystem.listMilestones(),
-					this.core.filesystem.listArchivedMilestones(),
-				]);
-				const resolveMilestoneFilterValue = createMilestoneFilterValueResolver([
-					...activeMilestones,
-					...archivedMilestones,
-				]);
-				const milestoneValues = milestoneCandidates.map((draft) => draft.milestone ?? "");
-				const matchesMilestone = createMilestoneFilterMatcher(
-					args.milestone,
-					milestoneValues,
-					resolveMilestoneFilterValue,
-				);
-				drafts = drafts.filter((draft) => matchesMilestone(draft.milestone ?? ""));
-			}
-
-			const labelFilters = args.labels ?? [];
-			if (labelFilters.length > 0) {
-				drafts = drafts.filter((draft) => {
-					const draftLabels = draft.labels ?? [];
-					return labelFilters.every((label) => draftLabels.includes(label));
-				});
-			}
-
-			if (args.ready) {
-				const readinessGraph = await loadReadinessGraph(this.core);
-				drafts = drafts.filter((draft) => getTaskReadiness(draft, readinessGraph).isReady);
-			}
+			const drafts = applyTaskFilters(await this.core.filesystem.listDrafts(), {
+				query: args.search,
+				// Searching drafts has always narrowed to the literal "Draft" status; listing them has not.
+				status: args.search || args.type?.length || args.project?.length ? "Draft" : undefined,
+				type: args.type,
+				project: args.project,
+				assignee: args.assignee,
+				unassigned: args.unassigned,
+				milestone: args.milestone,
+				resolveMilestoneLabel: args.milestone ? await this.createMilestoneFilterValueResolver() : undefined,
+				labels: args.labels,
+				labelMatch: "all",
+				ready: args.ready ? await loadReadinessGraph(this.core) : undefined,
+			});
 
 			if (drafts.length === 0) {
 				return {
@@ -258,6 +240,10 @@ export class TaskHandlers {
 		if (args.milestone) {
 			filters.milestone = args.milestone;
 		}
+		if (args.labels?.length) {
+			filters.labels = args.labels;
+			filters.labelMatch = "all";
+		}
 
 		let tasks = await this.core.queryTasks({
 			query: args.search,
@@ -270,14 +256,7 @@ export class TaskHandlers {
 			tasks = tasks.filter((task) => getTaskReadiness(task, readinessGraph).isReady);
 		}
 
-		let filteredByLabels = tasks.filter((task) => isLocalEditableTask(task));
-		const labelFilters = args.labels ?? [];
-		if (labelFilters.length > 0) {
-			filteredByLabels = filteredByLabels.filter((task) => {
-				const taskLabels = task.labels ?? [];
-				return labelFilters.every((label) => taskLabels.includes(label));
-			});
-		}
+		const filteredByLabels = tasks.filter((task) => isLocalEditableTask(task));
 
 		if (filteredByLabels.length === 0) {
 			return {

--- a/src/test/task-search-parity.test.ts
+++ b/src/test/task-search-parity.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { ContentStore } from "../core/content-store.ts";
+import { SearchService } from "../core/search-service.ts";
+import { FileSystem } from "../file-system/operations.ts";
+import { McpServer } from "../mcp/server.ts";
+import { registerTaskTools } from "../mcp/tools/tasks/index.ts";
+import type { Task, TaskSearchResult } from "../types/index.ts";
+import { applyTaskFilters, buildTaskSearchBodyText, createTaskSearchIndex } from "../utils/task-search.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+
+/**
+ * The local one-shot index (`task list --search`, the TUI views, the MCP adapter) and the
+ * cross-branch SearchService (`backlog search`, the web API) must agree on what a query matches
+ * and on what a filter means. These tests pin that agreement.
+ */
+
+const labelledTask: Task = {
+	id: "task-1",
+	title: "Rework the exporter",
+	status: "To Do",
+	assignee: ["@morgan"],
+	reporter: "@morgan",
+	createdDate: "2026-01-05 09:00",
+	labels: ["backend", "infrastructure"],
+	dependencies: [],
+	rawContent: "## Description\nNothing here mentions the label or the assignee.",
+	description: "Nothing here mentions the label or the assignee.",
+};
+
+const otherTask: Task = {
+	id: "task-2",
+	title: "Polish the sidebar",
+	status: "To Do",
+	assignee: ["@riley"],
+	reporter: "@riley",
+	createdDate: "2026-01-05 09:00",
+	labels: ["backend"],
+	dependencies: [],
+	rawContent: "## Description\nUnrelated body text.",
+	description: "Unrelated body text.",
+};
+
+const tasks = [labelledTask, otherTask];
+
+function taskIds(results: Task[]): string[] {
+	return results.map((task) => task.id).sort();
+}
+
+describe("task search corpus", () => {
+	it("puts labels and assignees in the searchable text", () => {
+		const bodyText = buildTaskSearchBodyText(labelledTask);
+		expect(bodyText).toContain("infrastructure");
+		expect(bodyText).toContain("@morgan");
+	});
+});
+
+describe("cross-surface search parity", () => {
+	let TEST_DIR: string;
+	let filesystem: FileSystem;
+	let store: ContentStore;
+	let search: SearchService;
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("task-search-parity");
+		filesystem = new FileSystem(TEST_DIR);
+		await filesystem.ensureBacklogStructure();
+		for (const task of tasks) {
+			await filesystem.saveTask(task);
+		}
+		store = new ContentStore(filesystem);
+		search = new SearchService(store);
+		await search.ensureInitialized();
+	});
+
+	afterEach(async () => {
+		search?.dispose();
+		store?.dispose();
+		await safeCleanup(TEST_DIR);
+	});
+
+	const searchServiceTaskIds = (query: string): string[] =>
+		search
+			.search({ query, types: ["task"] })
+			.filter((result): result is TaskSearchResult => result.type === "task")
+			.map((result) => result.task.id)
+			.sort();
+
+	it("finds a task by a label it carries through both surfaces", () => {
+		const localMatches = taskIds(createTaskSearchIndex(tasks).search({ query: "infrastructure" }));
+
+		expect(localMatches).toEqual(["task-1"]);
+		expect(searchServiceTaskIds("infrastructure")).toEqual(["TASK-1"]);
+	});
+
+	it("finds a task by its assignee through both surfaces", () => {
+		const localMatches = taskIds(createTaskSearchIndex(tasks).search({ query: "morgan" }));
+
+		expect(localMatches).toEqual(["task-1"]);
+		expect(searchServiceTaskIds("morgan")).toEqual(["TASK-1"]);
+	});
+
+	it("agrees on a label filter applied without a query", () => {
+		const localMatches = taskIds(applyTaskFilters(tasks, { labels: ["backend"] }));
+		const serviceMatches = search
+			.search({ types: ["task"], filters: { labels: ["backend"] } })
+			.filter((result): result is TaskSearchResult => result.type === "task")
+			.map((result) => result.task.id)
+			.sort();
+
+		expect(localMatches).toEqual(["task-1", "task-2"]);
+		expect(serviceMatches).toEqual(["TASK-1", "TASK-2"]);
+	});
+
+	it("agrees on an assignee filter applied without a query", () => {
+		const localMatches = taskIds(applyTaskFilters(tasks, { assignee: "@MORGAN" }));
+		const serviceMatches = search
+			.search({ types: ["task"], filters: { assignee: "@MORGAN" } })
+			.filter((result): result is TaskSearchResult => result.type === "task")
+			.map((result) => result.task.id)
+			.sort();
+
+		expect(localMatches).toEqual(["task-1"]);
+		expect(serviceMatches).toEqual(["TASK-1"]);
+	});
+
+	it("applies the same labelMatch semantics with and without a query", () => {
+		const bothLabels = ["backend", "infrastructure"];
+
+		expect(taskIds(applyTaskFilters(tasks, { labels: bothLabels, labelMatch: "all" }))).toEqual(["task-1"]);
+		expect(taskIds(applyTaskFilters(tasks, { labels: bothLabels, labelMatch: "any" }))).toEqual(["task-1", "task-2"]);
+
+		const withQuery = { query: "the", labels: bothLabels } as const;
+		expect(taskIds(applyTaskFilters(tasks, { ...withQuery, labelMatch: "all" }))).toEqual(["task-1"]);
+		expect(taskIds(applyTaskFilters(tasks, { ...withQuery, labelMatch: "any" }))).toEqual(["task-1", "task-2"]);
+	});
+});
+
+describe("labelMatch semantics", () => {
+	it("defaults to matching any selected label", () => {
+		expect(taskIds(applyTaskFilters(tasks, { labels: ["backend", "infrastructure"] }))).toEqual(["task-1", "task-2"]);
+	});
+
+	it("requires every label when the caller asks for all", () => {
+		expect(taskIds(applyTaskFilters(tasks, { labels: ["backend", "infrastructure"], labelMatch: "all" }))).toEqual([
+			"task-1",
+		]);
+	});
+
+	it("matches labels case-insensitively in both modes", () => {
+		expect(taskIds(applyTaskFilters(tasks, { labels: ["BACKEND"] }))).toEqual(["task-1", "task-2"]);
+		expect(taskIds(applyTaskFilters(tasks, { labels: ["BackEnd", "INFRASTRUCTURE"], labelMatch: "all" }))).toEqual([
+			"task-1",
+		]);
+	});
+});
+
+/**
+ * Filters reach the shared predicate through several different call sites, and an argument dropped
+ * at any one of them is invisible to a test that only exercises the predicate directly. These tests
+ * drive the real CLI and MCP surfaces so the wiring itself is pinned.
+ */
+describe("filter wiring across surfaces", () => {
+	const cliPath = getTestCliPath();
+	let testDir: string;
+	let core: Core;
+	let mcpServer: McpServer;
+
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("task-search-wiring");
+		await mkdir(testDir, { recursive: true });
+		core = new Core(testDir);
+		await initializeFilesystemTestProject(core, "Filter Wiring");
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Expected test config");
+		await core.filesystem.saveConfig({ ...config, projects: ["Web", "API"] });
+
+		await core.createTaskFromInput(
+			{ title: "Wiring both labels", project: "web", status: "To Do", labels: ["backend", "infrastructure"] },
+			false,
+		);
+		await core.createTaskFromInput(
+			{ title: "Wiring one label", project: "api", status: "To Do", labels: ["backend"] },
+			false,
+		);
+		await core.createTaskFromInput({ title: "Wiring no labels", status: "To Do" }, false);
+
+		mcpServer = new McpServer(testDir, "Test instructions");
+		const mcpConfig = await mcpServer.filesystem.loadConfig();
+		if (!mcpConfig) throw new Error("Expected MCP test config");
+		registerTaskTools(mcpServer, mcpConfig);
+	});
+
+	afterEach(async () => {
+		await mcpServer.stop();
+		core.disposeSearchService();
+		core.disposeContentStore();
+		await safeCleanup(testDir);
+	});
+
+	const mcpTaskList = async (args: Record<string, unknown>): Promise<string> => {
+		const result = await mcpServer.testInterface.callTool({ params: { name: "task_list", arguments: args } });
+		const content = result.content as Array<{ text?: string }> | undefined;
+		return content?.[0]?.text ?? "";
+	};
+
+	it("requires every label through the MCP task_list labels argument", async () => {
+		const bothLabels = await mcpTaskList({ labels: ["backend", "infrastructure"] });
+		expect(bothLabels).toContain("Wiring both labels");
+		expect(bothLabels).not.toContain("Wiring one label");
+		expect(bothLabels).not.toContain("Wiring no labels");
+
+		const oneLabel = await mcpTaskList({ labels: ["backend"] });
+		expect(oneLabel).toContain("Wiring both labels");
+		expect(oneLabel).toContain("Wiring one label");
+	});
+
+	it("matches MCP labels case-insensitively like every other surface", async () => {
+		const upper = await mcpTaskList({ labels: ["BACKEND", "INFRASTRUCTURE"] });
+		expect(upper).toContain("Wiring both labels");
+		expect(upper).not.toContain("Wiring one label");
+	});
+
+	it("requires every label through the CLI task list --labels flag", async () => {
+		const both = await $`bun ${cliPath} task list --labels backend,infrastructure --plain`.cwd(testDir).quiet();
+		expect(both.exitCode).toBe(0);
+		expect(both.stdout.toString()).toContain("Wiring both labels");
+		expect(both.stdout.toString()).not.toContain("Wiring one label");
+
+		const single = await $`bun ${cliPath} task list --labels backend --plain`.cwd(testDir).quiet();
+		expect(single.exitCode).toBe(0);
+		expect(single.stdout.toString()).toContain("Wiring both labels");
+		expect(single.stdout.toString()).toContain("Wiring one label");
+	});
+
+	it("filters by project identically through Core, the search service, MCP, and both CLI entry points", async () => {
+		const expected = ["Wiring both labels"];
+
+		// Core.queryTasks backs `task list` and `GET /api/tasks`.
+		const coreTasks = await core.queryTasks({ filters: { project: "web" }, includeCrossBranch: false });
+		expect(coreTasks.map((task) => task.title)).toEqual(expected);
+
+		// SearchService backs `backlog search` and `GET /api/search`.
+		const searchService = await core.getSearchService();
+		const serviceTitles = searchService
+			.search({ types: ["task"], filters: { project: "web" } })
+			.filter((result): result is TaskSearchResult => result.type === "task")
+			.map((result) => result.task.title);
+		expect(serviceTitles).toEqual(expected);
+
+		const mcpOutput = await mcpTaskList({ project: ["web"] });
+		expect(mcpOutput).toContain("Wiring both labels");
+		expect(mcpOutput).not.toContain("Wiring one label");
+		expect(mcpOutput).not.toContain("Wiring no labels");
+
+		const list = await $`bun ${cliPath} task list --project web --plain`.cwd(testDir).quiet();
+		expect(list.exitCode).toBe(0);
+		expect(list.stdout.toString()).toContain("Wiring both labels");
+		expect(list.stdout.toString()).not.toContain("Wiring one label");
+
+		const search = await $`bun ${cliPath} search "Wiring" --project web --plain`.cwd(testDir).quiet();
+		expect(search.exitCode).toBe(0);
+		expect(search.stdout.toString()).toContain("Wiring both labels");
+		expect(search.stdout.toString()).not.toContain("Wiring one label");
+	});
+
+	it("keeps OR semantics when several projects are requested", async () => {
+		const both = await core.queryTasks({ filters: { project: ["WEB", "api"] }, includeCrossBranch: false });
+		expect(both.map((task) => task.title).sort()).toEqual(["Wiring both labels", "Wiring one label"]);
+		// A task with no project never matches a non-empty project filter.
+		expect(both.some((task) => task.project === undefined)).toBe(false);
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,13 @@
 export type TaskStatus = string;
 
 /**
+ * How a multi-label filter is combined. Interactive multi-select pickers use "any" so adding a
+ * label widens the result set; callers that pass an explicitly typed label list (the CLI
+ * `--labels` flag and the MCP `labels` argument) use "all" so every listed label is required.
+ */
+export type LabelMatchMode = "any" | "all";
+
+/**
  * Entity types in the backlog system.
  * Used for ID generation and prefix resolution.
  */
@@ -189,6 +196,8 @@ export interface TaskListFilter {
 	milestone?: string;
 	parentTaskId?: string;
 	labels?: string[];
+	/** Defaults to "any"; callers passing an explicitly typed label list use "all". */
+	labelMatch?: LabelMatchMode;
 }
 
 export interface Decision {
@@ -264,6 +273,8 @@ export interface SearchFilters {
 	project?: string | string[];
 	assignee?: string | string[];
 	labels?: string | string[];
+	/** Defaults to "any"; callers passing an explicitly typed label list use "all". */
+	labelMatch?: LabelMatchMode;
 	modifiedFiles?: string | string[];
 }
 

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -7,7 +7,7 @@ import {
 	generateMilestoneGroupedBoard,
 } from "../board.ts";
 import { type Core, createRuntimeCore } from "../core/backlog.ts";
-import type { Milestone, Task, TaskCreateInput } from "../types/index.ts";
+import type { LabelMatchMode, Milestone, Task, TaskCreateInput } from "../types/index.ts";
 import { copyToClipboard } from "../utils/clipboard.ts";
 import { areLabelSelectionsEqual, collectAvailableLabels } from "../utils/label-filter.ts";
 import {
@@ -17,7 +17,7 @@ import {
 } from "../utils/milestone-filter.ts";
 import { getPriorityOptions } from "../utils/priority-config.ts";
 import { getProjectValues, resolveProjectValues } from "../utils/project-config.ts";
-import { applySharedTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
+import { applyTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { compareTaskIds } from "../utils/task-sorting.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
 import { taskContentSignature } from "../utils/task-watcher.ts";
@@ -476,7 +476,7 @@ export async function renderBoardTui(
 				filteredTasks = [...currentTasks];
 			} else {
 				const searchIndex = createTaskSearchIndex(currentTasks);
-				filteredTasks = applySharedTaskFilters(
+				filteredTasks = applyTaskFilters(
 					currentTasks,
 					{
 						query: sharedFilters.searchQuery,

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -10,7 +10,7 @@ import {
 	formatDateForDisplay,
 	formatTaskPlainText,
 } from "../formatters/task-plain-text.ts";
-import type { Milestone, Task, TaskSearchResult } from "../types/index.ts";
+import type { LabelMatchMode, Milestone, Task, TaskSearchResult } from "../types/index.ts";
 import { copyToClipboard } from "../utils/clipboard.ts";
 import { areLabelSelectionsEqual, collectAvailableLabels, labelsToLower } from "../utils/label-filter.ts";
 import {
@@ -29,7 +29,7 @@ import {
 	type ReadinessGraph,
 } from "../utils/readiness.ts";
 import { canonicalTaskId, taskIdsEqual } from "../utils/task-id.ts";
-import { applyTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
+import { applyTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
 import { formatAcceptanceCriteriaProgress } from "./acceptance-criteria-progress.ts";

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -4,12 +4,12 @@
 
 import type { Core } from "../core/backlog.ts";
 import { findLocalDuplicateTaskIds } from "../core/duplicate-task-repair.ts";
-import type { Milestone, Task, TaskCreateInput } from "../types/index.ts";
+import type { LabelMatchMode, Milestone, Task, TaskCreateInput } from "../types/index.ts";
 import { watchConfig } from "../utils/config-watcher.ts";
 import { formatDuplicateTaskIdSummary } from "../utils/duplicate-detection.ts";
 import { collectAvailableLabels } from "../utils/label-filter.ts";
 import { hasAnyPrefix } from "../utils/prefix-config.ts";
-import { applySharedTaskFilters, createTaskSearchIndex, type LabelMatchMode } from "../utils/task-search.ts";
+import { applyTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { type TaskWatcherCallbacks, watchTasks } from "../utils/task-watcher.ts";
 import { renderBoardTui } from "./board.ts";
 import { createLoadingScreen } from "./loading.ts";
@@ -168,7 +168,7 @@ export function filterTasksForKanban(
 	}
 
 	const searchIndex = createTaskSearchIndex(tasks);
-	const filteredTasks = applySharedTaskFilters(
+	const filteredTasks = applyTaskFilters(
 		tasks,
 		{
 			query: filters.searchQuery,

--- a/src/utils/task-search.ts
+++ b/src/utils/task-search.ts
@@ -1,13 +1,18 @@
 /**
- * In-memory task search using Fuse.js
- * Used when tasks are already loaded to avoid re-fetching via ContentStore
+ * Task search: the single owner of the searchable-text builder, the Fuse configuration, and the
+ * task filter predicates. Every surface that searches or filters tasks (the CLI, the TUI views,
+ * the MCP adapter, the web API, and the cross-branch SearchService) goes through this module so
+ * the same query and the same filters mean the same thing everywhere.
+ *
+ * Callers still decide which corpus to search: the local working copy or the cross-branch store.
  */
 
-import Fuse from "fuse.js";
-import type { Task } from "../types/index.ts";
+import Fuse, { type IFuseOptions } from "fuse.js";
+import type { LabelMatchMode, Task } from "../types/index.ts";
 import { labelsToLower } from "./label-filter.ts";
 import {
 	createMilestoneFilterMatcher,
+	createMilestoneFilterValueResolver,
 	type MilestoneFilterValueResolver,
 	NO_MILESTONE_FILTER_VALUE,
 } from "./milestone-filter.ts";
@@ -16,39 +21,35 @@ import { normalizePriorityValue } from "./priority-config.ts";
 import { matchesProjectFilter } from "./project-config.ts";
 import { getTaskReadiness, type ReadinessGraph } from "./readiness.ts";
 import { normalizeStatusSet, statusMatchesSet } from "./status-filter.ts";
+import { taskIdsEqual } from "./task-id.ts";
 import { createTaskIdSearchVariants } from "./task-id-search.ts";
 import { matchesTaskTypeFilter } from "./task-type-config.ts";
 
-export type LabelMatchMode = "any" | "all";
+/** The task fields the shared Fuse configuration indexes. */
+export interface TaskSearchFields {
+	title: string;
+	bodyText: string;
+	id: string;
+	idVariants: string[];
+	dependencyIds: string[];
+	modifiedFiles: string[];
+}
 
-export interface TaskSearchOptions {
+export interface TaskFilterOptions {
 	query?: string;
 	status?: string | string[];
 	excludeStatus?: string | string[];
 	type?: string | string[];
 	project?: string | string[];
-	priority?: string;
-	labels?: string[];
+	priority?: string | string[];
+	assignee?: string | string[];
+	unassigned?: boolean;
+	labels?: string | string[];
 	labelMatch?: LabelMatchMode;
-	modifiedFiles?: string[];
-}
-
-export interface SharedTaskFilterOptions {
-	query?: string;
-	excludeStatus?: string | string[];
-	type?: string | string[];
-	project?: string | string[];
-	priority?: string;
-	labels?: string[];
-	labelMatch?: LabelMatchMode;
-	modifiedFiles?: string[];
+	modifiedFiles?: string | string[];
+	parentTaskId?: string;
 	milestone?: string;
 	resolveMilestoneLabel?: (milestone: string) => string;
-}
-
-export interface TaskFilterOptions extends SharedTaskFilterOptions {
-	status?: string | string[];
-	excludeStatus?: string | string[];
 	/**
 	 * When set, keep only tasks that are ready according to this graph. The graph carries the full
 	 * task corpus, so readiness never depends on which tasks survived the other filters.
@@ -57,228 +58,205 @@ export interface TaskFilterOptions extends SharedTaskFilterOptions {
 }
 
 export interface TaskSearchIndex {
-	search(options: TaskSearchOptions): Task[];
+	search(options: TaskFilterOptions): Task[];
 }
 
-interface SearchableTask {
-	task: Task;
-	title: string;
-	bodyText: string;
-	id: string;
-	idVariants: string[];
-	dependencyIds: string[];
-	statusLower: string;
-	priorityLower?: string;
-	labelsLower: string[];
-	modifiedFiles: string[];
-}
-
-function buildSearchableTask(task: Task): SearchableTask {
-	const bodyParts: string[] = [];
-	if (task.description) bodyParts.push(task.description);
+/**
+ * Build the searchable text for one task. Labels and assignees are part of the searchable text on
+ * every surface, so `--search backend` finds a task labelled `backend` from the CLI, the MCP
+ * adapter, and the web API alike.
+ */
+export function buildTaskSearchBodyText(task: Task): string {
+	const parts: string[] = [];
+	if (task.description) parts.push(task.description);
 	if (Array.isArray(task.acceptanceCriteriaItems) && task.acceptanceCriteriaItems.length > 0) {
 		const lines = [...task.acceptanceCriteriaItems]
 			.sort((a, b) => a.index - b.index)
 			.map((criterion) => `- [${criterion.checked ? "x" : " "}] ${criterion.text}`);
-		bodyParts.push(lines.join("\n"));
+		parts.push(lines.join("\n"));
 	}
-	if (task.implementationPlan) bodyParts.push(task.implementationPlan);
-	if (task.implementationNotes) bodyParts.push(task.implementationNotes);
+	if (task.implementationPlan) parts.push(task.implementationPlan);
+	if (task.implementationNotes) parts.push(task.implementationNotes);
 	if (Array.isArray(task.comments) && task.comments.length > 0) {
-		bodyParts.push(task.comments.map((comment) => comment.body).join(" "));
+		parts.push(task.comments.map((comment) => comment.body).join("\n\n"));
 	}
-	if (task.labels?.length) bodyParts.push(task.labels.join(" "));
-	if (task.assignee?.length) bodyParts.push(task.assignee.join(" "));
-	if (task.modifiedFiles?.length) bodyParts.push(task.modifiedFiles.join(" "));
+	if (task.labels?.length) parts.push(task.labels.join("\n"));
+	if (task.assignee?.length) parts.push(task.assignee.join("\n"));
+	if (task.modifiedFiles?.length) parts.push(task.modifiedFiles.join("\n"));
 
+	return parts.join("\n\n");
+}
+
+/** Build every field the shared Fuse configuration indexes, so keys and content cannot drift. */
+export function buildTaskSearchFields(task: Task): TaskSearchFields {
 	return {
-		task,
 		title: task.title,
-		bodyText: bodyParts.join(" "),
+		bodyText: buildTaskSearchBodyText(task),
 		id: task.id,
 		idVariants: createTaskIdSearchVariants(task.id),
 		dependencyIds: (task.dependencies ?? []).flatMap((dependency) => createTaskIdSearchVariants(dependency)),
-		statusLower: (task.status || "").toLowerCase(),
-		priorityLower: normalizePriorityValue(task.priority),
-		labelsLower: (task.labels || []).map((label) => label.toLowerCase()),
 		modifiedFiles: task.modifiedFiles ?? [],
 	};
 }
 
+/** The shared fuzzy-match configuration. Consumers add `includeMatches` when they need highlights. */
+export const TASK_SEARCH_FUSE_OPTIONS: IFuseOptions<TaskSearchFields> = {
+	includeScore: true,
+	threshold: 0.35,
+	ignoreLocation: true,
+	minMatchCharLength: 2,
+	keys: [
+		{ name: "title", weight: 0.35 },
+		{ name: "bodyText", weight: 0.3 },
+		{ name: "id", weight: 0.2 },
+		{ name: "idVariants", weight: 0.1 },
+		{ name: "dependencyIds", weight: 0.05 },
+		{ name: "modifiedFiles", weight: 0.15 },
+	],
+};
+
+function toList(value: string | string[] | undefined): string[] {
+	if (!value) return [];
+	const values = Array.isArray(value) ? value : [value];
+	return values.map((item) => item.trim()).filter((item) => item.length > 0);
+}
+
+function toLowerList(value: string | string[] | undefined): string[] {
+	return toList(value).map((item) => item.toLowerCase());
+}
+
 /**
- * Create an in-memory search index for tasks
+ * Build the shared task predicate. `corpus` is the full task list the milestone matcher compares
+ * against, so a milestone filter resolves the same way no matter which tasks survive other filters.
  */
-export function createTaskSearchIndex(tasks: Task[]): TaskSearchIndex {
-	const searchableTasks = tasks.map(buildSearchableTask);
+export function createTaskFilterMatcher(options: TaskFilterOptions, corpus: Task[] = []): (task: Task) => boolean {
+	const checks: Array<(task: Task) => boolean> = [];
 
-	const fuse = new Fuse(searchableTasks, {
-		includeScore: true,
-		threshold: 0.35,
-		ignoreLocation: true,
-		minMatchCharLength: 2,
-		keys: [
-			{ name: "title", weight: 0.35 },
-			{ name: "bodyText", weight: 0.3 },
-			{ name: "id", weight: 0.2 },
-			{ name: "idVariants", weight: 0.1 },
-			{ name: "dependencyIds", weight: 0.05 },
-			{ name: "modifiedFiles", weight: 0.15 },
-		],
-	});
-
-	return {
-		search(options: TaskSearchOptions): Task[] {
-			let results: SearchableTask[];
-
-			// If we have a query, use Fuse for fuzzy search
-			if (options.query?.trim()) {
-				const fuseResults = fuse.search(options.query.trim());
-				results = fuseResults.map((r) => r.item);
-			} else {
-				// No query - start with all tasks
-				results = [...searchableTasks];
-			}
-
-			// Apply status filter: any of the given statuses, matching the stores.
-			const wantedStatuses = options.status ? normalizeStatusSet(options.status) : null;
-			if (wantedStatuses && wantedStatuses.size > 0) {
-				results = results.filter((t) => statusMatchesSet(wantedStatuses, t.statusLower));
-			}
-			if (options.excludeStatus) {
-				const excluded = normalizeStatusSet(options.excludeStatus);
-				if (excluded.size > 0) {
-					results = results.filter((t) => !statusMatchesSet(excluded, t.statusLower));
-				}
-			}
-			if (options.type) {
-				results = results.filter((task) => matchesTaskTypeFilter(task.task.type, options.type));
-			}
-			if (options.project) {
-				results = results.filter((task) => matchesProjectFilter(task.task.project, options.project));
-			}
-
-			// Apply priority filter
-			if (options.priority) {
-				const priorityLower = normalizePriorityValue(options.priority);
-				results = results.filter((t) => t.priorityLower === priorityLower);
-			}
-
-			// Apply label filters. Interactive UI filters match any selected
-			// label; CLI-seeded --labels filters request all-label matching.
-			if (options.labels && options.labels.length > 0) {
-				const required = labelsToLower(options.labels);
-				const labelMatch = options.labelMatch ?? "any";
-				results = results.filter((t) => {
-					if (!t.labelsLower || t.labelsLower.length === 0) {
-						return false;
-					}
-					const labelSet = new Set(t.labelsLower);
-					return labelMatch === "all"
-						? required.every((label) => labelSet.has(label))
-						: required.some((label) => labelSet.has(label));
-				});
-			}
-
-			const modifiedFiles = normalizeModifiedFileFilters(options.modifiedFiles);
-			if (modifiedFiles) {
-				results = results.filter((task) => matchesModifiedFileFilters(task.modifiedFiles, modifiedFiles));
-			}
-
-			return results.map((r) => r.task);
-		},
-	};
-}
-
-function applyMilestoneFilter(
-	tasks: Task[],
-	milestone: string,
-	resolveMilestoneLabel?: (milestone: string) => string,
-	milestoneCandidates: Task[] = tasks,
-): Task[] {
-	const normalizedMilestone = milestone.trim().toLowerCase();
-	if (!normalizedMilestone) {
-		return tasks;
-	}
-	if (normalizedMilestone === NO_MILESTONE_FILTER_VALUE) {
-		return tasks.filter((task) => !task.milestone?.trim());
-	}
-	if (resolveMilestoneLabel && "resolveExactId" in resolveMilestoneLabel) {
-		const milestoneValues = milestoneCandidates.map((task) => task.milestone ?? "");
-		const matchesMilestone = createMilestoneFilterMatcher(
-			milestone,
-			milestoneValues,
-			resolveMilestoneLabel as MilestoneFilterValueResolver,
-		);
-		return tasks.filter((task) => matchesMilestone(task.milestone ?? ""));
+	const wantedStatuses = normalizeStatusSet(options.status);
+	if (wantedStatuses.size > 0) {
+		checks.push((task) => statusMatchesSet(wantedStatuses, task.status));
 	}
 
-	return tasks.filter((task) => {
-		if (!task.milestone) {
-			return false;
-		}
-		const value = resolveMilestoneLabel ? resolveMilestoneLabel(task.milestone) : task.milestone;
-		return value.trim().toLowerCase() === normalizedMilestone;
-	});
-}
+	const excludedStatuses = normalizeStatusSet(options.excludeStatus);
+	if (excludedStatuses.size > 0) {
+		checks.push((task) => !statusMatchesSet(excludedStatuses, task.status));
+	}
 
-export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, index?: TaskSearchIndex): Task[] {
-	const query = options.query?.trim() ?? "";
-	const hasBaseFilters = Boolean(
-		query ||
-			options.status ||
-			options.excludeStatus ||
-			options.type ||
-			options.project ||
-			options.priority ||
-			(options.labels && options.labels.length > 0) ||
-			(options.modifiedFiles && options.modifiedFiles.length > 0),
+	if (options.type) {
+		const types = options.type;
+		checks.push((task) => matchesTaskTypeFilter(task.type, types));
+	}
+
+	if (options.project) {
+		const projects = options.project;
+		checks.push((task) => matchesProjectFilter(task.project, projects));
+	}
+
+	const priorities = new Set(
+		toList(options.priority)
+			.map((priority) => normalizePriorityValue(priority))
+			.filter((priority): priority is string => Boolean(priority)),
 	);
+	if (priorities.size > 0) {
+		checks.push((task) => {
+			const priority = normalizePriorityValue(task.priority);
+			return Boolean(priority) && priorities.has(priority as string);
+		});
+	}
 
-	let results = hasBaseFilters
-		? (index ?? createTaskSearchIndex(tasks)).search({
-				query,
-				status: options.status,
-				excludeStatus: options.excludeStatus,
-				type: options.type,
-				project: options.project,
-				priority: options.priority,
-				labels: options.labels,
-				labelMatch: options.labelMatch,
-				modifiedFiles: options.modifiedFiles,
-			})
-		: [...tasks];
+	const assignees = new Set(toLowerList(options.assignee));
+	if (assignees.size > 0) {
+		checks.push((task) => (task.assignee ?? []).some((value) => assignees.has(value.trim().toLowerCase())));
+	}
 
-	if (options.milestone) {
-		results = applyMilestoneFilter(results, options.milestone, options.resolveMilestoneLabel, tasks);
+	if (options.unassigned) {
+		checks.push((task) => !(task.assignee ?? []).some((value) => value.trim().length > 0));
+	}
+
+	const requiredLabels = labelsToLower(toList(options.labels));
+	if (requiredLabels.length > 0) {
+		const matchAll = options.labelMatch === "all";
+		checks.push((task) => {
+			const taskLabels = new Set(labelsToLower(task.labels ?? []));
+			if (taskLabels.size === 0) return false;
+			return matchAll
+				? requiredLabels.every((label) => taskLabels.has(label))
+				: requiredLabels.some((label) => taskLabels.has(label));
+		});
+	}
+
+	const modifiedFiles = normalizeModifiedFileFilters(options.modifiedFiles);
+	if (modifiedFiles) {
+		checks.push((task) => matchesModifiedFileFilters(task.modifiedFiles, modifiedFiles));
+	}
+
+	if (options.parentTaskId) {
+		const parentFilter = options.parentTaskId;
+		checks.push((task) => Boolean(task.parentTaskId) && taskIdsEqual(parentFilter, task.parentTaskId as string));
+	}
+
+	const milestone = options.milestone?.trim().toLowerCase();
+	if (milestone) {
+		const resolveLabel = options.resolveMilestoneLabel;
+		if (milestone === NO_MILESTONE_FILTER_VALUE) {
+			checks.push((task) => !task.milestone?.trim());
+		} else if (!resolveLabel || "resolveExactId" in resolveLabel) {
+			// A full resolver knows the configured milestones, so it can match ids and closest titles.
+			const matchesMilestone = createMilestoneFilterMatcher(
+				options.milestone as string,
+				corpus.map((task) => task.milestone ?? ""),
+				(resolveLabel as MilestoneFilterValueResolver | undefined) ?? createMilestoneFilterValueResolver([]),
+			);
+			checks.push((task) => matchesMilestone(task.milestone ?? ""));
+		} else {
+			// A plain label lookup only supports exact, case-insensitive title comparison.
+			checks.push(
+				(task) =>
+					Boolean(task.milestone) &&
+					resolveLabel(task.milestone as string)
+						.trim()
+						.toLowerCase() === milestone,
+			);
+		}
 	}
 
 	if (options.ready) {
 		const graph = options.ready;
-		results = results.filter((task) => getTaskReadiness(task, graph).isReady);
+		checks.push((task) => getTaskReadiness(task, graph).isReady);
 	}
 
-	return results;
+	return (task) => checks.every((check) => check(task));
 }
 
-export function applySharedTaskFilters(
-	tasks: Task[],
-	options: SharedTaskFilterOptions,
-	index?: TaskSearchIndex,
-): Task[] {
-	return applyTaskFilters(
-		tasks,
-		{
-			query: options.query,
-			excludeStatus: options.excludeStatus,
-			type: options.type,
-			project: options.project,
-			priority: options.priority,
-			labels: options.labels,
-			labelMatch: options.labelMatch,
-			modifiedFiles: options.modifiedFiles,
-			milestone: options.milestone,
-			resolveMilestoneLabel: options.resolveMilestoneLabel,
-		},
-		index,
+/**
+ * Create an in-memory search index for tasks. Useful when the corpus is already loaded and the
+ * caller wants to run several queries over it without rebuilding the index each time.
+ */
+export function createTaskSearchIndex(tasks: Task[]): TaskSearchIndex {
+	const entries = tasks.map((task) => ({ task, fields: buildTaskSearchFields(task) }));
+	const fuse = new Fuse(
+		entries.map((entry) => entry.fields),
+		TASK_SEARCH_FUSE_OPTIONS,
 	);
+	const taskByFields = new Map(entries.map((entry) => [entry.fields, entry.task]));
+
+	return {
+		search(options: TaskFilterOptions): Task[] {
+			const query = options.query?.trim() ?? "";
+			const matched = query
+				? fuse.search(query).map((result) => taskByFields.get(result.item) as Task)
+				: entries.map((entry) => entry.task);
+
+			const matches = createTaskFilterMatcher(options, tasks);
+			return matched.filter(matches);
+		},
+	};
+}
+
+export function applyTaskFilters(tasks: Task[], options: TaskFilterOptions, index?: TaskSearchIndex): Task[] {
+	if (options.query?.trim()) {
+		return (index ?? createTaskSearchIndex(tasks)).search(options);
+	}
+	const matches = createTaskFilterMatcher(options, tasks);
+	return tasks.filter(matches);
 }


### PR DESCRIPTION
Stage 1 of the task-search unification (BACK-649). `src/utils/task-search.ts` becomes the single owner of the searchable-text builder, the Fuse configuration, and the task filter predicates.

## What changed

**One search corpus.** `buildTaskSearchFields` produces exactly the fields `TASK_SEARCH_FUSE_OPTIONS` indexes, so the keys and the text behind them cannot drift. `SearchService` imports both and its duplicated `buildTaskBodyText` and inline Fuse config are deleted.

**Labels and assignees are searchable everywhere.** `SearchService`'s body text omitted them, so a query matching a label found the task via `task list --search` and MCP but not via `backlog search` or the web API. It no longer does.

**One filter implementation.** Four copies collapsed into `createTaskFilterMatcher`: `Core.applyTaskFilters`, `SearchService.applyTaskFilters` *and* its second copy `SearchService.matchesTaskFilters`, the CLI's `taskMatchesAllLabels`, and the MCP adapter's two hand-rolled label loops.

## labelMatch

Resolved explicitly: the shared predicate **defaults to `any`**, and callers passing an explicitly typed label list pass `all`.

Only one surface documents the semantics — the `task list --labels` help text, "require every comma-separated label" — and the MCP `labels` argument already required every label, so both pass `labelMatch: "all"`. Every remaining consumer is an interactive multi-select picker (TUI board and unified view, web label dropdown) where adding a label must *widen* the result set, so those keep `any`, as do the undocumented HTTP `label` parameters.

Two pre-existing bugs fell out of this:

- The plain/JSON `task list --labels` path filtered with a local all-labels helper *after* the query while `Core.applyTaskFilters` matched any label; one predicate now serves both.
- MCP label matching compared raw strings, so a task labelled `Backend` did not match `backend`. It is case-insensitive now, like every other surface.

MCP drafts also lose their hand-rolled filter chain. Draft assignee matching is now trimmed and case-insensitive (it was an exact `Array.includes`). The "search narrows drafts to the literal `Draft` status, listing them does not" quirk was preserved deliberately rather than silently changed.

## Out of scope

The local vs cross-branch corpus split (a deliberate v1.50 decision) is untouched, as are the TUI viewer fallback and `MilestonesPage` — those are BACK-650.

## Rebased onto BACK-643

BACK-643 (#924) added the `project` task attribute after this branch was cut, and it had added project filtering to **every** filter copy this PR deletes. A conflict resolution taking either side wholesale would have silently dropped project filtering from `backlog search --project`, `/api/search`, MCP, and the TUI.

The resolution folds it into the shared predicate instead: `TaskFilterOptions` gains `project`, `createTaskFilterMatcher` calls `matchesProjectFilter` (OR across the list; a task with no project never matches a non-empty filter), and every former call site keeps threading it — the `Core.queryTasks` `searchFilters` pass-through, the MCP task and draft paths including the draft status condition, the board, and the unified view.

## Wiring tests

An argument dropped at a call site is invisible to a predicate-level test, so the new `filter wiring across surfaces` block drives the real CLI and MCP surfaces. Each pin was mutation-verified:

| Mutation | Result |
| --- | --- |
| drop `labelMatch: "all"` from the MCP handler | 2 tests fail |
| drop `labelMatch: "all"` from CLI `baseFilters` | 1 test fails |
| drop the project check from the shared predicate | 2 tests fail |

All mutations were reverted after checking.

## Verification

Against a scratch project: `backlog search infrastructure`, `task list --search infrastructure`, and `GET /api/search?query=infrastructure` all return the same task, as do the same three surfaces for the assignee query `morgan`. `task list --labels backend,infrastructure` returns only the task carrying both; `--labels BACKEND` matches case-insensitively; `GET /api/tasks?label=backend&label=infrastructure` still returns both tasks, so the interactive picker keeps widening.

`bunx tsc --noEmit` clean, `bun run check .` clean, `bun test` 2563 pass / 0 fail — including fourteen cross-surface parity and wiring tests in `src/test/task-search-parity.test.ts`.

Net **-290 lines** of production code (+276 test).
