### PR TITLE
BACK-657 - Make the TUI acceptance-criteria bar degrade gracefully without Block Element glyphs

### DIFF
--- a/backlog/tasks/back-657 - Make-the-TUI-acceptance-criteria-bar-degrade-gracefully-without-Block-Element-glyphs.md
+++ b/backlog/tasks/back-657 - Make-the-TUI-acceptance-criteria-bar-degrade-gracefully-without-Block-Element-glyphs.md
@@ -3,9 +3,11 @@ id: BACK-657
 title: >-
   Make the TUI acceptance-criteria bar degrade gracefully without Block Element
   glyphs
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-30 13:19'
+updated_date: '2026-08-30 15:40'
 labels:
   - tui
   - bug
@@ -21,14 +23,36 @@ src/ui/acceptance-criteria-progress.ts:22 builds the list/board progress bar fro
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The progress bar renders a visibly filled bar on terminals whose font lacks Block Element glyphs
-- [ ] #2 Rendering in a UTF-8-capable terminal with full fonts is unchanged or better
-- [ ] #3 A test pins the emitted characters
+- [x] #1 The progress bar renders a visibly filled bar on terminals whose font lacks Block Element glyphs
+- [x] #2 Rendering in a UTF-8-capable terminal with full fonts is unchanged or better
+- [x] #3 A test pins the emitted characters
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Research: confirmed in neo-neo-bblessed lib/widgets/screen.ts (draw) that only DEC Special Graphics chars (tput.acscr) are ACS-routed; U+2588/U+2591 are in neither acscr nor the utoa ASCII fallback, so fonts without Block Elements show blanks and non-UTF-8 locales show '?'.
+2. Decision: use plain ASCII '#' (filled) and '-' (empty) instead of ACS-routed glyphs. Rationale: the only DEC fill glyph is the checkerboard U+2592, which utoa maps to a space on broken/absent-ACS terminals (bar would vanish) and reads as half-shade; ASCII is below '~' so it bypasses every charset translation and renders identically on all terminals, fonts, and locales.
+3. Change the bar characters in src/ui/acceptance-criteria-progress.ts only (BACK-652 covers the web component; PR #945 owns board.ts).
+4. Update src/test/tui-acceptance-criteria-progress.test.ts to pin the emitted characters.
+5. Verify: bunx tsc --noEmit, bun run check ., bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Chose plain ASCII '#'/'-' over ACS-routed glyphs: the only DEC fill glyph (U+2592 checkerboard, ACS 'a') falls back to a *space* via blessed's utoa table on broken/absent-ACS terminals, so an ACS bar would vanish on exactly the degraded terminals this task targets; ASCII stays below '~' and bypasses every charset translation in neo-neo-bblessed screen draw, rendering identically on all terminals, fonts, and locales. Verification: bunx tsc --noEmit clean; bun run check . clean; full bun run test 2568 pass / 0 fail (one unrelated flake in an early run did not reproduce twice). Test pins exact bars ([######----] 4/7, [###--] 4/7, [#######---] 5/7, [##########] 2/2) plus an ASCII-only regex over varied widths/ratios. src/ui/root-entry.ts splash logo also uses Block Elements but is decorative and out of scope.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced the raw U+2588/U+2591 bar cells in src/ui/acceptance-criteria-progress.ts with ASCII '#' (filled) and '-' (empty), so the list/board acceptance-criteria bar renders a visibly filled bar on any terminal font or locale instead of blank cells or question marks. Verified with pinned-character tests in src/test/tui-acceptance-criteria-progress.test.ts and green tsc, biome, and full bun test runs.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/tui-acceptance-criteria-progress.test.ts
+++ b/src/test/tui-acceptance-criteria-progress.test.ts
@@ -31,10 +31,27 @@ describe("TUI acceptance-criteria progress", () => {
 	it("renders the exact wide and constrained bars from live checklist state", () => {
 		const task = makeTask();
 
-		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[██████░░░░] 4/7");
-		expect(formatAcceptanceCriteriaProgress(task, 39)).toBe("[███░░] 4/7");
+		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[######----] 4/7");
+		expect(formatAcceptanceCriteriaProgress(task, 39)).toBe("[###--] 4/7");
 		if (task.acceptanceCriteriaItems?.[4]) task.acceptanceCriteriaItems[4].checked = true;
-		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[███████░░░] 5/7");
+		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[#######---] 5/7");
+	});
+
+	it("emits only ASCII bar characters so terminals without Block Element glyphs stay legible", () => {
+		// blessed only ACS-routes DEC Special Graphics; U+2588/U+2591 would render
+		// as blank cells on fonts without Block Elements and as "?" without UTF-8.
+		for (const [total, checked, width] of [
+			[7, 4, 40],
+			[7, 4, 39],
+			[10, 0, 40],
+			[3, 3, 20],
+		] as const) {
+			const bar = formatAcceptanceCriteriaProgress(
+				makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }),
+				width,
+			);
+			expect(bar).toMatch(/^\[[#-]*\] \d+\/\d+$/);
+		}
 	});
 
 	it("omits progress when criteria are absent or the task is not in progress", () => {
@@ -48,12 +65,12 @@ describe("TUI acceptance-criteria progress", () => {
 		const progress = formatAcceptanceCriteriaProgress(task, 40);
 		const listItem = stripBlessedFgTags(formatTaskViewerListItem(task, 40));
 
-		expect(progress).toBe("[██████████] 2/2");
+		expect(progress).toBe("[##########] 2/2");
 		expect(progress).not.toContain("AC");
 		expect(progress).not.toContain("%");
 		expect(progress).not.toContain("{");
 		expect(task.status).toBe("In Progress");
-		expect(listItem).toContain("◒ [██████████] 2/2");
+		expect(listItem).toContain("◒ [##########] 2/2");
 		expect(listItem).not.toContain("✔");
 	});
 
@@ -61,7 +78,7 @@ describe("TUI acceptance-criteria progress", () => {
 		const task = makeTask({ status: " IN PROGRESS " });
 		const listItem = stripBlessedFgTags(formatTaskViewerListItem(task, 40));
 
-		expect(listItem).toContain("◒ [██████░░░░] 4/7");
+		expect(listItem).toContain("◒ [######----] 4/7");
 	});
 
 	it("reuses the same responsive indicator in board cards and task-list summaries", () => {
@@ -70,8 +87,8 @@ describe("TUI acceptance-criteria progress", () => {
 		const compactBoardCard = stripBlessedFgTags(formatTaskListItem(task, false, 20));
 		const compactListItem = stripBlessedFgTags(formatTaskViewerListItem(task, 20));
 
-		expect(wideBoardCard).toContain("[██████░░░░] 4/7 {bold}BACK-551{/bold}");
-		expect(compactBoardCard).toContain("[███░░] 4/7 {bold}BACK-551{/bold}");
-		expect(compactListItem).toContain("◒ [███░░] 4/7 {bold}BACK-551{/bold}");
+		expect(wideBoardCard).toContain("[######----] 4/7 {bold}BACK-551{/bold}");
+		expect(compactBoardCard).toContain("[###--] 4/7 {bold}BACK-551{/bold}");
+		expect(compactListItem).toContain("◒ [###--] 4/7 {bold}BACK-551{/bold}");
 	});
 });

--- a/src/ui/acceptance-criteria-progress.ts
+++ b/src/ui/acceptance-criteria-progress.ts
@@ -6,6 +6,13 @@ const WIDE_PROGRESS_MIN_WIDTH = 40;
 const WIDE_PROGRESS_CELLS = 10;
 const COMPACT_PROGRESS_CELLS = 5;
 
+// Plain ASCII on purpose: blessed only guarantees glyph fallback for DEC Special
+// Graphics (box drawing), so Block Elements like U+2588/U+2591 render as blank
+// cells when the terminal font lacks them and as "?" without a UTF-8 locale.
+// ASCII stays below "~" and bypasses every charset translation.
+const FILLED_CELL = "#";
+const EMPTY_CELL = "-";
+
 function isInProgress(status: string): boolean {
 	return status.trim().toLowerCase() === "in progress";
 }
@@ -19,5 +26,5 @@ export function formatAcceptanceCriteriaProgress(task: Task, availableWidth = Nu
 	const cells = availableWidth >= WIDE_PROGRESS_MIN_WIDTH ? WIDE_PROGRESS_CELLS : COMPACT_PROGRESS_CELLS;
 	const filled = Math.round((checked / criteria.length) * cells);
 
-	return `[${"█".repeat(filled)}${"░".repeat(cells - filled)}] ${checked}/${criteria.length}`;
+	return `[${FILLED_CELL.repeat(filled)}${EMPTY_CELL.repeat(cells - filled)}] ${checked}/${criteria.length}`;
 }


### PR DESCRIPTION
## Summary
- The list/board acceptance-criteria progress bar was built from raw U+2588 FULL BLOCK and U+2591 LIGHT SHADE. blessed only guarantees fallback for DEC Special Graphics (box drawing) via the ACS charset, so a terminal font lacking Block Elements drew the bar as blank cells (maintainer-observed: a 9/10 bar rendered empty), and without a UTF-8 locale every cell became `?`.
- The bar now uses plain ASCII: `#` for filled cells and `-` for empty ones, e.g. `[######----] 4/7`.

## Why ASCII instead of ACS-routed glyphs
The only fill-like glyph in the DEC Special Graphics set is the checkerboard U+2592 (ACS `a`). On terminals with broken or absent ACS, blessed falls back to its `utoa` table, which maps U+2592 to a **space** — the bar would vanish on exactly the degraded terminals this fix targets, and it reads as a half-shade rather than filled. ASCII stays below `~`, so it bypasses every charset translation in `neo-neo-bblessed`'s screen draw and renders identically on all terminals, fonts, and locales.

## Scope
- Only `src/ui/acceptance-criteria-progress.ts` and its test change (the web `AcceptanceCriteriaProgress` component is tracked separately as BACK-652; `src/ui/board.ts` untouched to avoid overlap with #945).

## Verification
- `bunx tsc --noEmit` clean
- `bun run check .` clean
- `bun run test`: 2568 pass, 0 fail
- Tests pin the exact emitted characters and an ASCII-only shape (`/^\[[#-]*\] \d+\/\d+$/`) across widths and ratios.