### PR TITLE
BACK-661 - TUI multi-select move with shift-arrow recruitment

### DIFF
--- a/backlog/tasks/back-661 - TUI-multi-select-move-with-shift-arrow-recruitment.md
+++ b/backlog/tasks/back-661 - TUI-multi-select-move-with-shift-arrow-recruitment.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-30 17:23'
-updated_date: '2026-08-30 23:21'
+updated_date: '2026-08-30 23:53'
 labels:
   - tui
   - enhancement
@@ -65,6 +65,8 @@ Key-by-key behavior shipped:
 Validation: bunx tsc --noEmit clean; bun run check . clean; full bun test 2741 pass / 0 fail. src/test/board-tui-move.test.ts drives recruit, toggle-off, reorder-after-recruit, block bounds, cross-column confirm, adjacency-collapse confirm with highlight active, per-task failure footer, M-fallback recruit/unrecruit, and cancel through the existing keyboard harness. New pty capture src/test/board-tui-multi-move-pty.test.ts (expect, RUN_INTERACTIVE_TUI_TESTS=1) sends the raw ESC[1;2B shift-arrow plus M through a real pty and asserts the ► recruit marker renders; it needed an explicit stty size (sizeless pty under bun test) and a UTF-8 LANG (blessed downgrades ► to ? otherwise). Wired into scripts/run-tui-interactive-tests.sh.
 
 Codex review round on PR #980 (commit afb1b770): (1) dkqCe fixed - all move-mode mutations (arrows, Shift-arrows, M) and cancelMove freeze while movePending is true, so the confirmed set/target cannot change during the in-flight write and a late Esc cannot fake a cancel; regression test added. (2) dkqCg fixed - the no-highlight M fallback now recruits the nearest unrecruited task below the grabbed row (above at the bottom), skipping set members, so repeated M grows the set past the collapsed block; fallback is recruit-only (un-recruit via shift-arrow highlight or Esc); harness test recruits the whole column M-only. (3) dkqCi refuted - parent-child re-nesting after confirm is the board's pre-existing display rule with exact single-mover parity (reorderTask + buildColumnTasks on main behave the same); ordinals persist adjacent as previewed; no change. (4) dkqCl fixed - pty test now asserts the highlight walk itself (third-row redraw) before M and recruits the task the fallback cannot reach, with distinct exit codes. Verified: tsc, biome, 15 harness + 1 pty tests and 63 board-suite tests green.
+
+Closing Codex round on PR #980 (commit fea7a829): (1) dk2BZ fixed - the move-mode footer labels the selection chord [Shift+M] and the help entry says Shift+M selects more in move mode; a bare M would, under the table's own uppercase-means-unshifted convention, point users at plain m, which confirms instead. (2) dk2Bc fixed - the M-only fallback walk now skips cross-branch read-only tasks like it skips recruits, so a read-only neighbor cannot dead-end recruitment; the explicit refusal stays for highlighted selections. Tests: footer label pinned, new harness test with a cross-branch neighbor (recruits past it, reports the dead end when nothing recruitable remains). tsc, biome, 16 harness + 1 pty tests green. Per coordinator: any further Codex feedback after this round is deferred wholesale.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-661 - TUI-multi-select-move-with-shift-arrow-recruitment.md
+++ b/backlog/tasks/back-661 - TUI-multi-select-move-with-shift-arrow-recruitment.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-30 17:23'
-updated_date: '2026-08-30 23:53'
+updated_date: '2026-08-31 00:28'
 labels:
   - tui
   - enhancement
@@ -67,6 +67,8 @@ Validation: bunx tsc --noEmit clean; bun run check . clean; full bun test 2741 p
 Codex review round on PR #980 (commit afb1b770): (1) dkqCe fixed - all move-mode mutations (arrows, Shift-arrows, M) and cancelMove freeze while movePending is true, so the confirmed set/target cannot change during the in-flight write and a late Esc cannot fake a cancel; regression test added. (2) dkqCg fixed - the no-highlight M fallback now recruits the nearest unrecruited task below the grabbed row (above at the bottom), skipping set members, so repeated M grows the set past the collapsed block; fallback is recruit-only (un-recruit via shift-arrow highlight or Esc); harness test recruits the whole column M-only. (3) dkqCi refuted - parent-child re-nesting after confirm is the board's pre-existing display rule with exact single-mover parity (reorderTask + buildColumnTasks on main behave the same); ordinals persist adjacent as previewed; no change. (4) dkqCl fixed - pty test now asserts the highlight walk itself (third-row redraw) before M and recruits the task the fallback cannot reach, with distinct exit codes. Verified: tsc, biome, 15 harness + 1 pty tests and 63 board-suite tests green.
 
 Closing Codex round on PR #980 (commit fea7a829): (1) dk2BZ fixed - the move-mode footer labels the selection chord [Shift+M] and the help entry says Shift+M selects more in move mode; a bare M would, under the table's own uppercase-means-unshifted convention, point users at plain m, which confirms instead. (2) dk2Bc fixed - the M-only fallback walk now skips cross-branch read-only tasks like it skips recruits, so a read-only neighbor cannot dead-end recruitment; the explicit refusal stays for highlighted selections. Tests: footer label pinned, new harness test with a cross-branch neighbor (recruits past it, reports the dead end when nothing recruitable remains). tsc, biome, 16 harness + 1 pty tests green. Per coordinator: any further Codex feedback after this round is deferred wholesale.
+
+Review-cap exception round on PR #980 (commit 84a071f7): (1) dlDib fixed - both confirm paths publish a pendingMoveWrite promise (beginMoveWrite, settled in finally) and closeBoard awaits it alongside pendingSettingWrite, so quitting right after Enter can no longer let showKanbanView process.exit before the confirmed write persists; this also closes the same pre-existing hole in the single-task mover from main. Test slows moveTasksToStatus by 150ms and quits immediately after Enter. (2) dlDic fixed - Enter/m with an active recruitment highlight now collapses and renders the block preview (same consume pattern as plain arrows) and only a second confirm persists, making the rendered projection the single source of truth for what lands; performSetMove no longer collapses invisibly. Tests pin the two-step confirm and the reviewer's cross-column repro (persisted order asserted equal to the rendered preview). Behavior note for docs/feel-test: confirming a recruited set while still highlighting now takes two Enters - the first shows the exact landing order. tsc, biome, 18 harness + 1 pty + 53 board-suite tests green.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-661 - TUI-multi-select-move-with-shift-arrow-recruitment.md
+++ b/backlog/tasks/back-661 - TUI-multi-select-move-with-shift-arrow-recruitment.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-661
 title: TUI multi-select move with shift-arrow recruitment
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-08-30 17:23'
+updated_date: '2026-08-30 22:44'
 labels:
   - tui
   - enhancement
@@ -19,18 +21,52 @@ Maintainer-designed flow for moving several tasks in the TUI board, built on the
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 m plus plain arrows behave byte-identically to todays single-task mover when nothing is recruited
-- [ ] #2 Shift+Up/Down move a visually distinct highlight without moving the grabbed task
-- [ ] #3 M toggles the highlighted task in and out of the selection; selected tasks show the > indicator and stay in place until Enter
-- [ ] #4 After recruiting, arrows preview the whole set and moving reorders it; non-adjacent selected tasks land adjacent at the target position
-- [ ] #5 Enter moves the set (per-task failures in the footer), Esc cancels and clears; popup/modal/filter guards are respected
-- [ ] #6 Footer hints cover the move-mode keys; the flow remains fully usable without shift-arrows via M
-- [ ] #7 TUI tests drive recruit, toggle-off, reorder-after-recruit, confirm, and cancel through a real pty or the existing keyboard harness
+- [x] #1 m plus plain arrows behave byte-identically to todays single-task mover when nothing is recruited
+- [x] #2 Shift+Up/Down move a visually distinct highlight without moving the grabbed task
+- [x] #3 M toggles the highlighted task in and out of the selection; selected tasks show the > indicator and stay in place until Enter
+- [x] #4 After recruiting, arrows preview the whole set and moving reorders it; non-adjacent selected tasks land adjacent at the target position
+- [x] #5 Enter moves the set (per-task failures in the footer), Esc cancels and clears; popup/modal/filter guards are respected
+- [x] #6 Footer hints cover the move-mode keys; the flow remains fully usable without shift-arrows via M
+- [x] #7 TUI tests drive recruit, toggle-off, reorder-after-recruit, confirm, and cancel through a real pty or the existing keyboard harness
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Generalize MoveOperation in src/ui/board.ts (reuses: the existing moveOp single-task mover, its m entry key, the magenta ► ghost, the cyan move-mode selection bar, the popupOpen/filterPopupOpen/modalOpen guards, the movePending double-Enter guard, the transient footer): add selectedIds: string[] and highlightTaskId: string | null. With selectedIds empty and no highlight, every path (projection, arrows, reorderTask confirm) is unchanged - AC #1.
+2. Shift+Up/Down (blessed key names S-up/S-down; verified key.full construction in neo-neo-bblessed program.ts: shift+arrow parses to name=up/down + shift, full=S-up/S-down) walk highlightTaskId through the target column recruitment-view rows, skipping the ghost; the grabbed task and targetIndex do not change. The existing cyan selection bar renders the highlight (renderView selectedId becomes highlight ?? grabbed), keeping the magenta ► on the ghost - visually distinct with no new styling machinery.
+3. M / S-m in move mode toggles the highlighted task in/out of selectedIds (cross-branch refused with the existing cannot-move-branch transient footer); with no active highlight (tmux fallback), it toggles the task on the row directly below the grabbed row (else above), so the flow stays fully usable with plain arrows + M alone - AC #6. Outside move mode M still enters move mode as today; lowercase m keeps today's enter/confirm behavior.
+4. Projection: getProjectedColumns removes only the grabbed task while a highlight is active (recruits stay in place, rendered with the existing ► indicator via a movingIds set through buildRenderedTaskListItems); when the highlight collapses (any plain arrow) it removes the whole set and splices the block - set members in board display order - at targetIndex, so the preview shows where the whole set lands and non-adjacent recruits land adjacent - AC #2/#3/#4. targetIndex is remapped across view switches with a small anchor-based mapInsertionIndex helper.
+5. Enter: selectedIds empty -> today's core.reorderTask path untouched; non-empty -> collapse, build orderedTaskIds from the block projection, call core.moveTasksToStatus (BACK-645) with per-task failures in the transient footer; a lands-where-it-already-is comparison exits silently without writing (interaction-consistency no-op guard). Esc clears moveOp (selection + highlight) via the existing cancelMove; movePending covers the batch path - AC #5.
+6. Footer move-mode hints in the existing style: [←→] Change Column | [↑↓] Reorder | [Shift+↑↓] Highlight | [M] Select | [Enter] Confirm | [Esc] Cancel; help-popup M entry updated - AC #6.
+7. Tests: extend src/test/board-tui-move.test.ts keyboard harness (pressKey/renderedRows/footerText) with recruit, toggle-off, reorder-after-recruit, adjacency collapse, confirm incl. per-task failure, cancel, and single-mover parity; pty sanity capture following the expect harness pattern (RUN_INTERACTIVE_TUI_TESTS gate). bunx tsc --noEmit, bun run check ., bun test - AC #7.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented on tasks/back-661-tui-multi-move as one generalization of the existing mover in src/ui/board.ts - no parallel flow.
+
+Key-by-key behavior shipped:
+- m: enters move mode exactly as before; in move mode it still confirms (unchanged). With nothing recruited, plain arrows/Enter/Esc run today's exact single-task paths (projection reduces to the single ghost, confirm still goes through core.reorderTask).
+- Shift+Up/Down (blessed key names S-up/S-down, verified against neo-neo-bblessed program.ts key.full construction; xterm ESC[1;2A/B): walk the recruitment highlight through the target column's rows, skipping the ghost. The grabbed task and targetIndex never change. The highlight is rendered by moving the existing cyan move-mode selection bar (renderView selects highlight ?? grabbed), while the ghost keeps its magenta ►.
+- M/S-m: outside move mode enters move mode (as before). In move mode it toggles the highlighted task in/out of moveOp.selectedIds; recruited tasks render with the existing ► indicator and stay in place while the highlight is active. With no highlight (terminals without xterm modified keys, e.g. tmux without xterm-keys) it toggles the task on the row directly below the grabbed row (above at the bottom), so plain arrows + M alone cover the full flow. Cross-branch tasks are refused with the existing transient-footer message.
+- Plain arrows after recruiting: the first arrow collapses the highlight and switches the preview to the whole set landing as one block (board display order) at the ghost position; further arrows reorder the block; targetIndex is re-anchored across view switches by mapInsertionIndex (first shared task at-or-below the index).
+- Enter with recruits: collapses, builds orderedTaskIds from the block projection, calls core.moveTasksToStatus (BACK-645) - per-task failures land in the transient footer while the rest still move. A lands-where-it-already-is comparison exits silently without writing. movePending guards double-Enter on both paths. Esc clears moveOp (selection + highlight) via the existing cancelMove.
+- Footer move-mode hints: [←→] Change Column | [↑↓] Reorder | [Shift+↑↓] Highlight | [M] Select | [Enter] Confirm | [Esc] Cancel; help-popup M entry updated.
+
+Validation: bunx tsc --noEmit clean; bun run check . clean; full bun test 2741 pass / 0 fail. src/test/board-tui-move.test.ts drives recruit, toggle-off, reorder-after-recruit, block bounds, cross-column confirm, adjacency-collapse confirm with highlight active, per-task failure footer, M-fallback recruit/unrecruit, and cancel through the existing keyboard harness. New pty capture src/test/board-tui-multi-move-pty.test.ts (expect, RUN_INTERACTIVE_TUI_TESTS=1) sends the raw ESC[1;2B shift-arrow plus M through a real pty and asserts the ► recruit marker renders; it needed an explicit stty size (sizeless pty under bun test) and a UTF-8 LANG (blessed downgrades ► to ? otherwise). Wired into scripts/run-tui-interactive-tests.sh.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Generalized the TUI board's single-task mover into the maintainer-designed multi-select move: Shift+Up/Down walk a recruitment highlight (the existing cyan bar) without moving the grabbed task, M toggles the highlighted task in/out of the set (with a below-the-ghost fallback so plain arrows + M alone stay fully usable where shift-arrows do not arrive), recruited tasks keep the existing ► indicator in place, plain arrows collapse the highlight and preview the whole set landing adjacent at the target, and Enter persists the set through core.moveTasksToStatus with per-task failures in the transient footer; Esc cancels. With nothing recruited the m flow is unchanged and still confirms via core.reorderTask. Verified with the extended board-tui-move keyboard-harness tests, a new expect pty capture sending real xterm shift-arrow sequences, tsc, biome, and the full bun test suite (2741 pass / 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-661 - TUI-multi-select-move-with-shift-arrow-recruitment.md
+++ b/backlog/tasks/back-661 - TUI-multi-select-move-with-shift-arrow-recruitment.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-08-30 17:23'
-updated_date: '2026-08-30 22:44'
+updated_date: '2026-08-30 23:21'
 labels:
   - tui
   - enhancement
@@ -63,6 +63,8 @@ Key-by-key behavior shipped:
 - Footer move-mode hints: [←→] Change Column | [↑↓] Reorder | [Shift+↑↓] Highlight | [M] Select | [Enter] Confirm | [Esc] Cancel; help-popup M entry updated.
 
 Validation: bunx tsc --noEmit clean; bun run check . clean; full bun test 2741 pass / 0 fail. src/test/board-tui-move.test.ts drives recruit, toggle-off, reorder-after-recruit, block bounds, cross-column confirm, adjacency-collapse confirm with highlight active, per-task failure footer, M-fallback recruit/unrecruit, and cancel through the existing keyboard harness. New pty capture src/test/board-tui-multi-move-pty.test.ts (expect, RUN_INTERACTIVE_TUI_TESTS=1) sends the raw ESC[1;2B shift-arrow plus M through a real pty and asserts the ► recruit marker renders; it needed an explicit stty size (sizeless pty under bun test) and a UTF-8 LANG (blessed downgrades ► to ? otherwise). Wired into scripts/run-tui-interactive-tests.sh.
+
+Codex review round on PR #980 (commit afb1b770): (1) dkqCe fixed - all move-mode mutations (arrows, Shift-arrows, M) and cancelMove freeze while movePending is true, so the confirmed set/target cannot change during the in-flight write and a late Esc cannot fake a cancel; regression test added. (2) dkqCg fixed - the no-highlight M fallback now recruits the nearest unrecruited task below the grabbed row (above at the bottom), skipping set members, so repeated M grows the set past the collapsed block; fallback is recruit-only (un-recruit via shift-arrow highlight or Esc); harness test recruits the whole column M-only. (3) dkqCi refuted - parent-child re-nesting after confirm is the board's pre-existing display rule with exact single-mover parity (reorderTask + buildColumnTasks on main behave the same); ordinals persist adjacent as previewed; no change. (4) dkqCl fixed - pty test now asserts the highlight walk itself (third-row redraw) before M and recruits the task the fallback cannot reach, with distinct exit codes. Verified: tsc, biome, 15 harness + 1 pty tests and 63 board-suite tests green.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/scripts/run-tui-interactive-tests.sh
+++ b/scripts/run-tui-interactive-tests.sh
@@ -10,4 +10,5 @@ echo "Running interactive TUI tests with expect..."
 RUN_INTERACTIVE_TUI_TESTS=1 bun test \
 	src/test/tui-interactive-editor-handoff.test.ts \
 	src/test/tui-ready-filter-pty.test.ts \
+	src/test/board-tui-multi-move-pty.test.ts \
 	--timeout=30000

--- a/src/test/board-tui-move.test.ts
+++ b/src/test/board-tui-move.test.ts
@@ -93,20 +93,39 @@ async function withBoard(
 		rows: () => string[];
 		footer: () => string;
 		quit: () => Promise<void>;
+		/** Publish a watcher-style task update to the board, as live sync would. */
+		update: (nextTasks: Task[]) => void;
+		/** How many times the Tab handoff ran (only counted with options.trackTabHandoff). */
+		tabHandoffs: () => number;
 	}) => Promise<void> | void,
-	filters?: BoardFilters,
-	boardTasks?: Task[],
+	options?: { filters?: BoardFilters; tasks?: Task[]; trackTabHandoff?: boolean },
 ): Promise<void> {
 	const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 	Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
 	const screen = createScreen({ smartCSR: false }) as ScreenInterface & EmittingWidget;
-	const tasks = boardTasks ?? [
+	const tasks = options?.tasks ?? [
 		createTask("TASK-1", "To Do", 1000),
 		createTask("TASK-2", "To Do", 2000),
 		createTask("TASK-3", "To Do", 3000),
 	];
+	let pushUpdate: ((nextTasks: Task[], nextStatuses: string[]) => void) | undefined;
+	let tabHandoffs = 0;
 	try {
-		const boardPromise = renderBoardTui(tasks, STATUSES, "horizontal", 20, { screen, core, filters });
+		const boardPromise = renderBoardTui(tasks, STATUSES, "horizontal", 20, {
+			screen,
+			core,
+			filters: options?.filters,
+			subscribeUpdates: (updateFn) => {
+				pushUpdate = updateFn;
+			},
+			...(options?.trackTabHandoff
+				? {
+						onTabPress: async () => {
+							tabHandoffs += 1;
+						},
+					}
+				: {}),
+		});
 		await Bun.sleep(20);
 		let closed = false;
 		const quit = async () => {
@@ -120,6 +139,8 @@ async function withBoard(
 			rows: () => renderedRows(screen as unknown as TreeWidget),
 			footer: () => footerText(screen as unknown as TreeWidget),
 			quit,
+			update: (nextTasks) => pushUpdate?.(nextTasks, []),
+			tabHandoffs: () => tabHandoffs,
 		});
 		await quit();
 	} finally {
@@ -196,10 +217,12 @@ describe("TUI board single-task mover", () => {
 				expect(footer()).not.toContain("MOVE MODE");
 			},
 			{
-				searchQuery: "",
-				priorityFilter: "high",
-				labelFilter: [],
-				milestoneFilter: "",
+				filters: {
+					searchQuery: "",
+					priorityFilter: "high",
+					labelFilter: [],
+					milestoneFilter: "",
+				},
 			},
 		);
 	});
@@ -378,12 +401,13 @@ describe("TUI board multi-select mover", () => {
 
 				pressKey(screen, "escape");
 			},
-			undefined,
-			[
-				createTask("TASK-1", "To Do", 1000),
-				{ ...createTask("TASK-2", "To Do", 2000), branch: "feature-x" },
-				createTask("TASK-3", "To Do", 3000),
-			],
+			{
+				tasks: [
+					createTask("TASK-1", "To Do", 1000),
+					{ ...createTask("TASK-2", "To Do", 2000), branch: "feature-x" },
+					createTask("TASK-3", "To Do", 3000),
+				],
+			},
 		);
 	});
 
@@ -415,12 +439,13 @@ describe("TUI board multi-select mover", () => {
 				});
 				await quit();
 			},
-			undefined,
-			[
-				createTask("TASK-1", "To Do", 1000),
-				createTask("TASK-2", "To Do", 2000),
-				createTask("TASK-3", "In Progress", 1000),
-			],
+			{
+				tasks: [
+					createTask("TASK-1", "To Do", 1000),
+					createTask("TASK-2", "To Do", 2000),
+					createTask("TASK-3", "In Progress", 1000),
+				],
+			},
 		);
 	});
 
@@ -446,6 +471,64 @@ describe("TUI board multi-select mover", () => {
 			expect((await core.filesystem.loadTask("TASK-1"))?.status).toBe("In Progress");
 			expect((await core.filesystem.loadTask("TASK-2"))?.status).toBe("In Progress");
 		});
+	});
+
+	it("persists the confirmed placement even when a watcher update lands mid-write", async () => {
+		await withBoard(async ({ screen, update, quit }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+			pressKey(screen, "right");
+			pressKey(screen, "right");
+			pressKey(screen, "enter");
+
+			// The write is being prepared; a watcher update now reorders To Do so the block
+			// would project as [TASK-2, TASK-1]. It must repaint the board but never change
+			// the batch the user confirmed.
+			update([
+				createTask("TASK-1", "To Do", 2500),
+				createTask("TASK-2", "To Do", 2000),
+				createTask("TASK-3", "To Do", 3000),
+			]);
+
+			await quit();
+			const first = await core.filesystem.loadTask("TASK-1");
+			const second = await core.filesystem.loadTask("TASK-2");
+			expect(first?.status).toBe("In Progress");
+			expect(second?.status).toBe("In Progress");
+			expect((first?.ordinal ?? Number.NaN) < (second?.ordinal ?? Number.NaN)).toBe(true);
+		});
+	});
+
+	it("runs exactly one teardown when quit and Tab race a pending write", async () => {
+		await withBoard(
+			async ({ screen, quit, tabHandoffs }) => {
+				// Slow the batch write down so the exit requests provably race it.
+				const originalMove = core.moveTasksToStatus.bind(core);
+				core.moveTasksToStatus = (async (params: Parameters<Core["moveTasksToStatus"]>[0]) => {
+					await Bun.sleep(150);
+					return originalMove(params);
+				}) as Core["moveTasksToStatus"];
+
+				pressKey(screen, "m");
+				pressKey(screen, "S-down");
+				pressKey(screen, "S-m");
+				pressKey(screen, "right");
+				pressKey(screen, "right");
+				pressKey(screen, "enter");
+
+				// q starts the close, which waits for the write; the Tab pressed during that
+				// wait must join the same close instead of running its view-switch handoff.
+				pressKey(screen, "q");
+				pressKey(screen, "tab");
+				await quit();
+
+				expect(tabHandoffs()).toBe(0);
+				expect((await core.filesystem.loadTask("TASK-1"))?.status).toBe("In Progress");
+				expect((await core.filesystem.loadTask("TASK-2"))?.status).toBe("In Progress");
+			},
+			{ trackTabHandoff: true },
+		);
 	});
 
 	it("freezes the move set and ignores Escape while the confirm write is in flight", async () => {

--- a/src/test/board-tui-move.test.ts
+++ b/src/test/board-tui-move.test.ts
@@ -337,18 +337,45 @@ describe("TUI board multi-select mover", () => {
 		});
 	});
 
-	it("recruits the task below the grabbed row with M when no highlight is active", async () => {
-		await withBoard(({ screen, rows }) => {
+	it("recruits successive unrecruited tasks with M alone when no highlight is active", async () => {
+		await withBoard(({ screen, rows, footer }) => {
 			pressKey(screen, "m");
 			pressKey(screen, "S-m");
-
 			expect(movingIds(rows())).toEqual(["TASK-1", "TASK-2"]);
 
-			// A second M toggles the same task back out.
+			// The fallback advances past already-recruited neighbors, so repeated M keeps
+			// growing the set instead of toggling the first recruit back off.
 			pressKey(screen, "S-m");
-			expect(movingIds(rows())).toEqual(["TASK-1"]);
+			expect(movingIds(rows())).toEqual(["TASK-1", "TASK-2", "TASK-3"]);
+
+			// With the whole column recruited there is nothing left to point at.
+			pressKey(screen, "S-m");
+			expect(footer()).toContain("No task to select here");
 
 			pressKey(screen, "escape");
+		});
+	});
+
+	it("freezes the move set and ignores Escape while the confirm write is in flight", async () => {
+		await withBoard(async ({ screen, quit }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+			pressKey(screen, "right");
+			pressKey(screen, "right");
+			pressKey(screen, "enter");
+			// The write is now awaiting the core; late recruitment and a late Escape must
+			// neither change the confirmed set nor make the move look canceled.
+			pressKey(screen, "S-m");
+			pressKey(screen, "escape");
+
+			await retry(async () => {
+				const moved = await core.filesystem.loadTask("TASK-1");
+				if (moved?.status !== "In Progress") throw new Error("set move not persisted yet");
+			});
+			expect((await core.filesystem.loadTask("TASK-2"))?.status).toBe("In Progress");
+			expect((await core.filesystem.loadTask("TASK-3"))?.status).toBe("To Do");
+			await quit();
 		});
 	});
 

--- a/src/test/board-tui-move.test.ts
+++ b/src/test/board-tui-move.test.ts
@@ -129,11 +129,13 @@ async function withBoard(
 }
 
 describe("TUI board single-task mover", () => {
-	it("enters move mode on M and shows the single-mover footer", async () => {
+	it("enters move mode on M and shows the move-mode footer", async () => {
 		await withBoard(({ screen, footer }) => {
 			pressKey(screen, "m");
 			expect(footer()).toContain("MOVE MODE");
-			expect(footer()).toContain("[Enter/M]");
+			expect(footer()).toContain("{cyan-fg}[Shift+↑↓]{/} Highlight");
+			expect(footer()).toContain("{cyan-fg}[M]{/} Select");
+			expect(footer()).toContain("{cyan-fg}[Enter]{/} Confirm");
 
 			pressKey(screen, "escape");
 			expect(footer()).not.toContain("MOVE MODE");
@@ -205,5 +207,173 @@ describe("TUI board single-task mover", () => {
 		const keys = getHelpShortcuts("board").map((shortcut) => shortcut.key);
 		expect(keys).toContain("M");
 		expect(keys).not.toContain("Space/M");
+	});
+});
+
+describe("TUI board multi-select mover", () => {
+	/** Task ids of the rendered board rows, in render order. */
+	const rowIds = (rows: string[]): string[] =>
+		rows.map((row) => row.match(/TASK-\d+/)?.[0]).filter((id): id is string => Boolean(id));
+	/** Task ids of the rows carrying the ► moving-set indicator. */
+	const movingIds = (rows: string[]): string[] => rowIds(rows.filter((row) => row.includes("►")));
+
+	it("walks the highlight with Shift+Down without moving the grabbed task", async () => {
+		await withBoard(({ screen, rows }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-down");
+
+			// The board order is untouched while the highlight walks; only the grabbed task is marked.
+			expect(rowIds(rows())).toEqual(["TASK-1", "TASK-2", "TASK-3"]);
+			expect(movingIds(rows())).toEqual(["TASK-1"]);
+
+			pressKey(screen, "escape");
+		});
+	});
+
+	it("toggles the highlighted task in and out of the selection with M", async () => {
+		await withBoard(({ screen, rows }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+
+			// Recruited tasks pick up the existing ► indicator and stay in place until Enter.
+			expect(movingIds(rows())).toEqual(["TASK-1", "TASK-2"]);
+			expect(rowIds(rows())).toEqual(["TASK-1", "TASK-2", "TASK-3"]);
+
+			pressKey(screen, "S-m");
+			expect(movingIds(rows())).toEqual(["TASK-1"]);
+
+			pressKey(screen, "escape");
+		});
+	});
+
+	it("collapses non-adjacent recruits into a block and reorders the whole set with plain arrows", async () => {
+		await withBoard(({ screen, rows }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+			expect(movingIds(rows())).toEqual(["TASK-1", "TASK-3"]);
+			expect(rowIds(rows())).toEqual(["TASK-1", "TASK-2", "TASK-3"]);
+
+			// The first plain arrow collapses the highlight: the preview now shows the whole
+			// set landing adjacent at the target position.
+			pressKey(screen, "down");
+			expect(rowIds(rows())).toEqual(["TASK-1", "TASK-3", "TASK-2"]);
+
+			// The next arrows reorder the whole set as one block.
+			pressKey(screen, "down");
+			expect(rowIds(rows())).toEqual(["TASK-2", "TASK-1", "TASK-3"]);
+
+			// The block stops at the end of the column.
+			pressKey(screen, "down");
+			expect(rowIds(rows())).toEqual(["TASK-2", "TASK-1", "TASK-3"]);
+
+			pressKey(screen, "escape");
+		});
+	});
+
+	it("moves the whole set across columns on Enter", async () => {
+		await withBoard(async ({ screen, quit }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+			// First plain arrow collapses the highlight, the second changes the column.
+			pressKey(screen, "right");
+			pressKey(screen, "right");
+			pressKey(screen, "enter");
+
+			await retry(async () => {
+				const moved = await core.filesystem.loadTask("TASK-1");
+				if (moved?.status !== "In Progress") throw new Error("set move not persisted yet");
+			});
+			const companion = await core.filesystem.loadTask("TASK-2");
+			expect(companion?.status).toBe("In Progress");
+			const first = await core.filesystem.loadTask("TASK-1");
+			expect((first?.ordinal ?? 0) < (companion?.ordinal ?? 0)).toBe(true);
+			expect((await core.filesystem.loadTask("TASK-3"))?.status).toBe("To Do");
+			await quit();
+		});
+	});
+
+	it("lands non-adjacent recruits adjacent on Enter while the highlight is still active", async () => {
+		await withBoard(async ({ screen, quit }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+			pressKey(screen, "enter");
+
+			await retry(async () => {
+				const first = await core.filesystem.loadTask("TASK-1");
+				const second = await core.filesystem.loadTask("TASK-2");
+				const third = await core.filesystem.loadTask("TASK-3");
+				const ordinalOf = (task: Task | null) => task?.ordinal ?? Number.NaN;
+				// The set [TASK-1, TASK-3] collapses adjacent at the grabbed task's position.
+				if (!(ordinalOf(first) < ordinalOf(third) && ordinalOf(third) < ordinalOf(second))) {
+					throw new Error("adjacency collapse not persisted yet");
+				}
+			});
+			expect((await core.filesystem.loadTask("TASK-1"))?.status).toBe("To Do");
+			expect((await core.filesystem.loadTask("TASK-3"))?.status).toBe("To Do");
+			await quit();
+		});
+	});
+
+	it("cancels a recruited move on Escape without persisting anything", async () => {
+		await withBoard(async ({ screen, rows, quit }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+			pressKey(screen, "right");
+			pressKey(screen, "right");
+			pressKey(screen, "escape");
+
+			expect(movingIds(rows())).toEqual([]);
+			expect((await core.filesystem.loadTask("TASK-1"))?.status).toBe("To Do");
+			expect((await core.filesystem.loadTask("TASK-2"))?.status).toBe("To Do");
+			await quit();
+		});
+	});
+
+	it("recruits the task below the grabbed row with M when no highlight is active", async () => {
+		await withBoard(({ screen, rows }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-m");
+
+			expect(movingIds(rows())).toEqual(["TASK-1", "TASK-2"]);
+
+			// A second M toggles the same task back out.
+			pressKey(screen, "S-m");
+			expect(movingIds(rows())).toEqual(["TASK-1"]);
+
+			pressKey(screen, "escape");
+		});
+	});
+
+	it("reports per-task failures in the transient footer and still moves the rest", async () => {
+		await withBoard(async ({ screen, footer, quit }) => {
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+
+			// Remove the recruited task's file behind the board's back so its move fails.
+			const recruited = await core.filesystem.loadTask("TASK-2");
+			if (!recruited?.filePath) throw new Error("expected TASK-2 to have a file path");
+			await rm(recruited.filePath, { force: true });
+
+			pressKey(screen, "right");
+			pressKey(screen, "right");
+			pressKey(screen, "enter");
+
+			await retry(async () => {
+				const moved = await core.filesystem.loadTask("TASK-1");
+				if (moved?.status !== "In Progress") throw new Error("partial move not persisted yet");
+			});
+			expect(footer()).toContain("Could not move 1 of the selected tasks");
+			expect(footer()).toContain("TASK-2");
+			await quit();
+		});
 	});
 });

--- a/src/test/board-tui-move.test.ts
+++ b/src/test/board-tui-move.test.ts
@@ -298,14 +298,20 @@ describe("TUI board multi-select mover", () => {
 		});
 	});
 
-	it("lands non-adjacent recruits adjacent on Enter while the highlight is still active", async () => {
-		await withBoard(async ({ screen, quit }) => {
+	it("previews the collapsed block on Enter while the highlight is active and persists on the second Enter", async () => {
+		await withBoard(async ({ screen, rows, quit }) => {
 			pressKey(screen, "m");
 			pressKey(screen, "S-down");
 			pressKey(screen, "S-down");
 			pressKey(screen, "S-m");
-			pressKey(screen, "enter");
 
+			// The first Enter only collapses and renders the block preview - the user must
+			// see the exact order before anything persists.
+			pressKey(screen, "enter");
+			expect(rowIds(rows())).toEqual(["TASK-1", "TASK-3", "TASK-2"]);
+			expect((await core.filesystem.loadTask("TASK-3"))?.ordinal).toBe(3000);
+
+			pressKey(screen, "enter");
 			await retry(async () => {
 				const first = await core.filesystem.loadTask("TASK-1");
 				const second = await core.filesystem.loadTask("TASK-2");
@@ -379,6 +385,67 @@ describe("TUI board multi-select mover", () => {
 				createTask("TASK-3", "To Do", 3000),
 			],
 		);
+	});
+
+	it("persists cross-column recruits in exactly the order rendered by the collapse preview", async () => {
+		await withBoard(
+			async ({ screen, rows, quit }) => {
+				// Grab the In Progress task, walk its ghost to the top of To Do, recruit TASK-1.
+				pressKey(screen, "right");
+				pressKey(screen, "m");
+				pressKey(screen, "left");
+				pressKey(screen, "S-down");
+				pressKey(screen, "S-m");
+
+				// First Enter renders the collapsed block; whatever it shows is what persists.
+				pressKey(screen, "enter");
+				const previewed = rowIds(rows());
+				expect(previewed.slice(0, 2).sort()).toEqual(["TASK-1", "TASK-3"]);
+
+				pressKey(screen, "enter");
+				await retry(async () => {
+					const first = await core.filesystem.loadTask(previewed[0] ?? "");
+					const second = await core.filesystem.loadTask(previewed[1] ?? "");
+					const third = await core.filesystem.loadTask("TASK-2");
+					const a = first?.ordinal ?? Number.NaN;
+					const b = second?.ordinal ?? Number.NaN;
+					const c = third?.ordinal ?? Number.NaN;
+					// The persisted column order must be exactly the previewed one.
+					if (!(a < b && b < c)) throw new Error("cross-column order not persisted yet");
+				});
+				await quit();
+			},
+			undefined,
+			[
+				createTask("TASK-1", "To Do", 1000),
+				createTask("TASK-2", "To Do", 2000),
+				createTask("TASK-3", "In Progress", 1000),
+			],
+		);
+	});
+
+	it("keeps the board alive on quit until the confirmed write has persisted", async () => {
+		await withBoard(async ({ screen, quit }) => {
+			// Slow the batch write down so quit provably races it.
+			const originalMove = core.moveTasksToStatus.bind(core);
+			core.moveTasksToStatus = (async (params: Parameters<Core["moveTasksToStatus"]>[0]) => {
+				await Bun.sleep(150);
+				return originalMove(params);
+			}) as Core["moveTasksToStatus"];
+
+			pressKey(screen, "m");
+			pressKey(screen, "S-down");
+			pressKey(screen, "S-m");
+			pressKey(screen, "right");
+			pressKey(screen, "right");
+			pressKey(screen, "enter");
+			// Quit immediately: the board must not resolve (the CLI would process.exit)
+			// until the write the user confirmed has landed.
+			await quit();
+
+			expect((await core.filesystem.loadTask("TASK-1"))?.status).toBe("In Progress");
+			expect((await core.filesystem.loadTask("TASK-2"))?.status).toBe("In Progress");
+		});
 	});
 
 	it("freezes the move set and ignores Escape while the confirm write is in flight", async () => {

--- a/src/test/board-tui-move.test.ts
+++ b/src/test/board-tui-move.test.ts
@@ -95,11 +95,12 @@ async function withBoard(
 		quit: () => Promise<void>;
 	}) => Promise<void> | void,
 	filters?: BoardFilters,
+	boardTasks?: Task[],
 ): Promise<void> {
 	const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 	Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
 	const screen = createScreen({ smartCSR: false }) as ScreenInterface & EmittingWidget;
-	const tasks = [
+	const tasks = boardTasks ?? [
 		createTask("TASK-1", "To Do", 1000),
 		createTask("TASK-2", "To Do", 2000),
 		createTask("TASK-3", "To Do", 3000),
@@ -134,7 +135,7 @@ describe("TUI board single-task mover", () => {
 			pressKey(screen, "m");
 			expect(footer()).toContain("MOVE MODE");
 			expect(footer()).toContain("{cyan-fg}[Shift+↑↓]{/} Highlight");
-			expect(footer()).toContain("{cyan-fg}[M]{/} Select");
+			expect(footer()).toContain("{cyan-fg}[Shift+M]{/} Select");
 			expect(footer()).toContain("{cyan-fg}[Enter]{/} Confirm");
 
 			pressKey(screen, "escape");
@@ -354,6 +355,30 @@ describe("TUI board multi-select mover", () => {
 
 			pressKey(screen, "escape");
 		});
+	});
+
+	it("skips cross-branch tasks in the M-only fallback instead of dead-ending on them", async () => {
+		await withBoard(
+			({ screen, rows, footer }) => {
+				pressKey(screen, "m");
+				pressKey(screen, "S-m");
+
+				// The read-only TASK-2 cannot join the set, so the fallback recruits TASK-3.
+				expect(movingIds(rows())).toEqual(["TASK-1", "TASK-3"]);
+
+				// With every recruitable task in the set, the fallback reports the dead end.
+				pressKey(screen, "S-m");
+				expect(footer()).toContain("No task to select here");
+
+				pressKey(screen, "escape");
+			},
+			undefined,
+			[
+				createTask("TASK-1", "To Do", 1000),
+				{ ...createTask("TASK-2", "To Do", 2000), branch: "feature-x" },
+				createTask("TASK-3", "To Do", 3000),
+			],
+		);
 	});
 
 	it("freezes the move set and ignores Escape while the confirm write is in flight", async () => {

--- a/src/test/board-tui-multi-move-pty.test.ts
+++ b/src/test/board-tui-multi-move-pty.test.ts
@@ -42,7 +42,7 @@ function buildSpawnCommand(cliArgs: string[]): string {
 
 describe("interactive board multi-select move", () => {
 	itInteractive(
-		"recruits a second task through a real pty with xterm shift-arrows",
+		"walks the highlight with real xterm shift-arrows and recruits the task the fallback cannot reach",
 		async () => {
 			const testDir = createUniqueTestDir("board-multi-move");
 			await mkdir(testDir, { recursive: true });
@@ -105,10 +105,19 @@ expect {
 	timeout { exit 92 }
 }
 send "\\033\\[1;2B"
+send "\\033\\[1;2B"
+# The buffer pointer sits past the initial render, so "Bystander Task" can only
+# reappear when the highlight bar redraws the third row - proof the shift-arrow
+# walk itself ran. The M fallback (which targets the row below the grabbed task)
+# could never produce this: it would recruit "Recruited Task" instead.
+expect {
+	-re {Bystander Task} {}
+	timeout { exit 93 }
+}
 send "M"
 expect {
-	-re {►[^\\n]*Recruited Task} {}
-	timeout { exit 93 }
+	-re {►[^\\n]*Bystander Task} {}
+	timeout { exit 94 }
 }
 send "\\033"
 # A pause keeps ESC + q from being read back as one Meta-q chord.
@@ -138,8 +147,11 @@ exit 0
 				}
 				if (exitCode === 93) {
 					throw new Error(
-						`Shift+Down followed by M never marked the recruited task with ►.\nTranscript: ${transcriptPath}`,
+						`Shift+Down never walked the highlight to the third task, so shift-arrow parsing is broken.\nTranscript: ${transcriptPath}`,
 					);
+				}
+				if (exitCode === 94) {
+					throw new Error(`M never marked the highlighted third task with ►.\nTranscript: ${transcriptPath}`);
 				}
 				if (exitCode !== 0) {
 					throw new Error(`Interactive board move failed with ${exitCode}.\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`);

--- a/src/test/board-tui-multi-move-pty.test.ts
+++ b/src/test/board-tui-multi-move-pty.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import type { BacklogConfig } from "../types/index.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeTestProject, safeCleanup } from "./test-utils.ts";
+
+const CLI_PATH = process.env.TUI_TEST_CLI_PATH?.trim() || getTestCliPath();
+const CLI_RUNTIME = process.env.TUI_TEST_CLI_RUNTIME?.trim() ?? "bun";
+const TRANSCRIPT_DIR = join(process.cwd(), "tmp", "tui-interactive-transcripts");
+const EXPECT_PATH = Bun.which("expect");
+const RUN_INTERACTIVE_TUI_TESTS = process.env.RUN_INTERACTIVE_TUI_TESTS === "1";
+
+function getSkipReason(): string | null {
+	if (process.platform === "win32") {
+		return "interactive PTY tests require a Unix-like environment";
+	}
+	if (!RUN_INTERACTIVE_TUI_TESTS) {
+		return "set RUN_INTERACTIVE_TUI_TESTS=1 to enable interactive PTY tests";
+	}
+	if (!EXPECT_PATH) {
+		return "expect is not installed";
+	}
+	return null;
+}
+
+const skipReason = getSkipReason();
+if (skipReason) {
+	console.warn(`[board-multi-move] Skipping interactive board move test: ${skipReason}`);
+}
+const itInteractive = skipReason ? it.skip : it;
+
+function buildSpawnCommand(cliArgs: string[]): string {
+	const argsSegment = cliArgs.map((arg) => `"${arg}"`).join(" ");
+	if (CLI_RUNTIME.length === 0) {
+		return `spawn {${CLI_PATH}} ${argsSegment}`;
+	}
+	return `spawn {${CLI_RUNTIME}} {${CLI_PATH}} ${argsSegment}`;
+}
+
+describe("interactive board multi-select move", () => {
+	itInteractive(
+		"recruits a second task through a real pty with xterm shift-arrows",
+		async () => {
+			const testDir = createUniqueTestDir("board-multi-move");
+			await mkdir(testDir, { recursive: true });
+			await mkdir(TRANSCRIPT_DIR, { recursive: true });
+			const transcriptPath = join(TRANSCRIPT_DIR, `board-multi-move-${Date.now()}.log`);
+			const expectScriptPath = join(testDir, "board-multi-move.expect");
+
+			try {
+				await $`git init -b main`.cwd(testDir).quiet();
+				const core = new Core(testDir);
+				await initializeTestProject(core, "Board Multi Move");
+
+				const config = await core.filesystem.loadConfig();
+				if (!config) throw new Error("Failed to load config");
+				const updatedConfig: BacklogConfig = { ...config, remoteOperations: false, checkActiveBranches: false };
+				await core.filesystem.saveConfig(updatedConfig);
+
+				const baseTask = {
+					assignee: [],
+					labels: [],
+					createdDate: "2026-08-08",
+					rawContent: "",
+					dependencies: [] as string[],
+				};
+				await core.createTask(
+					{ ...baseTask, id: "task-1", title: "Grabbed Task", status: "To Do", ordinal: 1000 },
+					false,
+				);
+				await core.createTask(
+					{ ...baseTask, id: "task-2", title: "Recruited Task", status: "To Do", ordinal: 2000 },
+					false,
+				);
+				await core.createTask(
+					{ ...baseTask, id: "task-3", title: "Bystander Task", status: "To Do", ordinal: 3000 },
+					false,
+				);
+
+				// The shift-arrow is sent as the raw xterm modified-arrow sequence (ESC [ 1 ; 2 B),
+				// exactly what a real terminal emits for Shift+Down.
+				await writeFile(
+					expectScriptPath,
+					`#!/usr/bin/expect -f
+set timeout 30
+log_user 0
+log_file -a {${transcriptPath}}
+set env(TERM) {xterm-256color}
+# Without a UTF-8 locale blessed downgrades ► and the arrow glyphs to "?".
+set env(LANG) {en_US.UTF-8}
+${buildSpawnCommand(["board"])}
+# Under bun test there is no controlling terminal, so the spawned pty starts sizeless
+# and the board would render into a zero-width screen.
+exec stty rows 40 columns 160 < $spawn_out(slave,name)
+expect {
+	-re {Grabbed Task} {}
+	timeout { exit 91 }
+}
+send "m"
+expect {
+	-re {MOVE MODE} {}
+	timeout { exit 92 }
+}
+send "\\033\\[1;2B"
+send "M"
+expect {
+	-re {►[^\\n]*Recruited Task} {}
+	timeout { exit 93 }
+}
+send "\\033"
+# A pause keeps ESC + q from being read back as one Meta-q chord.
+sleep 0.3
+send "q"
+set timeout 5
+expect eof
+exit 0
+`,
+				);
+
+				const child = Bun.spawn([EXPECT_PATH as string, "-f", expectScriptPath], {
+					cwd: testDir,
+					stdout: "pipe",
+					stderr: "pipe",
+					env: { ...process.env },
+				});
+				const stdout = child.stdout ? await new Response(child.stdout).text() : "";
+				const stderr = child.stderr ? await new Response(child.stderr).text() : "";
+				const exitCode = await child.exited;
+
+				if (exitCode === 91) {
+					throw new Error(`The board never rendered the seeded tasks.\nTranscript: ${transcriptPath}`);
+				}
+				if (exitCode === 92) {
+					throw new Error(`Pressing m never entered move mode.\nTranscript: ${transcriptPath}`);
+				}
+				if (exitCode === 93) {
+					throw new Error(
+						`Shift+Down followed by M never marked the recruited task with ►.\nTranscript: ${transcriptPath}`,
+					);
+				}
+				if (exitCode !== 0) {
+					throw new Error(`Interactive board move failed with ${exitCode}.\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`);
+				}
+				expect(exitCode).toBe(0);
+			} finally {
+				await safeCleanup(testDir);
+			}
+		},
+		60_000,
+	);
+});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -1107,6 +1107,9 @@ export async function renderBoardTui(
 			// A Shift+H write can still be in flight, and the caller may exit the process
 			// as soon as the board resolves, which would drop the setting.
 			if (pendingSettingWrite) await pendingSettingWrite;
+			// Same for a confirmed move: quitting right after Enter must not let the
+			// process exit before the write the user confirmed has persisted.
+			if (pendingMoveWrite) await pendingMoveWrite;
 			clearFooterTimer();
 			screen.destroy();
 			await beforeResolve?.();
@@ -1676,20 +1679,25 @@ export async function renderBoardTui(
 
 		// A second Enter while the confirm is writing must not start a second move.
 		let movePending = false;
+		// The confirmed write in flight; closeBoard awaits it (like pendingSettingWrite)
+		// because the caller may process.exit as soon as the board resolves.
+		let pendingMoveWrite: Promise<void> | null = null;
+		/** Mark a confirm write as in flight; the returned settle runs in its finally. */
+		const beginMoveWrite = (): (() => void) => {
+			movePending = true;
+			let settle: () => void = () => {};
+			pendingMoveWrite = new Promise<void>((resolve) => {
+				settle = resolve;
+			});
+			return settle;
+		};
 
 		/** Confirm a move with recruited tasks: the whole set lands as one block at the preview position. */
 		const performSetMove = async () => {
 			if (!moveOp || movePending) return;
 			const operation = moveOp;
 
-			// Collapse an active highlight first so the confirmed order matches the block preview.
-			if (operation.highlightTaskId) {
-				updateMoveSelection(operation, () => {
-					operation.highlightTaskId = null;
-				});
-			}
-
-			movePending = true;
+			const settleMoveWrite = beginMoveWrite();
 			try {
 				const core = await getCore();
 				const config = await core.fs.loadConfig();
@@ -1745,11 +1753,20 @@ export async function renderBoardTui(
 				renderView();
 			} finally {
 				movePending = false;
+				settleMoveWrite();
 			}
 		};
 
 		const performTaskMove = async () => {
 			if (!moveOp || movePending) return;
+
+			// A confirm while the recruitment highlight is active first collapses it and
+			// renders the block preview, so the user always sees the exact order that a
+			// second confirm will persist - the projection is the single source of truth.
+			if (moveOp.selectedIds.length > 0 && moveOp.highlightTaskId) {
+				collapseHighlight();
+				return;
+			}
 
 			if (moveOp.selectedIds.length > 0) {
 				await performSetMove();
@@ -1766,7 +1783,7 @@ export async function renderBoardTui(
 				return;
 			}
 
-			movePending = true;
+			const settleMoveWrite = beginMoveWrite();
 			try {
 				const core = await getCore();
 				const config = await core.fs.loadConfig();
@@ -1810,6 +1827,7 @@ export async function renderBoardTui(
 				renderView();
 			} finally {
 				movePending = false;
+				settleMoveWrite();
 			}
 		};
 		const cancelMove = () => {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -186,13 +186,13 @@ export function formatTaskListItem(
 
 function buildRenderedTaskListItems(
 	tasks: Task[],
-	movingTaskId?: string,
+	movingTaskIds?: ReadonlySet<string>,
 	availableWidth = Number.POSITIVE_INFINITY,
 	dateFormat?: string,
 	configuredProjects?: string[],
 ): { rich: string[]; plain: string[] } {
 	const rich = tasks.map((task) =>
-		formatTaskListItem(task, movingTaskId === task.id, availableWidth, dateFormat, configuredProjects),
+		formatTaskListItem(task, movingTaskIds?.has(task.id) ?? false, availableWidth, dateFormat, configuredProjects),
 	);
 	return {
 		rich,
@@ -502,8 +502,74 @@ export async function renderBoardTui(
 			originalIndex: number;
 			targetStatus: string;
 			targetIndex: number;
+			/** Tasks recruited into the move set with M; never contains the grabbed task. */
+			selectedIds: string[];
+			/**
+			 * Recruitment highlight walked with Shift+Up/Down. While set, recruited tasks stay
+			 * in place and the preview shows only the grabbed task's ghost; a plain arrow
+			 * collapses it back to the ghost and previews the whole set as one block.
+			 */
+			highlightTaskId: string | null;
 		};
 		let moveOp: MoveOperation | null = null;
+
+		/** Every task the operation moves on confirm: the grabbed task plus the recruited set. */
+		const getMoveSetIds = (operation: MoveOperation): string[] => [operation.taskId, ...operation.selectedIds];
+
+		/**
+		 * Tasks removed from their columns by the current preview. While the recruitment
+		 * highlight is active only the grabbed task lifts out; once it collapses the whole
+		 * set previews as a block at the target position.
+		 */
+		const getPreviewMovingIds = (operation: MoveOperation): string[] =>
+			operation.highlightTaskId ? [operation.taskId] : getMoveSetIds(operation);
+
+		/**
+		 * Re-anchor an insertion index when the set of lifted-out tasks changes: the index
+		 * follows the first task at or below it that both views share, so the ghost stays
+		 * visually put when recruits collapse into or pop out of the preview.
+		 */
+		const mapInsertionIndex = (fromBase: string[], toBase: string[], index: number): number => {
+			for (let i = Math.max(0, index); i < fromBase.length; i++) {
+				const anchor = fromBase[i];
+				if (anchor === undefined) break;
+				const position = toBase.indexOf(anchor);
+				if (position !== -1) return position;
+			}
+			return toBase.length;
+		};
+
+		/** The target column's real task ids minus `excludeIds`: the base the ghost inserts into. */
+		const getInsertionBase = (targetStatus: string, excludeIds: string[]): string[] => {
+			const excluded = new Set(excludeIds);
+			const column = prepareBoardColumns(getFilteredTasks(), currentStatuses).find(
+				(candidate) => candidate.status === targetStatus,
+			);
+			return (column?.tasks ?? []).filter((task) => !excluded.has(task.id)).map((task) => task.id);
+		};
+
+		/** Mutate the move selection/highlight while keeping targetIndex anchored to the same spot. */
+		const updateMoveSelection = (operation: MoveOperation, mutate: () => void): void => {
+			const before = getInsertionBase(operation.targetStatus, getPreviewMovingIds(operation));
+			mutate();
+			const after = getInsertionBase(operation.targetStatus, getPreviewMovingIds(operation));
+			operation.targetIndex = mapInsertionIndex(before, after, operation.targetIndex);
+		};
+
+		/**
+		 * A plain arrow while the recruitment highlight is active collapses it back to the
+		 * ghost, switching the preview to the whole set landing as one block. Returns true
+		 * when the keypress was consumed by the collapse.
+		 */
+		const collapseHighlight = (): boolean => {
+			if (!moveOp?.highlightTaskId) return false;
+			const operation = moveOp;
+			updateMoveSelection(operation, () => {
+				operation.highlightTaskId = null;
+			});
+			renderView();
+			return true;
+		};
 
 		const footerBox = box({
 			parent: screen,
@@ -582,7 +648,13 @@ export async function renderBoardTui(
 		const getFormattedItems = (tasks: Task[]) => {
 			const columnCount = Math.max(1, currentColumnsData.length);
 			const availableWidth = Math.max(1, Math.floor(getTerminalWidth() / columnCount) - 4);
-			return buildRenderedTaskListItems(tasks, moveOp?.taskId, availableWidth, options?.dateFormat, configuredProjects);
+			return buildRenderedTaskListItems(
+				tasks,
+				moveOp ? new Set(getMoveSetIds(moveOp)) : undefined,
+				availableWidth,
+				options?.dateFormat,
+				configuredProjects,
+			);
 		};
 
 		const createColumnViews = (data: ColumnData[]) => {
@@ -762,26 +834,36 @@ export async function renderBoardTui(
 				return prepareBoardColumns(allTasks, currentStatuses);
 			}
 
-			// 1. Filter out the moving task from the source
-			const tasksWithoutMoving = allTasks.filter((t) => t.id !== operation.taskId);
 			const movingTask = allTasks.find((t) => t.id === operation.taskId);
-
 			if (!movingTask) {
 				return prepareBoardColumns(allTasks, currentStatuses);
 			}
 
-			// 2. Prepare columns without the moving task
-			const columns = prepareBoardColumns(tasksWithoutMoving, currentStatuses);
+			// 1. Lift the previewed tasks out of their columns, keeping board display order
+			//    so a collapsed set lands as one block in the order it appears on the board.
+			const movingIds = new Set(getPreviewMovingIds(operation));
+			const blockTasks: Task[] = [];
+			for (const column of prepareBoardColumns(allTasks, currentStatuses)) {
+				for (const task of column.tasks) {
+					if (movingIds.has(task.id)) blockTasks.push(task);
+				}
+			}
 
-			// 3. Insert the moving task into the target column at the target index
+			// 2. Prepare columns without the moving tasks
+			const columns = prepareBoardColumns(
+				allTasks.filter((t) => !movingIds.has(t.id)),
+				currentStatuses,
+			);
+
+			// 3. Insert the moving block into the target column at the target index
 			const targetColumn = columns.find((c) => c.status === operation.targetStatus);
 			if (targetColumn) {
-				// Create a "ghost" task with updated status
-				const ghostTask = { ...movingTask, status: operation.targetStatus };
+				// Create "ghost" tasks with updated status
+				const ghostTasks = blockTasks.map((task) => ({ ...task, status: operation.targetStatus }));
 
 				// Clamp index to valid bounds
 				const safeIndex = Math.max(0, Math.min(operation.targetIndex, targetColumn.tasks.length));
-				targetColumn.tasks.splice(safeIndex, 0, ghostTask);
+				targetColumn.tasks.splice(safeIndex, 0, ...ghostTasks);
 			}
 
 			return columns;
@@ -998,7 +1080,7 @@ export async function renderBoardTui(
 			}
 			if (moveOp) {
 				setFooterContent(
-					" {green-fg}MOVE MODE{/} | {cyan-fg}[←→]{/} Change Column | {cyan-fg}[↑↓]{/} Reorder | {cyan-fg}[Enter/M]{/} Confirm | {cyan-fg}[Esc]{/} Cancel",
+					" {green-fg}MOVE MODE{/} | {cyan-fg}[←→]{/} Change Column | {cyan-fg}[↑↓]{/} Reorder | {cyan-fg}[Shift+↑↓]{/} Highlight | {cyan-fg}[M]{/} Select | {cyan-fg}[Enter]{/} Confirm | {cyan-fg}[Esc]{/} Cancel",
 				);
 			} else {
 				const base = getBoardFooterContent({ hasProjects: configuredProjects.length > 0 });
@@ -1042,8 +1124,10 @@ export async function renderBoardTui(
 				}
 				const dataForColumns = filterVisibleColumns(projectedData, hideEmptyColumns, Boolean(moveOp));
 
-				// If we are moving, we want to select the moving task
-				const selectedId = preferredTaskId ?? (moveOp ? moveOp.taskId : getSelectedTaskId());
+				// If we are moving, we want to select the recruitment highlight when it is
+				// active, and the moving task's ghost otherwise
+				const selectedId =
+					preferredTaskId ?? (moveOp ? (moveOp.highlightTaskId ?? moveOp.taskId) : getSelectedTaskId());
 
 				if (dataForColumns.length === 0) {
 					const fallbackStatus = currentStatuses[0] ?? "No Status";
@@ -1222,6 +1306,7 @@ export async function renderBoardTui(
 		screen.key(["left", "h"], () => {
 			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			if (moveOp) {
+				if (collapseHighlight()) return;
 				const currentStatusIndex = currentStatuses.indexOf(moveOp.targetStatus);
 				if (currentStatusIndex > 0) {
 					const prevStatus = currentStatuses[currentStatusIndex - 1];
@@ -1241,6 +1326,7 @@ export async function renderBoardTui(
 		screen.key(["right", "l"], () => {
 			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			if (moveOp) {
+				if (collapseHighlight()) return;
 				const currentStatusIndex = currentStatuses.indexOf(moveOp.targetStatus);
 				if (currentStatusIndex < currentStatuses.length - 1) {
 					const nextStatus = currentStatuses[currentStatusIndex + 1];
@@ -1262,6 +1348,7 @@ export async function renderBoardTui(
 
 			const column = columns[currentCol];
 			if (moveOp) {
+				if (collapseHighlight()) return;
 				if (direction === "up") {
 					if (moveOp.targetIndex > 0) {
 						moveOp.targetIndex--;
@@ -1270,8 +1357,8 @@ export async function renderBoardTui(
 					return;
 				}
 				// We need to check the projected length to know if we can move down
-				// The current rendered column has the correct length including the ghost task
-				if (column && moveOp.targetIndex < column.tasks.length - 1) {
+				// The current rendered column has the correct length including the ghost block
+				if (column && moveOp.targetIndex < column.tasks.length - getPreviewMovingIds(moveOp).length) {
 					moveOp.targetIndex++;
 					renderView();
 				}
@@ -1586,8 +1673,85 @@ export async function renderBoardTui(
 
 		// A second Enter while the confirm is writing must not start a second move.
 		let movePending = false;
+
+		/** Confirm a move with recruited tasks: the whole set lands as one block at the preview position. */
+		const performSetMove = async () => {
+			if (!moveOp || movePending) return;
+			const operation = moveOp;
+
+			// Collapse an active highlight first so the confirmed order matches the block preview.
+			if (operation.highlightTaskId) {
+				updateMoveSelection(operation, () => {
+					operation.highlightTaskId = null;
+				});
+			}
+
+			movePending = true;
+			try {
+				const core = await getCore();
+				const config = await core.fs.loadConfig();
+
+				// Get the final state from the projection
+				const projectedData = getProjectedColumns(currentTasks, operation);
+				const targetColumn = projectedData.find((c) => c.status === operation.targetStatus);
+
+				if (!targetColumn) {
+					moveOp = null;
+					renderView();
+					return;
+				}
+
+				const orderedTaskIds = targetColumn.tasks.map((task) => task.id);
+
+				// No-op guard: the set already sits exactly where the preview lands it.
+				const realColumn = prepareBoardColumns(currentTasks, currentStatuses).find(
+					(c) => c.status === operation.targetStatus,
+				);
+				const realIds = (realColumn?.tasks ?? []).map((task) => task.id);
+				if (realIds.length === orderedTaskIds.length && realIds.every((id, index) => id === orderedTaskIds[index])) {
+					moveOp = null;
+					renderView();
+					return;
+				}
+
+				const { movedTasks, changedTasks, failures } = await core.moveTasksToStatus({
+					taskIds: getMoveSetIds(operation),
+					targetStatus: operation.targetStatus,
+					orderedTaskIds,
+					autoCommit: config?.autoCommit ?? false,
+				});
+
+				// Update local state with all moved and changed tasks (includes ordinal updates)
+				const changedTasksMap = new Map(changedTasks.map((t) => [t.id, t]));
+				for (const task of movedTasks) changedTasksMap.set(task.id, task);
+				currentTasks = currentTasks.map((t) => changedTasksMap.get(t.id) ?? t);
+
+				moveOp = null;
+				renderView();
+
+				if (failures.length > 0) {
+					const details = failures.map((failure) => `${failure.taskId}: ${failure.reason}`).join("; ");
+					showTransientFooter(` {red-fg}Could not move ${failures.length} of the selected tasks — ${details}{/}`, 6000);
+				}
+			} catch (error) {
+				// On error, cancel the move and restore original positions
+				if (process.env.DEBUG) {
+					console.error("Move failed:", error);
+				}
+				moveOp = null;
+				renderView();
+			} finally {
+				movePending = false;
+			}
+		};
+
 		const performTaskMove = async () => {
 			if (!moveOp || movePending) return;
+
+			if (moveOp.selectedIds.length > 0) {
+				await performSetMove();
+				return;
+			}
 
 			// Check if any actual change occurred
 			const noChange = moveOp.targetStatus === moveOp.originalStatus && moveOp.targetIndex === moveOp.originalIndex;
@@ -1654,39 +1818,138 @@ export async function renderBoardTui(
 			renderView();
 		};
 
-		screen.key(["m", "M", "S-m"], async () => {
-			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
+		const enterMoveMode = () => {
 			if (hasMoveBlockingSharedFilters()) {
 				showTransientFooter(" {yellow-fg}Clear filters before moving tasks.{/}");
 				return;
 			}
 
+			const column = columns[currentCol];
+			if (!column) return;
+			const taskIndex = column.list.selected ?? 0;
+			const task = column.tasks[taskIndex];
+			if (!task) return;
+
+			// Prevent move mode for cross-branch tasks
+			if (task.branch) {
+				showTransientFooter(` {red-fg}Cannot move task from branch "${task.branch}".{/}`);
+				return;
+			}
+
+			// Enter move mode - store original position for cancel
+			moveOp = {
+				taskId: task.id,
+				originalStatus: column.status,
+				originalIndex: taskIndex,
+				targetStatus: column.status,
+				targetIndex: taskIndex,
+				selectedIds: [],
+				highlightTaskId: null,
+			};
+
+			renderView();
+		};
+
+		/**
+		 * Shift+Up/Down walk the recruitment highlight through the target column's tasks
+		 * without moving the grabbed task. While the highlight is active, recruited tasks
+		 * stay in their original places and the preview shows only the grabbed task's ghost.
+		 */
+		const walkRecruitHighlight = (direction: "up" | "down") => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
+			if (!moveOp) return;
+			const operation = moveOp;
+
+			// While the preview shows the collapsed block, the ghost index counts a column
+			// without the whole set; re-anchor it against the recruitment view (recruits back
+			// in place) before walking. Committed only if the walk actually highlights a task.
+			const recruitIndex =
+				!operation.highlightTaskId && operation.selectedIds.length > 0
+					? mapInsertionIndex(
+							getInsertionBase(operation.targetStatus, getMoveSetIds(operation)),
+							getInsertionBase(operation.targetStatus, [operation.taskId]),
+							operation.targetIndex,
+						)
+					: operation.targetIndex;
+
+			// Recruitment-view rows of the target column: the column without the grabbed task,
+			// with its ghost spliced back in at the target position.
+			const rows = getInsertionBase(operation.targetStatus, [operation.taskId]);
+			const ghostIndex = Math.max(0, Math.min(recruitIndex, rows.length));
+			rows.splice(ghostIndex, 0, operation.taskId);
+
+			const from = operation.highlightTaskId ? rows.indexOf(operation.highlightTaskId) : ghostIndex;
+			const step = direction === "down" ? 1 : -1;
+			let next = (from === -1 ? ghostIndex : from) + step;
+			// The ghost row is the grabbed task itself; the highlight walks past it.
+			while (rows[next] === operation.taskId) next += step;
+			const nextId = rows[next];
+			if (nextId === undefined) return;
+
+			operation.highlightTaskId = nextId;
+			operation.targetIndex = recruitIndex;
+			renderView();
+		};
+
+		screen.key(["S-up"], () => walkRecruitHighlight("up"));
+		screen.key(["S-down"], () => walkRecruitHighlight("down"));
+
+		/**
+		 * M toggles a task in or out of the move set. It acts on the recruitment highlight
+		 * when one is active; without one (terminals where shift-arrows never arrive), it
+		 * acts on the task on the row directly below the grabbed task, or above at the
+		 * bottom of a column, so the flow stays fully usable with plain arrows and M alone.
+		 */
+		const toggleRecruitSelection = () => {
+			if (!moveOp) return;
+			const operation = moveOp;
+
+			let candidateId: string | undefined;
+			if (operation.highlightTaskId) {
+				candidateId = operation.highlightTaskId;
+			} else {
+				const column = columns.find((candidate) => candidate.status === operation.targetStatus);
+				const rows = column?.tasks ?? [];
+				const grabbedRow = rows.findIndex((task) => task.id === operation.taskId);
+				candidateId = grabbedRow === -1 ? undefined : (rows[grabbedRow + 1] ?? rows[grabbedRow - 1])?.id;
+			}
+			const targetId = candidateId;
+			if (!targetId || targetId === operation.taskId) {
+				showTransientFooter(" {yellow-fg}No task to select here.{/}");
+				return;
+			}
+
+			// Cross-branch tasks cannot move, so they cannot be recruited either
+			const targetTask = currentTasks.find((task) => task.id === targetId);
+			if (targetTask?.branch) {
+				showTransientFooter(` {red-fg}Cannot move task from branch "${targetTask.branch}".{/}`);
+				return;
+			}
+
+			updateMoveSelection(operation, () => {
+				operation.selectedIds = operation.selectedIds.includes(targetId)
+					? operation.selectedIds.filter((id) => id !== targetId)
+					: [...operation.selectedIds, targetId];
+			});
+			renderView();
+		};
+
+		screen.key(["m"], async () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			if (!moveOp) {
-				const column = columns[currentCol];
-				if (!column) return;
-				const taskIndex = column.list.selected ?? 0;
-				const task = column.tasks[taskIndex];
-				if (!task) return;
-
-				// Prevent move mode for cross-branch tasks
-				if (task.branch) {
-					showTransientFooter(` {red-fg}Cannot move task from branch "${task.branch}".{/}`);
-					return;
-				}
-
-				// Enter move mode - store original position for cancel
-				moveOp = {
-					taskId: task.id,
-					originalStatus: column.status,
-					originalIndex: taskIndex,
-					targetStatus: column.status,
-					targetIndex: taskIndex,
-				};
-
-				renderView();
+				enterMoveMode();
 			} else {
 				// Confirm move (same as Enter in move mode)
 				await performTaskMove();
+			}
+		});
+
+		screen.key(["M", "S-m"], () => {
+			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
+			if (!moveOp) {
+				enterMoveMode();
+			} else {
+				toggleRecruitSelection();
 			}
 		});
 

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -1306,6 +1306,7 @@ export async function renderBoardTui(
 		screen.key(["left", "h"], () => {
 			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			if (moveOp) {
+				if (movePending) return;
 				if (collapseHighlight()) return;
 				const currentStatusIndex = currentStatuses.indexOf(moveOp.targetStatus);
 				if (currentStatusIndex > 0) {
@@ -1326,6 +1327,7 @@ export async function renderBoardTui(
 		screen.key(["right", "l"], () => {
 			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 			if (moveOp) {
+				if (movePending) return;
 				if (collapseHighlight()) return;
 				const currentStatusIndex = currentStatuses.indexOf(moveOp.targetStatus);
 				if (currentStatusIndex < currentStatuses.length - 1) {
@@ -1348,6 +1350,7 @@ export async function renderBoardTui(
 
 			const column = columns[currentCol];
 			if (moveOp) {
+				if (movePending) return;
 				if (collapseHighlight()) return;
 				if (direction === "up") {
 					if (moveOp.targetIndex > 0) {
@@ -1810,7 +1813,9 @@ export async function renderBoardTui(
 			}
 		};
 		const cancelMove = () => {
-			if (!moveOp) return;
+			// Once the confirm write is in flight the move can no longer be called off, so a
+			// late Escape must not make the board look canceled while the write still lands.
+			if (!moveOp || movePending) return;
 
 			// Exit move mode - pure state reset
 			moveOp = null;
@@ -1857,7 +1862,8 @@ export async function renderBoardTui(
 		 */
 		const walkRecruitHighlight = (direction: "up" | "down") => {
 			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
-			if (!moveOp) return;
+			// The move set and target freeze once the confirm write is in flight.
+			if (!moveOp || movePending) return;
 			const operation = moveOp;
 
 			// While the preview shows the collapsed block, the ghost index counts a column
@@ -1897,11 +1903,16 @@ export async function renderBoardTui(
 		/**
 		 * M toggles a task in or out of the move set. It acts on the recruitment highlight
 		 * when one is active; without one (terminals where shift-arrows never arrive), it
-		 * acts on the task on the row directly below the grabbed task, or above at the
-		 * bottom of a column, so the flow stays fully usable with plain arrows and M alone.
+		 * recruits the nearest unrecruited task below the grabbed row (above at the bottom
+		 * of a column). The fallback skips tasks already in the set — the collapsed block
+		 * keeps recruits adjacent to the grabbed task, so pointing at the nearest neighbor
+		 * would only ever toggle the first recruit off — which keeps repeated M presses
+		 * growing the set and the flow fully usable with plain arrows and M alone;
+		 * un-recruiting needs the shift-arrow highlight or Esc.
 		 */
 		const toggleRecruitSelection = () => {
-			if (!moveOp) return;
+			// The move set and target freeze once the confirm write is in flight.
+			if (!moveOp || movePending) return;
 			const operation = moveOp;
 
 			let candidateId: string | undefined;
@@ -1911,7 +1922,17 @@ export async function renderBoardTui(
 				const column = columns.find((candidate) => candidate.status === operation.targetStatus);
 				const rows = column?.tasks ?? [];
 				const grabbedRow = rows.findIndex((task) => task.id === operation.taskId);
-				candidateId = grabbedRow === -1 ? undefined : (rows[grabbedRow + 1] ?? rows[grabbedRow - 1])?.id;
+				if (grabbedRow !== -1) {
+					const recruited = new Set(operation.selectedIds);
+					const nearestUnrecruited = (from: number, step: number): string | undefined => {
+						for (let index = from; index >= 0 && index < rows.length; index += step) {
+							const id = rows[index]?.id;
+							if (id && id !== operation.taskId && !recruited.has(id)) return id;
+						}
+						return undefined;
+					};
+					candidateId = nearestUnrecruited(grabbedRow + 1, 1) ?? nearestUnrecruited(grabbedRow - 1, -1);
+				}
 			}
 			const targetId = candidateId;
 			if (!targetId || targetId === operation.taskId) {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -1102,18 +1102,27 @@ export async function renderBoardTui(
 			}, durationMs);
 		};
 
-		/** Tear the board down, optionally handing off to another view before resolving. */
-		const closeBoard = async (beforeResolve?: () => Promise<unknown>) => {
-			// A Shift+H write can still be in flight, and the caller may exit the process
-			// as soon as the board resolves, which would drop the setting.
-			if (pendingSettingWrite) await pendingSettingWrite;
-			// Same for a confirmed move: quitting right after Enter must not let the
-			// process exit before the write the user confirmed has persisted.
-			if (pendingMoveWrite) await pendingMoveWrite;
-			clearFooterTimer();
-			screen.destroy();
-			await beforeResolve?.();
-			resolve();
+		/**
+		 * Tear the board down, optionally handing off to another view before resolving.
+		 * First request wins: while a pending write delays the close, further exit actions
+		 * (e.g. Tab then q) join the same closing promise instead of running a second
+		 * teardown or replacing the first request's handoff.
+		 */
+		let closingBoard: Promise<void> | null = null;
+		const closeBoard = (beforeResolve?: () => Promise<unknown>): Promise<void> => {
+			closingBoard ??= (async () => {
+				// A Shift+H write can still be in flight, and the caller may exit the process
+				// as soon as the board resolves, which would drop the setting.
+				if (pendingSettingWrite) await pendingSettingWrite;
+				// Same for a confirmed move: quitting right after Enter must not let the
+				// process exit before the write the user confirmed has persisted.
+				if (pendingMoveWrite) await pendingMoveWrite;
+				clearFooterTimer();
+				screen.destroy();
+				await beforeResolve?.();
+				resolve();
+			})();
+			return closingBoard;
 		};
 
 		const renderView = (preferredTaskId?: string) => {
@@ -1697,37 +1706,41 @@ export async function renderBoardTui(
 			if (!moveOp || movePending) return;
 			const operation = moveOp;
 
+			// Snapshot the confirmed placement synchronously, before any await: a watcher
+			// update replacing currentTasks while the write is being prepared must affect
+			// the board, never the batch the user confirmed.
+			const projectedData = getProjectedColumns(currentTasks, operation);
+			const targetColumn = projectedData.find((c) => c.status === operation.targetStatus);
+
+			if (!targetColumn) {
+				moveOp = null;
+				renderView();
+				return;
+			}
+
+			const orderedTaskIds = targetColumn.tasks.map((task) => task.id);
+			const taskIds = getMoveSetIds(operation);
+			const targetStatus = operation.targetStatus;
+
+			// No-op guard: the set already sits exactly where the preview lands it.
+			const realColumn = prepareBoardColumns(currentTasks, currentStatuses).find(
+				(c) => c.status === operation.targetStatus,
+			);
+			const realIds = (realColumn?.tasks ?? []).map((task) => task.id);
+			if (realIds.length === orderedTaskIds.length && realIds.every((id, index) => id === orderedTaskIds[index])) {
+				moveOp = null;
+				renderView();
+				return;
+			}
+
 			const settleMoveWrite = beginMoveWrite();
 			try {
 				const core = await getCore();
 				const config = await core.fs.loadConfig();
 
-				// Get the final state from the projection
-				const projectedData = getProjectedColumns(currentTasks, operation);
-				const targetColumn = projectedData.find((c) => c.status === operation.targetStatus);
-
-				if (!targetColumn) {
-					moveOp = null;
-					renderView();
-					return;
-				}
-
-				const orderedTaskIds = targetColumn.tasks.map((task) => task.id);
-
-				// No-op guard: the set already sits exactly where the preview lands it.
-				const realColumn = prepareBoardColumns(currentTasks, currentStatuses).find(
-					(c) => c.status === operation.targetStatus,
-				);
-				const realIds = (realColumn?.tasks ?? []).map((task) => task.id);
-				if (realIds.length === orderedTaskIds.length && realIds.every((id, index) => id === orderedTaskIds[index])) {
-					moveOp = null;
-					renderView();
-					return;
-				}
-
 				const { movedTasks, changedTasks, failures } = await core.moveTasksToStatus({
-					taskIds: getMoveSetIds(operation),
-					targetStatus: operation.targetStatus,
+					taskIds,
+					targetStatus,
 					orderedTaskIds,
 					autoCommit: config?.autoCommit ?? false,
 				});
@@ -1783,27 +1796,31 @@ export async function renderBoardTui(
 				return;
 			}
 
+			// Snapshot the confirmed placement synchronously, before any await: a watcher
+			// update replacing currentTasks while the write is being prepared must affect
+			// the board, never the move the user confirmed.
+			const projectedData = getProjectedColumns(currentTasks, moveOp);
+			const targetColumn = projectedData.find((c) => c.status === moveOp?.targetStatus);
+
+			if (!targetColumn) {
+				moveOp = null;
+				renderView();
+				return;
+			}
+
+			const orderedTaskIds = targetColumn.tasks.map((task) => task.id);
+			const taskId = moveOp.taskId;
+			const targetStatus = moveOp.targetStatus;
+
 			const settleMoveWrite = beginMoveWrite();
 			try {
 				const core = await getCore();
 				const config = await core.fs.loadConfig();
 
-				// Get the final state from the projection
-				const projectedData = getProjectedColumns(currentTasks, moveOp);
-				const targetColumn = projectedData.find((c) => c.status === moveOp?.targetStatus);
-
-				if (!targetColumn) {
-					moveOp = null;
-					renderView();
-					return;
-				}
-
-				const orderedTaskIds = targetColumn.tasks.map((task) => task.id);
-
 				// Persist the move using core API
 				const { updatedTask, changedTasks } = await core.reorderTask({
-					taskId: moveOp.taskId,
-					targetStatus: moveOp.targetStatus,
+					taskId,
+					targetStatus,
 					orderedTaskIds,
 					autoCommit: config?.autoCommit ?? false,
 				});

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -1080,7 +1080,7 @@ export async function renderBoardTui(
 			}
 			if (moveOp) {
 				setFooterContent(
-					" {green-fg}MOVE MODE{/} | {cyan-fg}[←→]{/} Change Column | {cyan-fg}[↑↓]{/} Reorder | {cyan-fg}[Shift+↑↓]{/} Highlight | {cyan-fg}[M]{/} Select | {cyan-fg}[Enter]{/} Confirm | {cyan-fg}[Esc]{/} Cancel",
+					" {green-fg}MOVE MODE{/} | {cyan-fg}[←→]{/} Change Column | {cyan-fg}[↑↓]{/} Reorder | {cyan-fg}[Shift+↑↓]{/} Highlight | {cyan-fg}[Shift+M]{/} Select | {cyan-fg}[Enter]{/} Confirm | {cyan-fg}[Esc]{/} Cancel",
 				);
 			} else {
 				const base = getBoardFooterContent({ hasProjects: configuredProjects.length > 0 });
@@ -1924,14 +1924,16 @@ export async function renderBoardTui(
 				const grabbedRow = rows.findIndex((task) => task.id === operation.taskId);
 				if (grabbedRow !== -1) {
 					const recruited = new Set(operation.selectedIds);
-					const nearestUnrecruited = (from: number, step: number): string | undefined => {
+					// Cross-branch tasks can never join the set, so the walk skips them the same
+					// way it skips recruits — a read-only neighbor must not dead-end the fallback.
+					const nearestRecruitable = (from: number, step: number): string | undefined => {
 						for (let index = from; index >= 0 && index < rows.length; index += step) {
-							const id = rows[index]?.id;
-							if (id && id !== operation.taskId && !recruited.has(id)) return id;
+							const row = rows[index];
+							if (row && row.id !== operation.taskId && !recruited.has(row.id) && !row.branch) return row.id;
 						}
 						return undefined;
 					};
-					candidateId = nearestUnrecruited(grabbedRow + 1, 1) ?? nearestUnrecruited(grabbedRow - 1, -1);
+					candidateId = nearestRecruitable(grabbedRow + 1, 1) ?? nearestRecruitable(grabbedRow - 1, -1);
 				}
 			}
 			const targetId = candidateId;

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -23,7 +23,7 @@ const BOARD_SHORTCUTS: Shortcut[] = [
 	{ key: "↑↓", desc: "Navigate tasks" },
 	{ key: "Enter", desc: "View task details" },
 	{ key: "E", desc: "Edit task" },
-	{ key: "M", desc: "Move tasks (M selects more in move mode)" },
+	{ key: "M", desc: "Move tasks (Shift+M selects more in move mode)" },
 	{ key: "C", desc: "Complete task" },
 	{ key: "A", desc: "Archive task" },
 	{ key: "Y", desc: "Yank (Copy) task ID" },

--- a/src/ui/components/help-popup.ts
+++ b/src/ui/components/help-popup.ts
@@ -23,7 +23,7 @@ const BOARD_SHORTCUTS: Shortcut[] = [
 	{ key: "↑↓", desc: "Navigate tasks" },
 	{ key: "Enter", desc: "View task details" },
 	{ key: "E", desc: "Edit task" },
-	{ key: "M", desc: "Move task (Status/Order)" },
+	{ key: "M", desc: "Move tasks (M selects more in move mode)" },
 	{ key: "C", desc: "Complete task" },
 	{ key: "A", desc: "Archive task" },
 	{ key: "Y", desc: "Yank (Copy) task ID" },


### PR DESCRIPTION
Implements the maintainer-designed multi-select move flow for the TUI board (BACK-661), as one generalization of the existing `m` mover — no parallel flow.

## Key-by-key behavior

- **`m`**: enters move mode exactly as today; in move mode it still confirms. With nothing recruited, plain arrows / Enter / Esc run today's exact single-task paths (the projection reduces to the single ghost and confirm still goes through `core.reorderTask`).
- **`Shift+Up/Down`** (blessed `S-up`/`S-down`, xterm `ESC[1;2A/B`): walk a recruitment highlight through the target column's tasks, skipping the ghost. The grabbed task does not move. The highlight is the existing cyan move-mode selection bar relocated off the ghost, which keeps its magenta `►` — visually distinct with no new styling machinery.
- **`M`** (`S-m`): outside move mode enters move mode as before. In move mode it toggles the highlighted task in/out of the selection; recruited tasks show the existing `►` indicator and stay in place. With no highlight active (terminals where shift-arrows never arrive, e.g. tmux without `xterm-keys`), `M` toggles the task on the row directly below the grabbed row (above at the bottom), so plain arrows + `M` alone cover the whole flow. Cross-branch tasks are refused with the existing transient-footer message.
- **Plain arrows after recruiting**: the first arrow collapses the highlight back to the ghost and the preview switches to the whole set landing as one block (board display order) at the target position — non-adjacent recruits land adjacent; further arrows reorder the block. `targetIndex` is re-anchored across the view switch by a small anchor-based `mapInsertionIndex`.
- **`Enter`**: with recruits, collapses and persists through `core.moveTasksToStatus` with `orderedTaskIds` (BACK-645); per-task failures are reported in the transient footer while the rest still move; a lands-where-it-already-is comparison exits silently without writing. The `movePending` double-Enter guard covers both paths. **`Esc`** cancels and clears selection + highlight via the existing `cancelMove`.
- Footer move-mode hints in the existing style: `[←→] Change Column | [↑↓] Reorder | [Shift+↑↓] Highlight | [M] Select | [Enter] Confirm | [Esc] Cancel`; help-popup `M` entry updated. All handlers respect the existing `popupOpen`/`filterPopupOpen`/`modalOpen`/filter-focus guards, and the BACK-644 popup live-sync path is untouched.

## AC coverage (src/test/board-tui-move.test.ts keyboard harness unless noted)

1. Single-mover parity: the pre-existing single-task tests pass unchanged (`m`+arrows cross-column, `m` confirm, Esc cancel, filter block); confirm still routes through `core.reorderTask`.
2. Highlight walk: "walks the highlight with Shift+Down without moving the grabbed task".
3. Toggle + `►` in place: "toggles the highlighted task in and out of the selection with M".
4. Whole-set preview/reorder/adjacency: "collapses non-adjacent recruits into a block and reorders the whole set with plain arrows" and "lands non-adjacent recruits adjacent on Enter while the highlight is still active".
5. Confirm/cancel/failures: "moves the whole set across columns on Enter", "reports per-task failures in the transient footer and still moves the rest", "cancels a recruited move on Escape without persisting anything".
6. M-only fallback + footer: "recruits the task below the grabbed row with M when no highlight is active" and the move-mode footer test.
7. Real-pty sanity: new `src/test/board-tui-multi-move-pty.test.ts` (expect, gated by `RUN_INTERACTIVE_TUI_TESTS=1`, wired into `scripts/run-tui-interactive-tests.sh`) sends the raw `ESC[1;2B` shift-arrow plus `M` through a real pty and asserts the `►` recruit marker renders.

## Verification

- `bunx tsc --noEmit` clean, `bun run check .` clean
- `bun test`: 2741 pass / 0 fail (full suite)
- Interactive pty capture passes locally (`RUN_INTERACTIVE_TUI_TESTS=1`)