### PR TITLE
BACK-650 - Route TUI and milestone-page task search through the shared core search

### DIFF
--- a/backlog/tasks/back-650 - Route-TUI-and-milestone-page-task-search-through-the-shared-core-search.md
+++ b/backlog/tasks/back-650 - Route-TUI-and-milestone-page-task-search-through-the-shared-core-search.md
@@ -1,10 +1,11 @@
 ---
 id: BACK-650
 title: Route TUI and milestone-page task search through the shared core search
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-29 21:04'
-updated_date: '2026-08-29 21:04'
+updated_date: '2026-08-29 23:00'
 labels:
   - tui
   - web
@@ -21,14 +22,42 @@ Stage 2 of the search unification, after the config single-sourcing task: the TU
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The TUI task viewer's SearchService fallback branch and its hand-rolled post-filters are collapsed onto the shared search path
-- [ ] #2 MilestonesPage no longer ships a private Fuse configuration
-- [ ] #3 Search behavior in TUI and milestones view matches the other surfaces for the same query
+- [x] #1 The TUI task viewer's SearchService fallback branch and its hand-rolled post-filters are collapsed onto the shared search path
+- [x] #2 MilestonesPage no longer ships a private Fuse configuration
+- [x] #3 Search behavior in TUI and milestones view matches the other surfaces for the same query
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Branch tasks/back-650-shared-search-routing off origin/main (contains BACK-649's src/utils/task-search.ts).
+2. TUI (src/ui/task-viewer-with-search.ts): always build taskSearchIndex = createTaskSearchIndex(allTasks) after the corpus loads, in both the options.tasks branch and the ContentStore branch. Delete the searchService field, its applyFilters branch, and the hand-rolled milestone / labelMatch=all / ready post-filters; applyFilters keeps a single applyTaskFilters(allTasks, {...}, taskSearchIndex) call. Keep the ContentStore acquisition and dispose so watcher lifecycle is unchanged. Drop now-unconditional 'if (taskSearchIndex)' rebuild guards and unused imports.
+3. Web (src/web/components/MilestonesPage.tsx): delete the private Fuse instance, its id/title weights, and the MilestoneSearchEntry type; run the bucket task corpus through the shared createTaskSearchIndex so the milestone view uses the same keys, weights, and threshold as every other surface. Client-side rather than /api/search: the page filters buckets already built from its tasks prop, so an API round trip would only be reconciled back to the same corpus by id, and the search stays synchronous with no debounce or loading state.
+4. Tests: pin cross-surface parity - a TUI-corpus query and a milestone-page query return the same task set the shared index returns for the same query.
+5. Verify bunx tsc --noEmit, bun run check ., bun test; open the PR without merging.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TUI (src/ui/task-viewer-with-search.ts): the viewer now builds one createTaskSearchIndex over allTasks whatever way the corpus arrived, and applyFilters is a single applyTaskFilters call. Deleted the SearchService branch and the hand-rolled milestone / labelMatch=all / readiness post-filters, plus the now-dead hasActiveFilters short-circuit (an unset filter contributes no check, so the shared predicate already covers the no-filter case). Two latent inconsistencies go with them: the SearchService branch searched the whole ContentStore while the unfiltered list rendered the prefix-filtered allTasks snapshot, and it never re-indexed after an in-session edit, complete, or archive because the rebuild was guarded on the index the branch did not use.
+
+MilestonesPage (src/web/components/MilestonesPage.tsx): private Fuse (title 0.55 / id 0.45) and MilestoneSearchEntry deleted; the bucket corpus runs through the shared index instead. Chose the shared index over /api/search because the page filters buckets already built from its tasks prop, so an API round trip would only be reconciled back to the same corpus by id, and the filter stays synchronous with no debounce or loading state.
+
+User-visible change: the milestone page loses its exact-id-wins short-circuit, so a full-id query now returns the fuzzy id neighbours too (searching task-404 in a four-task corpus also matches task-101/202/303). That is exactly what the TUI and the sidebar already do with the shared config; the sidebar only hides it by ranking and slicing to 5, while this page uses the result as a set. Milestone search also widens from id+title to the full shared corpus (description, acceptance criteria, plan, notes, comments, labels, assignees), so the placeholder changed from 'Search by task ID or title' to 'Search tasks'.
+
+Validation: bunx tsc --noEmit clean; bun run check . clean; bun run test 2567 pass / 0 fail. Note the worktree needed bun install first - the shared node_modules had neo-neo-bblessed 1.0.9 while main locks 1.0.10, which failed three unrelated tui-emoji-width tests.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Routed the TUI task viewer and the web milestones page through the shared core task search. The viewer keeps one createTaskSearchIndex over its loaded corpus and filters with a single applyTaskFilters call, deleting the SearchService branch and its duplicate milestone / labelMatch / readiness post-filters; MilestonesPage drops its private Fuse config for the shared index. Verified with bunx tsc --noEmit, bun run check ., and bun run test (2567 pass, 0 fail), including new tests pinning that the milestone page renders exactly the shared index's matches for a query and that milestone, no-milestone, and readiness filters mean the same thing with and without a query.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/task-search-parity.test.ts
+++ b/src/test/task-search-parity.test.ts
@@ -8,6 +8,8 @@ import { FileSystem } from "../file-system/operations.ts";
 import { McpServer } from "../mcp/server.ts";
 import { registerTaskTools } from "../mcp/tools/tasks/index.ts";
 import type { Task, TaskSearchResult } from "../types/index.ts";
+import { NO_MILESTONE_FILTER_VALUE } from "../utils/milestone-filter.ts";
+import { createReadinessGraph } from "../utils/readiness.ts";
 import { applyTaskFilters, buildTaskSearchBodyText, createTaskSearchIndex } from "../utils/task-search.ts";
 import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
@@ -136,6 +138,68 @@ describe("cross-surface search parity", () => {
 		const withQuery = { query: "the", labels: bothLabels } as const;
 		expect(taskIds(applyTaskFilters(tasks, { ...withQuery, labelMatch: "all" }))).toEqual(["task-1"]);
 		expect(taskIds(applyTaskFilters(tasks, { ...withQuery, labelMatch: "any" }))).toEqual(["task-1", "task-2"]);
+	});
+});
+
+/**
+ * The TUI task viewer used to re-implement the milestone, labelMatch=all, and readiness filters by
+ * hand on top of a query, so those three could drift from the same filters applied without one.
+ * They all live in the shared predicate now; these pin that a query no longer changes what a filter
+ * means.
+ */
+describe("filters mean the same thing with and without a query", () => {
+	const milestoneTasks: Task[] = [
+		{
+			id: "task-10",
+			title: "Wire the release checklist",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-01-05 09:00",
+			labels: [],
+			dependencies: [],
+			milestone: "m-1",
+		},
+		{
+			id: "task-11",
+			title: "Wire the follow-up checklist",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-01-05 09:00",
+			labels: [],
+			dependencies: ["task-10"],
+			milestone: "m-2",
+		},
+		{
+			id: "task-12",
+			title: "Wire the unscheduled checklist",
+			status: "To Do",
+			assignee: [],
+			createdDate: "2026-01-05 09:00",
+			labels: [],
+			dependencies: [],
+		},
+	];
+	const resolveMilestoneLabel = (milestone: string) => (milestone === "m-1" ? "Release 1" : "Release 2");
+	// Every task's title matches, so the query narrows nothing and only the filter can change the set.
+	const query = "checklist";
+
+	it("resolves a milestone title the same way with and without a query", () => {
+		const options = { milestone: "Release 1", resolveMilestoneLabel } as const;
+		expect(taskIds(applyTaskFilters(milestoneTasks, options))).toEqual(["task-10"]);
+		expect(taskIds(applyTaskFilters(milestoneTasks, { ...options, query }))).toEqual(["task-10"]);
+	});
+
+	it("keeps the no-milestone filter meaning the same with and without a query", () => {
+		const options = { milestone: NO_MILESTONE_FILTER_VALUE, resolveMilestoneLabel } as const;
+		expect(taskIds(applyTaskFilters(milestoneTasks, options))).toEqual(["task-12"]);
+		expect(taskIds(applyTaskFilters(milestoneTasks, { ...options, query }))).toEqual(["task-12"]);
+	});
+
+	it("keeps dependency readiness meaning the same with and without a query", () => {
+		const ready = createReadinessGraph({ tasks: milestoneTasks, statuses: ["To Do", "In Progress", "Done"] });
+		// task-11 depends on an unfinished task-10, so it is the one readiness must drop.
+		expect(taskIds(applyTaskFilters(milestoneTasks, { ready }))).toEqual(["task-10", "task-12"]);
+		expect(taskIds(applyTaskFilters(milestoneTasks, { ready, query }))).toEqual(["task-10", "task-12"]);
 	});
 });
 

--- a/src/test/web-milestones-page-search.test.tsx
+++ b/src/test/web-milestones-page-search.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import type { Milestone, Task } from "../types/index.ts";
+import { createTaskSearchIndex } from "../utils/task-search.ts";
 import MilestonesPage from "../web/components/MilestonesPage.tsx";
 import { apiClient } from "../web/lib/api.ts";
 import { setNativeInputValue } from "./react-dom-input.ts";
@@ -207,7 +208,7 @@ describe("Web milestones page search", () => {
 	it("keeps unassigned section visible during search even when no unassigned tasks match", () => {
 		const container = renderPage();
 
-		setSearchValue(container, "task-404");
+		setSearchValue(container, "docs");
 		const filteredText = container.textContent ?? "";
 		expect(filteredText).toContain("Unassigned tasks");
 		expect(filteredText).toContain("No matching unassigned tasks.");
@@ -221,6 +222,26 @@ describe("Web milestones page search", () => {
 		expect(restoredText).toContain("Setup authentication flow");
 		expect(restoredText).toContain("Deploy pipeline");
 		expect(restoredText).toContain("Draft release notes");
+	});
+
+	it("matches exactly what the shared task search matches for the same query", () => {
+		for (const query of ["authentication", "docs", "pipeline", "release", "task-404", "zzzz-no-match"]) {
+			const expected = new Set(
+				createTaskSearchIndex(baseTasks)
+					.search({ query })
+					.map((task) => task.id),
+			);
+			const container = renderPage();
+			setSearchValue(container, query);
+			const text = container.textContent ?? "";
+			for (const task of baseTasks) {
+				expect({ query, id: task.id, shown: text.includes(task.id) }).toEqual({
+					query,
+					id: task.id,
+					shown: expected.has(task.id),
+				});
+			}
+		}
 	});
 
 	it("no-match search keeps milestone and unassigned sections visible", () => {

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -10,9 +10,9 @@ import {
 	formatDateForDisplay,
 	formatTaskPlainText,
 } from "../formatters/task-plain-text.ts";
-import type { LabelMatchMode, Milestone, Task, TaskSearchResult } from "../types/index.ts";
+import type { LabelMatchMode, Milestone, Task } from "../types/index.ts";
 import { copyToClipboard } from "../utils/clipboard.ts";
-import { areLabelSelectionsEqual, collectAvailableLabels, labelsToLower } from "../utils/label-filter.ts";
+import { areLabelSelectionsEqual, collectAvailableLabels } from "../utils/label-filter.ts";
 import {
 	createMilestoneFilterValueResolver,
 	type MilestoneFilterValueResolver,
@@ -267,9 +267,6 @@ export async function viewTaskEnhanced(
 	let configuredTaskTypes = getTaskTypeValues();
 	let configuredProjects = getProjectValues();
 	let availableLabels: string[] = [];
-	// When tasks are provided, use in-memory search; otherwise use ContentStore-backed search
-	let taskSearchIndex: ReturnType<typeof createTaskSearchIndex> | null = null;
-	let searchService: Awaited<ReturnType<typeof core.getSearchService>> | null = null;
 	let contentStore: Awaited<ReturnType<typeof core.getContentStore>> | null = null;
 	// Completed tasks are loaded alongside the milestone metadata so dependency readiness can
 	// resolve dependencies that already left the active corpus, without a second full task load.
@@ -287,7 +284,7 @@ export async function viewTaskEnhanced(
 	let projectName: string | undefined;
 
 	if (options.tasks) {
-		// Tasks already provided - use in-memory search (no ContentStore loading)
+		// Tasks already provided - no ContentStore loading
 		allTasks = options.tasks.filter((t) => t.id && t.id.trim() !== "" && hasAnyPrefix(t.id));
 		const config = await core.filesystem.loadConfig();
 		statuses = config?.statuses || ["To Do", "In Progress", "Done"];
@@ -297,7 +294,6 @@ export async function viewTaskEnhanced(
 		configuredProjects = getProjectValues(config);
 		dateFormat = config?.dateFormat;
 		projectName = config?.projectName;
-		taskSearchIndex = createTaskSearchIndex(allTasks);
 	} else {
 		// Need to load tasks - show loading screen
 		const loadingScreen = await createLoadingScreen("Loading tasks");
@@ -314,7 +310,6 @@ export async function viewTaskEnhanced(
 
 			loadingScreen?.update("Loading tasks from branches...");
 			contentStore = await core.getContentStore();
-			searchService = await core.getSearchService();
 
 			loadingScreen?.update("Preparing task list...");
 			const tasks = await core.queryTasks();
@@ -323,6 +318,10 @@ export async function viewTaskEnhanced(
 			await loadingScreen?.close();
 		}
 	}
+
+	// One shared index over the loaded corpus, however that corpus arrived. Searching exactly the
+	// tasks this list renders is what keeps its results identical to the other surfaces'.
+	let taskSearchIndex = createTaskSearchIndex(allTasks);
 
 	// Collect available labels from config, tasks, and CLI-provided filters.
 	availableLabels = collectAvailableLabels(allTasks, [...labels, ...(options.labelFilter ?? [])]);
@@ -773,76 +772,24 @@ export async function viewTaskEnhanced(
 
 	// Function to apply filters and refresh the task list
 	function applyFilters() {
-		const hasActiveFilters = Boolean(
-			searchQuery.trim() ||
-				statusFilter.length > 0 ||
-				excludeStatusFilter.length > 0 ||
-				taskTypeFilter.length > 0 ||
-				projectFilter.length > 0 ||
-				priorityFilter ||
-				labelFilter.length > 0 ||
-				milestoneFilter ||
-				options.readyFilter,
-		);
-		let nextFilteredTasks: Task[];
-		if (!hasActiveFilters) {
-			nextFilteredTasks = [...allTasks];
-		} else if (taskSearchIndex) {
-			nextFilteredTasks = applyTaskFilters(
-				allTasks,
-				{
-					query: searchQuery,
-					status: statusFilter.length > 0 ? [...statusFilter] : undefined,
-					excludeStatus: excludeStatusFilter,
-					type: taskTypeFilter,
-					project: projectFilter,
-					priority: priorityFilter || undefined,
-					labels: labelFilter,
-					labelMatch,
-					milestone: milestoneFilter || undefined,
-					resolveMilestoneLabel,
-					ready: options.readyFilter ? buildReadinessGraph() : undefined,
-				},
-				taskSearchIndex,
-			);
-		} else if (searchService) {
-			const searchResults = searchService.search({
+		// An unset filter contributes no check, so this covers the no-filters case too.
+		const nextFilteredTasks = applyTaskFilters(
+			allTasks,
+			{
 				query: searchQuery,
-				filters: {
-					status: statusFilter.length > 0 ? [...statusFilter] : undefined,
-					excludeStatus: excludeStatusFilter,
-					type: taskTypeFilter,
-					project: projectFilter,
-					priority: priorityFilter || undefined,
-					labels: labelFilter.length > 0 ? labelFilter : undefined,
-				},
-				types: ["task"],
-			});
-			nextFilteredTasks = searchResults.filter((r): r is TaskSearchResult => r.type === "task").map((r) => r.task);
-			if (milestoneFilter) {
-				nextFilteredTasks = nextFilteredTasks.filter((task) => {
-					if (milestoneFilter === NO_MILESTONE_FILTER_VALUE) {
-						return !task.milestone?.trim();
-					}
-					if (!task.milestone) return false;
-					const taskMilestoneTitle = resolveMilestoneLabel(task.milestone);
-					return taskMilestoneTitle.toLowerCase() === milestoneFilter.toLowerCase();
-				});
-			}
-			if (labelMatch === "all" && labelFilter.length > 0) {
-				const requiredLabels = labelsToLower(labelFilter);
-				nextFilteredTasks = nextFilteredTasks.filter((task) => {
-					const taskLabels = new Set(labelsToLower(task.labels ?? []));
-					return requiredLabels.every((label) => taskLabels.has(label));
-				});
-			}
-			if (options.readyFilter) {
-				const graph = buildReadinessGraph();
-				nextFilteredTasks = nextFilteredTasks.filter((task) => getTaskReadiness(task, graph).isReady);
-			}
-		} else {
-			nextFilteredTasks = [...allTasks];
-		}
+				status: statusFilter.length > 0 ? [...statusFilter] : undefined,
+				excludeStatus: excludeStatusFilter,
+				type: taskTypeFilter,
+				project: projectFilter,
+				priority: priorityFilter || undefined,
+				labels: labelFilter,
+				labelMatch,
+				milestone: milestoneFilter || undefined,
+				resolveMilestoneLabel,
+				ready: options.readyFilter ? buildReadinessGraph() : undefined,
+			},
+			taskSearchIndex,
+		);
 		filteredTasks = taskLimit !== undefined ? nextFilteredTasks.slice(0, taskLimit) : nextFilteredTasks;
 
 		// Update the task list label
@@ -1317,9 +1264,7 @@ export async function viewTaskEnhanced(
 				const enhancedTask = enrichTask(result.task) ?? result.task;
 				currentSelectedTask = enhancedTask;
 				options.onTaskChange?.(enhancedTask);
-				if (taskSearchIndex) {
-					taskSearchIndex = createTaskSearchIndex(allTasks);
-				}
+				taskSearchIndex = createTaskSearchIndex(allTasks);
 			}
 
 			applyFilters();
@@ -1347,9 +1292,7 @@ export async function viewTaskEnhanced(
 		const nextTask = remainingFilteredTasks[nextIndex] ?? null;
 
 		allTasks = allTasks.filter((taskItem) => taskItem.id !== taskId);
-		if (taskSearchIndex) {
-			taskSearchIndex = createTaskSearchIndex(allTasks);
-		}
+		taskSearchIndex = createTaskSearchIndex(allTasks);
 		if (nextTask) {
 			currentSelectedTask = enrichTask(nextTask) ?? nextTask;
 			options.onTaskChange?.(currentSelectedTask);
@@ -1529,7 +1472,6 @@ export async function viewTaskEnhanced(
 			}
 		} else {
 			// If already in task list, quit
-			searchService?.dispose();
 			contentStore?.dispose();
 			filterHeader.destroy();
 			screen.destroy();
@@ -1546,7 +1488,6 @@ export async function viewTaskEnhanced(
 			}
 			if (currentFocus === "list" || currentFocus === "detail") {
 				// Cleanup before switching
-				searchService?.dispose();
 				contentStore?.dispose();
 				filterHeader.destroy();
 				screen.destroy();
@@ -1560,7 +1501,6 @@ export async function viewTaskEnhanced(
 		if (modalOpen || filterPopupOpen) {
 			return;
 		}
-		searchService?.dispose();
 		contentStore?.dispose();
 		filterHeader.destroy();
 		screen.destroy();
@@ -1581,7 +1521,7 @@ export async function viewTaskEnhanced(
 		statuses = nextStatuses;
 		labels = nextLabels;
 		availableLabels = collectAvailableLabels(allTasks, labels);
-		if (taskSearchIndex) taskSearchIndex = createTaskSearchIndex(allTasks);
+		taskSearchIndex = createTaskSearchIndex(allTasks);
 
 		const previousTaskId = currentSelectedTask.id;
 		const currentTask =
@@ -1618,7 +1558,6 @@ export async function viewTaskEnhanced(
 				clearTimeout(helpRestoreTimer);
 				helpRestoreTimer = null;
 			}
-			searchService?.dispose();
 			contentStore?.dispose();
 			resolve();
 		});

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -1,17 +1,12 @@
 import React, { useMemo, useState, useCallback } from "react";
 import { Link } from "react-router-dom";
-import Fuse from "fuse.js";
 import { apiClient } from "../lib/api";
 import { buildMilestoneBuckets, collectArchivedMilestoneKeys, isDoneStatus, milestoneKey } from "../utils/milestones";
 import { type Milestone, type MilestoneBucket, type Task } from "../../types";
+import { createTaskSearchIndex } from "../../utils/task-search";
 import MilestoneTaskRow from "./MilestoneTaskRow";
 import Modal from "./Modal";
 import { formatStoredUtcDateForDisplay } from "../utils/date-display";
-
-interface MilestoneSearchEntry {
-	id: string;
-	title: string;
-}
 
 type RemoveTaskHandling = "clear" | "reassign";
 
@@ -110,33 +105,13 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 			return buckets;
 		}
 
-		const searchableTasks: MilestoneSearchEntry[] = buckets.flatMap((bucket) =>
-			bucket.tasks.map((task) => ({
-				id: task.id,
-				title: task.title,
-			})),
+		// The shared task index, so a query means here what it means in the CLI, the TUI, and the
+		// rest of the web. The buckets are already loaded, so this filters them in place.
+		const matchedTaskIds = new Set(
+			createTaskSearchIndex(buckets.flatMap((bucket) => bucket.tasks))
+				.search({ query: searchQueryTrimmed })
+				.map((task) => task.id),
 		);
-		if (searchableTasks.length === 0) {
-			return buckets.map((bucket) => rebuildFilteredBucket(bucket, [], statuses));
-		}
-		const normalizedQuery = searchQueryTrimmed.toLowerCase();
-		const exactIdMatches = searchableTasks.filter((task) => task.id.toLowerCase() === normalizedQuery);
-		const matchedTaskIds =
-			exactIdMatches.length > 0
-				? new Set(exactIdMatches.map((task) => task.id))
-				: (() => {
-						const fuse = new Fuse(searchableTasks, {
-							threshold: 0.35,
-							ignoreLocation: true,
-							minMatchCharLength: 2,
-							keys: [
-								{ name: "title", weight: 0.55 },
-								{ name: "id", weight: 0.45 },
-							],
-						});
-						const matches = fuse.search(searchQueryTrimmed);
-						return new Set(matches.map((match) => match.item.id));
-					})();
 
 		return buckets.map((bucket) => {
 			const filteredTasks = bucket.tasks.filter((task) => matchedTaskIds.has(task.id));
@@ -802,7 +777,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 							type="text"
 							value={searchQuery}
 							onInput={(event) => setSearchQuery((event.target as HTMLInputElement).value)}
-							placeholder="Search by task ID or title"
+							placeholder="Search tasks"
 							aria-label="Search milestones"
 							className="w-full pl-10 pr-10 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-stone-500 dark:focus:ring-stone-400 focus:border-transparent transition-colors duration-200"
 						/>


### PR DESCRIPTION
Stage 2 of the search unification, on top of BACK-649 (#958), which made `src/utils/task-search.ts` the single owner of the Fuse config, the searchable-text builder, and the task filter predicate. This routes the last two surfaces that still searched their own way.

## TUI task viewer

`src/ui/task-viewer-with-search.ts` kept two search paths: an in-memory `createTaskSearchIndex` when the caller passed tasks, and a `SearchService` branch otherwise — with the milestone, `labelMatch: "all"`, and readiness filters re-implemented by hand on top of the service's results because they could not be expressed through it.

It now builds one index over the loaded corpus however that corpus arrived, and `applyFilters` is a single `applyTaskFilters` call. The `hasActiveFilters` short-circuit went with it: an unset filter contributes no check, so the shared predicate already covers the no-filter case.

Two latent inconsistencies disappear as a side effect:

- the `SearchService` branch searched the whole ContentStore, while the unfiltered list rendered the prefix-filtered `allTasks` snapshot, so a query could surface a task the list itself would never show;
- it never re-indexed after an in-session edit, complete, or archive, because the rebuild was guarded on the index that branch did not use.

## Milestones page

`src/web/components/MilestonesPage.tsx` ran a third private Fuse over `id`/`title` with its own weights (0.55/0.45). Deleted; the bucket corpus goes through the shared index.

Shared index rather than `/api/search`: the page filters buckets already built from its `tasks` prop, so an API round trip would only be reconciled back to the same corpus by id, and the filter stays synchronous — no debounce, no loading state.

## User-visible behavior changes

Both are on the milestones page, and both are the shared semantics arriving:

1. **Exact-id-wins is gone.** The page used to short-circuit to exact id matches; a full-id query now also returns the fuzzy id neighbours (searching `task-404` in the test's four-task corpus also matches `task-101`, `task-202`, `task-303`). This is what the TUI and the sidebar already do with the shared threshold — the sidebar just hides it by ranking and slicing to 5, whereas this page uses the result as a set. If the noise is not acceptable, the fix belongs in the shared config for every surface rather than as a local exception here; happy to open that as a follow-up.
2. **Search widened from id + title to the full shared corpus** — description, acceptance criteria, plan, notes, comments, labels, assignees. The placeholder changed from "Search by task ID or title" to "Search tasks" to stop understating it.

Nothing else changes: the TUI's visible filter behavior is identical, and `Board.tsx`'s three-line client-side label display filter was left alone as previously decided — routing the milestones page did not make folding it free.

## Tests

- `src/test/web-milestones-page-search.test.tsx`: the rendered task set equals `createTaskSearchIndex(corpus).search({ query })` for the same query, across six queries including an id query and a no-match query.
- `src/test/task-search-parity.test.ts`: milestone-title, no-milestone, and readiness filters return the same set with and without a query — the three filters the TUI used to hand-roll, where a query was exactly what made them drift.

Combined with the existing shared-index/`SearchService` parity tests in that file, this pins both surfaces to the same results as the CLI, MCP, and web API.

## Verification

- `bunx tsc --noEmit` clean
- `bun run check .` clean
- `bun run test` — 2567 pass, 0 fail

One environment note: the worktree needed a `bun install` first. The shared `node_modules` had `neo-neo-bblessed` 1.0.9 while main locks 1.0.10, which failed three unrelated `tui-emoji-width` tests. No dependency change in this PR.
