### PR TITLE
BACK-652 - Replace the ASCII progress bar on web task summaries with a web-native indicator

### DIFF
--- a/backlog/tasks/back-652 - Replace-the-ASCII-progress-bar-on-web-task-summaries-with-a-web-native-indicator.md
+++ b/backlog/tasks/back-652 - Replace-the-ASCII-progress-bar-on-web-task-summaries-with-a-web-native-indicator.md
@@ -3,9 +3,11 @@ id: BACK-652
 title: >-
   Replace the ASCII progress bar on web task summaries with a web-native
   indicator
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-29 22:03'
+updated_date: '2026-08-30 22:07'
 labels:
   - web
 dependencies: []
@@ -20,13 +22,37 @@ Web task cards and summaries render acceptance-criteria progress as a text bar b
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Web task summaries show acceptance-criteria progress without ASCII/glyph bars, in both card and list densities, in light and dark themes
-- [ ] #2 The TUI acceptance-criteria progress rendering is unchanged
+- [x] #1 Web task summaries show acceptance-criteria progress without ASCII/glyph bars, in both card and list densities, in light and dark themes
+- [x] #2 The TUI acceptance-criteria progress rendering is unchanged
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reuse the indexing chip spinner-ring design (BranchIndexingIndicator, BACK-654) as the geometry/palette reference: small circle, 2px stroke, blue track (blue-200 / dark blue-400/30) with the component's existing blue-600 / dark blue-300 progress color.
+2. Rewrite src/web/components/AcceptanceCriteriaProgress.tsx: replace the glyph bar with a static SVG ring (track circle + strokeDasharray progress arc, rotated to start at 12 o'clock) plus the existing x/y fraction text; keep role=progressbar, aria attrs, title, and the data-acceptance-criteria-progress hook.
+3. Replace the glyph-specific cells prop with density: card | list (12px ring on board cards, 14px in the list); update TaskCard and TaskList prop wiring only.
+4. Update src/test/web-task-acceptance-progress.test.tsx: pin ring rendering (svg, arc dasharray from checked/total) at both densities, assert no block glyphs remain, keep aria and re-derive coverage.
+5. Verify: bunx tsc --noEmit, bun run check ., bun test; TUI renderer untouched (BACK-666).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the glyph bar in AcceptanceCriteriaProgress with a static SVG progress ring reusing the indexing chip spinner's geometry and palette (2px stroke, blue-200 track / dark blue-400-30, arc in the component's existing blue-600 / dark blue-300 via currentColor), with the x/y fraction beside it. Prop cells: 5|10 became density: card|list (12px ring on board cards, 14px in the list); TaskCard and TaskList wiring updated. Tests pin ring rendering (arc dasharray from checked/total, track-only at 0 checked, no block glyphs) at both densities. Verified in the running web UI: dark board at partial/zero fill, light All Tasks list at full fill. tsc, biome, scoped tests green; full suite running.
+
+Full-suite verification: 3 local failures are environmental, not from this change — 3x tui-emoji-width fixed by refreshing the worktree's stale node_modules (bun i, bun.lock unchanged), and 1 config-commands tab-indentation case is a Bun 1.4.0 Bun.YAML strictness change vs CI's pinned 1.3.14 (reproduces with this diff absent; flagged separately). Scoped web/TUI progress tests, tsc, and biome are green post-refresh.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced the web glyph progress bar in src/web/components/AcceptanceCriteriaProgress.tsx with a static SVG progress ring plus the x/y fraction, reusing the indexing chip spinner ring's geometry and palette (2px stroke, blue track, currentColor arc); prop cells:5|10 became density:card|list with matching one-line wiring updates in TaskCard and TaskList. Verified with updated jsdom tests pinning ring rendering (arc dasharray from checked/total, track-only at zero, no block glyphs) at both densities, tui-acceptance-criteria-progress tests proving the TUI renderer unchanged, live browser QA in dark board and light list views, and tsc/biome green.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/web-task-acceptance-progress.test.tsx
+++ b/src/test/web-task-acceptance-progress.test.tsx
@@ -76,6 +76,26 @@ const renderList = (task: Task): HTMLElement => {
 const getProgress = (container: HTMLElement): HTMLElement | null =>
 	container.querySelector("[data-acceptance-criteria-progress]");
 
+const RING_CIRCUMFERENCE = 2 * Math.PI * 5;
+
+const expectRing = (progress: HTMLElement | null, checked: number, total: number) => {
+	const svg = progress?.querySelector("svg");
+	expect(svg).toBeTruthy();
+	const circles = svg?.querySelectorAll("circle");
+	if (checked === 0) {
+		expect(circles?.length).toBe(1);
+	} else {
+		expect(circles?.length).toBe(2);
+		expect(circles?.[1]?.getAttribute("stroke-dasharray")).toBe(
+			`${(checked / total) * RING_CIRCUMFERENCE} ${RING_CIRCUMFERENCE}`,
+		);
+	}
+	expect(progress?.textContent).toBe(`${checked}/${total}`);
+	expect(progress?.textContent).not.toContain("█");
+	expect(progress?.textContent).not.toContain("░");
+	expect(progress?.textContent).not.toContain("[");
+};
+
 afterEach(() => {
 	if (activeRoot) {
 		act(() => {
@@ -88,16 +108,24 @@ afterEach(() => {
 });
 
 describe("browser task acceptance criteria progress", () => {
-	it("renders partial progress with five cells on a board card", () => {
+	it("renders a partial progress ring at card density on a board card", () => {
 		const container = renderCard(createTask({ acceptanceCriteriaItems: createCriteria(4, 7) }));
 		const progress = getProgress(container);
 
 		expect(progress).toBeTruthy();
-		expect(progress?.dataset.cellCount).toBe("5");
-		expect(progress?.children[0]?.textContent).toBe("[███░░]");
-		expect(progress?.children[1]?.textContent).toBe("4/7");
+		expect(progress?.dataset.density).toBe("card");
+		expect(progress?.querySelector("svg")?.getAttribute("class")).toContain("h-3 w-3");
+		expectRing(progress, 4, 7);
 		expect(progress?.textContent).not.toContain("%");
 		expect(progress?.textContent).not.toContain("Acceptance criteria");
+	});
+
+	it("renders only the ring track when no criteria are checked", () => {
+		const container = renderCard(createTask({ acceptanceCriteriaItems: createCriteria(0, 4) }));
+		const progress = getProgress(container);
+
+		expect(progress).toBeTruthy();
+		expectRing(progress, 0, 4);
 	});
 
 	it("includes card progress in the accessible name", () => {
@@ -113,14 +141,14 @@ describe("browser task acceptance criteria progress", () => {
 		expect(getProgress(container)).toBeNull();
 	});
 
-	it("renders ten-cell partial progress in the wide list summary", () => {
+	it("renders a partial progress ring at list density in the wide list summary", () => {
 		const container = renderList(createTask({ acceptanceCriteriaItems: createCriteria(4, 7) }));
 		const progress = getProgress(container);
 
 		expect(progress).toBeTruthy();
-		expect(progress?.dataset.cellCount).toBe("10");
-		expect(progress?.children[0]?.textContent).toBe("[██████░░░░]");
-		expect(progress?.children[1]?.textContent).toBe("4/7");
+		expect(progress?.dataset.density).toBe("list");
+		expect(progress?.querySelector("svg")?.getAttribute("class")).toContain("h-3.5 w-3.5");
+		expectRing(progress, 4, 7);
 	});
 
 	it("keeps an all-checked task visibly In Progress in the wide list summary", () => {
@@ -129,17 +157,15 @@ describe("browser task acceptance criteria progress", () => {
 		const statusCell = container.querySelector("tbody tr td:nth-child(3)");
 
 		expect(progress).toBeTruthy();
-		expect(progress?.dataset.cellCount).toBe("10");
-		expect(progress?.children[0]?.textContent).toBe("[██████████]");
-		expect(progress?.children[1]?.textContent).toBe("3/3");
+		expect(progress?.dataset.density).toBe("list");
+		expectRing(progress, 3, 3);
 		expect(progress?.className).toContain("text-blue-600");
 		expect(statusCell?.textContent?.trim()).toBe("In Progress");
 	});
 
 	it("derives progress again when the task criteria change", () => {
 		const container = renderCard(createTask({ acceptanceCriteriaItems: createCriteria(2, 5) }));
-		expect(getProgress(container)?.children[0]?.textContent).toBe("[██░░░]");
-		expect(getProgress(container)?.children[1]?.textContent).toBe("2/5");
+		expectRing(getProgress(container), 2, 5);
 
 		act(() => {
 			activeRoot?.render(
@@ -151,7 +177,6 @@ describe("browser task acceptance criteria progress", () => {
 			);
 		});
 
-		expect(getProgress(container)?.children[0]?.textContent).toBe("[████░]");
-		expect(getProgress(container)?.children[1]?.textContent).toBe("4/5");
+		expectRing(getProgress(container), 4, 5);
 	});
 });

--- a/src/web/components/AcceptanceCriteriaProgress.tsx
+++ b/src/web/components/AcceptanceCriteriaProgress.tsx
@@ -2,7 +2,7 @@ import type { Task } from "../../types";
 
 interface AcceptanceCriteriaProgressProps {
 	task: Pick<Task, "status" | "acceptanceCriteriaItems">;
-	cells: 5 | 10;
+	density: "card" | "list";
 	className?: string;
 }
 
@@ -20,22 +20,24 @@ export function getAcceptanceCriteriaProgressCounts(
 	};
 }
 
+const RING_RADIUS = 5;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
 export default function AcceptanceCriteriaProgress({
 	task,
-	cells,
+	density,
 	className = "",
 }: AcceptanceCriteriaProgressProps) {
 	const progress = getAcceptanceCriteriaProgressCounts(task);
 	if (!progress) return null;
 
-	const filledCells = Math.round((progress.checked / progress.total) * cells);
-	const bar = `[${"█".repeat(filledCells)}${"░".repeat(cells - filledCells)}]`;
+	const arcLength = (progress.checked / progress.total) * RING_CIRCUMFERENCE;
 
 	return (
 		<span
-			className={`inline-flex items-center gap-1 whitespace-nowrap font-mono text-[10px] font-medium text-blue-600 dark:text-blue-300 ${className}`}
+			className={`inline-flex items-center gap-1 whitespace-nowrap text-[10px] font-medium tabular-nums text-blue-600 dark:text-blue-300 ${className}`}
 			data-acceptance-criteria-progress
-			data-cell-count={cells}
+			data-density={density}
 			role="progressbar"
 			aria-label="Acceptance criteria progress"
 			aria-valuemin={0}
@@ -43,8 +45,36 @@ export default function AcceptanceCriteriaProgress({
 			aria-valuenow={progress.checked}
 			title={`${progress.checked} of ${progress.total} acceptance criteria checked`}
 		>
-			<span aria-hidden="true">{bar}</span>
-			<span>{progress.checked}/{progress.total}</span>
+			<svg
+				className={`-rotate-90 shrink-0 ${density === "card" ? "h-3 w-3" : "h-3.5 w-3.5"}`}
+				viewBox="0 0 12 12"
+				aria-hidden="true"
+			>
+				<circle
+					cx="6"
+					cy="6"
+					r={RING_RADIUS}
+					fill="none"
+					strokeWidth="2"
+					stroke="currentColor"
+					className="text-blue-200 dark:text-blue-400/30"
+				/>
+				{progress.checked > 0 && (
+					<circle
+						cx="6"
+						cy="6"
+						r={RING_RADIUS}
+						fill="none"
+						strokeWidth="2"
+						stroke="currentColor"
+						strokeLinecap="round"
+						strokeDasharray={`${arcLength} ${RING_CIRCUMFERENCE}`}
+					/>
+				)}
+			</svg>
+			<span>
+				{progress.checked}/{progress.total}
+			</span>
 		</span>
 	);
 }

--- a/src/web/components/TaskCard.tsx
+++ b/src/web/components/TaskCard.tsx
@@ -267,7 +267,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
           {task.title}
         </h4>
 
-        <AcceptanceCriteriaProgress task={task} cells={5} className="mt-2" />
+        <AcceptanceCriteriaProgress task={task} density="card" className="mt-2" />
 
         {/* Labels - limit to 3 */}
         {task.labels.length > 0 && (

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -910,7 +910,7 @@ const TaskList: React.FC<TaskListProps> = ({
 														</span>
 													)}
 												</div>
-												<AcceptanceCriteriaProgress task={task} cells={10} className="mt-1" />
+												<AcceptanceCriteriaProgress task={task} density="list" className="mt-1" />
 												{task.dueDate && (
 													<div className="mt-1 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
 														Due (UTC): {formatStoredUtcDateForDisplay(task.dueDate, dateFormat)}


### PR DESCRIPTION
## Summary

- Replace the glyph bar (`[████░] 3/5` via `"█".repeat()`, from #906) in `src/web/components/AcceptanceCriteriaProgress.tsx` with a web-native static SVG progress ring plus the existing `x/y` fraction — no ASCII/glyph art remains in the web UI
- Design reused: the indexing chip spinner ring from `BranchIndexingIndicator` (BACK-654 / #971) — same geometry (small circle, 2px stroke) and palette (blue-200 track / dark blue-400/30, arc in the component's existing blue-600 / dark blue-300 via `currentColor`), rendered as a static arc from checked/total starting at 12 o'clock
- Prop `cells: 5 | 10` became `density: "card" | "list"` (12px ring on board cards, 14px in the task list); one-line wiring updates in `TaskCard` and `TaskList`
- Accessibility unchanged: `role=progressbar`, aria value attrs, tooltip title, and the card's accessible-name integration all kept
- The TUI acceptance-criteria renderer is untouched (BACK-666 covers the TUI side)

## Testing

- jsdom tests pin ring rendering at both densities: arc `stroke-dasharray` derived from checked/total, track-only circle at zero checked, all-checked full ring, re-derive on prop change, and explicit no-█/░/[ assertions
- `src/test/tui-acceptance-criteria-progress.test.ts` green, proving the TUI rendering unchanged
- Live browser QA: dark-theme board (partial 9/10 and zero 0/4 rings) and light-theme All Tasks list (full 3/3 ring)
- `bunx tsc --noEmit`, `bun run check .` green; full `bun run test` shows only pre-existing environment failures unrelated to this diff (Bun 1.4.0 `Bun.YAML` tab strictness vs CI's pinned 1.3.14, flagged separately)