### PR TITLE
Configurable TUI task-list pane width

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,6 +139,7 @@ const CONFIG_GET_KEYS = [
 	"definitionOfDone",
 	"dateFormat",
 	"maxColumnWidth",
+	"taskListPaneWidth",
 	"defaultPort",
 	"autoOpenBrowser",
 	"remoteOperations",
@@ -157,6 +158,7 @@ const CONFIG_SET_KEYS = [
 	"defaultStatus",
 	"dateFormat",
 	"maxColumnWidth",
+	"taskListPaneWidth",
 	"autoOpenBrowser",
 	"defaultPort",
 	"remoteOperations",
@@ -4774,7 +4776,7 @@ agentsCmd
 
 // Config command group
 const CONFIG_AVAILABLE_KEYS =
-	"Available keys: defaultEditor, projectName, defaultAssignee, defaultStatus, statuses, labels, priorities, types, projects, milestones, definitionOfDone, dateFormat, maxColumnWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays";
+	"Available keys: defaultEditor, projectName, defaultAssignee, defaultStatus, statuses, labels, priorities, types, projects, milestones, definitionOfDone, dateFormat, maxColumnWidth, taskListPaneWidth, defaultPort, autoOpenBrowser, hideEmptyColumns, remoteOperations, autoCommit, filesystemOnly, bypassGitHooks, zeroPaddedIds, checkActiveBranches, activeBranchDays";
 
 const configCmd = addHelpSchema(program.command("config"), {
 	reads: "Project Backlog.md configuration",
@@ -4936,6 +4938,9 @@ addHelpSchema(configCmd.command("get <key>"), {
 				case "maxColumnWidth":
 					console.log(config.maxColumnWidth?.toString() || "");
 					break;
+				case "taskListPaneWidth":
+					console.log(config.taskListPaneWidth?.toString() || "");
+					break;
 				case "defaultPort":
 					console.log(config.defaultPort?.toString() || "");
 					break;
@@ -5039,6 +5044,15 @@ addHelpSchema(configCmd.command("set <key> <value>"), {
 						process.exit(1);
 					}
 					config.maxColumnWidth = width;
+					break;
+				}
+				case "taskListPaneWidth": {
+					const paneWidth = Number.parseInt(value, 10);
+					if (Number.isNaN(paneWidth) || paneWidth < 10 || paneWidth > 90) {
+						console.error("taskListPaneWidth must be a percentage between 10 and 90");
+						process.exit(1);
+					}
+					config.taskListPaneWidth = paneWidth;
 					break;
 				}
 				case "autoOpenBrowser": {
@@ -5241,6 +5255,7 @@ addHelpSchema(configCmd.command("list"), {
 			console.log(`  definitionOfDone: [${(config.definitionOfDone ?? []).join(", ")}]`);
 			console.log(`  dateFormat: ${config.dateFormat}`);
 			console.log(`  maxColumnWidth: ${config.maxColumnWidth || "(not set)"}`);
+			console.log(`  taskListPaneWidth: ${config.taskListPaneWidth ?? "(not set)"}`);
 			console.log(`  autoOpenBrowser: ${config.autoOpenBrowser ?? "(not set)"}`);
 			console.log(`  hideEmptyColumns: ${config.hideEmptyColumns ?? "(not set)"}`);
 			console.log(`  defaultPort: ${config.defaultPort ?? "(not set)"}`);

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -2121,6 +2121,9 @@ ${description || `Milestone: ${title}`}`,
 				case "max_column_width":
 					config.maxColumnWidth = Number.parseInt(value, 10);
 					break;
+				case "task_list_pane_width":
+					config.taskListPaneWidth = Number.parseInt(value, 10);
+					break;
 				case "default_editor":
 					config.defaultEditor = value.replace(/["']/g, "");
 					break;
@@ -2183,6 +2186,7 @@ ${description || `Milestone: ${title}`}`,
 			defaultStatus: config.defaultStatus,
 			dateFormat: config.dateFormat || "yyyy-mm-dd",
 			maxColumnWidth: config.maxColumnWidth,
+			taskListPaneWidth: config.taskListPaneWidth,
 			defaultEditor: config.defaultEditor,
 			autoOpenBrowser: config.autoOpenBrowser,
 			hideEmptyColumns: config.hideEmptyColumns,
@@ -2223,6 +2227,7 @@ ${description || `Milestone: ${title}`}`,
 				: []),
 			`date_format: ${config.dateFormat}`,
 			...(config.maxColumnWidth ? [`max_column_width: ${config.maxColumnWidth}`] : []),
+			...(typeof config.taskListPaneWidth === "number" ? [`task_list_pane_width: ${config.taskListPaneWidth}`] : []),
 			...(config.defaultEditor ? [`default_editor: "${config.defaultEditor}"`] : []),
 			...(typeof config.autoOpenBrowser === "boolean" ? [`auto_open_browser: ${config.autoOpenBrowser}`] : []),
 			...(typeof config.hideEmptyColumns === "boolean" ? [`hide_empty_columns: ${config.hideEmptyColumns}`] : []),

--- a/src/test/config-commands.test.ts
+++ b/src/test/config-commands.test.ts
@@ -180,6 +180,30 @@ describe("Config commands", () => {
 		expect(listOutput).toContain("hideEmptyColumns: true");
 	});
 
+	it("round-trips taskListPaneWidth through config get/set/list", async () => {
+		const defaultGet = await $`bun ${CLI_PATH} config get taskListPaneWidth`.cwd(TEST_DIR).text();
+		expect(defaultGet.trim()).toBe("");
+
+		await $`bun ${CLI_PATH} config set taskListPaneWidth 55`.cwd(TEST_DIR).quiet();
+
+		const afterSet = await $`bun ${CLI_PATH} config get taskListPaneWidth`.cwd(TEST_DIR).text();
+		expect(afterSet.trim()).toBe("55");
+
+		const listOutput = await $`bun ${CLI_PATH} config list`.cwd(TEST_DIR).text();
+		expect(listOutput).toContain("taskListPaneWidth: 55");
+
+		const reloaded = await new Core(TEST_DIR).filesystem.loadConfig();
+		expect(reloaded?.taskListPaneWidth).toBe(55);
+	});
+
+	it("rejects taskListPaneWidth values outside 10-90", async () => {
+		for (const value of ["5", "95", "abc"]) {
+			const result = await $`bun ${CLI_PATH} config set taskListPaneWidth ${value}`.cwd(TEST_DIR).nothrow().quiet();
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stderr.toString()).toContain("taskListPaneWidth must be a percentage between 10 and 90");
+		}
+	});
+
 	it("parses block-style YAML sequences identically to inline arrays for list keys", () => {
 		const inline = core.filesystem.parseConfig(
 			'project_name: "P"\nstatuses: ["To Do", "Done"]\nlabels: ["a", "b"]\ntypes: ["bug", "epic"]\npriorities: ["Critical", "Low"]\n',

--- a/src/test/task-list-pane-width.test.ts
+++ b/src/test/task-list-pane-width.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_TASK_LIST_PANE_WIDTH, resolveTaskListPaneWidth } from "../ui/task-viewer-with-search.ts";
+
+describe("resolveTaskListPaneWidth", () => {
+	it("defaults to 40 when unset", () => {
+		expect(resolveTaskListPaneWidth(undefined)).toBe(DEFAULT_TASK_LIST_PANE_WIDTH);
+		expect(DEFAULT_TASK_LIST_PANE_WIDTH).toBe(40);
+	});
+
+	it("passes through valid percentages", () => {
+		expect(resolveTaskListPaneWidth(10)).toBe(10);
+		expect(resolveTaskListPaneWidth(55)).toBe(55);
+		expect(resolveTaskListPaneWidth(90)).toBe(90);
+	});
+
+	it("clamps out-of-range values", () => {
+		expect(resolveTaskListPaneWidth(5)).toBe(10);
+		expect(resolveTaskListPaneWidth(95)).toBe(90);
+		expect(resolveTaskListPaneWidth(0)).toBe(10);
+	});
+
+	it("falls back to the default for non-finite values", () => {
+		expect(resolveTaskListPaneWidth(Number.NaN)).toBe(DEFAULT_TASK_LIST_PANE_WIDTH);
+		expect(resolveTaskListPaneWidth(Number.POSITIVE_INFINITY)).toBe(DEFAULT_TASK_LIST_PANE_WIDTH);
+	});
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -337,6 +337,8 @@ export interface BacklogConfig {
 	defaultStatus?: string;
 	dateFormat: string;
 	maxColumnWidth?: number;
+	/** Width of the task-list pane in the TUI list view, as a percentage of the terminal width (10-90). Defaults to 40. */
+	taskListPaneWidth?: number;
 	taskResolutionStrategy?: "most_recent" | "most_progressed";
 	defaultEditor?: string;
 	autoOpenBrowser?: boolean;

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -67,6 +67,14 @@ function getPriorityDisplay(priority?: string): string {
 	}
 }
 
+export const DEFAULT_TASK_LIST_PANE_WIDTH = 40;
+
+/** Clamps a configured task-list pane width to the supported 10-90% range, defaulting when unset. */
+export function resolveTaskListPaneWidth(value: number | undefined): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_TASK_LIST_PANE_WIDTH;
+	return Math.min(90, Math.max(10, Math.round(value)));
+}
+
 export function formatTaskViewerListItem(
 	task: Task,
 	availableWidth = Number.POSITIVE_INFINITY,
@@ -282,6 +290,7 @@ export async function viewTaskEnhanced(
 
 	let dateFormat: string | undefined;
 	let projectName: string | undefined;
+	let taskListPaneWidth = DEFAULT_TASK_LIST_PANE_WIDTH;
 
 	if (options.tasks) {
 		// Tasks already provided - no ContentStore loading
@@ -294,6 +303,7 @@ export async function viewTaskEnhanced(
 		configuredProjects = getProjectValues(config);
 		dateFormat = config?.dateFormat;
 		projectName = config?.projectName;
+		taskListPaneWidth = resolveTaskListPaneWidth(config?.taskListPaneWidth);
 	} else {
 		// Need to load tasks - show loading screen
 		const loadingScreen = await createLoadingScreen("Loading tasks");
@@ -307,6 +317,7 @@ export async function viewTaskEnhanced(
 			configuredProjects = getProjectValues(config);
 			dateFormat = config?.dateFormat;
 			projectName = config?.projectName;
+			taskListPaneWidth = resolveTaskListPaneWidth(config?.taskListPaneWidth);
 
 			loadingScreen?.update("Loading tasks from branches...");
 			contentStore = await core.getContentStore();
@@ -634,12 +645,12 @@ export async function viewTaskEnhanced(
 	// Get dynamic header height
 	const getHeaderHeight = () => filterHeader.getHeight();
 
-	// Task list pane (left 40%)
+	// Task list pane (left side, width configurable via taskListPaneWidth)
 	const taskListPane = box({
 		parent: container,
 		top: getHeaderHeight(),
 		left: 0,
-		width: "40%",
+		width: `${taskListPaneWidth}%`,
 		height: `100%-${getHeaderHeight() + 1}`,
 		border: { type: "line" },
 		style: { border: { fg: "gray" } },
@@ -650,7 +661,7 @@ export async function viewTaskEnhanced(
 	const detailPane = box({
 		parent: container,
 		top: getHeaderHeight(),
-		left: "40%",
+		left: `${taskListPaneWidth}%`,
 		right: 0,
 		height: `100%-${getHeaderHeight() + 1}`,
 		border: { type: "line" },
@@ -692,7 +703,7 @@ export async function viewTaskEnhanced(
 	}
 
 	function getTaskListSummaryWidth(): number {
-		return Math.max(1, Math.floor(getTerminalWidth() * 0.4) - 4);
+		return Math.max(1, Math.floor((getTerminalWidth() * taskListPaneWidth) / 100) - 4);
 	}
 
 	function syncPaneLayout() {

--- a/src/utils/config-watcher.ts
+++ b/src/utils/config-watcher.ts
@@ -27,7 +27,13 @@ const BOOLEAN_CONFIG_KEYS = new Set([
 	"check_active_branches",
 ]);
 const ARRAY_CONFIG_KEYS = new Set(["statuses", "labels", "types", "priorities"]);
-const INTEGER_CONFIG_KEYS = new Set(["max_column_width", "default_port", "zero_padded_ids", "active_branch_days"]);
+const INTEGER_CONFIG_KEYS = new Set([
+	"max_column_width",
+	"task_list_pane_width",
+	"default_port",
+	"zero_padded_ids",
+	"active_branch_days",
+]);
 const RECOGNIZED_CONFIG_KEYS = new Set([
 	"project_name",
 	"default_assignee",
@@ -71,6 +77,7 @@ function hasValidExplicitValues(content: string, config: BacklogConfig): boolean
 			const number = Number(value);
 			if (!/^\d+$/.test(value) || !Number.isSafeInteger(number)) return false;
 			if (key === "max_column_width" && number < 1) return false;
+			if (key === "task_list_pane_width" && (number < 10 || number > 90)) return false;
 			if (key === "default_port" && (number < 1 || number > 65_535)) return false;
 		}
 		if (key === "task_prefix" && !/^[a-zA-Z]+$/.test(value.replace(/['"]/g, ""))) return false;


### PR DESCRIPTION
Implements issue #946: user-configurable task-list/detail split in the TUI, replacing hardcoded 40/60 layout.

## Changes
- `src/types/index.ts`: `taskListPaneWidth` config key
- `src/cli.ts`: get/set/list commands with 10–90% validation
- `src/file-system/operations.ts`: parseConfig/serializeConfig round-trip
- `src/utils/config-watcher.ts`: external-edit guard for range validation
- `src/ui/task-viewer-with-search.ts`: wired to list/detail pane split + summary-width calculation
- `src/test/task-list-pane-width.test.ts`: defaults, clamping, NaN/Infinity fallback
- `src/test/config-commands.test.ts`: CLI validation and round-trip tests

## Usage
```bash
backlog config set taskListPaneWidth 75  # Set to 75% of terminal width
backlog config get taskListPaneWidth     # Retrieve current value
```

## Testing
- New unit tests: 4 pass (defaults, clamping, fallback)
- Config integration tests: new cases pass
- Range validation: 10–90% enforced, clamped beyond range
- Verified via `bun src/cli.ts task list` in real project: split renders at configured percentage after window resize and tab-switch

Closes #946