### PR TITLE
BACK-660 - Reject nested section markers in notes and fix append truncation

### DIFF
--- a/backlog/tasks/back-660 - Reject-nested-section-markers-in-notes-and-fix-append-truncation.md
+++ b/backlog/tasks/back-660 - Reject-nested-section-markers-in-notes-and-fix-append-truncation.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-660
 title: Reject nested section markers in notes and fix append truncation
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-30 15:23'
+updated_date: '2026-08-30 15:48'
 labels:
   - cli
   - bug
@@ -21,15 +23,38 @@ buildSectionBlock (src/markdown/structured-sections.ts:249) wraps a notes payloa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Writing notes containing section sentinel lines either strips them safely or fails with a clear error; the stored file stays readable
-- [ ] #2 --append-notes appends correctly when existing content contains marker-like substrings
-- [ ] #3 A corrupted nested-marker file from before the fix is at least readable by view commands or flagged by doctor
-- [ ] #4 Tests cover sentinel-in-payload, append-with-marker-substring, and round-trip stability
+- [x] #1 Writing notes containing section sentinel lines either strips them safely or fails with a clear error; the stored file stays readable
+- [x] #2 --append-notes appends correctly when existing content contains marker-like substrings
+- [x] #3 A corrupted nested-marker file from before the fix is at least readable by view commands or flagged by doctor
+- [x] #4 Tests cover sentinel-in-payload, append-with-marker-substring, and round-trip stability
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Root cause: buildSectionBlock wraps payloads blindly (nesting), and extraction regexes (sentinelBlockRegex and friends) stop at the first end-marker SUBSTRING, so reads truncate and --append-notes persists the loss.
+2. Reject, not strip: new section input (description/plan/notes/final summary, including appends) that contains the target section's own sentinel marker as a full line fails with a clear error naming the marker. Rationale: agent-written content is the record; silent stripping alters what the caller asked to store (manifesto: fail closed, review before consequence). Precedent: comment bodies already reject marker content. Scope is per-family only, so BACK-637's fenced cross-family marker round-trips stay valid. Escape hatch: indent the line to store it as literal text.
+3. Real boundaries: replace the sentinel-path regexes in structured-sections.ts with one shared line-anchored, depth-aware block scanner (heading, BEGIN line, depth-counted same-family lines, END at depth 0) used by extraction, section ranges, start/end index lookup, and strip. Line-anchor tokenizeKnownSentinels the same way (issue 932's own guidance). Inline marker substrings become inert; append no longer truncates.
+4. Corrupted pre-fix files: depth-aware extraction renders the full nested interior (nothing hidden, satisfies readability AC without expanding doctor), and a clean --notes rewrite strips the whole nested region, repairing the file.
+5. Validation lives in core (createTaskFromInput + applyTaskUpdateInput) so CLI, MCP, web server, and TUI-create all share it; TUI raw-file editing stays the human escape hatch. buildSectionBlock stays tolerant so corrupted files remain editable.
+6. Tests: sentinel-in-payload rejection per surface field, append with inline marker substring, nested-file readability + repair, round-trip stability; keep BACK-637 fence suite green.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented. Reject over strip: new section input (create/edit/append, all surfaces via createTaskFromInput + applyTaskUpdateInput) fails with a clear error when it contains the target section's own sentinel marker as a whole line; inline mentions, indented lines, and other families' markers (BACK-637 fence cases) stay legal. Replaced the five sentinel-path regexes in structured-sections.ts with one line-anchored, depth-aware block scanner (findSentinelBlocks), so extraction/append stop truncating at marker substrings, nested pre-fix files render their full interior, and a clean --notes rewrite strips the whole nested region (repairs the file). tokenizeKnownSentinels is now line-anchored per the issue's guidance. New suite src/test/section-marker-safety.test.ts (9 tests; 8 fail on pre-fix code). tsc, biome, and full bun test green except 3 pre-existing tui-emoji-width failures also present on clean origin/main.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rejected (not stripped) section payloads carrying their own sentinel marker as a whole line, at the shared core input boundary (createTaskFromInput + applyTaskUpdateInput, covering CLI/MCP/web/TUI-create), and replaced the sentinel regexes in structured-sections.ts with one line-anchored, depth-aware block scanner so reads, appends, strips, and insert positions all agree on the real section boundary. Inline marker mentions no longer truncate --append-notes; pre-fix nested-marker files render their full interior in task view and are repaired by a clean --notes rewrite. Verified with src/test/section-marker-safety.test.ts (9 tests, 8 red on pre-fix code) plus the BACK-637 fence round-trip suite; bunx tsc --noEmit, bun run check ., and full bun test green (3 tui-emoji-width failures pre-exist on origin/main).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -13,6 +13,7 @@ import {
 import { type GitBranchTip, type GitIndexEntry, GitOperations } from "../git/operations.ts";
 import { parseFrontmatter } from "../markdown/frontmatter.ts";
 import { parseTask } from "../markdown/parser.ts";
+import { assertSectionInputHasNoMarkerLines } from "../markdown/structured-sections.ts";
 import {
 	type AcceptanceCriterion,
 	type BacklogConfig,
@@ -269,6 +270,35 @@ function formatMissingDependenciesError(invalid: string[]): Error {
 	return new Error(
 		`The following dependencies do not exist: ${invalid.join(", ")}. Please create these tasks first or verify the IDs. ${LOCAL_TASK_LOOKUP_HINT}`,
 	);
+}
+
+/**
+ * Structured-section input that contains its own sentinel marker as a whole
+ * line is rejected before any write: wrapping it would nest markers and hide
+ * the stored content from every reader (GitHub issue #932).
+ */
+function assertSectionInputsSafe(input: {
+	description?: string;
+	implementationPlan?: string;
+	implementationNotes?: string;
+	finalSummary?: string;
+	appendImplementationPlan?: string[];
+	appendImplementationNotes?: string[];
+	appendFinalSummary?: string[];
+}): void {
+	assertSectionInputHasNoMarkerLines(input.description, "description");
+	assertSectionInputHasNoMarkerLines(input.implementationPlan, "implementationPlan");
+	assertSectionInputHasNoMarkerLines(input.implementationNotes, "implementationNotes");
+	assertSectionInputHasNoMarkerLines(input.finalSummary, "finalSummary");
+	for (const value of input.appendImplementationPlan ?? []) {
+		assertSectionInputHasNoMarkerLines(value, "implementationPlan");
+	}
+	for (const value of input.appendImplementationNotes ?? []) {
+		assertSectionInputHasNoMarkerLines(value, "implementationNotes");
+	}
+	for (const value of input.appendFinalSummary ?? []) {
+		assertSectionInputHasNoMarkerLines(value, "finalSummary");
+	}
 }
 
 export class Core {
@@ -1563,6 +1593,7 @@ export class Core {
 		if (!input.title || input.title.trim().length === 0) {
 			throw new Error("Title is required to create a task.");
 		}
+		assertSectionInputsSafe(input);
 
 		// Determine if this is a draft BEFORE generating the ID
 		const requestedStatus = input.status?.trim();
@@ -1785,6 +1816,7 @@ export class Core {
 		input: TaskUpdateInput,
 		statusResolver: (status: string) => Promise<string>,
 	): Promise<{ task: Task; mutated: boolean }> {
+		assertSectionInputsSafe(input);
 		let mutated = false;
 
 		const applyStringField = (

--- a/src/markdown/structured-sections.ts
+++ b/src/markdown/structured-sections.ts
@@ -314,7 +314,9 @@ interface ChecklistSentinelResolution {
 }
 
 function tokenizeKnownSentinels(content: string): SentinelToken[] {
-	const markerRegex = /<!-- (SECTION:[A-Z][A-Z0-9_]*|COMMENTS|COMMENT|AC|DOD):(BEGIN|END) -->/g;
+	// Anchored to whole lines: content that merely mentions a marker inline must
+	// never count as a structural sentinel (GitHub issue #932).
+	const markerRegex = /^<!-- (SECTION:[A-Z][A-Z0-9_]*|COMMENTS|COMMENT|AC|DOD):(BEGIN|END) -->[\t ]*$/gm;
 	const tokens: SentinelToken[] = [];
 	for (const match of content.matchAll(markerRegex)) {
 		const start = match.index ?? 0;
@@ -423,29 +425,16 @@ function findSectionEndIndex(content: string, title: string): number | undefined
 		return findChecklistSectionRanges(content, DEFINITION_OF_DONE_DEFINITION)[0]?.end;
 	}
 	const sentinelRanges = resolveKnownSentinelRanges(tokenizeKnownSentinels(content));
-	let sentinelMatch: RegExpExecArray | null = null;
 	if (normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()) {
-		sentinelMatch = findMatchOutsideRanges(commentsSentinelRegex(), content, sentinelRanges) ?? null;
-	} else {
-		const keyEntry = Object.entries(SECTION_CONFIG).find(
-			([, config]) => config.title.toLowerCase() === normalizedTitle.toLowerCase(),
-		);
-		if (keyEntry) {
-			const key = keyEntry[0] as StructuredSectionKey;
-			sentinelMatch =
-				findMatchOutsideRanges(
-					new RegExp(
-						`## ${escapeForRegex(getConfig(key).title)}\\s*\\n${escapeForRegex(getBeginMarker(key))}\\s*\\n([\\s\\S]*?)${escapeForRegex(getEndMarker(key))}`,
-						"i",
-					),
-					content,
-					sentinelRanges,
-				) ?? null;
+		const sentinelMatch = findMatchOutsideRanges(commentsSentinelRegex(), content, sentinelRanges);
+		if (sentinelMatch) {
+			return sentinelMatch.index + sentinelMatch[0].length;
 		}
-	}
-
-	if (sentinelMatch) {
-		return sentinelMatch.index + sentinelMatch[0].length;
+	} else {
+		const block = findSentinelBlockForTitle(content, normalizedTitle, sentinelRanges);
+		if (block) {
+			return block.end;
+		}
 	}
 
 	const legacyRegex =
@@ -459,6 +448,19 @@ function findSectionEndIndex(content: string, title: string): number | undefined
 	return undefined;
 }
 
+function findSentinelBlockForTitle(
+	content: string,
+	normalizedTitle: string,
+	maskedRanges: TextRange[],
+): SentinelBlock | undefined {
+	const keyEntry = Object.entries(SECTION_CONFIG).find(
+		([, config]) => config.title.toLowerCase() === normalizedTitle.toLowerCase(),
+	);
+	if (!keyEntry) return undefined;
+	const key = keyEntry[0] as StructuredSectionKey;
+	return findSentinelBlocks(content, key).find((candidate) => !isIndexWithinRanges(candidate.start, maskedRanges));
+}
+
 function findSectionStartIndex(content: string, title: string): number | undefined {
 	const normalizedTitle = title.trim();
 	if (normalizedTitle.toLowerCase() === ACCEPTANCE_CRITERIA_TITLE.toLowerCase()) {
@@ -468,29 +470,16 @@ function findSectionStartIndex(content: string, title: string): number | undefin
 		return findChecklistSectionRanges(content, DEFINITION_OF_DONE_DEFINITION)[0]?.start;
 	}
 	const sentinelRanges = resolveKnownSentinelRanges(tokenizeKnownSentinels(content));
-	let sentinelMatch: RegExpExecArray | null = null;
 	if (normalizedTitle.toLowerCase() === COMMENTS_TITLE.toLowerCase()) {
-		sentinelMatch = findMatchOutsideRanges(commentsSentinelRegex(), content, sentinelRanges) ?? null;
-	} else {
-		const keyEntry = Object.entries(SECTION_CONFIG).find(
-			([, config]) => config.title.toLowerCase() === normalizedTitle.toLowerCase(),
-		);
-		if (keyEntry) {
-			const key = keyEntry[0] as StructuredSectionKey;
-			sentinelMatch =
-				findMatchOutsideRanges(
-					new RegExp(
-						`(\\n|^)## ${escapeForRegex(getConfig(key).title)}\\s*\\n${escapeForRegex(getBeginMarker(key))}\\s*\\n([\\s\\S]*?)${escapeForRegex(getEndMarker(key))}`,
-						"i",
-					),
-					content,
-					sentinelRanges,
-				) ?? null;
+		const sentinelMatch = findMatchOutsideRanges(commentsSentinelRegex(), content, sentinelRanges);
+		if (sentinelMatch) {
+			return sentinelMatch.index;
 		}
-	}
-
-	if (sentinelMatch) {
-		return sentinelMatch.index;
+	} else {
+		const block = findSentinelBlockForTitle(content, normalizedTitle, sentinelRanges);
+		if (block) {
+			return block.start;
+		}
 	}
 
 	const legacyRegex =
@@ -501,11 +490,77 @@ function findSectionStartIndex(content: string, title: string): number | undefin
 	return legacyMatch?.index;
 }
 
-function sentinelBlockRegex(key: StructuredSectionKey): RegExp {
-	const { title } = getConfig(key);
-	const begin = escapeForRegex(getBeginMarker(key));
-	const end = escapeForRegex(getEndMarker(key));
-	return new RegExp(`## ${escapeForRegex(title)}\\s*\\n${begin}\\s*\\n([\\s\\S]*?)${end}`, "i");
+interface SentinelBlock {
+	start: number;
+	bodyStart: number;
+	bodyEnd: number;
+	end: number;
+}
+
+/**
+ * Locates `## Title` + BEGIN...END sentinel blocks for a structured section.
+ * Markers count only as whole lines (trailing whitespace tolerated), so a body
+ * that merely mentions a marker inline can never terminate the block early.
+ * Same-family BEGIN lines inside the block are depth-counted, so a file whose
+ * markers were nested by pre-fix writes still resolves to one block containing
+ * its full interior instead of hiding everything after the first END line.
+ */
+function findSentinelBlocks(content: string, key: StructuredSectionKey): SentinelBlock[] {
+	const heading = `## ${getConfig(key).title}`.toLowerCase();
+	const begin = getBeginMarker(key);
+	const end = getEndMarker(key);
+	const lines = content.split("\n");
+	let offset = 0;
+	const offsets = lines.map((line) => {
+		const start = offset;
+		offset += line.length + 1;
+		return start;
+	});
+	const blocks: SentinelBlock[] = [];
+	for (let index = 0; index < lines.length; index += 1) {
+		if ((lines[index] ?? "").trimEnd().toLowerCase() !== heading) continue;
+		let beginIndex = index + 1;
+		while (beginIndex < lines.length && (lines[beginIndex] ?? "").trim() === "") beginIndex += 1;
+		if ((lines[beginIndex] ?? "").trimEnd() !== begin) continue;
+		let depth = 1;
+		let endIndex = beginIndex + 1;
+		while (endIndex < lines.length) {
+			const candidate = (lines[endIndex] ?? "").trimEnd();
+			if (candidate === begin) depth += 1;
+			else if (candidate === end) {
+				depth -= 1;
+				if (depth === 0) break;
+			}
+			endIndex += 1;
+		}
+		if (depth !== 0) continue;
+		blocks.push({
+			start: offsets[index] ?? 0,
+			bodyStart: Math.min((offsets[beginIndex] ?? 0) + (lines[beginIndex] ?? "").length + 1, content.length),
+			bodyEnd: offsets[endIndex] ?? content.length,
+			end: (offsets[endIndex] ?? 0) + (lines[endIndex] ?? "").length,
+		});
+		index = endIndex;
+	}
+	return blocks;
+}
+
+/**
+ * Rejects section input that contains the target section's own sentinel marker
+ * as a whole line: wrapping such a payload would nest markers and hide content
+ * from every reader. Inline mentions and other sections' markers stay legal.
+ */
+export function assertSectionInputHasNoMarkerLines(value: string | undefined, key: StructuredSectionKey): void {
+	if (typeof value !== "string" || value.length === 0) return;
+	const begin = getBeginMarker(key);
+	const end = getEndMarker(key);
+	for (const line of value.replace(/\r\n/g, "\n").split("\n")) {
+		const trimmed = line.trimEnd();
+		if (trimmed !== begin && trimmed !== end) continue;
+		throw new Error(
+			`${getConfig(key).title} content cannot contain the reserved marker line "${trimmed}". Indent it with a space to include it as literal text.`,
+		);
+	}
 }
 
 interface SectionRange {
@@ -549,10 +604,8 @@ function findMatchOutsideRanges(
 function getStructuredSectionRanges(content: string): SectionRange[] {
 	const ranges: SectionRange[] = [];
 	for (const key of SECTION_INSERTION_ORDER) {
-		const sentinelRegex = new RegExp(sentinelBlockRegex(key).source, "gi");
-		for (const match of content.matchAll(sentinelRegex)) {
-			const index = match.index ?? 0;
-			ranges.push({ key, start: index, end: index + match[0].length, kind: "sentinel" });
+		for (const block of findSentinelBlocks(content, key)) {
+			ranges.push({ key, start: block.start, end: block.end, kind: "sentinel" });
 		}
 
 		const legacyRegex = legacySectionRegex(getConfig(key).title, "gi");
@@ -666,18 +719,12 @@ function findChecklistSectionRanges(
 }
 
 function stripSectionInstances(content: string, key: StructuredSectionKey): string {
-	const beginEsc = escapeForRegex(getBeginMarker(key));
-	const endEsc = escapeForRegex(getEndMarker(key));
-	const { title } = getConfig(key);
-
 	let stripped = content;
-	const sentinelRegex = new RegExp(
-		`(\n|^)## ${escapeForRegex(title)}\\s*\\n${beginEsc}\\s*\\n([\\s\\S]*?)${endEsc}(?:\\s*\n|$)`,
-		"gi",
-	);
-	stripped = stripped.replace(sentinelRegex, "\n");
+	for (const block of findSentinelBlocks(content, key).sort((left, right) => right.start - left.start)) {
+		stripped = `${stripped.slice(0, block.start)}${stripped.slice(block.end)}`;
+	}
 
-	const legacyRegex = legacySectionRegex(title, "gi");
+	const legacyRegex = legacySectionRegex(getConfig(key).title, "gi");
 	stripped = stripped.replace(legacyRegex, "\n");
 
 	return collapseBlankLines(stripped).trimEnd();
@@ -722,9 +769,9 @@ function appendBlock(content: string, block: string): string {
 export function extractStructuredSection(content: string, key: StructuredSectionKey): string | undefined {
 	const src = content.replace(/\r\n/g, "\n");
 	const otherRanges = getStructuredSectionRanges(src).filter((range) => range.key !== key);
-	const sentinelMatch = findMatchOutsideRanges(sentinelBlockRegex(key), src, otherRanges);
-	if (sentinelMatch?.[1]) {
-		return sentinelMatch[1].trim() || undefined;
+	const block = findSentinelBlocks(src, key).find((candidate) => !isIndexWithinRanges(candidate.start, otherRanges));
+	if (block) {
+		return src.slice(block.bodyStart, block.bodyEnd).trim() || undefined;
 	}
 	const legacyMatch = findMatchOutsideRanges(sectionHeaderRegex(key), src, otherRanges);
 	return legacyMatch?.[1]?.trim() || undefined;

--- a/src/test/section-marker-safety.test.ts
+++ b/src/test/section-marker-safety.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { parseTask } from "../markdown/parser.ts";
+import { updateTaskImplementationNotes } from "../markdown/serializer.ts";
+import { extractStructuredSection, updateStructuredSections } from "../markdown/structured-sections.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+
+let TEST_DIR: string;
+const CLI_PATH = getTestCliPath();
+
+const NOTES_BEGIN = "<!-- SECTION:NOTES:BEGIN -->";
+const NOTES_END = "<!-- SECTION:NOTES:END -->";
+
+async function findTaskFile(dir: string, id: string): Promise<string> {
+	const tasksDir = join(dir, "backlog", "tasks");
+	const entries = await readdir(tasksDir);
+	const name = entries.find((entry) => entry.startsWith(`${id} `) || entry.startsWith(`${id}-`));
+	if (!name) throw new Error(`No file for ${id} in ${tasksDir}`);
+	return join(tasksDir, name);
+}
+
+describe("Section marker safety (BACK-660, issue #932)", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-section-marker-safety");
+		await mkdir(TEST_DIR, { recursive: true });
+		const core = new Core(TEST_DIR);
+		await initializeFilesystemTestProject(core, "Section Marker Safety Test");
+	});
+
+	afterEach(async () => {
+		await safeCleanup(TEST_DIR);
+	});
+
+	describe("rejecting sentinel lines in section input", () => {
+		it("rejects --notes payloads containing the notes marker line and keeps the file readable", async () => {
+			const create = await $`bun ${[CLI_PATH, "task", "create", "Marker task", "--notes", "FIRST NOTE"]}`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(create.exitCode).toBe(0);
+
+			// The read-modify-write pattern from issue #932: the payload carries the
+			// existing marker lines back into --notes.
+			const payload = `${NOTES_BEGIN}\nFIRST NOTE\n${NOTES_END}\n\nSECOND NOTE`;
+			const edit = await $`bun ${[CLI_PATH, "task", "edit", "1", "--notes", payload]}`.cwd(TEST_DIR).quiet().nothrow();
+			expect(edit.exitCode).not.toBe(0);
+			expect(`${edit.stderr}${edit.stdout}`).toContain(
+				'Implementation Notes content cannot contain the reserved marker line "<!-- SECTION:NOTES:BEGIN -->".',
+			);
+
+			const content = await Bun.file(await findTaskFile(TEST_DIR, "task-1")).text();
+			expect(content.split(NOTES_BEGIN).length - 1).toBe(1);
+			expect(content.split(NOTES_END).length - 1).toBe(1);
+			expect(extractStructuredSection(content, "implementationNotes")).toBe("FIRST NOTE");
+		});
+
+		it("rejects marker lines in --append-notes and in create/plan/description/final summary input", async () => {
+			const core = new Core(TEST_DIR);
+			await expect(
+				core.createTaskFromInput({ title: "Bad notes", implementationNotes: `x\n${NOTES_END}\ny` }),
+			).rejects.toThrow("Implementation Notes content cannot contain the reserved marker line");
+			await expect(
+				core.createTaskFromInput({ title: "Bad description", description: "<!-- SECTION:DESCRIPTION:BEGIN -->" }),
+			).rejects.toThrow("Description content cannot contain the reserved marker line");
+
+			const create = await $`bun ${[CLI_PATH, "task", "create", "Append target"]}`.cwd(TEST_DIR).quiet().nothrow();
+			expect(create.exitCode).toBe(0);
+
+			const append = await $`bun ${[CLI_PATH, "task", "edit", "1", "--append-notes", `quoting:\n${NOTES_END}`]}`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(append.exitCode).not.toBe(0);
+			expect(`${append.stderr}${append.stdout}`).toContain("reserved marker line");
+
+			const plan = await $`bun ${[CLI_PATH, "task", "edit", "1", "--plan", "<!-- SECTION:PLAN:END -->"]}`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(plan.exitCode).not.toBe(0);
+			expect(`${plan.stderr}${plan.stdout}`).toContain("Implementation Plan content cannot contain");
+		});
+
+		it("still accepts inline mentions, indented marker lines, and other sections' markers in fences", async () => {
+			const inline = "The section ends at <!-- SECTION:NOTES:END --> on disk.";
+			const indented = ` ${NOTES_END}`;
+			const fencedForeign = "```\n<!-- SECTION:DESCRIPTION:BEGIN -->\nstill fenced\n```";
+			const notes = [inline, indented, fencedForeign].join("\n\n");
+
+			const create = await $`bun ${[CLI_PATH, "task", "create", "Literal marker talk", "--notes", notes]}`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(create.exitCode).toBe(0);
+
+			const content = await Bun.file(await findTaskFile(TEST_DIR, "task-1")).text();
+			expect(extractStructuredSection(content, "implementationNotes")).toBe(notes);
+		});
+	});
+
+	describe("append with marker-like substrings (issue #932 second symptom)", () => {
+		it("appends without truncating notes that mention the end marker inline", async () => {
+			const existing = "Terminator is <!-- SECTION:NOTES:END --> inline\n\nTail content";
+			const create = await $`bun ${[CLI_PATH, "task", "create", "Quoting task", "--notes", existing]}`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(create.exitCode).toBe(0);
+
+			const filePath = await findTaskFile(TEST_DIR, "task-1");
+			const sizeBefore = (await Bun.file(filePath).text()).length;
+
+			const append = await $`bun ${[CLI_PATH, "task", "edit", "1", "--append-notes", "APPENDED"]}`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(append.exitCode).toBe(0);
+
+			const content = await Bun.file(filePath).text();
+			expect(content.length).toBeGreaterThan(sizeBefore);
+			expect(extractStructuredSection(content, "implementationNotes")).toBe(`${existing}\n\nAPPENDED`);
+
+			const view = await $`bun ${[CLI_PATH, "task", "view", "1", "--plain"]}`.cwd(TEST_DIR).quiet().nothrow();
+			expect(view.stdout.toString()).toContain("Tail content");
+			expect(view.stdout.toString()).toContain("APPENDED");
+		});
+	});
+
+	describe("pre-existing nested-marker files (issue #932 corruption)", () => {
+		const nestedBody = [
+			"## Description",
+			"",
+			"<!-- SECTION:DESCRIPTION:BEGIN -->",
+			"seed description",
+			"<!-- SECTION:DESCRIPTION:END -->",
+			"",
+			"## Implementation Notes",
+			"",
+			NOTES_BEGIN,
+			NOTES_BEGIN,
+			"FIRST NOTE",
+			NOTES_END,
+			"",
+			"SECOND NOTE",
+			NOTES_END,
+		].join("\n");
+
+		const nestedFile = [
+			"---",
+			"id: task-1",
+			"title: repro",
+			"status: To Do",
+			"assignee: []",
+			"created_date: 2026-08-30 00:00",
+			"labels: []",
+			"dependencies: []",
+			"---",
+			"",
+			nestedBody,
+		].join("\n");
+
+		it("keeps every note line readable instead of hiding content after the inner END", () => {
+			const task = parseTask(nestedFile);
+			expect(task.implementationNotes).toContain("FIRST NOTE");
+			expect(task.implementationNotes).toContain("SECOND NOTE");
+			expect(task.description).toBe("seed description");
+		});
+
+		it("shows the full nested interior in task view", async () => {
+			const create = await $`bun ${[CLI_PATH, "task", "create", "repro"]}`.cwd(TEST_DIR).quiet().nothrow();
+			expect(create.exitCode).toBe(0);
+			const filePath = await findTaskFile(TEST_DIR, "task-1");
+			await Bun.write(filePath, nestedFile);
+
+			const view = await $`bun ${[CLI_PATH, "task", "view", "1", "--plain"]}`.cwd(TEST_DIR).quiet().nothrow();
+			expect(view.exitCode).toBe(0);
+			expect(view.stdout.toString()).toContain("FIRST NOTE");
+			expect(view.stdout.toString()).toContain("SECOND NOTE");
+		});
+
+		it("repairs the nested markers on a clean --notes rewrite without stranding old text", async () => {
+			const create = await $`bun ${[CLI_PATH, "task", "create", "repro"]}`.cwd(TEST_DIR).quiet().nothrow();
+			expect(create.exitCode).toBe(0);
+			const filePath = await findTaskFile(TEST_DIR, "task-1");
+			await Bun.write(filePath, nestedFile);
+
+			const edit = await $`bun ${[CLI_PATH, "task", "edit", "1", "--notes", "REPAIRED BODY"]}`
+				.cwd(TEST_DIR)
+				.quiet()
+				.nothrow();
+			expect(edit.exitCode).toBe(0);
+
+			const content = await Bun.file(filePath).text();
+			expect(content.split(NOTES_BEGIN).length - 1).toBe(1);
+			expect(content.split(NOTES_END).length - 1).toBe(1);
+			expect(extractStructuredSection(content, "implementationNotes")).toBe("REPAIRED BODY");
+			// The pre-fix bug stranded the displaced text above the notes header.
+			expect(content).not.toContain("SECOND NOTE");
+			expect(content.indexOf("## Implementation Notes")).toBeLessThan(content.indexOf(NOTES_BEGIN));
+		});
+
+		it("round-trips the nested body without growing or losing content", () => {
+			const once = updateTaskImplementationNotes(
+				nestedBody,
+				extractStructuredSection(nestedBody, "implementationNotes") ?? "",
+			);
+			const twice = updateTaskImplementationNotes(once, extractStructuredSection(once, "implementationNotes") ?? "");
+			expect(twice).toBe(once);
+			expect(once).toContain("FIRST NOTE");
+			expect(once).toContain("SECOND NOTE");
+		});
+
+		it("keeps updateStructuredSections stable across repeated serialization of clean content", () => {
+			const notes = `Mentions ${NOTES_END} inline\n\nMore prose`;
+			const once = updateStructuredSections("", { description: "desc", implementationNotes: notes });
+			const twice = updateStructuredSections(once, {
+				description: extractStructuredSection(once, "description") ?? "",
+				implementationNotes: extractStructuredSection(once, "implementationNotes") ?? "",
+			});
+			expect(twice).toBe(once);
+			expect(extractStructuredSection(once, "implementationNotes")).toBe(notes);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #932. Backlog task: BACK-660.

## Problem

`task edit --notes` wrapped payloads in a fresh `SECTION:NOTES:BEGIN/END` pair without reconciling marker lines already inside the payload, so the read-modify-write pattern nested the markers and hid everything after the inner `END` from `task view` — while the write reported success. Separately, section extraction stopped at the first end-marker *substring*, so notes that merely mention the terminator inline were truncated on read, and `--append-notes` persisted the loss. A clean rewrite over a nested file stranded the displaced text above the section header instead of repairing it.

## Fix

**Reject, not strip.** New section input (description, plan, notes, final summary — including the append flags) that contains the target section's *own* sentinel marker as a whole line now fails with a clear error naming the marker, before any write. Rationale: this content is the durable record, and silently altering what the caller asked to store is worse than a retryable error; comment bodies already reject reserved markers the same way. The check is per-family and whole-line only, so inline mentions, indented marker lines, and other sections' markers (including the fenced cross-family examples locked in by BACK-637) remain storable. Validation lives at the shared core input boundary (`createTaskFromInput` + `applyTaskUpdateInput`), so CLI, MCP, web server, and TUI create all agree; TUI raw-file editing remains the human escape hatch.

**Real boundaries.** The five sentinel-path regexes in `structured-sections.ts` are replaced by one line-anchored, depth-aware block scanner (`findSentinelBlocks`) shared by extraction, section ranges, insert-position lookup, and strip. Markers count only as whole lines (per the issue's own guidance), so inline substrings can never terminate a section early and append no longer truncates. Same-family `BEGIN` lines are depth-counted, so a pre-existing nested-marker file resolves to its full interior: `task view` shows every note line, and a clean `--notes` rewrite strips the whole nested region — repairing the file instead of stranding text. `tokenizeKnownSentinels` is line-anchored the same way, closing the equivalent inline-mention hazard for AC/DOD/comment masking.

## Verification

- New suite `src/test/section-marker-safety.test.ts` (9 tests): rejection across create/edit/append with readable files after failure, inline/indented/fenced-foreign markers still round-tripping, append with marker-like substrings (byte-level no-shrink), nested-file readability in `task view`, repair on clean rewrite, and round-trip stability. 8 of 9 fail on pre-fix code.
- BACK-637 fence round-trip suite untouched and green.
- `bunx tsc --noEmit`, `bun run check .`, and full `bun test` green — except 3 `tui-emoji-width` failures that reproduce identically on a clean `origin/main` checkout (environment-specific, unrelated).