### PR TITLE
BACK-666 - Compact colored acceptance-criteria bar in the TUI

### DIFF
--- a/backlog/tasks/back-666 - Compact-colored-acceptance-criteria-bar-in-the-TUI.md
+++ b/backlog/tasks/back-666 - Compact-colored-acceptance-criteria-bar-in-the-TUI.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-666
 title: Compact colored acceptance-criteria bar in the TUI
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-30 21:48'
+updated_date: '2026-08-30 22:09'
 labels:
   - tui
   - enhancement
@@ -19,14 +21,41 @@ The TUI list/board AC bar is currently a plain uncolored 10-cell ASCII bar (BACK
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The bar occupies about half its former width; task id and title regain the space
-- [ ] #2 The filled portion is colored by completion ratio using the TUI'\''s existing color conventions; renders correctly on terminals without Block Element fonts
-- [ ] #3 Board and task list both use the one implementation; tests pin cells and color tags
+- [x] #1 The bar occupies about half its former width; task id and title regain the space
+- [x] #2 The filled portion is colored by completion ratio using the TUI'\''s existing color conventions; renders correctly on terminals without Block Element fonts
+- [x] #3 Board and task list both use the one implementation; tests pin cells and color tags
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Rework src/ui/acceptance-criteria-progress.ts (the one shared implementation used by board.ts and task-viewer-with-search.ts):
+   - Halve the cell counts, keeping the existing availableWidth adaptivity: >= 40 cols -> 5 cells (was 10), narrower -> 3 cells (was 5).
+   - Clamp rounding so >0% never renders 0 filled cells and <100% never renders all cells filled (e.g. 1/20 -> 1 cell, 19/20 -> 4 of 5).
+   - Color the filled run via the existing wrapStatusColor helper from status-icon.ts, using the TUI's established red/yellow/green semantics: green when checked === total, red when ratio <= 1/3, yellow otherwise.
+   - Keep ASCII glyphs (# and -) from BACK-657 and the x/y count text.
+2. Exact renderings (wide, 5 cells): 3/5 -> "[{yellow-fg}###{/}--] 3/5"; 1/7 -> "[{red-fg}#{/}----] 1/7"; 5/5 -> "[{green-fg}#####{/}] 5/5"; 0/4 -> "[-----] 0/4" (nothing filled, no tag). Narrow (<40 cols, 3 cells): 4/7 -> "[{yellow-fg}##{/}-] 4/7".
+3. Tags are deliberate markup: no data-derived text enters the bar, so #960's escapeBlessedTags for labels is untouched; stripBlessedFgTags used by the board's plain search index strips the -fg tags cleanly.
+4. Update src/test/tui-acceptance-criteria-progress.test.ts: pin new cell counts, rounding edges (never-0/never-full clamps), the exact color tags per ratio band, and that both consumers render the identical bar.
+5. Verify: bunx tsc --noEmit, bun run check ., bun test; pty capture of task list + board for the maintainer.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented compact colored bar in src/ui/acceptance-criteria-progress.ts: wide bar 10->5 cells, narrow 5->3 (same availableWidth>=40 breakpoint); rounding clamped so >0% never shows 0 filled and <100% never shows full; filled run wrapped via the existing wrapStatusColor helper (green complete, red for ratio<=1/3, yellow otherwise). ASCII # / - glyphs and x/y count kept. No data-derived text enters the bar so no interaction with the #960 label escaping; stripBlessedFgTags (board plain search index) strips the tags cleanly.
+Verification: bunx tsc --noEmit pass; bun run check . pass; scoped tests 8/8 pass pinning cells, rounding clamps, and exact color tags. Full bun test: 2729 pass; the 3 failures in tui-emoji-width.test.ts fail identically on clean origin/main in this environment (pre-existing, unrelated). Pty capture (expect, TERM=xterm-256color, 140x35) of a demo project through both task list and board TUIs shows ESC[31m# (red 1/7), ESC[33m### (yellow 3/5), ESC[32m##### (green 2/2); the selected row renders the fg-stripped variant by existing selection-highlight design.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Halved the TUI acceptance-criteria bar (5 cells wide, 3 narrow, same responsive breakpoint) and colored the filled run red/yellow/green by completion ratio via the existing wrapStatusColor helper, keeping BACK-657's ASCII glyphs and the x/y count. Board and task list still render through the one shared formatter. Verified with tsc, biome, scoped tests pinning cells/rounding-clamps/color-tags, and pty captures of both TUIs showing the ANSI colors live.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/tui-acceptance-criteria-progress.test.ts
+++ b/src/test/tui-acceptance-criteria-progress.test.ts
@@ -31,10 +31,31 @@ describe("TUI acceptance-criteria progress", () => {
 	it("renders the exact wide and constrained bars from live checklist state", () => {
 		const task = makeTask();
 
-		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[######----] 4/7");
-		expect(formatAcceptanceCriteriaProgress(task, 39)).toBe("[###--] 4/7");
+		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[{yellow-fg}###{/}--] 4/7");
+		expect(formatAcceptanceCriteriaProgress(task, 39)).toBe("[{yellow-fg}##{/}-] 4/7");
 		if (task.acceptanceCriteriaItems?.[4]) task.acceptanceCriteriaItems[4].checked = true;
-		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[#######---] 5/7");
+		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[{yellow-fg}####{/}-] 5/7");
+	});
+
+	it("colors the filled run by completion ratio using the TUI's red/yellow/green semantics", () => {
+		const bar = (total: number, checked: number) =>
+			formatAcceptanceCriteriaProgress(makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }), 40);
+
+		expect(bar(3, 1)).toBe("[{red-fg}##{/}---] 1/3");
+		expect(bar(7, 4)).toBe("[{yellow-fg}###{/}--] 4/7");
+		expect(bar(2, 2)).toBe("[{green-fg}#####{/}] 2/2");
+		// Nothing checked leaves nothing to color: an all-empty bar carries no tag.
+		expect(bar(4, 0)).toBe("[-----] 0/4");
+	});
+
+	it("never rounds progress to an empty bar or unfinished work to a full one", () => {
+		const bar = (total: number, checked: number, width: number) =>
+			formatAcceptanceCriteriaProgress(makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }), width);
+
+		expect(bar(20, 1, 40)).toBe("[{red-fg}#{/}----] 1/20");
+		expect(bar(20, 19, 40)).toBe("[{yellow-fg}####{/}-] 19/20");
+		expect(bar(10, 1, 20)).toBe("[{red-fg}#{/}--] 1/10");
+		expect(bar(10, 9, 20)).toBe("[{yellow-fg}##{/}-] 9/10");
 	});
 
 	it("emits only ASCII bar characters so terminals without Block Element glyphs stay legible", () => {
@@ -50,7 +71,7 @@ describe("TUI acceptance-criteria progress", () => {
 				makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }),
 				width,
 			);
-			expect(bar).toMatch(/^\[[#-]*\] \d+\/\d+$/);
+			expect(stripBlessedFgTags(bar)).toMatch(/^\[[#-]*\] \d+\/\d+$/);
 		}
 	});
 
@@ -65,12 +86,11 @@ describe("TUI acceptance-criteria progress", () => {
 		const progress = formatAcceptanceCriteriaProgress(task, 40);
 		const listItem = stripBlessedFgTags(formatTaskViewerListItem(task, 40));
 
-		expect(progress).toBe("[##########] 2/2");
+		expect(stripBlessedFgTags(progress)).toBe("[#####] 2/2");
 		expect(progress).not.toContain("AC");
 		expect(progress).not.toContain("%");
-		expect(progress).not.toContain("{");
 		expect(task.status).toBe("In Progress");
-		expect(listItem).toContain("◒ [##########] 2/2");
+		expect(listItem).toContain("◒ [#####] 2/2");
 		expect(listItem).not.toContain("✔");
 	});
 
@@ -78,17 +98,17 @@ describe("TUI acceptance-criteria progress", () => {
 		const task = makeTask({ status: " IN PROGRESS " });
 		const listItem = stripBlessedFgTags(formatTaskViewerListItem(task, 40));
 
-		expect(listItem).toContain("◒ [######----] 4/7");
+		expect(listItem).toContain("◒ [###--] 4/7");
 	});
 
 	it("reuses the same responsive indicator in board cards and task-list summaries", () => {
 		const task = makeTask();
-		const wideBoardCard = stripBlessedFgTags(formatTaskListItem(task, false, 40));
+		const wideBoardCard = formatTaskListItem(task, false, 40);
 		const compactBoardCard = stripBlessedFgTags(formatTaskListItem(task, false, 20));
 		const compactListItem = stripBlessedFgTags(formatTaskViewerListItem(task, 20));
 
-		expect(wideBoardCard).toContain("[######----] 4/7 {bold}BACK-551{/bold}");
-		expect(compactBoardCard).toContain("[###--] 4/7 {bold}BACK-551{/bold}");
-		expect(compactListItem).toContain("◒ [###--] 4/7 {bold}BACK-551{/bold}");
+		expect(wideBoardCard).toContain("[{yellow-fg}###{/}--] 4/7 {bold}BACK-551{/bold}");
+		expect(compactBoardCard).toContain("[##-] 4/7 {bold}BACK-551{/bold}");
+		expect(compactListItem).toContain("◒ [##-] 4/7 {bold}BACK-551{/bold}");
 	});
 });

--- a/src/ui/acceptance-criteria-progress.ts
+++ b/src/ui/acceptance-criteria-progress.ts
@@ -1,10 +1,11 @@
 import type { Task } from "../types/index.ts";
+import { wrapStatusColor } from "./status-icon.ts";
 
-// A 10-cell indicator occupies about half this width, leaving room for task identity and title.
-// Keep enough room for the task identity and a meaningful title after the indicator.
+// A compact indicator leaves the task id and title most of the row; the color of the
+// filled run carries the completion signal that the dropped cells used to spell out.
 const WIDE_PROGRESS_MIN_WIDTH = 40;
-const WIDE_PROGRESS_CELLS = 10;
-const COMPACT_PROGRESS_CELLS = 5;
+const WIDE_PROGRESS_CELLS = 5;
+const COMPACT_PROGRESS_CELLS = 3;
 
 // Plain ASCII on purpose: blessed only guarantees glyph fallback for DEC Special
 // Graphics (box drawing), so Block Elements like U+2588/U+2591 render as blank
@@ -17,6 +18,15 @@ function isInProgress(status: string): boolean {
 	return status.trim().toLowerCase() === "in progress";
 }
 
+/**
+ * The TUI's established completion semantics (see status-icon.ts / priority dots):
+ * green means done, yellow means underway, red means barely started.
+ */
+function completionColor(checked: number, total: number): string {
+	if (checked === total) return "green";
+	return checked / total <= 1 / 3 ? "red" : "yellow";
+}
+
 /** Format a " (ac: checked/total)" suffix for plain and MCP task list lines; empty without criteria. */
 export function formatAcceptanceCriteriaSummarySuffix(task: Task): string {
 	const criteria = task.acceptanceCriteriaItems ?? [];
@@ -26,14 +36,25 @@ export function formatAcceptanceCriteriaSummarySuffix(task: Task): string {
 	return ` (ac: ${checked}/${criteria.length})`;
 }
 
-/** Format live acceptance-criteria completion for one-line TUI task summaries. */
+/**
+ * Format live acceptance-criteria completion for one-line TUI task summaries.
+ *
+ * The filled run is wrapped in a deliberate blessed color tag; no task-derived text
+ * enters the bar, so callers embed the result in tag-parsed content without escaping.
+ */
 export function formatAcceptanceCriteriaProgress(task: Task, availableWidth = Number.POSITIVE_INFINITY): string {
 	const criteria = task.acceptanceCriteriaItems ?? [];
 	if (!isInProgress(task.status) || criteria.length === 0) return "";
 
 	const checked = criteria.filter((criterion) => criterion.checked).length;
 	const cells = availableWidth >= WIDE_PROGRESS_MIN_WIDTH ? WIDE_PROGRESS_CELLS : COMPACT_PROGRESS_CELLS;
-	const filled = Math.round((checked / criteria.length) * cells);
+	// Clamp rounding so any progress shows at least one cell and unfinished work never fills the bar.
+	let filled = Math.round((checked / criteria.length) * cells);
+	if (checked > 0 && filled === 0) filled = 1;
+	if (checked < criteria.length && filled === cells) filled = cells - 1;
 
-	return `[${FILLED_CELL.repeat(filled)}${EMPTY_CELL.repeat(cells - filled)}] ${checked}/${criteria.length}`;
+	const filledRun =
+		filled > 0 ? wrapStatusColor(FILLED_CELL.repeat(filled), completionColor(checked, criteria.length)) : "";
+
+	return `[${filledRun}${EMPTY_CELL.repeat(cells - filled)}] ${checked}/${criteria.length}`;
 }


### PR DESCRIPTION
## Summary
- Halves the TUI acceptance-criteria bar: 5 cells on wide rows (was 10), 3 cells below the existing 40-column breakpoint (was 5), so task id and title regain the space.
- Colors the filled run with the TUI's established red/yellow/green semantics via the existing `wrapStatusColor` helper: green when all criteria are checked, red when the ratio is <= 1/3, yellow in between. An all-empty bar carries no tag.
- Clamps rounding so any progress shows at least one filled cell and unfinished work never fills the bar (e.g. 1/20 -> `[{red-fg}#{/}----] 1/20`, 19/20 -> `[{yellow-fg}####{/}-] 19/20`).
- Keeps BACK-657's plain-ASCII `#`/`-` glyphs and the `x/y` count; board (`formatTaskListItem`) and task list (`formatTaskViewerListItem`) still render through the one shared `formatAcceptanceCriteriaProgress` implementation.
- No task-derived text enters the bar, so the #960 label escaping is untouched; the color tags are deliberate markup and `stripBlessedFgTags` (board plain search index, selected-row rendering) strips them cleanly.

## Rendering
- 3/5 wide: `[{yellow-fg}###{/}--] 3/5`
- 1/7 wide: `[{red-fg}#{/}----] 1/7`
- 2/2 wide: `[{green-fg}#####{/}] 2/2`
- 0/4 wide: `[-----] 0/4`
- 4/7 narrow (<40 cols): `[{yellow-fg}##{/}-] 4/7`

## Verification
- `bunx tsc --noEmit`, `bun run check .` pass.
- `src/test/tui-acceptance-criteria-progress.test.ts` (8 tests) pins cell counts, the never-empty/never-full rounding clamps, the exact color tag per ratio band, and identical bars in both consumers.
- Full `bun test`: 2729 pass; the 3 failures in `tui-emoji-width.test.ts` fail identically on clean origin/main in this environment (pre-existing, unrelated).
- Pty capture (expect, TERM=xterm-256color, 140x35) of a demo project through both the task list and board TUIs shows the live ANSI output: `ESC[31m#` (red, 1/7), `ESC[33m###` (yellow, 3/5), `ESC[32m#####` (green, 2/2); the selected row shows the fg-stripped variant per the existing selection-highlight design.

Closes BACK-666.