### PR TITLE
BACK-659 - Include grandchild subtasks in board export grouping

### DIFF
--- a/backlog/tasks/back-659 - Include-grandchild-subtasks-in-board-export-grouping.md
+++ b/backlog/tasks/back-659 - Include-grandchild-subtasks-in-board-export-grouping.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-659
 title: Include grandchild subtasks in board export grouping
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-30 15:23'
+updated_date: '2026-08-30 15:45'
 labels:
   - cli
   - bug
@@ -21,14 +23,35 @@ The markdown board export builds its children map keyed only by top-level parent
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A subtask of a subtask appears in the exported board markdown
-- [ ] #2 Existing flat parent/child export output is unchanged
-- [ ] #3 A test pins the nested case
+- [x] #1 A subtask of a subtask appears in the exported board markdown
+- [x] #2 Existing flat parent/child export output is unchanged
+- [x] #3 A test pins the nested case
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. In generateKanbanBoardWithMetadata (src/board.ts), replace the single-level top+children flattening with a depth-first emit: after pushing a task, recursively push its own children from the children map (sorted by ID ascending, as today). Flat data has no nested children, so output stays byte-identical.
+2. Grandchildren keep the existing subtask rendering shape (single '└─ ' prefix), matching the current export format.
+3. Add tests in src/test/board.test.ts: one pinning that a subtask-of-a-subtask appears in the export under its parent chain, one pinning the exact flat parent/child output unchanged.
+4. Verify: bunx tsc --noEmit, bun run check ., bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: generateKanbanBoardWithMetadata built each column as top-level tasks plus their direct children only; a subtask grouped under a parent that is itself a subtask (children map keyed by the intermediate id) was never emitted. Fix: depth-first pushWithChildren recursion over the existing children map; per-level ID-ascending sort kept. Flat output proven byte-identical: the new exact-output flat test passes against pre-fix board.ts (verified via git stash), while the nested test fails pre-fix and passes post-fix. Full suite: only 3 pre-existing tui-emoji-width failures remain, also failing on clean main in this environment.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the markdown board export dropping subtasks of subtasks (issue #944) by flattening each column depth-first over the existing children map in src/board.ts instead of one level deep; grandchildren keep the existing '└─ ' subtask shape. Verified with two new tests in src/test/board.test.ts: an exact-output test pinning the nested chain and an exact-output flat parent/child test that also passes against the pre-fix code, proving unchanged flat output. bunx tsc --noEmit, bun run check ., and board tests all pass.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/board.ts
+++ b/src/board.ts
@@ -124,9 +124,9 @@ Project: ${projectName}
 			}
 		}
 
-		// Build final list with subtasks nested under parents
+		// Build final list depth-first so subtasks of subtasks stay under their parent
 		const result: Task[] = [];
-		for (const t of top) {
+		const pushWithChildren = (t: Task) => {
 			result.push(t);
 			const subs = children.get(t.id) || [];
 			subs.sort((a, b) => {
@@ -134,7 +134,12 @@ Project: ${projectName}
 				const idB = Number.parseInt(b.id.replace("task-", ""), 10);
 				return idA - idB; // Subtasks in ascending order
 			});
-			result.push(...subs);
+			for (const sub of subs) {
+				pushWithChildren(sub);
+			}
+		};
+		for (const t of top) {
+			pushWithChildren(t);
 		}
 
 		return result;

--- a/src/test/board.test.ts
+++ b/src/test/board.test.ts
@@ -168,6 +168,118 @@ describe("exportKanbanBoardToFile", () => {
 		await rm(dir, { recursive: true, force: true });
 	});
 
+	it("includes subtasks of subtasks under their parent", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "board-export-"));
+		const file = join(dir, "README.md");
+		const tasks: Task[] = [
+			{
+				id: "task-10",
+				title: "Epic",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-01-01",
+				labels: [],
+				dependencies: [],
+			},
+			{
+				id: "task-11",
+				title: "Child",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-01-02",
+				labels: [],
+				dependencies: [],
+				parentTaskId: "task-10",
+			},
+			{
+				id: "task-12",
+				title: "Grandchild",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-01-03",
+				labels: [],
+				dependencies: [],
+				parentTaskId: "task-11",
+			},
+		];
+
+		await exportKanbanBoardToFile(tasks, ["To Do"], file, "TestProject");
+		const content = await Bun.file(file).text();
+
+		const normalized = content.replace(/^Generated on: .*$/m, "Generated on: TIMESTAMP");
+		expect(normalized).toBe(
+			[
+				"# Kanban Board Export (powered by Backlog.md)",
+				"Generated on: TIMESTAMP",
+				"Project: TestProject",
+				"",
+				"| To Do |",
+				"| --- |",
+				"| **TASK-10** - Epic |",
+				"| └─ **TASK-11** - Child |",
+				"| └─ **TASK-12** - Grandchild |",
+				"",
+			].join("\n"),
+		);
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("keeps flat parent/child export output unchanged", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "board-export-"));
+		const file = join(dir, "README.md");
+		const tasks: Task[] = [
+			{
+				id: "task-204",
+				title: "Test Task",
+				status: "To Do",
+				assignee: ["alice"],
+				createdDate: "2025-01-01",
+				labels: ["ui"],
+				dependencies: [],
+			},
+			{
+				id: "task-205",
+				title: "Subtask Example",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2025-01-02",
+				labels: [],
+				dependencies: [],
+				parentTaskId: "task-204",
+			},
+			{
+				id: "task-206",
+				title: "Standalone",
+				status: "Done",
+				assignee: [],
+				createdDate: "2025-01-03",
+				labels: [],
+				dependencies: [],
+			},
+		];
+
+		await exportKanbanBoardToFile(tasks, ["To Do", "Done"], file, "TestProject");
+		const content = await Bun.file(file).text();
+
+		const normalized = content.replace(/^Generated on: .*$/m, "Generated on: TIMESTAMP");
+		expect(normalized).toBe(
+			[
+				"# Kanban Board Export (powered by Backlog.md)",
+				"Generated on: TIMESTAMP",
+				"Project: TestProject",
+				"",
+				"| To Do | Done |",
+				"| --- | --- |",
+				"| **TASK-204** - Test Task [@alice]<br>*#ui* | **TASK-206** - Standalone |",
+				"| └─ **TASK-205** - Subtask Example |  |",
+				"",
+			].join("\n"),
+		);
+
+		await rm(dir, { recursive: true, force: true });
+	});
+
 	it("handles assignees with existing @ symbols correctly", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "board-export-"));
 		const file = join(dir, "README.md");


### PR DESCRIPTION
Fixes #944.

## Problem
The markdown board export (`backlog board export`) built each status column as top-level tasks plus their direct children only. A subtask whose parent is itself a subtask was collected into the children map under the intermediate subtask's id — which was never walked — so grandchildren silently disappeared from the exported board.

## Fix
Flatten each column depth-first over the existing children map (`pushWithChildren` recursion in `src/board.ts`) instead of one level deep. The per-level ID-ascending sort is unchanged, and grandchildren render with the existing `└─ ` subtask shape.

## Proof
- New test pins the nested chain (parent → child → grandchild) with exact expected output; it fails on pre-fix code and passes now.
- New exact-output flat parent/child test passes against both pre-fix and post-fix code (verified via `git stash`), proving flat export output is byte-identical.
- `bunx tsc --noEmit`, `bun run check .`, and `bun test src/test/board.test.ts` (10/10) pass. Full-suite run shows only the 3 pre-existing `tui-emoji-width` failures that also fail on clean main in this environment.

Backlog task: BACK-659 (included in this PR with checked ACs and final summary).