### PR TITLE
Wire defaultReporter config into task creation

### DIFF
--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1628,6 +1628,9 @@ export class Core {
 		// assignee replaces it entirely, and an explicit empty list means "unassigned".
 		const resolvedAssignees =
 			input.assignee === undefined ? (normalizeStringList(config?.defaultAssignee) ?? []) : normalizedAssignees;
+		// New tasks and drafts pick up the project's configured defaultReporter; there is no
+		// per-task override surface yet (see backlog.md#941), so this is the sole write path.
+		const resolvedReporter = config?.defaultReporter || undefined;
 		const autoCommitEnabled = await this.shouldAutoCommit(autoCommit);
 
 		const { task, write } = await this.withCreateLock(async () => {
@@ -1648,6 +1651,7 @@ export class Core {
 				modifiedFiles: normalizedModifiedFiles,
 				rawContent: input.rawContent ?? "",
 				createdDate,
+				...(resolvedReporter && { reporter: resolvedReporter }),
 				...(dueDate && { dueDate }),
 				...(parentTaskId && { parentTaskId }),
 				...(priority && { priority }),

--- a/src/test/core.test.ts
+++ b/src/test/core.test.ts
@@ -1402,6 +1402,39 @@ describe("Core", () => {
 			const { task } = await core.createTaskFromInput({ title: "No default assignee" }, false);
 			expect(task.assignee).toEqual([]);
 		});
+
+		// createTaskFromInput is the shared create path for every surface (CLI, wizard, TUI, Web, MCP),
+		// so applying defaultReporter here is what keeps the surfaces consistent. There is no
+		// per-task reporter override surface yet, so unlike defaultAssignee this is a one-way default.
+		it("should apply defaultReporter to tasks and drafts created without one", async () => {
+			await initializeTestProject(core, "Default Reporter Project");
+			const config = await core.filesystem.loadConfig();
+			if (!config) throw new Error("Expected config");
+			config.defaultReporter = "@dana";
+			await core.filesystem.saveConfig(config);
+
+			const { task } = await core.createTaskFromInput({ title: "Inherits default reporter" }, false);
+			expect(task.reporter).toBe("@dana");
+
+			const loadedTask = await core.filesystem.loadTask(task.id);
+			expect(loadedTask?.reporter).toBe("@dana");
+
+			const { task: draft } = await core.createTaskFromInput(
+				{ title: "Draft inherits default reporter", status: "Draft" },
+				false,
+			);
+			expect(draft.reporter).toBe("@dana");
+		});
+
+		it("should leave new tasks without a reporter when defaultReporter is unset", async () => {
+			await initializeTestProject(core, "No Default Reporter Project");
+
+			const { task } = await core.createTaskFromInput({ title: "No default reporter" }, false);
+			expect(task.reporter).toBeUndefined();
+
+			const loadedTask = await core.filesystem.loadTask(task.id);
+			expect(loadedTask?.reporter).toBeUndefined();
+		});
 	});
 
 	describe("directory accessor integration", () => {


### PR DESCRIPTION
Implements #941 (option 1): apply existing defaultReporter config value to every newly created task/draft.

## Change
Applies configured `defaultReporter` to every newly created task/draft, matching how `defaultAssignee` already flows through `createTaskFromInput`. No CLI flag or config get/set exposure added (out of scope).

## Files
- `src/core/backlog.ts`: wire config.defaultReporter into createTaskFromInput
- `src/test/core.test.ts`: test cases covering both creation paths (5 expects)

## Testing
- New tests pass: 2/2 (`bun test src/test/core.test.ts -t defaultReporter`)
- Full integration: 68/68 core tests pass

## Precedence
No per-task override surface yet (no input.reporter field), so configured value applies unconditionally to all new tasks/drafts when set.