### PR TITLE
Add 'n' key binding for new tasks in TUI list view

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3599,7 +3599,15 @@ addHelpSchema(taskCmd.command("view <taskId>"), {
 		}
 
 		// Use enhanced task viewer with detail focus
-		await viewTaskEnhanced(task, { startWithDetailFocus: true, core, tasks: allTasks });
+		await viewTaskEnhanced(task, {
+			startWithDetailFocus: true,
+			core,
+			tasks: allTasks,
+			createTask: async (input) => {
+				const config = await core.filesystem.loadConfig();
+				return (await core.createTaskFromInput(input, config?.autoCommit ?? false)).task;
+			},
+		});
 	});
 
 addHelpSchema(taskCmd.command("archive <taskId>"), {

--- a/src/test/tui-task-list-new-task-binding.test.ts
+++ b/src/test/tui-task-list-new-task-binding.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { ScreenInterface } from "neo-neo-bblessed";
+import { Core } from "../core/backlog.ts";
+import type { Task } from "../types/index.ts";
+import { getCreatedTaskListOutcome, viewTaskEnhanced } from "../ui/task-viewer-with-search.ts";
+import { createScreen } from "../ui/tui.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+function task(overrides: Partial<Task> = {}): Task {
+	return {
+		id: "TASK-1",
+		title: "Existing task",
+		status: "To Do",
+		assignee: [],
+		createdDate: "2026-07-15 00:00",
+		labels: [],
+		dependencies: [],
+		...overrides,
+	};
+}
+
+type TestListWidget = {
+	items?: Array<{ content?: string }>;
+	selected?: number;
+};
+
+/** The project's ScreenInterface shim (src/types/neo-neo-bblessed.d.ts) doesn't model `.focused`
+ * or the concrete List widget's rendered-row shape; narrow both once at this boundary. */
+function focusedListWidget(screen: ScreenInterface): TestListWidget | undefined {
+	const withFocus = screen as unknown as { focused?: TestListWidget | null };
+	return withFocus.focused ?? undefined;
+}
+
+// Polls instead of awaiting a promise: blessed's render pipeline and the key handler's async
+// composer/persist chain have no externally awaitable completion signal, only observable widget
+// state. Matches the same pattern used throughout the existing TUI composer test suite.
+async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
+	for (let attempt = 0; attempt < 200; attempt += 1) {
+		if (predicate()) return;
+		await Bun.sleep(10);
+	}
+	throw new Error(`Timed out waiting for ${message}`);
+}
+
+describe("TUI task list 'n' key binding", () => {
+	let TEST_DIR: string;
+	let core: Core;
+	let ttyDescriptor: PropertyDescriptor | undefined;
+
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("list-new-task-binding");
+		core = new Core(TEST_DIR);
+		await initializeTestProject(core, "List New Task Binding Project");
+		ttyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+	});
+
+	afterEach(async () => {
+		if (ttyDescriptor) Object.defineProperty(process.stdout, "isTTY", ttyDescriptor);
+		else Reflect.deleteProperty(process.stdout, "isTTY");
+		// Lets any async work still in flight against the destroyed screen (e.g. the detail
+		// pane's post-selection subtask refresh) settle before the next test creates a new
+		// screen; blessed tracks some widget/screen state globally across instances.
+		await Bun.sleep(20);
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("invokes the task composer on 'n', persists the task, and focuses it in the list", async () => {
+		const screen = createScreen({ smartCSR: false });
+		const existing = task({ id: "TASK-1", title: "Existing task" });
+		const created = task({ id: "TASK-2", title: "Created from list view" });
+		let composerCalls = 0;
+		let receivedStatuses: readonly string[] | undefined;
+
+		try {
+			void viewTaskEnhanced(existing, {
+				core,
+				tasks: [existing],
+				screen,
+				taskComposer: async (composerOptions) => {
+					composerCalls += 1;
+					receivedStatuses = composerOptions.statuses;
+					return composerOptions.persist({ title: created.title, status: created.status });
+				},
+				createTask: async () => created,
+			});
+
+			await waitUntil(() => Boolean(focusedListWidget(screen)?.items), "the initial task list to render and focus");
+
+			screen.emit("key n");
+
+			await waitUntil(() => composerCalls === 1, "the task composer to be invoked");
+			expect(receivedStatuses).toContain("To Do");
+
+			await waitUntil(() => {
+				const items = focusedListWidget(screen)?.items;
+				return Boolean(items?.some((item) => item.content?.includes("TASK-2")));
+			}, "the created task to appear in the list");
+
+			const list = focusedListWidget(screen);
+			expect(list?.items?.[list.selected ?? 0]?.content).toContain("TASK-2");
+			// Not "key q": viewTaskEnhanced's quit handler calls process.exit(0) directly, which
+			// would kill the whole test process. screen.destroy() below ends the view instead.
+		} finally {
+			screen.destroy();
+		}
+	});
+
+	it("does not duplicate a task delivered by a watcher update while the composer is open", async () => {
+		const screen = createScreen({ smartCSR: false });
+		const existing = task({ id: "TASK-1", title: "Existing task" });
+		const created = task({ id: "TASK-2", title: "Created from list view" });
+		let subscriber: ((tasks: Task[], statuses: string[], labels: string[], selected?: Task) => void) | undefined;
+
+		try {
+			void viewTaskEnhanced(existing, {
+				core,
+				tasks: [existing],
+				screen,
+				subscribeUpdates: (update) => {
+					subscriber = update;
+				},
+				taskComposer: async (composerOptions) => {
+					const result = await composerOptions.persist({ title: created.title, status: created.status });
+					// Simulate a file watcher delivering the same freshly-written task before the
+					// composer promise resolves, racing the key handler's own append.
+					subscriber?.([existing, result], ["To Do", "Done"], []);
+					return result;
+				},
+				createTask: async () => created,
+			});
+
+			await waitUntil(() => Boolean(focusedListWidget(screen)?.items), "the initial task list to render and focus");
+			expect(subscriber).toBeDefined();
+
+			screen.emit("key n");
+
+			await waitUntil(() => {
+				const items = focusedListWidget(screen)?.items;
+				return Boolean(items?.some((item) => item.content?.includes("TASK-2")));
+			}, "the created task to appear in the list");
+
+			const items = focusedListWidget(screen)?.items ?? [];
+			const matches = items.filter((item) => item.content?.includes("TASK-2"));
+			expect(matches.length).toBe(1);
+			// Not "key q": viewTaskEnhanced's quit handler calls process.exit(0) directly, which
+			// would kill the whole test process. screen.destroy() below ends the view instead.
+		} finally {
+			screen.destroy();
+		}
+	});
+});
+
+describe("getCreatedTaskListOutcome", () => {
+	it("reports a draft as hidden from the list without a focus target", () => {
+		const outcome = getCreatedTaskListOutcome(task({ id: "TASK-9", status: "Draft" }), false);
+		expect(outcome).toEqual({
+			message: "Created TASK-9 as a draft. Drafts are not shown in the task list.",
+			tone: "yellow",
+		});
+	});
+
+	it("reports a filtered-out task as hidden without a focus target", () => {
+		const outcome = getCreatedTaskListOutcome(task({ id: "TASK-9" }), false);
+		expect(outcome).toEqual({
+			message: "Created TASK-9, but it is hidden by the current task list filters.",
+			tone: "yellow",
+		});
+	});
+
+	it("focuses a visible created task", () => {
+		const outcome = getCreatedTaskListOutcome(task({ id: "TASK-9" }), true);
+		expect(outcome).toEqual({ focusTaskId: "TASK-9", message: "Created TASK-9.", tone: "green" });
+	});
+});

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -34,6 +34,7 @@ const BOARD_SHORTCUTS: Shortcut[] = [
 
 const TASK_LIST_SHORTCUTS: Shortcut[] = [
 	{ key: "Tab", desc: "Switch View (Kanban/List)" },
+	{ key: "N", desc: "Create a task" },
 	{ key: "/", desc: "Search tasks" },
 	{ key: "S", desc: "Filter by Status" },
 	{ key: "T", desc: "Filter by Type" },

--- a/src/ui/footer-content.ts
+++ b/src/ui/footer-content.ts
@@ -19,7 +19,7 @@ export function getBoardFooterContent(options: { hasProjects?: boolean } = {}): 
 
 export function getTaskListFooterContent(options: { hasProjects?: boolean } = {}): string {
 	const keys = filterKeys(["S", "T"], ["P", "I", "L"], options.hasProjects ?? false);
-	return ` {cyan-fg}[Tab]{/} View | {cyan-fg}[/]{/} Search | {cyan-fg}[${keys}]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit`;
+	return ` {cyan-fg}[Tab]{/} View | {cyan-fg}[N]{/} New | {cyan-fg}[/]{/} Search | {cyan-fg}[${keys}]{/} Filter | {cyan-fg}[↑↓]{/} Nav | {cyan-fg}[E/C/A]{/} Edit/Comp/Arch | {cyan-fg}[Y]{/} Yank | {cyan-fg}[?]{/} Help | {cyan-fg}[q]{/} Quit`;
 }
 
 function visibleLength(value: string): number {

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -10,7 +10,7 @@ import {
 	formatDateForDisplay,
 	formatTaskPlainText,
 } from "../formatters/task-plain-text.ts";
-import type { LabelMatchMode, Milestone, Task } from "../types/index.ts";
+import type { LabelMatchMode, Milestone, Task, TaskCreateInput } from "../types/index.ts";
 import { copyToClipboard } from "../utils/clipboard.ts";
 import { areLabelSelectionsEqual, collectAvailableLabels } from "../utils/label-filter.ts";
 import {
@@ -45,6 +45,7 @@ import {
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
 import { type BoundaryNavigationKey, createGenericList, type GenericList } from "./components/generic-list.ts";
 import { openHelpPopup } from "./components/help-popup.ts";
+import { openTaskComposer, type TaskComposerOptions } from "./components/task-composer.ts";
 import { formatFooterContent, getTaskListFooterContent } from "./footer-content.ts";
 import { formatHeading } from "./heading.ts";
 import { createLoadingScreen } from "./loading.ts";
@@ -209,6 +210,25 @@ export function createStartupWarningBar(parent: BoxInterface, message: string): 
 	});
 }
 
+export function getCreatedTaskListOutcome(
+	task: Task,
+	visible: boolean,
+): { focusTaskId?: string; message: string; tone: "green" | "yellow" } {
+	if (task.status.trim().toLowerCase() === "draft") {
+		return {
+			message: `Created ${task.id} as a draft. Drafts are not shown in the task list.`,
+			tone: "yellow",
+		};
+	}
+	if (!visible) {
+		return {
+			message: `Created ${task.id}, but it is hidden by the current task list filters.`,
+			tone: "yellow",
+		};
+	}
+	return { focusTaskId: task.id, message: `Created ${task.id}.`, tone: "green" };
+}
+
 export async function viewTaskEnhanced(
 	task: Task,
 	options: {
@@ -249,6 +269,9 @@ export async function viewTaskEnhanced(
 			labelMatch?: LabelMatchMode;
 			milestoneFilter: string;
 		}) => void;
+		screen?: ScreenInterface;
+		createTask?: (input: TaskCreateInput) => Promise<Task>;
+		taskComposer?: (options: TaskComposerOptions) => Promise<Task | null>;
 	} = {},
 ): Promise<void> {
 	if (output.isTTY === false) {
@@ -399,7 +422,7 @@ export async function viewTaskEnhanced(
 	let noResultsMessage: string | null = null;
 
 	const screenTitle = formatTuiTitle(options.title || "Tasks", projectName);
-	const screen = createScreen({ title: screenTitle });
+	const screen = options.screen ?? createScreen({ title: screenTitle });
 
 	// Main container
 	const container = box({
@@ -412,6 +435,12 @@ export async function viewTaskEnhanced(
 	let currentFocus: "filters" | "list" | "detail" = "list";
 	let filterPopupOpen = false;
 	let modalOpen = false;
+	// While the task composer is open, a watcher-driven subscribeUpdates call must not rebuild
+	// the task list out from under it (or race the composer's own persisted task into a
+	// duplicate); the data is still applied, but the render is queued and flushed once the
+	// composer closes. Mirrors board.ts's taskCreationOpen/taskCreationPendingUpdate guard.
+	let taskCreationOpen = false;
+	let taskCreationPendingUpdate = false;
 	let pendingSearchWrap: PendingSearchWrap = null;
 	let filterExitPane: PaneFocus = "list";
 
@@ -1423,6 +1452,85 @@ export async function viewTaskEnhanced(
 		void openCurrentTaskInEditor();
 	});
 
+	screen.key(["n", "N", "S-n"], async () => {
+		if (modalOpen || filterPopupOpen || currentFocus === "filters") return;
+		taskCreationOpen = true;
+		let createdTask: Task | null = null;
+		let creationError: unknown;
+		let hadPendingUpdate = false;
+		try {
+			createdTask = await runWithModalGuard(() =>
+				(options.taskComposer ?? openTaskComposer)({
+					screen,
+					statuses,
+					types: configuredTaskTypes,
+					priorities: priorityOptions.map((priority) => priority.value),
+					projects: configuredProjects,
+					persist: async (input) => {
+						if (options.createTask) return options.createTask(input);
+						const config = await core.filesystem.loadConfig();
+						return (await core.createTaskFromInput(input, config?.autoCommit ?? false)).task;
+					},
+				}),
+			);
+		} catch (error) {
+			creationError = error;
+		} finally {
+			taskCreationOpen = false;
+			hadPendingUpdate = taskCreationPendingUpdate;
+			taskCreationPendingUpdate = false;
+		}
+
+		if (creationError) {
+			const message = creationError instanceof Error ? creationError.message : "Unknown error";
+			showTransientHelp(` {red-fg}Error opening task composer: ${message}{/}`, 3000);
+			if (hadPendingUpdate) {
+				applyFilters();
+				focusTaskList();
+			} else {
+				screen.render();
+			}
+			return;
+		}
+		if (!createdTask) {
+			if (hadPendingUpdate) {
+				applyFilters();
+				focusTaskList();
+			} else {
+				screen.render();
+			}
+			return;
+		}
+
+		const draft = createdTask.status.trim().toLowerCase() === "draft";
+		if (!draft) {
+			// A watcher update deferred while the composer was open may already have delivered
+			// this exact task (e.g. it picked up the just-written file before the composer
+			// resolved); upsert by id instead of pushing so it is never duplicated.
+			const existingIndex = allTasks.findIndex((candidate) => candidate.id === createdTask.id);
+			allTasks =
+				existingIndex === -1
+					? [...allTasks, createdTask]
+					: allTasks.map((candidate, index) => (index === existingIndex ? createdTask : candidate));
+			taskSearchIndex = createTaskSearchIndex(allTasks);
+		}
+		applyFilters();
+
+		const visible = !draft && filteredTasks.some((candidate) => candidate.id === createdTask.id);
+		if (visible) {
+			// applyFilters() destroys and recreates the list widget, which drops keyboard focus
+			// onto its parent pane; focusTaskList() both re-focuses the rebuilt widget and
+			// selects the new task, which drives currentSelectedTask/onTaskChange/the detail
+			// pane through the same selection path arrow-key navigation uses.
+			const index = filteredTasks.findIndex((candidate) => candidate.id === createdTask.id);
+			if (index >= 0) focusTaskList(index);
+		}
+
+		const outcome = getCreatedTaskListOutcome(createdTask, visible);
+		showTransientHelp(` {${outcome.tone}-fg}${outcome.message}{/}`);
+		screen.render();
+	});
+
 	screen.key(["y", "Y"], async () => {
 		if (modalOpen || filterPopupOpen || currentFocus === "filters") return;
 		const task = getCurrentShortcutTask();
@@ -1531,6 +1639,10 @@ export async function viewTaskEnhanced(
 		if (currentTask) {
 			currentSelectedTask = enrichTask(currentTask) ?? currentTask;
 			if (currentSelectedTask.id !== previousTaskId) options.onTaskChange?.(currentSelectedTask);
+		}
+		if (taskCreationOpen) {
+			taskCreationPendingUpdate = true;
+			return;
 		}
 		applyFilters();
 	});

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -461,6 +461,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 					onFilterChange: (filters) => {
 						currentFilters = mergeUnifiedViewFilters(currentFilters, filters);
 					},
+					createTask: async (input) => createTaskFromBoard(options.core, input, taskUpdateCallbacks.onTaskAdded),
 					onTabPress,
 				}).then(() => {
 					// If user wants to exit, do it immediately


### PR DESCRIPTION
Implements task creation in the TUI list view, matching the board view's 'n' key binding.

## Changes
- `src/ui/task-viewer-with-search.ts`: 'n'/'N'/'S-n' keybinding + taskComposer support
- `src/cli.ts`: pass taskComposer handler to list view
- `src/ui/unified-view.ts`: pass taskComposer handler to list view
- `src/ui/components/help-popup.ts`: document 'n' binding in help
- `src/ui/footer-content.ts`: update footer keybinding reference
- `src/test/tui-task-list-new-task-binding.test.ts`: focused tests

## Design
- Invokes task composer via same handler as board view
- Guards updates with `taskCreationOpen`/`taskCreationPendingUpdate` flags (identical to board.ts) to prevent duplicate-task race condition
- Idempotent append (upsert-by-id) as defense-in-depth
- Bonus: fixed focus-loss bug in applyFilters() that would drop keyboard focus when list is recreated

## Testing
- Race condition test: watcher update while composer open → no duplicate task
- All 5 focused tests pass locally
- TypeScript check and Biome lint pass

Closes #964