### PR TITLE
OSC 52 clipboard fallback for SSH/headless environments

### DIFF
--- a/src/test/clipboard-osc52.test.ts
+++ b/src/test/clipboard-osc52.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { buildOsc52Sequence } from "../utils/clipboard.ts";
+
+describe("buildOsc52Sequence", () => {
+	it("wraps the base64-encoded text in an OSC 52 clipboard sequence", () => {
+		const sequence = buildOsc52Sequence("BACK-123");
+		const payload = Buffer.from("BACK-123", "utf8").toString("base64");
+		expect(sequence).toBe(`\x1b]52;c;${payload}\x07`);
+	});
+
+	it("encodes multi-byte text as UTF-8", () => {
+		const sequence = buildOsc52Sequence("täsk ✓");
+		const payload = Buffer.from("täsk ✓", "utf8").toString("base64");
+		expect(sequence).toBe(`\x1b]52;c;${payload}\x07`);
+	});
+
+	it("returns an empty-payload sequence for empty text", () => {
+		const sequence = buildOsc52Sequence("");
+		expect(sequence).toBe("\x1b]52;c;\x07");
+	});
+
+	it("wraps the sequence in a tmux DCS passthrough with doubled escapes", () => {
+		const payload = Buffer.from("BACK-123", "utf8").toString("base64");
+		const sequence = buildOsc52Sequence("BACK-123", { tmuxPassthrough: true });
+		expect(sequence).toBe(`\x1bPtmux;\x1b\x1b]52;c;${payload}\x07\x1b\\`);
+		expect(sequence.startsWith("\x1bPtmux;")).toBe(true);
+		expect(sequence.endsWith("\x1b\\")).toBe(true);
+	});
+
+	it("omits tmux wrapping when tmuxPassthrough is false", () => {
+		const payload = Buffer.from("BACK-123", "utf8").toString("base64");
+		const sequence = buildOsc52Sequence("BACK-123", { tmuxPassthrough: false });
+		expect(sequence).toBe(`\x1b]52;c;${payload}\x07`);
+	});
+});

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,46 +1,79 @@
 /**
  * Lightweight clipboard utility for copying text to the system clipboard.
- * Supports macOS (pbcopy), Windows (clip.exe), and Linux (xclip/wl-copy/xsel).
+ * Supports macOS (pbcopy), Windows (clip.exe), and Linux (xclip/wl-copy/xsel),
+ * with an OSC 52 escape-sequence fallback so yank still works over SSH in
+ * terminals that support it (kitty, WezTerm, iTerm2, ...).
  */
+
+/**
+ * Build an OSC 52 sequence that asks the terminal to set the system clipboard.
+ * When running inside tmux the sequence must be wrapped in a DCS passthrough
+ * (with embedded ESC bytes doubled) so tmux forwards it to the outer terminal.
+ */
+export function buildOsc52Sequence(text: string, options?: { tmuxPassthrough?: boolean }): string {
+	const payload = Buffer.from(text, "utf8").toString("base64");
+	const sequence = `\x1b]52;c;${payload}\x07`;
+	if (options?.tmuxPassthrough) {
+		return `\x1bPtmux;${sequence.replaceAll("\x1b", "\x1b\x1b")}\x1b\\`;
+	}
+	return sequence;
+}
+
+async function pipeToCommand(cmd: string[], text: string): Promise<boolean> {
+	try {
+		const proc = Bun.spawn(cmd, { stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+		proc.stdin.write(text);
+		await proc.stdin.end();
+		return (await proc.exited) === 0;
+	} catch {
+		return false;
+	}
+}
+
+async function copyViaLocalTool(text: string): Promise<boolean> {
+	const platform = process.platform;
+
+	if (platform === "darwin") {
+		return pipeToCommand(["pbcopy"], text);
+	}
+
+	if (platform === "win32") {
+		return pipeToCommand(["clip.exe"], text);
+	}
+
+	if (platform === "linux") {
+		// Try wl-copy first, then xclip, then xsel
+		const commands = ["wl-copy", "xclip -selection clipboard", "xsel --clipboard --input"];
+		for (const cmdStr of commands) {
+			if (await pipeToCommand(cmdStr.split(" "), text)) return true;
+		}
+	}
+
+	return false;
+}
+
+async function copyViaOsc52(text: string): Promise<boolean> {
+	const insideTmux = Boolean(process.env.TMUX);
+	if (insideTmux) {
+		// tmux forwards the buffer to the outer terminal via OSC 52 when
+		// set-clipboard is enabled; -w requires tmux >= 3.2.
+		if (await pipeToCommand(["tmux", "load-buffer", "-w", "-"], text)) return true;
+	}
+	try {
+		const tty = Bun.file("/dev/tty");
+		await Bun.write(tty, buildOsc52Sequence(text, { tmuxPassthrough: insideTmux }));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export async function copyToClipboard(text: string): Promise<boolean> {
 	try {
-		const platform = process.platform;
-
-		if (platform === "darwin") {
-			const proc = Bun.spawn(["pbcopy"], {
-				stdin: "pipe",
-			});
-			proc.stdin.write(text);
-			await proc.stdin.end();
-			return (await proc.exited) === 0;
-		}
-
-		if (platform === "win32") {
-			const proc = Bun.spawn(["clip.exe"], {
-				stdin: "pipe",
-			});
-			proc.stdin.write(text);
-			await proc.stdin.end();
-			return (await proc.exited) === 0;
-		}
-
-		if (platform === "linux") {
-			// Try wl-copy first, then xclip, then xsel
-			const commands = ["wl-copy", "xclip -selection clipboard", "xsel --clipboard --input"];
-			for (const cmdStr of commands) {
-				const cmd = cmdStr.split(" ");
-				try {
-					const proc = Bun.spawn(cmd, {
-						stdin: "pipe",
-					});
-					proc.stdin.write(text);
-					await proc.stdin.end();
-					if ((await proc.exited) === 0) return true;
-				} catch {}
-			}
-		}
-
-		return false;
+		if (await copyViaLocalTool(text)) return true;
+		// No local clipboard tool worked (e.g. over SSH without a display):
+		// ask the terminal itself to set the clipboard.
+		return await copyViaOsc52(text);
 	} catch (error) {
 		if (process.env.DEBUG) {
 			console.error("Clipboard copy failed:", error);


### PR DESCRIPTION
Implements #947: clipboard fallback via OSC 52 escape sequence when no native OS tool succeeds (e.g., over SSH with no local display).

## Changes
- `src/utils/clipboard.ts`: OSC 52 fallback + tmux passthrough
- `src/test/clipboard-osc52.test.ts`: 6 focused unit tests

## Design
- Local tools (pbcopy/clip.exe/wl-copy/xclip/xsel) unchanged in behavior
- Fallback only after all OS tools return false
- OSC 52 sequence: `\x1b]52;c;<base64>\x07` (BEL-terminated)
- tmux: tries `load-buffer -w` first (3.2+), falls back to passthrough-wrapped write

## Testing
Tests pass locally: `bun test src/test/clipboard-osc52.test.ts` → 5 pass