### PR TITLE
BACK-642 - Show acceptance criteria progress in MCP and plain task lists

### DIFF
--- a/backlog/tasks/back-642 - Show-acceptance-criteria-progress-in-MCP-and-plain-task-lists.md
+++ b/backlog/tasks/back-642 - Show-acceptance-criteria-progress-in-MCP-and-plain-task-lists.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-642
 title: Show acceptance criteria progress in MCP and plain task lists
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-29 17:53'
-updated_date: '2026-08-30 15:18'
+updated_date: '2026-08-30 15:34'
 labels:
   - cli
   - mcp
@@ -21,17 +21,17 @@ External tools can already read per-task acceptance criteria progress from `back
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 MCP task list summary lines include acceptance criteria progress as completed/total for each task that has criteria
-- [ ] #2 `backlog task list --plain` includes the same completed/total progress per task
-- [ ] #3 Tasks without acceptance criteria render without progress noise, consistently across both surfaces
-- [ ] #4 Automated tests cover MCP list and plain list output with and without acceptance criteria
+- [x] #1 MCP task list summary lines include acceptance criteria progress as completed/total for each task that has criteria
+- [x] #2 `backlog task list --plain` includes the same completed/total progress per task
+- [x] #3 Tasks without acceptance criteria render without progress noise, consistently across both surfaces
+- [x] #4 Automated tests cover MCP list and plain list output with and without acceptance criteria
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -47,4 +47,12 @@ External tools can already read per-task acceptance criteria progress from `back
 
 <!-- SECTION:NOTES:BEGIN -->
 Added shared formatAcceptanceCriteriaSummarySuffix in src/ui/acceptance-criteria-progress.ts and wired it into formatPlainTaskListRow (cli.ts) and MCP formatTaskSummaryLine. Tests added in cli-task-list.test.ts and mcp-tasks.test.ts (with/without criteria). tsc and biome clean; full suite running.
+
+Validation: bunx tsc --noEmit clean; bun run check . clean; bun test src/test/cli-task-list.test.ts src/test/mcp-tasks.test.ts 55 pass / 0 fail. Full suite: only pre-existing failures remain (tui-emoji-width fails identically on origin/main - BACK-657 glyph environment issue; web modal/server tests flaky under full-suite load, pass in isolation). Real-data smoke: plain list shows '(ac: 0/4)' style after status, tasks without criteria unchanged.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added a shared formatAcceptanceCriteriaSummarySuffix helper (src/ui/acceptance-criteria-progress.ts) that renders ' (ac: checked/total)' only when a task has acceptance criteria, and appended it to the CLI plain list row (formatPlainTaskListRow in src/cli.ts) and the MCP summary line (formatTaskSummaryLine in src/mcp/tools/tasks/handlers.ts), after the status suffix. Tasks without criteria render unchanged on both surfaces; task list --json untouched. Verified with new tests in cli-task-list.test.ts and mcp-tasks.test.ts covering with/without criteria (55 pass), tsc, Biome, and a real-project smoke run.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-642 - Show-acceptance-criteria-progress-in-MCP-and-plain-task-lists.md
+++ b/backlog/tasks/back-642 - Show-acceptance-criteria-progress-in-MCP-and-plain-task-lists.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-642
 title: Show acceptance criteria progress in MCP and plain task lists
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-29 17:53'
+updated_date: '2026-08-30 15:18'
 labels:
   - cli
   - mcp
@@ -31,3 +33,18 @@ External tools can already read per-task acceptance criteria progress from `back
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add shared helper formatAcceptanceCriteriaSummarySuffix(task) in src/ui/acceptance-criteria-progress.ts returning ' (ac: checked/total)' when the task has acceptance criteria, empty string otherwise (no status gate; lists show progress for any task with criteria).
+2. Append the suffix in the CLI plain list row formatter (formatPlainTaskListRow in src/cli.ts) and the MCP list summary line (formatTaskSummaryLine in src/mcp/tools/tasks/handlers.ts), after the status suffix. Keep the two line formatters separate; only the AC fragment is shared. Do not touch formatTaskPlainText or task detail output (PR #960 overlap).
+3. Add tests in src/test/cli-task-list.test.ts and src/test/mcp-tasks.test.ts covering list output with and without criteria on both surfaces.
+4. Leave task list --json unchanged. Verify with bunx tsc --noEmit, bun run check ., bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added shared formatAcceptanceCriteriaSummarySuffix in src/ui/acceptance-criteria-progress.ts and wired it into formatPlainTaskListRow (cli.ts) and MCP formatTaskSummaryLine. Tests added in cli-task-list.test.ts and mcp-tasks.test.ts (with/without criteria). tsc and biome clean; full suite running.
+<!-- SECTION:NOTES:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,7 @@ import {
 	type TaskUpdateInput,
 } from "./types/index.ts";
 import type { TaskEditArgs } from "./types/task-edit-args.ts";
+import { formatAcceptanceCriteriaSummarySuffix } from "./ui/acceptance-criteria-progress.ts";
 import { genericSelectList } from "./ui/components/generic-list.ts";
 import { createLoadingScreen } from "./ui/loading.ts";
 import { viewTaskEnhanced } from "./ui/task-viewer-with-search.ts";
@@ -305,8 +306,9 @@ function formatPlainTaskListRow(task: Task, options: { includeStatus?: boolean }
 	const priorityIndicator = task.priority ? `[${task.priority.toUpperCase()}] ` : "";
 	const typeIndicator = task.type ? `[${task.type}] ` : "";
 	const statusIndicator = options.includeStatus && task.status ? ` (${task.status})` : "";
+	const acceptanceCriteria = formatAcceptanceCriteriaSummarySuffix(task);
 	const dueDate = task.dueDate ? ` (due ${formatUtcDateForDisplay(task.dueDate, { appendUtcLabel: true })})` : "";
-	return `  ${priorityIndicator}${typeIndicator}${task.id} - ${task.title}${statusIndicator}${dueDate}`;
+	return `  ${priorityIndicator}${typeIndicator}${task.id} - ${task.title}${statusIndicator}${acceptanceCriteria}${dueDate}`;
 }
 
 async function normalizeCliStatusList(core: Core, values: string[], optionName: string): Promise<string[] | null> {

--- a/src/mcp/tools/tasks/handlers.ts
+++ b/src/mcp/tools/tasks/handlers.ts
@@ -9,6 +9,7 @@ import {
 	type TaskListFilter,
 } from "../../../types/index.ts";
 import type { TaskEditArgs, TaskEditRequest } from "../../../types/task-edit-args.ts";
+import { formatAcceptanceCriteriaSummarySuffix } from "../../../ui/acceptance-criteria-progress.ts";
 import { formatDuplicateTaskIdWarning } from "../../../utils/duplicate-detection.ts";
 import {
 	createMilestoneFilterValueResolver,
@@ -106,8 +107,9 @@ export class TaskHandlers {
 		const projectIndicator = task.project ? `[${task.project}] ` : "";
 		const status = task.status || (task.source === "completed" ? "Done" : "");
 		const statusText = options.includeStatus && status ? ` (${status})` : "";
+		const acceptanceCriteria = formatAcceptanceCriteriaSummarySuffix(task);
 		const dueDate = task.dueDate ? ` (due ${formatUtcDateForDisplay(task.dueDate, { appendUtcLabel: true })})` : "";
-		return `  ${priorityIndicator}${typeIndicator}${projectIndicator}${task.id} - ${task.title}${statusText}${dueDate}`;
+		return `  ${priorityIndicator}${typeIndicator}${projectIndicator}${task.id} - ${task.title}${statusText}${acceptanceCriteria}${dueDate}`;
 	}
 
 	private async loadTaskOrThrow(id: string): Promise<Task> {

--- a/src/test/cli-task-list.test.ts
+++ b/src/test/cli-task-list.test.ts
@@ -137,6 +137,48 @@ describe("CLI Integration", () => {
 			expect(out).not.toContain("TASK-1");
 		});
 
+		it("should show acceptance criteria progress only for tasks with criteria", async () => {
+			const core = new Core(TEST_DIR);
+
+			await core.createTask(
+				{
+					id: "task-1",
+					title: "Task With Criteria",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					rawContent: "Task with acceptance criteria",
+					acceptanceCriteriaItems: [
+						{ index: 1, text: "First criterion", checked: true },
+						{ index: 2, text: "Second criterion", checked: false },
+						{ index: 3, text: "Third criterion", checked: false },
+					],
+				},
+				false,
+			);
+			await core.createTask(
+				{
+					id: "task-2",
+					title: "Task Without Criteria",
+					status: "To Do",
+					assignee: [],
+					createdDate: "2025-06-08",
+					labels: [],
+					dependencies: [],
+					rawContent: "Task without acceptance criteria",
+				},
+				false,
+			);
+
+			const result = await $`bun ${CLI_PATH} task list --plain`.cwd(TEST_DIR).quiet();
+			const out = result.stdout.toString();
+			expect(out).toContain("TASK-1 - Task With Criteria (ac: 1/3)");
+			expect(out).toContain("TASK-2 - Task Without Criteria");
+			expect(out).not.toContain("Task Without Criteria (ac:");
+		});
+
 		it("should filter tasks by status case-insensitively", async () => {
 			const core = new Core(TEST_DIR);
 

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -137,6 +137,36 @@ describe("MCP task tools (MVP)", () => {
 		expect(searchText).not.toContain("Implementation Plan:");
 	});
 
+	it("shows acceptance criteria progress in task_list only for tasks with criteria", async () => {
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Task with criteria",
+					acceptanceCriteria: ["First criterion", "Second criterion", "Third criterion"],
+				},
+			},
+		});
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: { id: "TASK-1", acceptanceCriteriaCheck: [1] },
+			},
+		});
+		await mcpServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Task without criteria" } },
+		});
+
+		const listResult = await mcpServer.testInterface.callTool({
+			params: { name: "task_list", arguments: {} },
+		});
+
+		const listText = getText(listResult.content);
+		expect(listText).toContain("TASK-1 - Task with criteria (ac: 1/3)");
+		expect(listText).toContain("TASK-2 - Task without criteria");
+		expect(listText).not.toContain("Task without criteria (ac:");
+	});
+
 	it("creates, reports, edits, and clears dueDate", async () => {
 		const tools = await mcpServer.testInterface.listTools();
 		const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));

--- a/src/ui/acceptance-criteria-progress.ts
+++ b/src/ui/acceptance-criteria-progress.ts
@@ -10,6 +10,15 @@ function isInProgress(status: string): boolean {
 	return status.trim().toLowerCase() === "in progress";
 }
 
+/** Format a " (ac: checked/total)" suffix for plain and MCP task list lines; empty without criteria. */
+export function formatAcceptanceCriteriaSummarySuffix(task: Task): string {
+	const criteria = task.acceptanceCriteriaItems ?? [];
+	if (criteria.length === 0) return "";
+
+	const checked = criteria.filter((criterion) => criterion.checked).length;
+	return ` (ac: ${checked}/${criteria.length})`;
+}
+
 /** Format live acceptance-criteria completion for one-line TUI task summaries. */
 export function formatAcceptanceCriteriaProgress(task: Task, availableWidth = Number.POSITIVE_INFINITY): string {
 	const criteria = task.acceptanceCriteriaItems ?? [];


### PR DESCRIPTION
Closes the last two list surfaces that hid acceptance-criteria progress: MCP `task_list` summary lines and `backlog task list --plain` now show ` (ac: checked/total)` for every task that has criteria, matching the counts already exposed by `task list --json` and rendered by the TUI/web.

## Changes
- New shared helper `formatAcceptanceCriteriaSummarySuffix` in `src/ui/acceptance-criteria-progress.ts` (the existing AC-progress formatting module): returns ` (ac: 1/3)` when a task has criteria, empty string otherwise.
- `formatPlainTaskListRow` (`src/cli.ts`) and `formatTaskSummaryLine` (`src/mcp/tools/tasks/handlers.ts`) append the suffix after the status indicator. Tasks without criteria render exactly as before on both surfaces.
- `task list --json` (`acceptanceCriteriaCompleted`/`acceptanceCriteriaCount`) unchanged.
- No changes to `formatTaskPlainText` or task-detail output (avoids overlap with #960).

## Example
```
In Progress:
  [MEDIUM] BACK-636 - Fail closed on ambiguous draft identities (ac: 0/4)
  BACK-649 - Single-source task search config and filters in core (ac: 4/4)
```

## Verification
- New tests: `cli-task-list.test.ts` (plain list with/without criteria) and `mcp-tasks.test.ts` (`task_list` with checked/unchecked/no criteria) — 55 pass across both files.
- `bunx tsc --noEmit`, `bun run check .` clean.
- Full `bun run test`: only pre-existing failures remain — `tui-emoji-width` fails identically on `origin/main` (glyph environment issue, BACK-657); web-modal/server tests are flaky under full-suite load and pass in isolation.