### PR TITLE
BACK-654 - Polish the cross-branch indexing loading indicator in the web UI

### DIFF
--- a/backlog/tasks/back-654 - Polish-the-cross-branch-indexing-loading-indicator-in-the-web-UI.md
+++ b/backlog/tasks/back-654 - Polish-the-cross-branch-indexing-loading-indicator-in-the-web-UI.md
@@ -1,11 +1,11 @@
 ---
 id: BACK-654
 title: Polish the cross-branch indexing loading indicator in the web UI
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-30 11:55'
-updated_date: '2026-08-30 15:46'
+updated_date: '2026-08-30 15:51'
 labels:
   - web
   - enhancement
@@ -21,16 +21,16 @@ While the web UI indexes other local branches it shows a spinner with the text "
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The cross-branch indexing state is shown with a polished, design-consistent indicator instead of the current spinner-plus-sentence
-- [ ] #2 Already-loaded content stays fully interactive while indexing runs
-- [ ] #3 The indicator disappears cleanly when indexing completes, including the fast-completion case without flicker
+- [x] #1 The cross-branch indexing state is shown with a polished, design-consistent indicator instead of the current spinner-plus-sentence
+- [x] #2 Already-loaded content stays fully interactive while indexing runs
+- [x] #3 The indicator disappears cleanly when indexing completes, including the fast-completion case without flicker
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -66,3 +66,9 @@ Implemented on tasks/back-654-indexing-indicator: new BranchIndexingIndicator (h
 
 Full-suite triage: 3 tui-emoji-width failures were the worktree's stale node_modules (neo-neo-bblessed 1.0.9 vs locked 1.0.10; bun i fixed, bun.lock unchanged). The remaining 3 were web-task-detail-deeplink reconciliation tests observing the removed raw phase sentence; they now observe the indicator (its sr-only text carries the full server message) by waiting out the 250ms appear / 200ms exit windows, with renderApp's afterInitialStatus hook moved outside act so callbacks can observe flushed DOM. All 29 deeplink tests pass; final full suite running.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced the spinner-plus-sentence cross-branch indexing treatment with a shell-level indicator in the top header: a compact status chip (active-nav blue pill tokens, 12px spinner ring, label 'Indexing branches', full server progress message as tooltip and sr-only text on role=status) plus a 2px gradient sweep along the header's bottom border (motion-reduce aware). The indicator mounts only after the indexing state persists 250ms and fades out 200ms on completion, so fast completions never flash (verified live: warm-cache restart showed no flash or residue; cold start against ~120 local branches showed the chip in dark theme). App.tsx now gates the blocking skeleton on first load only (hasLoadedDataRef), so already-loaded content stays mounted and interactive during mid-session indexing, and the raw sentence was removed from the sidebar (LoadingPhase is a pure skeleton) and the board (App no longer passes loadingMessage; Board.tsx untouched to avoid PR #945/#960 overlap). Verified with bunx tsc --noEmit, bun run check ., and the full bun test suite (2571 pass / 0 fail) including new jsdom coverage in web-branch-indexing-indicator.test.tsx for delayed appearance, announced message, fast-completion no-flash, clean fade-out unmount, and message replacement. PR #971; maintainer visual pass on the final look (esp. light-theme chip and whether the sweep bar stays) still pending.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-654 - Polish-the-cross-branch-indexing-loading-indicator-in-the-web-UI.md
+++ b/backlog/tasks/back-654 - Polish-the-cross-branch-indexing-loading-indicator-in-the-web-UI.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-654
 title: Polish the cross-branch indexing loading indicator in the web UI
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-30 11:55'
+updated_date: '2026-08-30 15:46'
 labels:
   - web
   - enhancement
@@ -30,3 +32,37 @@ While the web UI indexes other local branches it shows a spinner with the text "
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Design proposal (for maintainer review before code)
+
+Current treatment being replaced: the WebSocket browser-loading messages ("Indexing 35 other local branches...") render as a raw sentence next to the board spinner (Board.tsx loading block) and three more times in SideNavigation via LoadingPhase. App.tsx also sets isLoading(true) on any mid-session loading event, which flips already-loaded content back to skeletons - that is the AC #2 violation.
+
+Proposed design: a single shell-level "branch indexing" indicator in the top header (Navigation.tsx), two coordinated parts rendered by one new component, BranchIndexingIndicator:
+
+1. Hairline sweep bar: absolutely positioned 2px bar (h-0.5, inset-x-0 bottom-0) sitting exactly on the header's existing bottom border, so the border "comes alive" while indexing. Motion: a ~40%-width gradient segment (from-transparent via-blue-500 to-transparent; dark: via-blue-400) sweeping left-to-right, ~1.4s infinite ease-in-out, defined next to the existing slide-in-down keyframes in styles/source.css. pointer-events-none, no layout shift, hidden under motion-reduce.
+
+2. Status chip in the header's right cluster (before ThemeToggle): compact rounded-full pill reusing the active-nav accent (bg-blue-50 dark:bg-blue-600/20 text-blue-600 dark:text-blue-400), text-xs font-medium, containing a 12px spinner ring reusing the board spinner style (border-2, border-t current accent, animate-spin) and the single label "Indexing branches" - no sentence, no count, per the UI-copy rule. The full server message is preserved as title tooltip and sr-only text; the chip is role="status" so screen readers hear the real progress line.
+
+Motion/flicker rules (AC #3): indicator mounts only after the loading message has persisted ~250ms (fast completions never flash anything); entry is a 200ms fade+2px rise (matching the app's duration-200 conventions); on completion it fades out 200ms and unmounts. Delays are props so jsdom tests can use short values.
+
+Reused design elements: header nav bar placement, active-NavLink blue accent pill, board spinner ring style, animate-pulse skeletons (kept in sidebar), duration-200 transitions, source.css keyframe pattern.
+
+Implementation steps:
+1. New src/web/components/BranchIndexingIndicator.tsx with the delayed-appear/fade-out state machine; sweep keyframe added to styles/source.css.
+2. Navigation.tsx gains relative positioning and an optional loadingMessage prop; Layout.tsx passes it through.
+3. App.tsx: mid-session WS "loading" events no longer set isLoading(true) once data has loaded (hasLoadedDataRef) - loaded content stays mounted and interactive while the indicator runs (AC #2). Initial load keeps today's behavior.
+4. Remove the raw sentence everywhere: SideNavigation drops the loadingMessage prop and LoadingPhase renders only its skeleton pulse; App stops passing loadingMessage to BoardPage (Board.tsx untouched - its optional prop simply stays unset, avoiding overlap with PRs #945/#960).
+5. Tests: new jsdom test (pattern of web-task-details-modal-keyboard-shortcuts.test.tsx) covering: no render before the appear delay, visible chip+bar with role=status after it, fast completion never appears, clean fade-out unmount on completion; update web-side-navigation-loading.test.tsx for the removed sentence.
+6. Verify: bunx tsc --noEmit, bun run check ., bun test; manual light+dark visual pass in the browser.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented on tasks/back-654-indexing-indicator: new BranchIndexingIndicator (header chip reusing the active-nav blue pill + 12px spinner ring, hairline indexing-sweep bar on the header's bottom border, 250ms delayed appear, 200ms fade-out, motion-reduce fallbacks). Navigation/Layout wire the WS loading message to it; SideNavigation's LoadingPhase is now a pure skeleton and App no longer passes the raw sentence to the board. App.tsx gates the blocking skeleton on first-load only (hasLoadedDataRef) so loaded content stays mounted and interactive during later indexing. Verified live in the browser against this repo's 119 local branches: dark-theme chip visible during cold indexing; warm restart completes fast with no flash or residue (light theme). tsc, biome, and the new jsdom tests (4) pass; full suite running.
+
+Full-suite triage: 3 tui-emoji-width failures were the worktree's stale node_modules (neo-neo-bblessed 1.0.9 vs locked 1.0.10; bun i fixed, bun.lock unchanged). The remaining 3 were web-task-detail-deeplink reconciliation tests observing the removed raw phase sentence; they now observe the indicator (its sr-only text carries the full server message) by waiting out the 250ms appear / 200ms exit windows, with renderApp's afterInitialStatus hook moved outside act so callbacks can observe flushed DOM. All 29 deeplink tests pass; final full suite running.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/back-654 - Polish-the-cross-branch-indexing-loading-indicator-in-the-web-UI.md
+++ b/backlog/tasks/back-654 - Polish-the-cross-branch-indexing-loading-indicator-in-the-web-UI.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-30 11:55'
-updated_date: '2026-08-30 15:51'
+updated_date: '2026-08-30 19:40'
 labels:
   - web
   - enhancement
@@ -65,6 +65,8 @@ Implementation steps:
 Implemented on tasks/back-654-indexing-indicator: new BranchIndexingIndicator (header chip reusing the active-nav blue pill + 12px spinner ring, hairline indexing-sweep bar on the header's bottom border, 250ms delayed appear, 200ms fade-out, motion-reduce fallbacks). Navigation/Layout wire the WS loading message to it; SideNavigation's LoadingPhase is now a pure skeleton and App no longer passes the raw sentence to the board. App.tsx gates the blocking skeleton on first-load only (hasLoadedDataRef) so loaded content stays mounted and interactive during later indexing. Verified live in the browser against this repo's 119 local branches: dark-theme chip visible during cold indexing; warm restart completes fast with no flash or residue (light theme). tsc, biome, and the new jsdom tests (4) pass; full suite running.
 
 Full-suite triage: 3 tui-emoji-width failures were the worktree's stale node_modules (neo-neo-bblessed 1.0.9 vs locked 1.0.10; bun i fixed, bun.lock unchanged). The remaining 3 were web-task-detail-deeplink reconciliation tests observing the removed raw phase sentence; they now observe the indicator (its sr-only text carries the full server message) by waiting out the 250ms appear / 200ms exit windows, with renderApp's afterInitialStatus hook moved outside act so callbacks can observe flushed DOM. All 29 deeplink tests pass; final full suite running.
+
+PR #971 review round: both Codex threads were real. (1) App.tsx now clears loadError on every WS loading frame (only setIsLoading stays first-load gated), so a passive client that had cached content plus a stale terminal error shows its content again when another browser's retry starts indexing; regression test added (clears a stale terminal error and shows cached content when indexing restarts). (2) The chip label is hidden below the sm breakpoint (icon-only pill, sr-only message intact) so narrow headers do not overflow; verified at 375px that the remaining header crowding pre-exists with the chip unmounted. Scoped tests 38 pass, tsc and biome clean. Head 83dab5ba.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/test/web-branch-indexing-indicator.test.tsx
+++ b/src/test/web-branch-indexing-indicator.test.tsx
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { BranchIndexingIndicator } from "../web/components/BranchIndexingIndicator";
+
+let activeRoot: Root | null = null;
+let activeDom: JSDOM | null = null;
+
+const APPEAR_MS = 20;
+const EXIT_MS = 20;
+
+const setupDom = () => {
+	activeDom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: "http://localhost",
+		pretendToBeVisual: true,
+	});
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+	globalThis.window = activeDom.window as unknown as Window & typeof globalThis;
+	globalThis.document = activeDom.window.document as Document;
+	globalThis.navigator = activeDom.window.navigator as Navigator;
+	globalThis.HTMLElement = activeDom.window.HTMLElement;
+	globalThis.requestAnimationFrame = activeDom.window.requestAnimationFrame.bind(activeDom.window);
+	globalThis.cancelAnimationFrame = activeDom.window.cancelAnimationFrame.bind(activeDom.window);
+	return activeDom.window.document.getElementById("root") as HTMLElement;
+};
+
+const wait = async (ms: number) => {
+	await act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, ms));
+	});
+};
+
+const renderIndicator = (container: HTMLElement, message: string | null) => {
+	if (!activeRoot) activeRoot = createRoot(container);
+	const root = activeRoot;
+	act(() => {
+		root.render(<BranchIndexingIndicator message={message} appearDelayMs={APPEAR_MS} exitDurationMs={EXIT_MS} />);
+	});
+};
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => {
+			activeRoot?.unmount();
+		});
+		activeRoot = null;
+	}
+	activeDom = null;
+});
+
+describe("BranchIndexingIndicator", () => {
+	it("appears only after the indexing state persists and announces the real progress message", async () => {
+		const container = setupDom();
+		renderIndicator(container, "Indexing 35 other local branches...");
+
+		// Not mounted before the appear delay elapses.
+		expect(container.querySelector('[role="status"]')).toBeNull();
+
+		await wait(APPEAR_MS * 3);
+
+		const chip = container.querySelector('[role="status"]');
+		expect(chip).not.toBeNull();
+		expect(chip?.textContent).toContain("Indexing branches");
+		expect(chip?.getAttribute("title")).toBe("Indexing 35 other local branches...");
+		expect(chip?.querySelector(".sr-only")?.textContent).toBe("Indexing 35 other local branches...");
+		expect(container.querySelector(".animate-indexing-sweep")).not.toBeNull();
+	});
+
+	it("never flashes when indexing completes before the appear delay", async () => {
+		const container = setupDom();
+		renderIndicator(container, "Indexing 2 other local branches...");
+		renderIndicator(container, null);
+
+		await wait(APPEAR_MS * 3);
+
+		expect(container.querySelector('[role="status"]')).toBeNull();
+		expect(container.querySelector(".animate-indexing-sweep")).toBeNull();
+	});
+
+	it("fades out and unmounts cleanly when indexing completes", async () => {
+		const container = setupDom();
+		renderIndicator(container, "Indexing 35 other local branches...");
+		await wait(APPEAR_MS * 3);
+		expect(container.querySelector('[role="status"]')).not.toBeNull();
+
+		renderIndicator(container, null);
+
+		// Still mounted while the exit fade runs, already transitioning to hidden.
+		const fading = container.querySelector('[role="status"]');
+		expect(fading).not.toBeNull();
+		expect(fading?.className).toContain("opacity-0");
+
+		await wait(EXIT_MS * 3);
+
+		expect(container.querySelector('[role="status"]')).toBeNull();
+		expect(container.querySelector(".animate-indexing-sweep")).toBeNull();
+	});
+
+	it("stays visible when consecutive progress messages replace each other", async () => {
+		const container = setupDom();
+		renderIndicator(container, "Indexing 3 recent remote branches...");
+		await wait(APPEAR_MS * 3);
+		renderIndicator(container, "Indexing 35 other local branches...");
+		await wait(5);
+
+		const chip = container.querySelector('[role="status"]');
+		expect(chip).not.toBeNull();
+		expect(chip?.className).toContain("opacity-100");
+		expect(chip?.getAttribute("title")).toBe("Indexing 35 other local branches...");
+	});
+});

--- a/src/test/web-side-navigation-loading.test.tsx
+++ b/src/test/web-side-navigation-loading.test.tsx
@@ -16,7 +16,7 @@ globalThis.localStorage = {
 	},
 } as Storage;
 
-const renderNavigation = (isLoading: boolean, taskCount: number, error?: Error, loadingMessage?: string): string =>
+const renderNavigation = (isLoading: boolean, taskCount: number, error?: Error): string =>
 	renderToString(
 		<MemoryRouter>
 			<SideNavigation
@@ -24,7 +24,6 @@ const renderNavigation = (isLoading: boolean, taskCount: number, error?: Error, 
 				docs={[]}
 				decisions={[]}
 				isLoading={isLoading}
-				loadingMessage={loadingMessage}
 				error={error}
 				onRetry={async () => {}}
 				onRefreshData={async () => {}}
@@ -32,7 +31,7 @@ const renderNavigation = (isLoading: boolean, taskCount: number, error?: Error, 
 		</MemoryRouter>,
 	);
 
-const renderBoard = (isLoading: boolean, error?: Error, loadingMessage?: string): string =>
+const renderBoard = (isLoading: boolean, error?: Error): string =>
 	renderToString(
 		<MemoryRouter>
 			<BoardPage
@@ -45,7 +44,6 @@ const renderBoard = (isLoading: boolean, error?: Error, loadingMessage?: string)
 				milestoneEntities={[]}
 				archivedMilestones={[]}
 				isLoading={isLoading}
-				loadingMessage={loadingMessage}
 				loadError={error}
 				onRefreshData={async () => {}}
 			/>
@@ -54,14 +52,13 @@ const renderBoard = (isLoading: boolean, error?: Error, loadingMessage?: string)
 
 describe("SideNavigation task loading", () => {
 	it("keeps navigation mounted while only the task count is loading", () => {
-		const phase = "Loading tasks from 7 local branches...";
-		const loading = renderNavigation(true, 0, undefined, phase);
+		const loading = renderNavigation(true, 0);
 		expect(loading).toContain("Kanban Board");
 		expect(loading).toContain("All Tasks");
 		expect(loading).toContain('aria-label="Loading task count"');
 		expect(loading).toContain('aria-label="Loading document count"');
 		expect(loading).toContain('aria-label="Loading decision count"');
-		expect(loading).toContain(phase);
+		expect(loading).toContain('aria-label="Loading content"');
 		expect(loading).not.toContain("No documents");
 		expect(loading).not.toContain("No decisions");
 
@@ -99,16 +96,14 @@ describe("SideNavigation task loading", () => {
 	});
 
 	it("keeps Kanban loading, loaded-empty, and error states distinct", () => {
-		const phase = "Applying latest task states from branch scans...";
-		const loading = renderBoard(true, undefined, phase);
+		const loading = renderBoard(true);
 		expect(loading).toContain("Kanban Board");
-		expect(loading).toContain(phase);
 		expect(loading).toContain('role="status"');
 		expect(loading).not.toContain("Empty");
 
 		const loadedEmpty = renderBoard(false);
 		expect(loadedEmpty).toContain("Empty");
-		expect(loadedEmpty).not.toContain(phase);
+		expect(loadedEmpty).not.toContain('aria-label="Loading tasks"');
 
 		const failed = renderBoard(false, new Error("corpus failed"));
 		expect(failed).toContain("Failed to load tasks");

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -512,8 +512,10 @@ const renderApp = async (
 		await act(async () => options.beforeInitialStatus?.(container as HTMLElement));
 	}
 	await act(async () => operation.settle("initial status"));
+	// Runs outside act so the callback can wrap its own act-based waits and then
+	// observe flushed DOM state.
 	if (options.afterInitialStatus) {
-		await act(async () => options.afterInitialStatus?.(container as HTMLElement));
+		await options.afterInitialStatus(container as HTMLElement);
 	}
 	await act(async () => operation.settle("initial search"));
 	if (controlledTimer) {
@@ -615,6 +617,17 @@ const assertState = (predicate: () => boolean, message: string) => {
 	expect(predicate(), message).toBe(true);
 };
 
+// The header indexing indicator appears 250ms after a loading message arrives and
+// fades out 200ms after it clears; these waits let real timers cross those windows.
+const waitForIndicatorAppearance = () =>
+	act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 350));
+	});
+const waitForIndicatorExit = () =>
+	act(async () => {
+		await new Promise((resolve) => setTimeout(resolve, 300));
+	});
+
 afterEach(async () => {
 	const fetchErrors: Error[] = [];
 	controlledTimerCleanup?.();
@@ -659,7 +672,8 @@ describe("task detail routes", () => {
 				getAppDataWebSocket().deliver(JSON.stringify({ type: "loading", message: phase }));
 				await Promise.resolve();
 			},
-			afterInitialStatus: (rendered) => {
+			afterInitialStatus: async (rendered) => {
+				await waitForIndicatorAppearance();
 				observedWhileSearchPending = rendered.textContent?.includes(phase) ?? false;
 			},
 		});
@@ -704,6 +718,7 @@ describe("task detail routes", () => {
 			dataSocket.deliver(JSON.stringify({ type: "loading", message: phase }));
 			await Promise.resolve();
 		});
+		await waitForIndicatorAppearance();
 		expect(container.textContent).toContain(phase);
 
 		const reconciliation = new FetchOperation("passive shared retry completion", [
@@ -717,6 +732,7 @@ describe("task detail routes", () => {
 		await act(async () => reconciliation.settle("passive config", "passive search"));
 		reconciliation.finish();
 
+		await waitForIndicatorExit();
 		expect(container.textContent).not.toContain(phase);
 		expect(container.querySelector("[aria-label='Loading tasks']")).toBeNull();
 		expect(container.textContent).toContain(tasks[0]?.title ?? "");
@@ -757,6 +773,7 @@ describe("task detail routes", () => {
 			dataSocket.deliver(JSON.stringify({ type: "loading", message: phase }));
 			await Promise.resolve();
 		});
+		await waitForIndicatorAppearance();
 		expect(container.textContent).toContain(phase);
 
 		const recovery = new FetchOperation("protocol-only socket close recovery", []);

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -788,6 +788,24 @@ describe("task detail routes", () => {
 		recovery.finish();
 	});
 
+	it("clears a stale terminal error and shows cached content when indexing restarts", async () => {
+		const container = await renderApp("/board?lane=none");
+		const dataSocket = getAppDataWebSocket();
+		await act(async () => {
+			dataSocket.deliver(JSON.stringify({ type: "error", message: "corpus failed" }));
+			await Promise.resolve();
+		});
+		expect(container.textContent).toContain("Failed to load tasks");
+
+		await act(async () => {
+			dataSocket.deliver(JSON.stringify({ type: "loading", message: "Loading tasks from local branches..." }));
+			await Promise.resolve();
+		});
+		expect(container.textContent).not.toContain("Failed to load tasks");
+		expect(container.querySelector("[aria-label='Loading tasks']")).toBeNull();
+		expect(container.textContent).toContain(tasks[0]?.title ?? "");
+	});
+
 	it("preserves a terminal shared error when the data socket closes", async () => {
 		const container = await renderApp("/board?lane=none");
 		const dataSocket = getAppDataWebSocket();

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -213,6 +213,7 @@ function AppContent() {
   const previousOnlineRef = useRef<boolean | null>(null);
   const hasBeenRunningRef = useRef(false);
   const loadAllDataRequestRef = useRef(0);
+  const hasLoadedDataRef = useRef(false);
   const pendingDataRequestRef = useRef<number | null>(null);
   const protocolOnlyLoadingRef = useRef(false);
   const location = useLocation();
@@ -307,7 +308,9 @@ function AppContent() {
 	protocolOnlyLoadingRef.current = false;
 		pendingDataRequestRef.current = requestId;
 		try {
-			setIsLoading(true);
+			// Show the blocking skeleton only before the first successful load; later
+			// refreshes keep the current content on screen and update it in place.
+			if (!hasLoadedDataRef.current) setIsLoading(true);
 			setLoadError(null);
       const shellDataPromise = Promise.all([
         apiClient.fetchStatuses(),
@@ -340,6 +343,7 @@ function AppContent() {
       const archivedKeys = new Set(collectArchivedMilestoneKeys(archivedMilestonesData, milestonesData));
       const milestoneAliases = buildMilestoneAliasMap(milestonesData, archivedMilestonesData);
       const { tasks: tasksList } = applySearchResults(searchResults, archivedKeys, milestoneAliases);
+      hasLoadedDataRef.current = true;
 
       setMilestones(
         collectMilestoneIds(tasksList, milestonesData, archivedMilestonesData).filter(
@@ -584,8 +588,12 @@ function AppContent() {
 	  const loadingState = parseBrowserLoadingState(event.data);
 	  if (loadingState?.type === 'loading') {
 		if (pendingDataRequestRef.current === null) protocolOnlyLoadingRef.current = true;
-		setIsLoading(true);
-		setLoadError(null);
+		// Once content is on screen it stays interactive; the header indexing
+		// indicator (driven by loadingMessage) is the only loading signal.
+		if (!hasLoadedDataRef.current) {
+			setIsLoading(true);
+			setLoadError(null);
+		}
 		setLoadingMessage(loadingState.message);
 	  } else if (loadingState?.type === 'loaded') {
 		const shouldRefresh = protocolOnlyLoadingRef.current && pendingDataRequestRef.current === null;
@@ -681,7 +689,6 @@ function AppContent() {
       milestoneEntities={milestoneEntities}
       archivedMilestones={archivedMilestones}
       isLoading={isLoading}
-      loadingMessage={loadingMessage}
       loadError={loadError}
       hideEmptyColumns={config?.hideEmptyColumns ?? false}
       dateFormat={config?.dateFormat}

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -589,11 +589,11 @@ function AppContent() {
 	  if (loadingState?.type === 'loading') {
 		if (pendingDataRequestRef.current === null) protocolOnlyLoadingRef.current = true;
 		// Once content is on screen it stays interactive; the header indexing
-		// indicator (driven by loadingMessage) is the only loading signal.
-		if (!hasLoadedDataRef.current) {
-			setIsLoading(true);
-			setLoadError(null);
-		}
+		// indicator (driven by loadingMessage) is the only loading signal. A new
+		// loading attempt always clears a stale terminal error, so a passive
+		// client shows its cached content instead of the obsolete failure.
+		if (!hasLoadedDataRef.current) setIsLoading(true);
+		setLoadError(null);
 		setLoadingMessage(loadingState.message);
 	  } else if (loadingState?.type === 'loaded') {
 		const shouldRefresh = protocolOnlyLoadingRef.current && pendingDataRequestRef.current === null;

--- a/src/web/components/BranchIndexingIndicator.tsx
+++ b/src/web/components/BranchIndexingIndicator.tsx
@@ -57,7 +57,9 @@ export function BranchIndexingIndicator({
 					className="h-3 w-3 shrink-0 animate-spin rounded-circle border-2 border-blue-200 border-t-blue-600 motion-reduce:animate-none dark:border-blue-400/30 dark:border-t-blue-400"
 					aria-hidden="true"
 				/>
-				<span aria-hidden="true">Indexing branches</span>
+				<span aria-hidden="true" className="hidden sm:inline">
+					Indexing branches
+				</span>
 				<span className="sr-only">{detail ?? "Indexing branches"}</span>
 			</div>
 			<div

--- a/src/web/components/BranchIndexingIndicator.tsx
+++ b/src/web/components/BranchIndexingIndicator.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+
+interface BranchIndexingIndicatorProps {
+	message?: string | null;
+	/** How long the loading message must persist before the indicator appears. */
+	appearDelayMs?: number;
+	/** Fade-out duration before the indicator unmounts. */
+	exitDurationMs?: number;
+}
+
+/**
+ * Shell-level indicator for cross-branch indexing. Renders a compact status chip
+ * in the header plus a hairline sweep bar on the header's bottom border.
+ * Appears only after the indexing state persists (no flash on fast completion)
+ * and fades out cleanly when indexing finishes.
+ */
+export function BranchIndexingIndicator({
+	message,
+	appearDelayMs = 250,
+	exitDurationMs = 200,
+}: BranchIndexingIndicatorProps) {
+	const [mounted, setMounted] = useState(false);
+	const [active, setActive] = useState(false);
+	const lastMessageRef = useRef<string | null>(null);
+	if (message) lastMessageRef.current = message;
+
+	useEffect(() => {
+		if (message) {
+			if (mounted) {
+				// Runs post-paint, so the first activation still transitions from the
+				// hidden state the chip mounted with.
+				setActive(true);
+				return;
+			}
+			const timer = window.setTimeout(() => setMounted(true), appearDelayMs);
+			return () => window.clearTimeout(timer);
+		}
+		if (!mounted) return;
+		setActive(false);
+		const timer = window.setTimeout(() => setMounted(false), exitDurationMs);
+		return () => window.clearTimeout(timer);
+	}, [message, mounted, appearDelayMs, exitDurationMs]);
+
+	if (!mounted) return null;
+
+	const detail = lastMessageRef.current ?? undefined;
+	return (
+		<>
+			<div
+				role="status"
+				title={detail}
+				className={`flex items-center gap-2 rounded-circle bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-600 transition-all duration-200 dark:bg-blue-600/20 dark:text-blue-400 ${
+					active ? "translate-y-0 opacity-100" : "-translate-y-0.5 opacity-0"
+				}`}
+			>
+				<span
+					className="h-3 w-3 shrink-0 animate-spin rounded-circle border-2 border-blue-200 border-t-blue-600 motion-reduce:animate-none dark:border-blue-400/30 dark:border-t-blue-400"
+					aria-hidden="true"
+				/>
+				<span aria-hidden="true">Indexing branches</span>
+				<span className="sr-only">{detail ?? "Indexing branches"}</span>
+			</div>
+			<div
+				aria-hidden="true"
+				className={`pointer-events-none absolute inset-x-0 bottom-0 h-0.5 overflow-hidden transition-opacity duration-200 motion-reduce:hidden ${
+					active ? "opacity-100" : "opacity-0"
+				}`}
+			>
+				<div className="animate-indexing-sweep h-full w-2/5 bg-gradient-to-r from-transparent via-blue-500 to-transparent dark:via-blue-400" />
+			</div>
+		</>
+	);
+}

--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -41,13 +41,12 @@ export default function Layout({
 				docs={docs}
 				decisions={decisions}
 				isLoading={isLoading}
-				loadingMessage={loadingMessage}
 				error={error}
 				onRetry={onRefreshData}
 				onRefreshData={onRefreshData}
 			/>
 			<div className="flex-1 flex flex-col min-h-0 min-w-0">
-				<Navigation projectName={projectName} />
+				<Navigation projectName={projectName} loadingMessage={loadingMessage} />
 				<DuplicateIdWarning plan={duplicateRepairPlan} onRepaired={onRefreshData} />
 				<main className="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden">
 					<Outlet context={{ tasks, docs, decisions, isLoading, onRefreshData }} />

--- a/src/web/components/Navigation.tsx
+++ b/src/web/components/Navigation.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
+import { BranchIndexingIndicator } from './BranchIndexingIndicator';
 import ThemeToggle from './ThemeToggle';
 
 interface NavigationProps {
     projectName: string;
+    loadingMessage?: string | null;
 }
 
-const Navigation: React.FC<NavigationProps> = ({projectName}) => {
+const Navigation: React.FC<NavigationProps> = ({projectName, loadingMessage}) => {
     return (
-        <nav className="px-8 h-18 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 transition-colors duration-200">
+        <nav className="relative px-8 h-18 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 transition-colors duration-200">
             <div className="h-full flex items-center justify-between">
                 <div className="flex items-center gap-2">
                     <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">{projectName || 'Loading...'}</h1>
@@ -21,7 +23,10 @@ const Navigation: React.FC<NavigationProps> = ({projectName}) => {
                         Backlog.md
                     </a>
                 </div>
-                <ThemeToggle />
+                <div className="flex items-center gap-3">
+                    <BranchIndexingIndicator message={loadingMessage} />
+                    <ThemeToggle />
+                </div>
             </div>
         </nav>
     );

--- a/src/web/components/SideNavigation.tsx
+++ b/src/web/components/SideNavigation.tsx
@@ -33,14 +33,12 @@ const hasTaskSearchFilters = (parsedQuery: ReturnType<typeof parseSearchCommandQ
 	);
 };
 
-const LoadingPhase = ({ message, className }: { message?: string | null; className: string }) => (
+const LoadingPhase = ({ className }: { className: string }) => (
 	<p className={className} role="status">
-		{message ?? (
-			<span
-				className="inline-block h-3 w-32 animate-pulse rounded bg-gray-300 dark:bg-gray-700"
-				aria-label="Loading content"
-			/>
-		)}
+		<span
+			className="inline-block h-3 w-32 animate-pulse rounded bg-gray-300 dark:bg-gray-700"
+			aria-label="Loading content"
+		/>
 	</p>
 );
 
@@ -260,7 +258,6 @@ interface SideNavigationProps {
 	docs: Document[];
 	decisions: Decision[];
 	isLoading: boolean;
-	loadingMessage?: string | null;
 	error?: Error | null;
 	onRetry?: () => void;
 	onRefreshData: () => Promise<void>;
@@ -270,9 +267,8 @@ const SideNavigation = memo(function SideNavigation({
 	taskCount,
 	docs, 
 	decisions, 
-	isLoading, 
-	loadingMessage,
-	error, 
+	isLoading,
+	error,
 	onRetry
 }: SideNavigationProps) {
 	const [isCollapsed, setIsCollapsed] = useState(() => {
@@ -643,7 +639,7 @@ const SideNavigation = memo(function SideNavigation({
 							</span>
 						</div>
 						{isLoading && (
-							<LoadingPhase message={loadingMessage} className="mt-2 text-xs text-gray-500 dark:text-gray-400" />
+							<LoadingPhase className="mt-2 text-xs text-gray-500 dark:text-gray-400" />
 						)}
 					</div>
 				)}
@@ -764,7 +760,7 @@ const SideNavigation = memo(function SideNavigation({
 							{!isDocsCollapsed && (
 								<div className="space-y-1">
 									{isLoading ? (
-										<LoadingPhase message={loadingMessage} className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400" />
+										<LoadingPhase className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400" />
 									) : error ? (
 										<p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">Documents unavailable</p>
 									) : filteredDocs.length === 0 ? (
@@ -832,7 +828,7 @@ const SideNavigation = memo(function SideNavigation({
 							{!isDecisionsCollapsed && (
 								<div className="space-y-1">
 									{isLoading ? (
-										<LoadingPhase message={loadingMessage} className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400" />
+										<LoadingPhase className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400" />
 									) : error ? (
 										<p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">Decisions unavailable</p>
 									) : filteredDecisions.length === 0 ? (

--- a/src/web/styles/source.css
+++ b/src/web/styles/source.css
@@ -183,6 +183,21 @@
         animation: slide-in-down 0.3s ease-out;
     }
 
+    /* Branch indexing indicator: hairline segment sweeping along the header border */
+    @keyframes indexing-sweep {
+        from {
+            transform: translateX(-100%);
+        }
+
+        to {
+            transform: translateX(250%);
+        }
+    }
+
+    .animate-indexing-sweep {
+        animation: indexing-sweep 1.4s ease-in-out infinite;
+    }
+
     /* Avoid forcing internal editor heights; use component props instead */
 
     /* Fix for long content in markdown preview - scope to preview containers only */


### PR DESCRIPTION
Implements BACK-654.

## What changed

The cross-branch indexing state ("Indexing 35 other local branches...") used to render as a raw progress sentence next to the board spinner and three more times in the side navigation. It is now a single shell-level indicator in the top header:

- **Status chip** in the header's right cluster: a compact pill reusing the active-nav accent (`bg-blue-50 dark:bg-blue-600/20 text-blue-600 dark:text-blue-400`) with a 12px spinner ring (the board spinner style, scaled down) and the single label "Indexing branches". The full server progress message is preserved as tooltip and `sr-only` text on a `role="status"` element, so screen readers still hear the real progress line.
- **Hairline sweep bar**: a 2px gradient segment sweeping along the header's bottom border while indexing runs (`indexing-sweep` keyframe in `styles/source.css`, next to the existing health-check animations). `pointer-events-none`, no layout shift, hidden under `prefers-reduced-motion`.

## Motion / flicker behavior

- The indicator mounts only after the indexing state has persisted 250ms - fast completions never flash anything.
- Entry is a 200ms fade + 2px rise; on completion it fades out 200ms and unmounts. Delays are props so the jsdom tests use short values.

## Interactivity (AC #2)

`App.tsx` now flips the blocking skeleton (`isLoading`) only before the first successful load (`hasLoadedDataRef`). Mid-session WebSocket `loading` events no longer blank already-loaded content: the header indicator is the only loading signal once content is on screen, and later refreshes update content in place instead of re-showing skeletons.

## Kept out of scope

- `Board.tsx`, `TaskCard`, `TaskDetailsModal` are untouched (in-flight overlap with #945/#960). The board's `loadingMessage` prop is simply no longer fed by `App.tsx`; removing the now-dead prop plumbing through `BoardPage`/`Board` can happen once those PRs land.
- The generic first-load board skeleton remains: during initial indexing there is no loaded content yet, so the skeleton plus the header indicator describe that state together.

## Verification

- `bunx tsc --noEmit`, `bun run check .`, `bun test` green.
- New jsdom test `src/test/web-branch-indexing-indicator.test.tsx`: no render before the appear delay, visible chip + sweep with `role="status"` and the announced server message after it, fast completion never appears, clean fade-out unmount, message replacement keeps it visible.
- `web-task-detail-deeplink.test.tsx`'s three phase-visibility assertions now observe the indicator (waiting out its appear/exit windows) instead of the removed raw sentence; their real subject - fetch reconciliation - is unchanged. `web-side-navigation-loading.test.tsx` asserts the sidebar skeleton instead of the sentence.
- Verified live against this repo's ~120 local branches: dark-theme chip visible during cold indexing; warm restart completes without flash or residue (light theme).

## For the maintainer's visual pass

- Chip + sweep bar proportions in the header, both themes (dark was captured live during a cold index; light-theme indexing completed too fast to catch on a warm cache - the chip uses the same tokens as the active nav pill).
- Whether the "Indexing branches" label wording fits, and whether the sweep bar earns its keep or the chip alone is enough.
