### PR TITLE
BACK-658 - Resolve dependency targets in completed and archived tasks

### DIFF
--- a/backlog/tasks/back-658 - Resolve-dependency-targets-in-completed-and-archived-tasks.md
+++ b/backlog/tasks/back-658 - Resolve-dependency-targets-in-completed-and-archived-tasks.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-658
 title: Resolve dependency targets in completed and archived tasks
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Fable'
 created_date: '2026-08-30 15:23'
+updated_date: '2026-08-30 15:43'
 labels:
   - cli
   - mcp
@@ -23,15 +25,39 @@ validateDependencies (src/utils/task-builders.ts:52-84) builds its known-ID set 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A dependency on a task in completed/ or archive is accepted at create and edit time on CLI, MCP, and web
-- [ ] #2 Editing the dependency list of a task whose predecessors are Done works
-- [ ] #3 Unknown IDs are still rejected; ambiguous identities still fail closed
-- [ ] #4 Tests cover completed, archived, draft, unknown, and ambiguous targets
+- [x] #1 A dependency on a task in completed/ or archive is accepted at create and edit time on CLI, MCP, and web
+- [x] #2 Editing the dependency list of a task whose predecessors are Done works
+- [x] #3 Unknown IDs are still rejected; ambiguous identities still fail closed
+- [x] #4 Tests cover completed, archived, draft, unknown, and ambiguous targets
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Widen the known-ID corpus in validateDependencies (src/utils/task-builders.ts) to include filesystem.listCompletedTasks() and filesystem.listArchivedTasks() alongside working-copy tasks and drafts; identity matching stays taskIdsEqual/canonicalTaskId.
+2. Keep the core.loadTaskById working-copy ambiguity check as-is: its index already covers completed tasks, and archived-only IDs resolve to null there exactly like drafts (the call exists only to catch multi-file ID claims). Update the comments.
+3. Tests in src/test/dependency.test.ts: completed target accepted at create and edit, archived target accepted, draft target still accepted, unknown ID still rejected, duplicate identity across stores fails closed; bare task/draft numeric ambiguity covered by existing cli-custom-prefix test stays green.
+4. No readiness/graph changes; keep the change composable with BACK-656 (future self/cycle checks in the same function).
+5. Verify: bunx tsc --noEmit, bun run check ., bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Widened the validateDependencies corpus with listCompletedTasks/listArchivedTasks; loadTaskById ambiguity check unchanged (its index already covers completed; archived resolve null like drafts). Tests added in src/test/dependency.test.ts for completed/archived/draft/unknown/duplicate-identity targets; bare task+draft numeric ambiguity test stays green. Notable: the ID allocator reuses an archived task's ID when it was the highest, so a dependency on such an archived task correctly fails closed as ambiguous once the ID is reissued.
+
+Verification: bunx tsc --noEmit clean, bun run check . clean, full bun run test green (2579 tests, 0 fail) after bun i refreshed a stale worktree node_modules (neo-neo-bblessed 1.0.9 -> 1.0.10, known cross-worktree issue). Added a CLI end-to-end test for the completed-predecessor scenario on top of the core-level coverage; MCP and web funnel through the same createTaskFromInput/updateTaskFromInput paths.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Widened the validateDependencies known-ID corpus (src/utils/task-builders.ts) to span working-copy tasks, drafts, completed, and archived records under the existing taskIdsEqual/canonicalTaskId identity rules, so a Done or archived predecessor is a valid dependency target at create and edit time on CLI, MCP, and web. Validation only: readiness/graph semantics untouched, unknown IDs still rejected, ambiguous identities still fail closed (bare task/draft numerics and duplicate identities across stores). Verified with new tests in src/test/dependency.test.ts and src/test/cli-dependency.test.ts covering completed, archived, draft, unknown, and ambiguous targets, plus tsc, biome, and the full bun test suite.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/cli-dependency.test.ts
+++ b/src/test/cli-dependency.test.ts
@@ -185,6 +185,20 @@ describe("CLI dependency options", () => {
 		expect(result.stdout.toString()).toContain("--clear-deps");
 	});
 
+	it("accepts a completed task as a dependency at create and edit time", async () => {
+		await $`bun ${CLI_PATH} task create "Done predecessor" -s Done`.cwd(testDir).quiet();
+		await $`bun ${CLI_PATH} task complete 1`.cwd(testDir).quiet();
+
+		const created = await $`bun ${CLI_PATH} task create "Dependent task" --dep TASK-1`.cwd(testDir).quiet().nothrow();
+		expect(created.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual(["TASK-1"]);
+
+		await $`bun ${CLI_PATH} task create "Other target"`.cwd(testDir).quiet();
+		const edited = await $`bun ${CLI_PATH} task edit 2 --depends-on TASK-1,TASK-3`.cwd(testDir).quiet().nothrow();
+		expect(edited.exitCode).toBe(0);
+		expect((await core.filesystem.loadTask("TASK-2"))?.dependencies).toEqual(["TASK-1", "TASK-3"]);
+	});
+
 	it("rejects a dependency that does not exist", async () => {
 		const result = await $`bun ${CLI_PATH} task create "Dependent task" --dep TASK-999`.cwd(testDir).quiet().nothrow();
 

--- a/src/test/dependency.test.ts
+++ b/src/test/dependency.test.ts
@@ -311,6 +311,82 @@ describe("Task Dependencies", () => {
 		expect(updatedDependent?.dependencies).toEqual([]);
 	});
 
+	test("accepts a completed task as a dependency at create and edit time", async () => {
+		const { task: predecessor } = await core.createTaskFromInput({ title: "Finished predecessor", status: "Done" });
+		expect(await core.completeTask(predecessor.id, false)).toBe(true);
+
+		const { task: created } = await core.createTaskFromInput({
+			title: "Created after completion",
+			dependencies: [predecessor.id],
+		});
+		expect(created.dependencies).toEqual([predecessor.id]);
+
+		const { task: edited } = await core.createTaskFromInput({ title: "Edited after completion" });
+		await core.updateTaskFromInput(edited.id, { dependencies: [predecessor.id] }, false);
+		expect((await core.filesystem.loadTask(edited.id))?.dependencies).toEqual([predecessor.id]);
+	});
+
+	test("accepts an archived task as a dependency at create and edit time", async () => {
+		const { task: predecessor } = await core.createTaskFromInput({ title: "Archived predecessor" });
+		// Keep an active task with a higher ID so the allocator does not reuse the archived ID.
+		const { task: edited } = await core.createTaskFromInput({ title: "Edited after archive" });
+		expect(await core.archiveTask(predecessor.id, false)).toBe(true);
+
+		const { task: created } = await core.createTaskFromInput({
+			title: "Created after archive",
+			dependencies: [predecessor.id],
+		});
+		expect(created.dependencies).toEqual([predecessor.id]);
+
+		await core.updateTaskFromInput(edited.id, { dependencies: [predecessor.id] }, false);
+		expect((await core.filesystem.loadTask(edited.id))?.dependencies).toEqual([predecessor.id]);
+	});
+
+	test("re-editing the dependency list of a task whose predecessor completed keeps working", async () => {
+		const { task: predecessor } = await core.createTaskFromInput({ title: "Predecessor", status: "Done" });
+		const { task: other } = await core.createTaskFromInput({ title: "Other target" });
+		const { task: dependent } = await core.createTaskFromInput({
+			title: "Dependent",
+			dependencies: [predecessor.id],
+		});
+
+		expect(await core.completeTask(predecessor.id, false)).toBe(true);
+
+		// --depends-on replaces the whole list, so the existing completed entry must revalidate too.
+		await core.updateTaskFromInput(dependent.id, { dependencies: [predecessor.id, other.id] }, false);
+		expect((await core.filesystem.loadTask(dependent.id))?.dependencies).toEqual([predecessor.id, other.id]);
+	});
+
+	test("still accepts drafts and rejects unknown dependency IDs", async () => {
+		const { task: draft } = await core.createTaskFromInput({ title: "Draft target", status: "Draft" }, false);
+		const { task } = await core.createTaskFromInput({ title: "Dependent task" });
+
+		await core.updateTaskFromInput(task.id, { dependencies: [draft.id] }, false);
+		expect((await core.filesystem.loadTask(task.id))?.dependencies).toEqual([draft.id]);
+
+		await expect(core.updateTaskFromInput(task.id, { dependencies: ["task-999"] }, false)).rejects.toThrow(
+			"The following dependencies do not exist: task-999",
+		);
+	});
+
+	test("fails closed when a completed task and an active file claim the same identity", async () => {
+		const { task: predecessor } = await core.createTaskFromInput({ title: "Predecessor", status: "Done" });
+		const { task: dependent } = await core.createTaskFromInput({ title: "Dependent" });
+		expect(await core.completeTask(predecessor.id, false)).toBe(true);
+
+		// Recreate the completed task's file in the active tasks directory so two files claim its ID.
+		const completed = (await core.filesystem.listCompletedTasks()).find((task) => task.id === predecessor.id);
+		expect(completed?.filePath).toBeDefined();
+		if (!completed?.filePath) return;
+		const duplicatePath = join(core.filesystem.tasksDir, "task-1 - Duplicate.md");
+		await Bun.write(duplicatePath, await Bun.file(completed.filePath).text());
+
+		await expect(core.updateTaskFromInput(dependent.id, { dependencies: [predecessor.id] }, false)).rejects.toThrow(
+			/ambiguous/,
+		);
+		expect((await core.filesystem.loadTask(dependent.id))?.dependencies ?? []).toEqual([]);
+	});
+
 	test("should not sanitize draft dependencies when archiving", async () => {
 		const archiveTarget: Task = {
 			id: "task-1",

--- a/src/utils/task-builders.ts
+++ b/src/utils/task-builders.ts
@@ -37,6 +37,11 @@ function resolveUniqueDependency(dependency: string, matches: Task[]): string | 
 /**
  * Validate that all dependencies exist in the working copy.
  *
+ * The corpus spans working-copy tasks, drafts, completed, and archived records: Done is the normal
+ * end state of a predecessor, so a task whose target moved to completed/ or the archive must keep a
+ * valid, editable dependency list. Only validation resolves these targets; readiness and graph
+ * semantics are unchanged.
+ *
  * Inputs are matched by task identity, so bare numeric IDs resolve under any configured prefix, and
  * identity fails closed exactly as it does for the task a command targets. That takes two checks,
  * mirroring the identity index itself: the corpus answers whether the input names more than one
@@ -58,11 +63,13 @@ export async function validateDependencies(
 	if (dependencies.length === 0) {
 		return { valid, invalid };
 	}
-	const [tasks, drafts] = await Promise.all([
+	const [tasks, drafts, completed, archived] = await Promise.all([
 		core.queryTasks({ includeCrossBranch: false }),
 		core.filesystem.listDrafts(),
+		core.filesystem.listCompletedTasks(),
+		core.filesystem.listArchivedTasks(),
 	]);
-	const known = [...tasks, ...drafts];
+	const known = [...tasks, ...drafts, ...completed, ...archived];
 	for (const dependency of dependencies) {
 		const resolved = resolveUniqueDependency(
 			dependency,
@@ -73,7 +80,8 @@ export async function validateDependencies(
 			continue;
 		}
 		// Called for its ambiguity check: it raises AmbiguousTaskIdError when several working-copy
-		// files claim this ID. Drafts resolve to null here and keep their own local-only lookup.
+		// files (active or completed) claim this ID. Drafts and archived tasks resolve to null here
+		// and rely on the corpus check above.
 		await core.loadTaskById(resolved, { includeCrossBranch: false });
 		// Equivalent spellings of one task (1 and BACK-1) must not persist twice.
 		if (!valid.some((existing) => taskIdsEqual(existing, resolved))) {


### PR DESCRIPTION
Closes #942. Implements BACK-658.

## Problem

`validateDependencies` built its known-ID corpus from working-copy tasks plus drafts only, so a dependency on a task living in `backlog/completed/` or the archive was refused at write time — even though Done is the normal end state of a predecessor. Combined with the replace-only semantics of `--depends-on`, a task whose predecessor completed could no longer have its dependency list edited at all.

## Change

- `validateDependencies` (src/utils/task-builders.ts) now resolves dependency targets across working-copy tasks, drafts, completed, and archived records, using the same shared identity rules (`taskIdsEqual` / `canonicalTaskId`) as before.
- The `core.loadTaskById` working-copy ambiguity check is unchanged: its identity index already covers completed tasks, and archived-only IDs resolve to null there exactly like drafts — the call exists only to catch several files claiming one ID.
- Validation only. Readiness and dependency-graph semantics for completed/archived targets are untouched, and nothing here overlaps the planned self/cycle checks (BACK-656).
- Unknown IDs are still rejected; ambiguous identities still fail closed, including the bare-numeric case spanning the task and draft counters and duplicate identities across active/completed/archived stores.

CLI, MCP, and web all funnel through `createTaskFromInput`/`updateTaskFromInput`, so the one corpus fix covers all three surfaces.

## Tests

New coverage in `src/test/dependency.test.ts`:

- completed target accepted at create and edit time
- archived target accepted at create and edit time
- re-editing the dependency list of a task whose predecessor completed (the #942 scenario, replace semantics revalidating the completed entry)
- draft target still accepted, unknown ID still rejected
- duplicate identity across active and completed stores fails closed

The existing bare task/draft numeric ambiguity test (`cli-custom-prefix-id-resolution.test.ts`) stays green.

## Verification

- `bunx tsc --noEmit` clean
- `bun run check .` clean
- `bun run test` green
