### PR TITLE
BACK-655 - Open task details in place from sidebar dependency chips

### DIFF
--- a/backlog/tasks/back-655 - Open-task-details-in-place-from-sidebar-dependency-chips.md
+++ b/backlog/tasks/back-655 - Open-task-details-in-place-from-sidebar-dependency-chips.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-655
 title: Open task details in place from sidebar dependency chips
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-30 12:21'
+updated_date: '2026-08-30 15:41'
 labels:
   - web
   - bug
@@ -19,15 +21,42 @@ Task links in the web sidebar dependency chips (DependencyInput.tsx:132) hardcod
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Clicking a dependency chip from the board opens the task detail while staying on the board
-- [ ] #2 Clicking one from All Tasks behaves as today
-- [ ] #3 External deep links to /tasks/<id> still resolve
-- [ ] #4 A test pins the stay-on-page behavior for the board path
+- [x] #1 Clicking a dependency chip from the board opens the task detail while staying on the board
+- [x] #2 Clicking one from All Tasks behaves as today
+- [x] #3 External deep links to /tasks/<id> still resolve
+- [x] #4 A test pins the stay-on-page behavior for the board path
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reuse the established in-place navigation pattern: App.tsx handleEditTask (and BACK-548 graph links) derive the task-detail base path from the current location ('/board' vs '/tasks'). PR #960's useTaskHref hook is not on main yet, so implement the same derivation locally in DependencyInput via useLocation, shaped so #960's hook can absorb it trivially later.
+2. In DependencyInput.tsx replace the hardcoded /tasks/<id> chip href with <base>/<id> where base is '/board' when location.pathname starts with /board, otherwise '/tasks' (canonical fallback keeps today's behavior on other pages and for external deep links; routes are untouched).
+3. Extend src/test/web-dependency-input-links.test.tsx: pin that a chip rendered under /board links to /board/<id> (stay-on-board) and under /tasks keeps /tasks/<id>; existing tests pin the default fallback.
+4. Verify: bunx tsc --noEmit, bun run check ., bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the hardcoded /tasks/<id> chip href in DependencyInput.tsx with a location-derived base path: '/board' when the reader is on the board, otherwise the canonical '/tasks' (fallback keeps today's behavior on other pages and leaves external /tasks/<id> deep links untouched). This mirrors App.tsx handleEditTask's base-path derivation, the same pattern the BACK-548 graph/parent/subtask navigation uses.
+
+Consolidation note: PR #960 (unmerged) introduces a useTaskHref hook with this exact derivation for graph links. That hook is not on main yet, so this fix implements the logic locally (one useLocation + one ternary inside DependencyInput); when #960 lands, the chip href can trivially switch to useTaskHref by deleting the local derivation. Nothing was cherry-picked from the #960 branch and TaskDetailsModal was not touched.
+
+Tests: extended src/test/web-dependency-input-links.test.tsx - chips rendered under /board link within /board (stay-on-board, AC #4), chips under /tasks keep /tasks hrefs, and the existing default-route tests pin the /tasks fallback.
+
+Refinement: the first cut called useLocation at DependencyInput's top level, which broke 53 existing TaskDetailsModal tests that render without a Router (previously safe because Link only mounts when a chip resolves). Moved the derivation into a local TaskChipLink subcomponent inside DependencyInput.tsx, so router context is only required exactly where a link renders - same contract as before. All previously failing web suites pass again; the 3 tui-emoji-width failures in the local run reproduce on a pristine origin/main worktree (environment-related, pre-existing, unrelated to this change).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Dependency chips in the task-detail sidebar now open tasks in place: DependencyInput's chip link derives its base path from the current location ('/board' when reading from the board, canonical '/tasks' everywhere else) via a local TaskChipLink subcomponent that mirrors App.tsx handleEditTask's derivation - the same pattern as the BACK-548 parent/subtask navigation. PR #960's unmerged useTaskHref hook can absorb the derivation trivially once it lands; nothing was cherry-picked and TaskDetailsModal was untouched. Verified: new tests in web-dependency-input-links.test.tsx pin /board chips staying on /board (AC 1, 4) and /tasks chips unchanged (AC 2); routes untouched and default-route tests pin the /tasks fallback so external deep links resolve (AC 3); bunx tsc --noEmit, bun run check ., and full bun test green (2566 pass; only 3 tui-emoji-width failures that reproduce identically on pristine origin/main).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-655 - Open-task-details-in-place-from-sidebar-dependency-chips.md
+++ b/backlog/tasks/back-655 - Open-task-details-in-place-from-sidebar-dependency-chips.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-30 12:21'
-updated_date: '2026-08-30 15:41'
+updated_date: '2026-08-30 15:49'
 labels:
   - web
   - bug
@@ -53,6 +53,8 @@ Consolidation note: PR #960 (unmerged) introduces a useTaskHref hook with this e
 Tests: extended src/test/web-dependency-input-links.test.tsx - chips rendered under /board link within /board (stay-on-board, AC #4), chips under /tasks keep /tasks hrefs, and the existing default-route tests pin the /tasks fallback.
 
 Refinement: the first cut called useLocation at DependencyInput's top level, which broke 53 existing TaskDetailsModal tests that render without a Router (previously safe because Link only mounts when a chip resolves). Moved the derivation into a local TaskChipLink subcomponent inside DependencyInput.tsx, so router context is only required exactly where a link renders - same contract as before. All previously failing web suites pass again; the 3 tui-emoji-width failures in the local run reproduce on a pristine origin/main worktree (environment-related, pre-existing, unrelated to this change).
+
+Review follow-up (Codex threads on PR #968), both confirmed real and fixed: (1) chip hrefs now carry the page's query string so URL-backed board/task-list filters (lane, milestone, status, assignee) survive opening a dependency - verified against BoardPage/TaskList useSearchParams and handleCloseModal returning to base+search; (2) TaskChipLink now fully mirrors handleEditTask's navigation: it replaces an already-open task route and carries the existing taskModalFrom state forward (or seeds it with base+search from a plain base page), so closing the opened dependency returns to the board instead of leaving the previous task in history. Kept as a Link (not onNavigateToTask) deliberately: the modal's unsaved-edits confirm intercepts a[href] links, and threading the callback through TaskDetailsModal would overlap PR #960. Tests: SSR test pins query preservation in the href; a client-render test clicks a chip on /board/BACK-20?lane=milestone and asserts the landing location, carried taskModalFrom, and that Back returns to /board (replace semantics).
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/test/web-dependency-input-links.test.tsx
+++ b/src/test/web-dependency-input-links.test.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
 import type { Task } from "../types/index.ts";
 import DependencyInput from "../web/components/DependencyInput.tsx";
 
@@ -49,6 +51,76 @@ describe("DependencyInput dependency chips", () => {
 		const link = rendered.querySelector('a[href="/tasks/BACK-10"]');
 
 		expect(link).toBeTruthy();
+	});
+
+	it("carries the page's query string so URL-backed board filters survive", () => {
+		const rendered = renderChips(["BACK-10"], availableTasks, "/board/BACK-20?lane=milestone&milestone=v2");
+
+		// JSDOM's selector engine cannot match attribute values containing "&", so read the href directly.
+		expect(rendered.querySelector("a")?.getAttribute("href")).toBe("/board/BACK-10?lane=milestone&milestone=v2");
+	});
+
+	it("replaces an open task route and preserves its taskModalFrom return context", async () => {
+		const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+			url: "http://localhost",
+		});
+		(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+		globalThis.window = dom.window as unknown as Window & typeof globalThis;
+		globalThis.document = dom.window.document as Document;
+		globalThis.navigator = dom.window.navigator as Navigator;
+
+		const observed: { current: { pathname: string; search: string; state: unknown } | null } = { current: null };
+		const goBack: { current: (() => void) | null } = { current: null };
+		const LocationProbe = () => {
+			const location = useLocation();
+			const navigate = useNavigate();
+			observed.current = { pathname: location.pathname, search: location.search, state: location.state };
+			goBack.current = () => navigate(-1);
+			return null;
+		};
+
+		const container = document.getElementById("root") as HTMLElement;
+		const root = createRoot(container);
+		await act(async () => {
+			root.render(
+				<MemoryRouter
+					initialEntries={[
+						"/board?lane=milestone",
+						{ pathname: "/board/BACK-20", search: "?lane=milestone", state: { taskModalFrom: "/board?lane=milestone" } },
+					]}
+					initialIndex={1}
+				>
+					<DependencyInput value={["BACK-10"]} onChange={() => {}} availableTasks={availableTasks} />
+					<LocationProbe />
+				</MemoryRouter>,
+			);
+			await Promise.resolve();
+		});
+
+		const chip = container.querySelector('a[href="/board/BACK-10?lane=milestone"]') as HTMLAnchorElement | null;
+		expect(chip).toBeTruthy();
+		await act(async () => {
+			chip?.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
+			await Promise.resolve();
+		});
+
+		// The chip navigation lands on the dependency with the original return context intact.
+		expect(observed.current).toEqual({
+			pathname: "/board/BACK-10",
+			search: "?lane=milestone",
+			state: { taskModalFrom: "/board?lane=milestone" },
+		});
+
+		// It replaced the previous task route, so Back returns to the board, not the previous task.
+		await act(async () => {
+			goBack.current?.();
+			await Promise.resolve();
+		});
+		expect(observed.current).toEqual({ pathname: "/board", search: "?lane=milestone", state: null });
+
+		await act(async () => {
+			root.unmount();
+		});
 	});
 
 	it("resolves dependencies that differ in case or zero padding", () => {

--- a/src/test/web-dependency-input-links.test.tsx
+++ b/src/test/web-dependency-input-links.test.tsx
@@ -18,9 +18,9 @@ const taskFixtures = (...ids: string[]): Task[] =>
 
 const availableTasks = taskFixtures("BACK-10");
 
-function renderChips(dependencies: string[], tasks: Task[] = availableTasks): Document {
+function renderChips(dependencies: string[], tasks: Task[] = availableTasks, path = "/"): Document {
 	const html = renderToString(
-		<MemoryRouter>
+		<MemoryRouter initialEntries={[path]}>
 			<DependencyInput value={dependencies} onChange={() => {}} availableTasks={tasks} />
 		</MemoryRouter>,
 	);
@@ -34,6 +34,21 @@ describe("DependencyInput dependency chips", () => {
 
 		expect(link).toBeTruthy();
 		expect(link?.textContent).toBe("BACK-10 - Task BACK-10");
+	});
+
+	it("keeps the reader on the board: chips clicked from /board link within /board", () => {
+		const rendered = renderChips(["BACK-10"], availableTasks, "/board/BACK-20");
+		const link = rendered.querySelector('a[href="/board/BACK-10"]');
+
+		expect(link).toBeTruthy();
+		expect(rendered.querySelector('a[href="/tasks/BACK-10"]')).toBeNull();
+	});
+
+	it("links chips through /tasks when reading from the task list", () => {
+		const rendered = renderChips(["BACK-10"], availableTasks, "/tasks/BACK-20");
+		const link = rendered.querySelector('a[href="/tasks/BACK-10"]');
+
+		expect(link).toBeTruthy();
 	});
 
 	it("resolves dependencies that differ in case or zero padding", () => {

--- a/src/web/components/DependencyInput.tsx
+++ b/src/web/components/DependencyInput.tsx
@@ -1,9 +1,24 @@
 import React, { useState, useRef, useEffect, useMemo, type KeyboardEvent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { type Task } from '../../types';
 import { buildTaskIdIndex, resolveTaskReference } from '../utils/task-id-links';
 
 const CHIP_LABEL_CLASS = 'truncate max-w-[16rem] sm:max-w-[20rem] md:max-w-[24rem]';
+
+// Chip links open the task detail in place, mirroring App's handleEditTask base-path
+// derivation: stay on the board when reading from it, otherwise use the canonical
+// /tasks route (which also keeps external deep links working). Kept as a subcomponent
+// so the router context is only required where a link actually renders, and so PR
+// #960's useTaskHref hook can replace the derivation once it lands.
+const TaskChipLink: React.FC<{ taskId: string; display: string }> = ({ taskId, display }) => {
+  const location = useLocation();
+  const taskBasePath = location.pathname.startsWith('/board') ? '/board' : '/tasks';
+  return (
+    <Link to={`${taskBasePath}/${taskId}`} className={`${CHIP_LABEL_CLASS} hover:underline`} title={display}>
+      {display}
+    </Link>
+  );
+};
 
 interface DependencyInputProps {
   value: string[];
@@ -128,13 +143,7 @@ const DependencyInput: React.FC<DependencyInputProps> = ({ value, onChange, avai
                   className="inline-flex items-center gap-1 px-2 py-0.5 text-sm bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200 rounded-md transition-colors duration-200 min-w-0 max-w-full"
                 >
                   {dependency ? (
-                    <Link
-                      to={`/tasks/${dependency.id}`}
-                      className={`${CHIP_LABEL_CLASS} hover:underline`}
-                      title={display}
-                    >
-                      {display}
-                    </Link>
+                    <TaskChipLink taskId={dependency.id} display={display} />
                   ) : (
                     <span className={CHIP_LABEL_CLASS} title={display}>{display}</span>
                   )}

--- a/src/web/components/DependencyInput.tsx
+++ b/src/web/components/DependencyInput.tsx
@@ -5,16 +5,36 @@ import { buildTaskIdIndex, resolveTaskReference } from '../utils/task-id-links';
 
 const CHIP_LABEL_CLASS = 'truncate max-w-[16rem] sm:max-w-[20rem] md:max-w-[24rem]';
 
-// Chip links open the task detail in place, mirroring App's handleEditTask base-path
-// derivation: stay on the board when reading from it, otherwise use the canonical
-// /tasks route (which also keeps external deep links working). Kept as a subcomponent
-// so the router context is only required where a link actually renders, and so PR
-// #960's useTaskHref hook can replace the derivation once it lands.
+// Chip links open the task detail in place, mirroring App's handleEditTask navigation:
+// stay on the board when reading from it (canonical /tasks everywhere else, which also
+// keeps external deep links working), carry the page's query string so URL-backed
+// filters survive, and replace an already-open task route while preserving its
+// original taskModalFrom return context so closing the target does not walk back
+// through this task. Kept as a subcomponent so the router context is only required
+// where a link actually renders, and so PR #960's useTaskHref hook can replace the
+// derivation once it lands.
 const TaskChipLink: React.FC<{ taskId: string; display: string }> = ({ taskId, display }) => {
   const location = useLocation();
-  const taskBasePath = location.pathname.startsWith('/board') ? '/board' : '/tasks';
+  const basePath = location.pathname.startsWith('/board')
+    ? '/board'
+    : location.pathname.startsWith('/tasks')
+      ? '/tasks'
+      : null;
+  const search = basePath ? location.search : '';
+  const isReplacingTaskRoute = basePath !== null && location.pathname.startsWith(`${basePath}/`);
+  const currentTaskModalFrom =
+    location.state && typeof location.state === 'object'
+      ? (location.state as { taskModalFrom?: string }).taskModalFrom
+      : undefined;
+  const taskModalFrom = isReplacingTaskRoute ? currentTaskModalFrom : basePath ? `${basePath}${search}` : undefined;
   return (
-    <Link to={`${taskBasePath}/${taskId}`} className={`${CHIP_LABEL_CLASS} hover:underline`} title={display}>
+    <Link
+      to={`${basePath ?? '/tasks'}/${taskId}${search}`}
+      replace={isReplacingTaskRoute}
+      state={taskModalFrom ? { taskModalFrom } : undefined}
+      className={`${CHIP_LABEL_CLASS} hover:underline`}
+      title={display}
+    >
       {display}
     </Link>
   );


### PR DESCRIPTION
## Summary
- Dependency chips in the task-detail sidebar hardcoded `/tasks/<id>`, so clicking one while reading the Kanban Board jumped to the All Tasks page. The chip link now derives its base path from the reader's current location: `/board` when on the board, the canonical `/tasks` everywhere else.
- Implemented as a local `TaskChipLink` subcomponent inside `DependencyInput.tsx` that mirrors `App.tsx` `handleEditTask`'s base-path derivation (the pattern BACK-548 parent/subtask navigation already uses). The subcomponent mounts only where a chip resolves, so router context is required exactly where the previous `Link` needed it.
- PR #960 (unmerged) introduces a `useTaskHref` hook with this same derivation for graph links; it is not on main yet, so nothing was cherry-picked. Once #960 lands, `TaskChipLink` can switch to that hook by deleting the local one-liner. `TaskDetailsModal.tsx` is untouched to avoid overlap.
- External deep links to `/tasks/<id>` are unaffected: routes are unchanged and non-board locations keep the canonical `/tasks` href.

## Testing
- New tests in `src/test/web-dependency-input-links.test.tsx` pin that chips rendered under `/board` link within `/board` (stay-on-board) and chips under `/tasks` keep `/tasks` hrefs; existing tests pin the default `/tasks` fallback.
- `bunx tsc --noEmit`, `bun run check .`, and full `bun test` green locally (2566 pass; the only 3 failures are `tui-emoji-width` cases that reproduce identically on a pristine `origin/main` worktree, i.e. pre-existing and unrelated).

Closes BACK-655.