### PR TITLE
BACK-653 - Update web views in place instead of full reload on data changes

### DIFF
--- a/backlog/tasks/back-653 - Update-web-views-in-place-instead-of-full-reload-on-data-changes.md
+++ b/backlog/tasks/back-653 - Update-web-views-in-place-instead-of-full-reload-on-data-changes.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-653
 title: Update web views in place instead of full reload on data changes
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Claude'
 created_date: '2026-08-29 22:03'
+updated_date: '2026-08-30 23:57'
 labels:
   - web
   - bug
@@ -19,15 +21,41 @@ Every server file-watcher broadcast ("tasks-updated") makes the web app call ref
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A task mutation from the UI or an external edit updates the board and list views in place without showing the global loading shell
-- [ ] #2 A single-card drag causes no full refetch burst
-- [ ] #3 Full refetch remains as a fallback for changes that cannot be applied incrementally, and initial page load is unchanged
-- [ ] #4 Automated web tests cover the in-place update path for edit, move, and external change
+- [x] #1 A task mutation from the UI or an external edit updates the board and list views in place without showing the global loading shell
+- [x] #2 A single-card drag causes no full refetch burst
+- [x] #3 Full refetch remains as a fallback for changes that cannot be applied incrementally, and initial page load is unchanged
+- [x] #4 Automated web tests cover the in-place update path for edit, move, and external change
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Server: generalize the debounced broadcastTasksUpdated into broadcastDataUpdated(scope) — store/task events keep the 'tasks-updated' wire message; milestone endpoints (create/update/remove/archive) send 'milestones-updated'; the debounce merges a pending tasks scope up into milestones.
+2. Client (App.tsx): generalize the single-card reorder mechanism (onTasksUpdated -> applyReorderedTasks surgical store update) into the refresh path. Add refs mirroring tasks/docs/decisions/milestoneEntities/archivedMilestones so refreshes can reconcile without resubscribing the WebSocket.
+3. New incremental refreshTasksData(includeMilestones): fetch /api/search only (plus milestones + archived milestones when milestone-scoped), normalize milestones as today, then reconcile into state with an identity-preserving deep-equal reconcileById (unchanged records keep object identity, unchanged lists keep array identity — the no-op guard: a broadcast echoing a change already applied surgically produces zero state churn). Never touches isLoading; clears loadError on success. Refetch the duplicate repair plan in the background only when the reconciled task list actually changed.
+4. Wire-up: refreshData (post-mutation callbacks + WS 'tasks-updated') = incremental tasks scope + drafts-updated event; WS 'milestones-updated' and MilestonesPage onRefreshData = incremental milestone scope; full loadAllData stays for initial load, config-updated, connection-restore, cross-branch indexing loaded/onclose paths, and as the fallback when an incremental refresh throws.
+5. Shared helper src/web/utils/reconcile.ts (deepEqual + reconcileById) reused for tasks/docs/decisions.
+6. Tests: jsdom App-level tests for in-place edit, move, external change (assert no statuses/config/milestone refetch, no loading shell), no-op echo after a surgical drag (identity preserved, no duplicates refetch), and the fallback path (search failure -> full loadAllData). Server test for milestone-scoped broadcast message.
+7. Verify: bunx tsc --noEmit, bun run check ., bun test; measure request counts for a single drag before/after with the real server.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented: server broadcastDataUpdated(scope) keeps 'tasks-updated' for store/task events and sends 'milestones-updated' from milestone endpoints (create now broadcasts too). Client refreshTasksData refetches only /api/search (plus milestone entities on milestone scope) and reconciles tasks/docs/decisions in place via reconcileById (identity-preserving deep-equal); duplicates plan refetch is gated on the task ID multiset changing; full loadAllData remains for initial load, config-updated, indexing loaded/reconnect, and incremental failure fallback. Measured on a live server (6-task board, drop TASK-1 into In Progress): before = reorder POST + 6-request burst (statuses, config, milestones, archived, search, duplicates); after = reorder POST + 1 background search reconcile. External file edit/status change: 1 search request, view updates in place. Milestone create: 3 requests (milestones, archived, search).
+
+Deeplink suite (web-task-detail-deeplink) updated: 4 scenarios pinned the old full-burst expectations (config on tasks-updated, duplicates plan on same-ID reconciliations); now pin the incremental behavior, 31/31 pass. Full suite: 2748 pass / 2 fail (mcp-tasks task_search + server-statistics reconcile, both known full-suite-concurrency flakes, both pass isolated 43/43). tsc and biome clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Watcher broadcasts and post-mutation refreshes now update web views in place: the server publishes scoped data broadcasts (tasks-updated / milestones-updated, milestone create now broadcasts too) and the client generalizes the single-card reorder onTasksUpdated pattern into refreshTasksData, which refetches only the search corpus (plus milestone entities on milestone scope) and reconciles tasks/docs/decisions into the store with identity-preserving deep-equal (src/web/utils/reconcile.ts); the duplicate repair plan refetch is gated on the task ID multiset changing, and full loadAllData remains for initial load, config-updated, cross-branch indexing completion/reconnect, and as the incremental-failure fallback. Verified with 6 new jsdom App-level tests (edit, move, external create, echo no-op, milestone scope, fallback), reconcile unit tests, a server milestone-broadcast test, the updated 31-test deeplink suite, and live browser measurement: a single-card drag dropped from reorder POST + 6-request refetch burst to reorder POST + 1 background search reconcile, with external edits costing exactly 1 request and no loading shell.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-653 - Update-web-views-in-place-instead-of-full-reload-on-data-changes.md
+++ b/backlog/tasks/back-653 - Update-web-views-in-place-instead-of-full-reload-on-data-changes.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Claude'
 created_date: '2026-08-29 22:03'
-updated_date: '2026-08-30 23:57'
+updated_date: '2026-08-31 00:32'
 labels:
   - web
   - bug
@@ -52,6 +52,8 @@ Every server file-watcher broadcast ("tasks-updated") makes the web app call ref
 Implemented: server broadcastDataUpdated(scope) keeps 'tasks-updated' for store/task events and sends 'milestones-updated' from milestone endpoints (create now broadcasts too). Client refreshTasksData refetches only /api/search (plus milestone entities on milestone scope) and reconciles tasks/docs/decisions in place via reconcileById (identity-preserving deep-equal); duplicates plan refetch is gated on the task ID multiset changing; full loadAllData remains for initial load, config-updated, indexing loaded/reconnect, and incremental failure fallback. Measured on a live server (6-task board, drop TASK-1 into In Progress): before = reorder POST + 6-request burst (statuses, config, milestones, archived, search, duplicates); after = reorder POST + 1 background search reconcile. External file edit/status change: 1 search request, view updates in place. Milestone create: 3 requests (milestones, archived, search).
 
 Deeplink suite (web-task-detail-deeplink) updated: 4 scenarios pinned the old full-burst expectations (config on tasks-updated, duplicates plan on same-ID reconciliations); now pin the incremental behavior, 31/31 pass. Full suite: 2748 pass / 2 fail (mcp-tasks task_search + server-statistics reconcile, both known full-suite-concurrency flakes, both pass isolated 43/43). tsc and biome clean.
+
+Review round (PR #981, three Codex P2 threads, all accepted as genuine): (1) duplicates-plan gate widened - while a plan is null (initial read pending/superseded) or non-empty (duplicates exist), every incremental refresh refetches it, so same-ID edits keep the repair fingerprint fresh; the ID-multiset gate applies only in the healthy empty-plan steady state. (2) refreshTasksData escalates to the full loader whenever a load error stands (loadErrorRef), so the error retry and any broadcast during an error state re-request the failed resources. (3) A narrower refresh that supersedes an in-flight wider request now adopts its scope (pendingScopeRankRef: tasks < milestones < full), so a tasks-updated arriving during a config-updated reload runs the full loader instead of stranding stale config. Pinned by three new jsdom tests (9/9), deeplink 31/31, tsc+biome clean. Commit 113d4abc.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -242,6 +242,7 @@ export class BacklogServer {
 	private browserLoadingState: BrowserLoadingState = { type: "loading", message: null };
 	private unsubscribeContentStore?: () => void;
 	private taskBroadcastTimer?: ReturnType<typeof setTimeout>;
+	private pendingDataBroadcastScope: "tasks" | "milestones" = "tasks";
 	private storeReadyBroadcasted = false;
 
 	constructor(projectPath: string) {
@@ -294,13 +295,13 @@ export class BacklogServer {
 						this.storeReadyBroadcasted = true;
 						return;
 					}
-					this.broadcastTasksUpdated();
+					this.broadcastDataUpdated();
 					return;
 				}
 
 				// Broadcast for tasks/documents/decisions so clients refresh caches/search
 				this.storeReadyBroadcasted = true;
-				this.broadcastTasksUpdated();
+				this.broadcastDataUpdated();
 			});
 		}
 
@@ -329,13 +330,18 @@ export class BacklogServer {
 		return this.server?.port ?? null;
 	}
 
-	private broadcastTasksUpdated() {
+	private broadcastDataUpdated(scope: "tasks" | "milestones" = "tasks") {
+		// Milestone changes widen the message so clients also refetch milestone
+		// entities; the debounce keeps the widest scope seen in the window.
+		if (scope === "milestones") this.pendingDataBroadcastScope = "milestones";
 		if (this.taskBroadcastTimer) clearTimeout(this.taskBroadcastTimer);
 		this.taskBroadcastTimer = setTimeout(() => {
 			this.taskBroadcastTimer = undefined;
+			const message = this.pendingDataBroadcastScope === "milestones" ? "milestones-updated" : "tasks-updated";
+			this.pendingDataBroadcastScope = "tasks";
 			for (const ws of this.sockets) {
 				try {
-					ws.send("tasks-updated");
+					ws.send(message);
 				} catch {}
 			}
 		}, 75);
@@ -1207,7 +1213,7 @@ export class BacklogServer {
 			}
 
 			// Notify listeners to refresh
-			this.broadcastTasksUpdated();
+			this.broadcastDataUpdated();
 			return Response.json({ success: true });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to complete task";
@@ -1225,7 +1231,7 @@ export class BacklogServer {
 				return Response.json({ error: "Task not found" }, { status: 404 });
 			}
 
-			this.broadcastTasksUpdated();
+			this.broadcastDataUpdated();
 			return Response.json({ success: true });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to demote task";
@@ -1234,7 +1240,7 @@ export class BacklogServer {
 				typeof error === "object" && error !== null && (error as { demotionState?: unknown }).demotionState;
 			const knownDemotionState = demotionState === "moved" || demotionState === "partial" ? demotionState : undefined;
 			if (knownDemotionState) {
-				this.broadcastTasksUpdated();
+				this.broadcastDataUpdated();
 			}
 			if (!conflict) {
 				console.error("Error demoting task:", error);
@@ -1648,6 +1654,7 @@ export class BacklogServer {
 			}
 
 			const milestone = await this.core.filesystem.createMilestone(title, body.description, dueDate.value ?? undefined);
+			this.broadcastDataUpdated("milestones");
 			return Response.json(milestone, { status: 201 });
 		} catch (error) {
 			console.error("Error creating milestone:", error);
@@ -1677,7 +1684,7 @@ export class BacklogServer {
 			const milestone =
 				(await this.core.filesystem.loadMilestone(sourceMilestone?.id ?? milestoneId)) ??
 				(await this.core.filesystem.loadMilestone(title));
-			this.broadcastTasksUpdated();
+			this.broadcastDataUpdated("milestones");
 			return Response.json({
 				success: true,
 				milestone: milestone ?? null,
@@ -1709,7 +1716,7 @@ export class BacklogServer {
 				taskHandling,
 				reassignTo,
 			});
-			this.broadcastTasksUpdated();
+			this.broadcastDataUpdated("milestones");
 			return Response.json({
 				success: true,
 				message: this.getMilestoneMutationMessage(result),
@@ -1725,7 +1732,7 @@ export class BacklogServer {
 			if (!result.success) {
 				return Response.json({ error: "Milestone not found" }, { status: 404 });
 			}
-			this.broadcastTasksUpdated();
+			this.broadcastDataUpdated("milestones");
 			return Response.json({ success: true, milestone: result.milestone ?? null });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to archive milestone";
@@ -1926,7 +1933,7 @@ export class BacklogServer {
 			}
 
 			// Notify listeners to refresh
-			this.broadcastTasksUpdated();
+			this.broadcastDataUpdated();
 
 			return Response.json({
 				success: true,

--- a/src/test/server-milestone-broadcast.test.ts
+++ b/src/test/server-milestone-broadcast.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { Core } from "../core/backlog.ts";
+import { BacklogServer } from "../server/index.ts";
+import { createUniqueTestDir, retry, safeCleanup, withTimeout } from "./test-utils.ts";
+
+let testDir: string;
+let server: BacklogServer | null = null;
+let serverPort = 0;
+let socket: WebSocket | null = null;
+
+beforeEach(async () => {
+	testDir = createUniqueTestDir("server-milestone-broadcast");
+	await mkdir(testDir, { recursive: true });
+	const core = new Core(testDir);
+	await core.filesystem.ensureBacklogStructure();
+	await core.filesystem.saveConfig({
+		projectName: "Server milestone broadcast",
+		statuses: ["To Do", "In Progress", "Done"],
+		labels: [],
+		milestones: [],
+		dateFormat: "YYYY-MM-DD",
+		remoteOperations: false,
+		checkActiveBranches: false,
+		autoCommit: false,
+	});
+
+	server = new BacklogServer(testDir);
+	await server.start(0, false);
+	serverPort = server.getPort() ?? 0;
+	await retry(async () => {
+		const response = await fetch(`http://127.0.0.1:${serverPort}/api/status`);
+		if (!response.ok) throw new Error("Server is not ready");
+	});
+});
+
+afterEach(async () => {
+	socket?.close();
+	socket = null;
+	await server?.stop();
+	server = null;
+	await safeCleanup(testDir);
+});
+
+const openSocket = async (messages: string[]) => {
+	socket = new WebSocket(`ws://127.0.0.1:${serverPort}`);
+	await withTimeout(
+		new Promise<void>((resolve, reject) => {
+			if (!socket) return reject(new Error("WebSocket was not created"));
+			socket.onopen = () => resolve();
+			socket.onerror = () => reject(new Error("WebSocket failed to open"));
+		}),
+		"milestone broadcast test WebSocket",
+		2000,
+	);
+	socket.onmessage = (event) => messages.push(String(event.data));
+};
+
+describe("milestone WebSocket publication", () => {
+	it("publishes a milestone-scoped update for milestone mutations", async () => {
+		const messages: string[] = [];
+		await openSocket(messages);
+
+		const createResponse = await fetch(`http://127.0.0.1:${serverPort}/api/milestones`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "Launch" }),
+		});
+		expect(createResponse.status).toBe(201);
+		const created = (await createResponse.json()) as { id: string };
+		await retry(async () => {
+			if (!messages.includes("milestones-updated")) throw new Error("Milestone creation was not published");
+		});
+
+		messages.length = 0;
+		const archiveResponse = await fetch(
+			`http://127.0.0.1:${serverPort}/api/milestones/${encodeURIComponent(created.id)}/archive`,
+			{ method: "POST" },
+		);
+		expect(archiveResponse.status).toBe(200);
+		await retry(async () => {
+			if (!messages.includes("milestones-updated")) throw new Error("Milestone archive was not published");
+		});
+	});
+});

--- a/src/test/web-in-place-refresh.test.tsx
+++ b/src/test/web-in-place-refresh.test.tsx
@@ -1,0 +1,350 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { JSDOM } from "jsdom";
+import { StrictMode, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { DuplicateRepairPlan } from "../core/duplicate-task-repair.ts";
+import type { Milestone, SearchResult, Task } from "../types/index.ts";
+import App from "../web/App.tsx";
+import { HealthCheckProvider } from "../web/contexts/HealthCheckContext.tsx";
+
+const makeTask = (id: string, title: string, status: string, overrides: Partial<Task> = {}): Task => ({
+	id,
+	title,
+	status,
+	assignee: [],
+	labels: [],
+	dependencies: [],
+	createdDate: "2026-07-10",
+	ordinal: 1000,
+	...overrides,
+});
+
+const defaultConfig = {
+	projectName: "In-place QA",
+	statuses: ["To Do", "In Progress", "Done"],
+	labels: [],
+	milestones: [],
+	dateFormat: "YYYY-MM-DD",
+	remoteOperations: false,
+};
+
+const emptyDuplicatePlan = (): DuplicateRepairPlan => ({
+	groups: [],
+	crossBranchFindings: [],
+	changes: [],
+	references: [],
+	referenceScanComplete: true,
+	blockedReasons: [],
+	repairable: false,
+	fingerprint: "empty",
+});
+
+let tasks: Task[] = [];
+let milestones: Milestone[] = [];
+let failNextSearch = false;
+let requestLog: string[] = [];
+
+let activeRoot: Root | null = null;
+let activeDom: JSDOM | null = null;
+const originalFetch = globalThis.fetch;
+const originalWebSocket = globalThis.WebSocket;
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalEvent = globalThis.Event;
+const originalCustomEvent = globalThis.CustomEvent;
+const originalElement = globalThis.Element;
+const originalHTMLElement = globalThis.HTMLElement;
+const originalNode = globalThis.Node;
+
+class FakeWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSED = 3;
+	static instances: FakeWebSocket[] = [];
+	readyState = FakeWebSocket.OPEN;
+	onopen: (() => void) | null = null;
+	onclose: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	onmessage: ((event: { data: string }) => void) | null = null;
+
+	constructor() {
+		FakeWebSocket.instances.push(this);
+	}
+
+	deliver(data: string) {
+		if (!this.onmessage) throw new Error(`Cannot deliver ${data}: WebSocket message handler is not installed`);
+		this.onmessage({ data });
+	}
+
+	close() {
+		this.readyState = FakeWebSocket.CLOSED;
+	}
+}
+
+const getAppDataWebSocket = (): FakeWebSocket => {
+	const socket = FakeWebSocket.instances.findLast(
+		(candidate) => candidate.readyState === FakeWebSocket.OPEN && candidate.onmessage !== null,
+	);
+	if (!socket) throw new Error("No live App data WebSocket found");
+	return socket;
+};
+
+class FakeResizeObserver {
+	disconnect() {}
+	observe() {}
+	unobserve() {}
+}
+
+const json = (data: unknown, status = 200) => Response.json(data, { status });
+
+const respond = async (url: URL): Promise<Response> => {
+	if (url.pathname === "/api/status") return json({ initialized: true, projectPath: "/tmp/project" });
+	if (url.pathname === "/api/statuses") return json(defaultConfig.statuses);
+	if (url.pathname === "/api/config") return json(defaultConfig);
+	if (url.pathname === "/api/search") {
+		if (failNextSearch) {
+			failNextSearch = false;
+			// 4xx so the api client surfaces the failure without retrying.
+			return json({ error: "search unavailable" }, 400);
+		}
+		const results: SearchResult[] = tasks.map((task) => ({ type: "task", task, score: 1 }));
+		return json(results);
+	}
+	if (url.pathname === "/api/milestones") return json(milestones);
+	if (url.pathname === "/api/milestones/archived") return json([]);
+	if (url.pathname === "/api/tasks/duplicates") return json(emptyDuplicatePlan());
+	if (url.pathname === "/api/version") return json({ version: "test" });
+	return json([]);
+};
+
+const installFetchMock = () => {
+	globalThis.fetch = (async (input: RequestInfo | URL) => {
+		const value = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+		const url = new URL(value, window.location.origin);
+		requestLog.push(url.pathname);
+		return respond(url);
+	}) as typeof fetch;
+};
+
+const setupDom = (path: string) => {
+	activeDom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", {
+		url: `http://localhost${path}`,
+		pretendToBeVisual: true,
+	});
+	globalThis.window = activeDom.window as unknown as Window & typeof globalThis;
+	globalThis.document = activeDom.window.document;
+	globalThis.navigator = activeDom.window.navigator;
+	globalThis.localStorage = activeDom.window.localStorage;
+	globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+	globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+	globalThis.Event = activeDom.window.Event;
+	globalThis.CustomEvent = activeDom.window.CustomEvent;
+	globalThis.Element = activeDom.window.Element;
+	globalThis.HTMLElement = activeDom.window.HTMLElement;
+	globalThis.Node = activeDom.window.Node;
+	(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+	window.matchMedia = () =>
+		({
+			matches: false,
+			media: "",
+			onchange: null,
+			addListener: () => {},
+			removeListener: () => {},
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			dispatchEvent: () => false,
+		}) as MediaQueryList;
+	window.scrollTo = () => {};
+	window.confirm = () => true;
+	installFetchMock();
+};
+
+const waitFor = async (predicate: () => boolean, description: string) => {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (predicate()) return;
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		});
+	}
+	throw new Error(`Timed out waiting for ${description}`);
+};
+
+const settle = async () => {
+	await act(async () => {
+		for (let turn = 0; turn < 5; turn++) {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
+	});
+};
+
+const renderBoard = async (): Promise<HTMLElement> => {
+	setupDom("/board");
+	const container = document.getElementById("root") as HTMLElement;
+	activeRoot = createRoot(container);
+	await act(async () => {
+		activeRoot?.render(
+			<StrictMode>
+				<HealthCheckProvider>
+					<App />
+				</HealthCheckProvider>
+			</StrictMode>,
+		);
+		await Promise.resolve();
+	});
+	await waitFor(() => (container.textContent ?? "").includes(tasks[0]?.title ?? ""), "initial board content");
+	await settle();
+	requestLog = [];
+	return container;
+};
+
+const requestedPaths = () => Array.from(new Set(requestLog)).sort();
+
+const hasLoadingShell = (container: HTMLElement) =>
+	container.querySelector('[role="status"][aria-label="Loading tasks"]') !== null;
+
+afterEach(() => {
+	if (activeRoot) {
+		act(() => {
+			activeRoot?.unmount();
+		});
+		activeRoot = null;
+	}
+	FakeWebSocket.instances = [];
+	globalThis.fetch = originalFetch;
+	globalThis.WebSocket = originalWebSocket;
+	globalThis.ResizeObserver = originalResizeObserver;
+	globalThis.Event = originalEvent;
+	globalThis.CustomEvent = originalCustomEvent;
+	globalThis.Element = originalElement;
+	globalThis.HTMLElement = originalHTMLElement;
+	globalThis.Node = originalNode;
+	activeDom = null;
+	tasks = [];
+	milestones = [];
+	failNextSearch = false;
+	requestLog = [];
+});
+
+describe("in-place data refresh", () => {
+	it("applies an external task edit in place through a single search refetch", async () => {
+		tasks = [makeTask("TASK-1", "Original title", "To Do"), makeTask("TASK-2", "Neighbor card", "To Do")];
+		const container = await renderBoard();
+		const neighborBefore = Array.from(container.querySelectorAll("h4")).find(
+			(node) => node.textContent === "Neighbor card",
+		);
+		expect(neighborBefore).toBeTruthy();
+
+		tasks = [makeTask("TASK-1", "Renamed title", "To Do"), tasks[1] as Task];
+		await act(async () => {
+			getAppDataWebSocket().deliver("tasks-updated");
+		});
+		await waitFor(() => (container.textContent ?? "").includes("Renamed title"), "renamed card");
+		await settle();
+
+		// Only the search corpus is refetched: no statuses, config, milestone, or
+		// duplicate-plan burst, and no loading shell.
+		expect(requestedPaths()).toEqual(["/api/search"]);
+		expect(hasLoadingShell(container)).toBe(false);
+		// The unchanged card kept its DOM node: the view updated in place.
+		const neighborAfter = Array.from(container.querySelectorAll("h4")).find(
+			(node) => node.textContent === "Neighbor card",
+		);
+		expect(neighborAfter).toBe(neighborBefore as HTMLHeadingElement);
+	});
+
+	it("moves a card between columns in place when its status changes externally", async () => {
+		tasks = [makeTask("TASK-1", "Moving card", "To Do")];
+		const container = await renderBoard();
+
+		// The nearest ancestor that carries an h3 heading is the task's column,
+		// and that heading is the column's status title.
+		const columnOf = (title: string): string | null => {
+			const card = Array.from(container.querySelectorAll("h4")).find((node) => node.textContent === title);
+			let node: Element | null = card ?? null;
+			while (node && node !== container) {
+				const heading = node.querySelector("h3");
+				if (heading?.textContent) return heading.textContent;
+				node = node.parentElement;
+			}
+			return null;
+		};
+		expect(columnOf("Moving card")).toBe("To Do");
+
+		tasks = [makeTask("TASK-1", "Moving card", "In Progress")];
+		await act(async () => {
+			getAppDataWebSocket().deliver("tasks-updated");
+		});
+		await waitFor(() => columnOf("Moving card") === "In Progress", "card in the In Progress column");
+		await settle();
+
+		expect(requestedPaths()).toEqual(["/api/search"]);
+		expect(hasLoadingShell(container)).toBe(false);
+	});
+
+	it("shows an externally created task without a full reload", async () => {
+		tasks = [makeTask("TASK-1", "Existing card", "To Do")];
+		const container = await renderBoard();
+
+		tasks = [...tasks, makeTask("TASK-2", "Brand new card", "To Do")];
+		await act(async () => {
+			getAppDataWebSocket().deliver("tasks-updated");
+		});
+		await waitFor(() => (container.textContent ?? "").includes("Brand new card"), "externally created card");
+		await settle();
+
+		// A new task ID can introduce a duplicate, so only this path also
+		// refreshes the duplicate repair plan.
+		expect(requestedPaths()).toEqual(["/api/search", "/api/tasks/duplicates"]);
+		expect(hasLoadingShell(container)).toBe(false);
+	});
+
+	it("treats a broadcast that echoes already-applied data as a no-op", async () => {
+		tasks = [makeTask("TASK-1", "Stable card", "To Do")];
+		await renderBoard();
+
+		await act(async () => {
+			getAppDataWebSocket().deliver("tasks-updated");
+		});
+		await settle();
+
+		// The echo after a surgical drag update costs exactly one search read.
+		expect(requestedPaths()).toEqual(["/api/search"]);
+	});
+
+	it("refetches milestone entities incrementally on a milestone-scoped broadcast", async () => {
+		tasks = [makeTask("TASK-1", "Milestone card", "To Do")];
+		await renderBoard();
+
+		milestones = [
+			{ id: "m-1", title: "Launch", description: "", rawContent: "", createdDate: "2026-07-10" } as Milestone,
+		];
+		await act(async () => {
+			getAppDataWebSocket().deliver("milestones-updated");
+		});
+		await settle();
+
+		expect(requestedPaths()).toEqual(["/api/milestones", "/api/milestones/archived", "/api/search"]);
+	});
+
+	it("falls back to the full reload when the incremental refresh fails", async () => {
+		tasks = [makeTask("TASK-1", "Fallback card", "To Do")];
+		const container = await renderBoard();
+
+		failNextSearch = true;
+		tasks = [makeTask("TASK-1", "Fallback card renamed", "To Do")];
+		await act(async () => {
+			getAppDataWebSocket().deliver("tasks-updated");
+		});
+		await waitFor(() => (container.textContent ?? "").includes("Fallback card renamed"), "card after fallback reload");
+		await settle();
+
+		expect(requestedPaths()).toEqual([
+			"/api/config",
+			"/api/milestones",
+			"/api/milestones/archived",
+			"/api/search",
+			"/api/statuses",
+			"/api/tasks/duplicates",
+		]);
+	});
+});

--- a/src/test/web-in-place-refresh.test.tsx
+++ b/src/test/web-in-place-refresh.test.tsx
@@ -41,7 +41,9 @@ const emptyDuplicatePlan = (): DuplicateRepairPlan => ({
 
 let tasks: Task[] = [];
 let milestones: Milestone[] = [];
+let duplicatePlan: DuplicateRepairPlan = emptyDuplicatePlan();
 let failNextSearch = false;
+let configHold: Promise<void> | null = null;
 let requestLog: string[] = [];
 
 let activeRoot: Root | null = null;
@@ -99,7 +101,10 @@ const json = (data: unknown, status = 200) => Response.json(data, { status });
 const respond = async (url: URL): Promise<Response> => {
 	if (url.pathname === "/api/status") return json({ initialized: true, projectPath: "/tmp/project" });
 	if (url.pathname === "/api/statuses") return json(defaultConfig.statuses);
-	if (url.pathname === "/api/config") return json(defaultConfig);
+	if (url.pathname === "/api/config") {
+		if (configHold) await configHold;
+		return json(defaultConfig);
+	}
 	if (url.pathname === "/api/search") {
 		if (failNextSearch) {
 			failNextSearch = false;
@@ -111,7 +116,7 @@ const respond = async (url: URL): Promise<Response> => {
 	}
 	if (url.pathname === "/api/milestones") return json(milestones);
 	if (url.pathname === "/api/milestones/archived") return json([]);
-	if (url.pathname === "/api/tasks/duplicates") return json(emptyDuplicatePlan());
+	if (url.pathname === "/api/tasks/duplicates") return json(duplicatePlan);
 	if (url.pathname === "/api/version") return json({ version: "test" });
 	return json([]);
 };
@@ -221,7 +226,9 @@ afterEach(() => {
 	activeDom = null;
 	tasks = [];
 	milestones = [];
+	duplicatePlan = emptyDuplicatePlan();
 	failNextSearch = false;
+	configHold = null;
 	requestLog = [];
 });
 
@@ -324,6 +331,89 @@ describe("in-place data refresh", () => {
 		await settle();
 
 		expect(requestedPaths()).toEqual(["/api/milestones", "/api/milestones/archived", "/api/search"]);
+	});
+
+	it("keeps refreshing the repair plan while duplicates exist, even for same-ID edits", async () => {
+		tasks = [makeTask("TASK-1", "Colliding card", "To Do")];
+		duplicatePlan = {
+			...emptyDuplicatePlan(),
+			groups: [
+				{
+					id: "TASK-1",
+					tasks: [
+						{ ...(tasks[0] as Task), filePath: "backlog/tasks/task-1 - A.md" } as Task,
+						{ ...(tasks[0] as Task), title: "Duplicate", filePath: "backlog/tasks/task-01 - B.md" } as Task,
+					],
+				},
+			],
+			repairable: true,
+			fingerprint: "live-plan",
+		} as DuplicateRepairPlan;
+		await renderBoard();
+
+		// Editing a colliding task changes the plan's fingerprint without
+		// changing the ID set, so the plan must be refetched anyway.
+		tasks = [makeTask("TASK-1", "Colliding card edited", "To Do")];
+		await act(async () => {
+			getAppDataWebSocket().deliver("tasks-updated");
+		});
+		await settle();
+
+		expect(requestedPaths()).toEqual(["/api/search", "/api/tasks/duplicates"]);
+	});
+
+	it("routes the next refresh through the full loader while a load error stands", async () => {
+		tasks = [makeTask("TASK-1", "Error-state card", "To Do")];
+		const container = await renderBoard();
+
+		await act(async () => {
+			getAppDataWebSocket().deliver(JSON.stringify({ type: "error", message: "corpus failed" }));
+		});
+		await settle();
+		expect(container.textContent).toContain("corpus failed");
+
+		requestLog = [];
+		await act(async () => {
+			getAppDataWebSocket().deliver("tasks-updated");
+		});
+		await settle();
+
+		// The standing error means state may be arbitrarily stale, so the retry
+		// is the full loader, which also clears the error on success.
+		expect(requestedPaths()).toEqual([
+			"/api/config",
+			"/api/milestones",
+			"/api/milestones/archived",
+			"/api/search",
+			"/api/statuses",
+			"/api/tasks/duplicates",
+		]);
+		expect(container.textContent).not.toContain("corpus failed");
+	});
+
+	it("adopts the scope of an in-flight full refresh instead of superseding it", async () => {
+		tasks = [makeTask("TASK-1", "Race card", "To Do")];
+		await renderBoard();
+
+		let releaseConfig = () => {};
+		configHold = new Promise<void>((resolve) => {
+			releaseConfig = resolve;
+		});
+		await act(async () => {
+			getAppDataWebSocket().deliver("config-updated");
+		});
+		// A tasks-updated arriving while the full reload is still waiting on
+		// config supersedes it through the request counter, so it must run the
+		// full loader itself instead of a search-only refresh on stale config.
+		await act(async () => {
+			getAppDataWebSocket().deliver("tasks-updated");
+		});
+		configHold = null;
+		releaseConfig();
+		await settle();
+
+		expect(requestLog.filter((path) => path === "/api/config").length).toBe(2);
+		expect(requestLog.filter((path) => path === "/api/search").length).toBe(2);
 	});
 
 	it("falls back to the full reload when the incremental refresh fails", async () => {

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -1456,18 +1456,19 @@ describe("task detail routes", () => {
 			operationRef: initialLoadRef,
 		});
 		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();
-		// The incremental refresh leaves the ID set unchanged, so it does not
-		// refetch the plan; it still bumps the request counter, which is what
-		// invalidates the stale plan response below.
+		// The initial plan read has not landed yet, so the incremental refresh
+		// fetches a replacement plan; bumping the request counter is what
+		// invalidates the stale initial response below.
 		const newerLoad = new FetchOperation("newer data load", [
 			expectFetch("newer search", "/api/search"),
+			expectFetch("newer duplicate plan", "/api/tasks/duplicates"),
 		]);
 		await act(async () => {
 			dataSocket.deliver("tasks-updated");
 			await Promise.resolve();
 		});
 		await act(async () => {
-			await newerLoad.settle("newer search");
+			await newerLoad.settle("newer search", "newer duplicate plan");
 		});
 		newerLoad.finish();
 		assertState(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "newer data load");

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -741,8 +741,9 @@ describe("task detail routes", () => {
 	it("does not duplicate an active data request when shared loading completes", async () => {
 		await renderApp("/board?lane=none");
 		const dataSocket = getAppDataWebSocket();
+		// A tasks-updated broadcast triggers the incremental refresh, which only
+		// refetches the search corpus.
 		const activeRefresh = new FetchOperation("active refresh during shared completion", [
-			expectFetch("active config", "/api/config"),
 			expectFetch("active search", "/api/search", { manual: true }),
 		]);
 
@@ -760,7 +761,7 @@ describe("task detail routes", () => {
 
 		await act(async () => {
 			activeRefresh.respond("active search", json(searchResults));
-			await activeRefresh.settle("active config", "active search");
+			await activeRefresh.settle("active search");
 		});
 		activeRefresh.finish();
 	});
@@ -861,9 +862,10 @@ describe("task detail routes", () => {
 		);
 		reorder.finish();
 
+		// The reconciliation edits an existing task, so the ID set is unchanged
+		// and the duplicate repair plan is not refetched.
 		const reconciliation = new FetchOperation("newer WebSocket reconciliation", [
 			expectFetch("newer search", "/api/search", { manual: true }),
-			expectFetch("newer duplicate plan", "/api/tasks/duplicates"),
 		]);
 		await act(async () => {
 			dataSocket.deliver("tasks-updated");
@@ -879,7 +881,7 @@ describe("task detail routes", () => {
 					{ type: "task", task: externallyEditedTask, score: 1 } satisfies SearchResult,
 				]),
 			);
-			await reconciliation.settle("newer search", "newer duplicate plan");
+			await reconciliation.settle("newer search");
 		});
 		reconciliation.finish();
 		expect(container.textContent).toContain(externallyEditedTask.title);
@@ -1047,8 +1049,9 @@ describe("task detail routes", () => {
 		});
 		staleRefresh.finish();
 
+		// The newer refresh rides a tasks-updated broadcast, so it is incremental
+		// and leaves config alone; the stale full refresh must still lose.
 		const newerRefresh = new FetchOperation("newer task refresh", [
-			expectFetch("newer config", "/api/config"),
 			expectFetch("newer search", "/api/search", { manual: true }),
 		]);
 		await act(async () => {
@@ -1060,7 +1063,7 @@ describe("task detail routes", () => {
 				"newer search",
 				json([{ type: "task", task: customerTask, score: 1 } satisfies SearchResult]),
 			);
-			await newerRefresh.settle("newer config", "newer search");
+			await newerRefresh.settle("newer search");
 		});
 		newerRefresh.finish();
 
@@ -1453,16 +1456,18 @@ describe("task detail routes", () => {
 			operationRef: initialLoadRef,
 		});
 		const dataSocket = assertHealthSocketDoesNotShadowDataSocket();
+		// The incremental refresh leaves the ID set unchanged, so it does not
+		// refetch the plan; it still bumps the request counter, which is what
+		// invalidates the stale plan response below.
 		const newerLoad = new FetchOperation("newer data load", [
 			expectFetch("newer search", "/api/search"),
-			expectFetch("newer duplicate plan", "/api/tasks/duplicates"),
 		]);
 		await act(async () => {
 			dataSocket.deliver("tasks-updated");
 			await Promise.resolve();
 		});
 		await act(async () => {
-			await newerLoad.settle("newer search", "newer duplicate plan");
+			await newerLoad.settle("newer search");
 		});
 		newerLoad.finish();
 		assertState(() => container.textContent?.includes(tasks[0]?.title ?? "") ?? false, "newer data load");

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -227,6 +227,13 @@ function AppContent() {
   const loadAllDataRequestRef = useRef(0);
   const hasLoadedDataRef = useRef(false);
   const pendingDataRequestRef = useRef<number | null>(null);
+  // Scope of the in-flight data request (only meaningful while
+  // pendingDataRequestRef is set): 0 tasks, 1 with milestones, 2 full load. A
+  // newer, narrower refresh supersedes the in-flight request through the shared
+  // counter, so it must adopt at least this scope or the wider data is lost.
+  const pendingScopeRankRef = useRef(0);
+  const loadErrorRef = useRef<Error | null>(null);
+  const duplicateRepairPlanRef = useRef<DuplicateRepairPlan | null>(null);
   const protocolOnlyLoadingRef = useRef(false);
   const location = useLocation();
   const navigate = useNavigate();
@@ -329,16 +336,27 @@ function AppContent() {
     );
   }, []);
 
+  const applyLoadError = useCallback((error: Error | null) => {
+    loadErrorRef.current = error;
+    setLoadError(error);
+  }, []);
+
+  const applyDuplicateRepairPlan = useCallback((plan: DuplicateRepairPlan | null) => {
+    duplicateRepairPlanRef.current = plan;
+    setDuplicateRepairPlan(plan);
+  }, []);
+
   const loadAllData = useCallback(async () => {
     const requestId = loadAllDataRequestRef.current + 1;
     loadAllDataRequestRef.current = requestId;
 	protocolOnlyLoadingRef.current = false;
 		pendingDataRequestRef.current = requestId;
+		pendingScopeRankRef.current = 2;
 		try {
 			// Show the blocking skeleton only before the first successful load; later
 			// refreshes keep the current content on screen and update it in place.
 			if (!hasLoadedDataRef.current) setIsLoading(true);
-			setLoadError(null);
+			applyLoadError(null);
       const shellDataPromise = Promise.all([
         apiClient.fetchStatuses(),
         apiClient.fetchConfig(),
@@ -380,14 +398,14 @@ function AppContent() {
         ),
       );
       void apiClient.fetchDuplicateTaskRepairPlan().then((duplicatePlan) => {
-        if (loadAllDataRequestRef.current === requestId) setDuplicateRepairPlan(duplicatePlan);
+        if (loadAllDataRequestRef.current === requestId) applyDuplicateRepairPlan(duplicatePlan);
       }).catch(() => {
-        if (loadAllDataRequestRef.current === requestId) setDuplicateRepairPlan(null);
+        if (loadAllDataRequestRef.current === requestId) applyDuplicateRepairPlan(null);
       });
     } catch (error) {
       if (loadAllDataRequestRef.current === requestId) {
         console.error('Failed to load data:', error);
-        setLoadError(error instanceof Error ? error : new Error('Failed to load data'));
+        applyLoadError(error instanceof Error ? error : new Error('Failed to load data'));
       }
     } finally {
       if (loadAllDataRequestRef.current === requestId) {
@@ -396,7 +414,7 @@ function AppContent() {
         setLoadingMessage(null);
       }
     }
-  }, [applySearchResults, applyMilestoneIds]);
+  }, [applySearchResults, applyMilestoneIds, applyLoadError, applyDuplicateRepairPlan]);
 
   React.useEffect(() => {
     // Only load data when initialized
@@ -595,27 +613,40 @@ function AppContent() {
   // the change was milestone-scoped) and reconciles it into the store in place;
   // statuses and config have their own "config-updated" broadcast, and the
   // duplicate repair plan (a filesystem rescan) refreshes in the background only
-  // when the set of task IDs changed. Anything that cannot be applied
-  // incrementally falls back to the full load.
+  // when it could have changed. Anything that cannot be applied incrementally
+  // falls back to the full load.
   const refreshTasksData = useCallback(async (includeMilestones: boolean) => {
-    if (!hasLoadedDataRef.current) {
+    // A never-completed or failed load leaves state an incremental refresh
+    // cannot patch (the failed resources would never be requested again), so
+    // both cases go through the full loader.
+    if (!hasLoadedDataRef.current || loadErrorRef.current) {
       await loadAllData();
       return;
     }
+    // Superseding an in-flight request discards its responses through the
+    // shared counter, so this refresh must adopt at least that request's scope
+    // or a concurrent config/milestone reload would be lost.
+    const supersededRank = pendingDataRequestRef.current !== null ? pendingScopeRankRef.current : -1;
+    if (supersededRank >= 2) {
+      await loadAllData();
+      return;
+    }
+    const withMilestones = includeMilestones || supersededRank >= 1;
     const requestId = loadAllDataRequestRef.current + 1;
     loadAllDataRequestRef.current = requestId;
     protocolOnlyLoadingRef.current = false;
     pendingDataRequestRef.current = requestId;
+    pendingScopeRankRef.current = withMilestones ? 1 : 0;
     try {
       const [milestonesData, archivedMilestonesData, searchResults] = await Promise.all([
-        includeMilestones ? apiClient.fetchMilestones() : milestoneEntitiesRef.current,
-        includeMilestones ? apiClient.fetchArchivedMilestones() : archivedMilestonesRef.current,
+        withMilestones ? apiClient.fetchMilestones() : milestoneEntitiesRef.current,
+        withMilestones ? apiClient.fetchArchivedMilestones() : archivedMilestonesRef.current,
         apiClient.search(),
       ]);
       if (loadAllDataRequestRef.current !== requestId) {
         return;
       }
-      if (includeMilestones) {
+      if (withMilestones) {
         milestoneEntitiesRef.current = milestonesData;
         archivedMilestonesRef.current = archivedMilestonesData;
         setMilestoneEntities(milestonesData);
@@ -635,13 +666,17 @@ function AppContent() {
           (milestone) => !archivedKeys.has(milestoneKey(milestone)),
         ),
       );
-      setLoadError(null);
-      // Duplicate IDs can only appear or disappear when the set of task IDs
-      // changes (an external file arriving, a repair renaming tasks), so edits
-      // and reorders skip the plan's filesystem rescan.
-      if (idSignature(tasksList) !== previousIdSignature) {
+      // In the healthy steady state (an empty plan on record), duplicate IDs can
+      // only appear when the set of task IDs changes, so edits and reorders skip
+      // the plan's filesystem rescan. While duplicates exist their plan
+      // fingerprint also covers content and references, and a still-null plan
+      // means the initial read has not landed (or was superseded), so both keep
+      // refreshing until the corpus is clean again.
+      const plan = duplicateRepairPlanRef.current;
+      const planUnsettled = plan === null || plan.groups.length > 0 || plan.crossBranchFindings.length > 0;
+      if (planUnsettled || idSignature(tasksList) !== previousIdSignature) {
         void apiClient.fetchDuplicateTaskRepairPlan().then((duplicatePlan) => {
-          if (loadAllDataRequestRef.current === requestId) setDuplicateRepairPlan(duplicatePlan);
+          if (loadAllDataRequestRef.current === requestId) applyDuplicateRepairPlan(duplicatePlan);
         }).catch(() => {});
       }
     } catch {
@@ -654,7 +689,7 @@ function AppContent() {
         pendingDataRequestRef.current = null;
       }
     }
-  }, [applySearchResults, applyMilestoneIds, loadAllData]);
+  }, [applySearchResults, applyMilestoneIds, applyDuplicateRepairPlan, loadAllData]);
 
   const refreshData = useCallback(async () => {
     await refreshTasksData(false);
@@ -722,7 +757,7 @@ function AppContent() {
 		// loading attempt always clears a stale terminal error, so a passive
 		// client shows its cached content instead of the obsolete failure.
 		if (!hasLoadedDataRef.current) setIsLoading(true);
-		setLoadError(null);
+		applyLoadError(null);
 		setLoadingMessage(loadingState.message);
 	  } else if (loadingState?.type === 'loaded') {
 		const shouldRefresh = protocolOnlyLoadingRef.current && pendingDataRequestRef.current === null;
@@ -735,7 +770,7 @@ function AppContent() {
 		protocolOnlyLoadingRef.current = false;
 		setIsLoading(false);
 		setLoadingMessage(null);
-		setLoadError(new Error(loadingState.message));
+		applyLoadError(new Error(loadingState.message));
       } else if (event.data === "tasks-updated") {
         void refreshData();
       } else if (event.data === "milestones-updated") {
@@ -754,7 +789,7 @@ function AppContent() {
 		disposed = true;
 		ws.close();
 	};
-  }, [refreshData, refreshMilestoneData, fullRefreshData, loadAllData]);
+  }, [refreshData, refreshMilestoneData, fullRefreshData, loadAllData, applyLoadError]);
 
   const handleSubmitTask = async (taskData: Partial<Task>) => {
     // Don't catch errors here - let TaskDetailsModal handle them

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -37,6 +37,7 @@ import { getProjectValues } from '../utils/project-config';
 import { getTaskTypeValues } from '../utils/task-type-config';
 import { createUrlPath } from './utils/urlHelpers';
 import { filterKanbanTasks } from './utils/kanban-tasks';
+import { reconcileById } from './utils/reconcile';
 import { parseBrowserLoadingState } from '../utils/browser-loading-state';
 
 type TaskRouteNavigationState = {
@@ -208,6 +209,13 @@ function AppContent() {
   const kanbanTasks = React.useMemo(() => filterKanbanTasks(tasks), [tasks]);
   const [docs, setDocs] = useState<Document[]>([]);
   const [decisions, setDecisions] = useState<Decision[]>([]);
+  // Mirrors of the store lists, so refreshes can reconcile in place without
+  // resubscribing the WebSocket effect to every state change.
+  const tasksRef = useRef<Task[]>([]);
+  const docsRef = useRef<Document[]>([]);
+  const decisionsRef = useRef<Decision[]>([]);
+  const milestoneEntitiesRef = useRef<Milestone[]>([]);
+  const archivedMilestonesRef = useRef<Milestone[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadingMessage, setLoadingMessage] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<Error | null>(null);
@@ -299,11 +307,26 @@ function AppContent() {
     const docsList = documentResults.map((result) => result.document);
     const decisionsList = decisionResults.map((result) => result.decision);
 
-    setTasks(normalizedTasks);
-    setDocs(docsList);
-    setDecisions(decisionsList);
+    // Reconcile instead of replacing: unchanged records keep their identity, so
+    // views re-render only for real changes and a refresh that merely echoes an
+    // already-applied update (e.g. after a surgical drag update) is a no-op.
+    const nextTasks = reconcileById(tasksRef.current, normalizedTasks);
+    tasksRef.current = nextTasks;
+    setTasks(nextTasks);
+    const nextDocs = reconcileById(docsRef.current, docsList);
+    docsRef.current = nextDocs;
+    setDocs(nextDocs);
+    const nextDecisions = reconcileById(decisionsRef.current, decisionsList);
+    decisionsRef.current = nextDecisions;
+    setDecisions(nextDecisions);
 
-    return { tasks: normalizedTasks, docs: docsList, decisions: decisionsList };
+    return { tasks: nextTasks };
+  }, []);
+
+  const applyMilestoneIds = useCallback((next: string[]) => {
+    setMilestones((current) =>
+      next.length === current.length && next.every((id, index) => id === current[index]) ? current : next,
+    );
   }, []);
 
   const loadAllData = useCallback(async () => {
@@ -335,6 +358,8 @@ function AppContent() {
       setProjectName(configData.projectName);
       setAvailableLabels(configData.labels || []);
       setConfig(configData);
+      milestoneEntitiesRef.current = milestonesData;
+      archivedMilestonesRef.current = archivedMilestonesData;
       setMilestoneEntities(milestonesData);
       setArchivedMilestones(archivedMilestonesData);
 
@@ -349,7 +374,7 @@ function AppContent() {
       const { tasks: tasksList } = applySearchResults(searchResults, archivedKeys, milestoneAliases);
       hasLoadedDataRef.current = true;
 
-      setMilestones(
+      applyMilestoneIds(
         collectMilestoneIds(tasksList, milestonesData, archivedMilestonesData).filter(
           (milestone) => !archivedKeys.has(milestoneKey(milestone)),
         ),
@@ -371,7 +396,7 @@ function AppContent() {
         setLoadingMessage(null);
       }
     }
-  }, [applySearchResults]);
+  }, [applySearchResults, applyMilestoneIds]);
 
   React.useEffect(() => {
     // Only load data when initialized
@@ -565,20 +590,97 @@ function AppContent() {
     }
   }, [taskRouteError]);
 
+  // Incremental refresh: the single-card reorder path's surgical store update,
+  // generalized. Refetches only the search corpus (plus milestone entities when
+  // the change was milestone-scoped) and reconciles it into the store in place;
+  // statuses and config have their own "config-updated" broadcast, and the
+  // duplicate repair plan (a filesystem rescan) refreshes in the background only
+  // when the set of task IDs changed. Anything that cannot be applied
+  // incrementally falls back to the full load.
+  const refreshTasksData = useCallback(async (includeMilestones: boolean) => {
+    if (!hasLoadedDataRef.current) {
+      await loadAllData();
+      return;
+    }
+    const requestId = loadAllDataRequestRef.current + 1;
+    loadAllDataRequestRef.current = requestId;
+    protocolOnlyLoadingRef.current = false;
+    pendingDataRequestRef.current = requestId;
+    try {
+      const [milestonesData, archivedMilestonesData, searchResults] = await Promise.all([
+        includeMilestones ? apiClient.fetchMilestones() : milestoneEntitiesRef.current,
+        includeMilestones ? apiClient.fetchArchivedMilestones() : archivedMilestonesRef.current,
+        apiClient.search(),
+      ]);
+      if (loadAllDataRequestRef.current !== requestId) {
+        return;
+      }
+      if (includeMilestones) {
+        milestoneEntitiesRef.current = milestonesData;
+        archivedMilestonesRef.current = archivedMilestonesData;
+        setMilestoneEntities(milestonesData);
+        setArchivedMilestones(archivedMilestonesData);
+      }
+      const archivedKeys = new Set(collectArchivedMilestoneKeys(archivedMilestonesData, milestonesData));
+      const milestoneAliases = buildMilestoneAliasMap(milestonesData, archivedMilestonesData);
+      const idSignature = (list: Task[]) =>
+        list
+          .map((task) => task.id)
+          .sort()
+          .join("\n");
+      const previousIdSignature = idSignature(tasksRef.current);
+      const { tasks: tasksList } = applySearchResults(searchResults, archivedKeys, milestoneAliases);
+      applyMilestoneIds(
+        collectMilestoneIds(tasksList, milestonesData, archivedMilestonesData).filter(
+          (milestone) => !archivedKeys.has(milestoneKey(milestone)),
+        ),
+      );
+      setLoadError(null);
+      // Duplicate IDs can only appear or disappear when the set of task IDs
+      // changes (an external file arriving, a repair renaming tasks), so edits
+      // and reorders skip the plan's filesystem rescan.
+      if (idSignature(tasksList) !== previousIdSignature) {
+        void apiClient.fetchDuplicateTaskRepairPlan().then((duplicatePlan) => {
+          if (loadAllDataRequestRef.current === requestId) setDuplicateRepairPlan(duplicatePlan);
+        }).catch(() => {});
+      }
+    } catch {
+      if (loadAllDataRequestRef.current !== requestId) {
+        return;
+      }
+      await loadAllData();
+    } finally {
+      if (loadAllDataRequestRef.current === requestId) {
+        pendingDataRequestRef.current = null;
+      }
+    }
+  }, [applySearchResults, applyMilestoneIds, loadAllData]);
+
   const refreshData = useCallback(async () => {
-    await loadAllData();
-    // Drafts are loaded by the drafts page, not by loadAllData, and creating, editing, promoting or
+    await refreshTasksData(false);
+    // Drafts are loaded by the drafts page, not by this refresh, and creating, editing, promoting or
     // demoting a task can change them, so tell that page to reload whenever the rest of the data does.
+    window.dispatchEvent(new Event('drafts-updated'));
+  }, [refreshTasksData]);
+
+  const refreshMilestoneData = useCallback(async () => {
+    await refreshTasksData(true);
+    window.dispatchEvent(new Event('drafts-updated'));
+  }, [refreshTasksData]);
+
+  const fullRefreshData = useCallback(async () => {
+    await loadAllData();
     window.dispatchEvent(new Event('drafts-updated'));
   }, [loadAllData]);
 
 	const applyReorderedTasks = useCallback((updatedTasks: Task[], requestTask: Task) => {
-		setTasks((current) => {
-			const currentRequest = current.find((task) => task.id === requestTask.id);
-			if (currentRequest !== requestTask) return current;
-			const updatesById = new Map(updatedTasks.map((task) => [task.id, task]));
-			return current.map((task) => updatesById.get(task.id) ?? task);
-		});
+		const current = tasksRef.current;
+		const currentRequest = current.find((task) => task.id === requestTask.id);
+		if (currentRequest !== requestTask) return;
+		const updatesById = new Map(updatedTasks.map((task) => [task.id, task]));
+		const next = current.map((task) => updatesById.get(task.id) ?? task);
+		tasksRef.current = next;
+		setTasks(next);
 	}, []);
 
   // Sync editingTask with refreshed tasks data to prevent stale state
@@ -626,14 +728,18 @@ function AppContent() {
 		const shouldRefresh = protocolOnlyLoadingRef.current && pendingDataRequestRef.current === null;
 		protocolOnlyLoadingRef.current = false;
 		setLoadingMessage(null);
-		if (shouldRefresh) void refreshData();
+		// Indexing can surface cross-branch data (including duplicate findings)
+		// that an incremental reconcile would miss, so reload everything.
+		if (shouldRefresh) void fullRefreshData();
 	  } else if (loadingState?.type === 'error') {
 		protocolOnlyLoadingRef.current = false;
 		setIsLoading(false);
 		setLoadingMessage(null);
 		setLoadError(new Error(loadingState.message));
       } else if (event.data === "tasks-updated") {
-        refreshData();
+        void refreshData();
+      } else if (event.data === "milestones-updated") {
+        void refreshMilestoneData();
       } else if (event.data === "config-updated") {
         // Reload statuses when config changes
         loadAllData();
@@ -642,13 +748,13 @@ function AppContent() {
 	ws.onclose = () => {
 		if (disposed || !protocolOnlyLoadingRef.current || pendingDataRequestRef.current !== null) return;
 		protocolOnlyLoadingRef.current = false;
-		void refreshData();
+		void fullRefreshData();
 	};
 	return () => {
 		disposed = true;
 		ws.close();
 	};
-  }, [refreshData, loadAllData]);
+  }, [refreshData, refreshMilestoneData, fullRefreshData, loadAllData]);
 
   const handleSubmitTask = async (taskData: Partial<Task>) => {
     // Don't catch errors here - let TaskDetailsModal handle them
@@ -804,7 +910,7 @@ function AppContent() {
                 milestoneEntities={milestoneEntities}
                 archivedMilestones={archivedMilestones}
                 onEditTask={handleEditTask}
-                onRefreshData={refreshData}
+                onRefreshData={refreshMilestoneData}
                 dateFormat={config?.dateFormat}
               />
             }

--- a/src/web/utils/reconcile.test.ts
+++ b/src/web/utils/reconcile.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { deepEqual, reconcileById } from "./reconcile.ts";
+
+describe("deepEqual", () => {
+	it("ignores key order and undefined-valued keys", () => {
+		expect(deepEqual({ a: 1, b: [1, 2] }, { b: [1, 2], a: 1 })).toBe(true);
+		expect(deepEqual({ a: 1, milestone: undefined }, { a: 1 })).toBe(true);
+		expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+		expect(deepEqual({ a: [1, 2] }, { a: [2, 1] })).toBe(false);
+		expect(deepEqual({ a: { b: null } }, { a: { b: null } })).toBe(true);
+	});
+});
+
+describe("reconcileById", () => {
+	const record = (id: string, value: number) => ({ id, value });
+
+	it("keeps the current array when nothing changed", () => {
+		const current = [record("a", 1), record("b", 2)];
+		expect(reconcileById(current, [record("a", 1), record("b", 2)])).toBe(current);
+	});
+
+	it("keeps unchanged records by identity when one record changes", () => {
+		const current = [record("a", 1), record("b", 2)];
+		const next = reconcileById(current, [record("a", 1), record("b", 3)]);
+		expect(next).not.toBe(current);
+		expect(next[0]).toBe(current[0] as { id: string; value: number });
+		expect(next[1]).toEqual(record("b", 3));
+	});
+
+	it("treats reorders, additions, and removals as changes", () => {
+		const current = [record("a", 1), record("b", 2)];
+		const reordered = reconcileById(current, [record("b", 2), record("a", 1)]);
+		expect(reordered).not.toBe(current);
+		expect(reordered[0]).toBe(current[1] as { id: string; value: number });
+		expect(reconcileById(current, [record("a", 1)])).toEqual([record("a", 1)]);
+		expect(reconcileById(current, [record("a", 1), record("b", 2), record("c", 3)])).toHaveLength(3);
+	});
+});

--- a/src/web/utils/reconcile.ts
+++ b/src/web/utils/reconcile.ts
@@ -1,0 +1,39 @@
+/**
+ * Structural equality for plain JSON-shaped records. Key order is irrelevant and
+ * keys holding `undefined` compare equal to absent keys, so a record refetched
+ * from the server matches its normalized in-store counterpart.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (Array.isArray(a) || Array.isArray(b)) {
+		if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+		return a.every((item, index) => deepEqual(item, b[index]));
+	}
+	if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+	const aRecord = a as Record<string, unknown>;
+	const bRecord = b as Record<string, unknown>;
+	const keys = new Set([...Object.keys(aRecord), ...Object.keys(bRecord)]);
+	for (const key of keys) {
+		if (!deepEqual(aRecord[key], bRecord[key])) return false;
+	}
+	return true;
+}
+
+/**
+ * Reconciles a freshly fetched list into the current store list while
+ * preserving identity: records that did not change keep their existing object,
+ * and a list whose content and order did not change keeps its array. React
+ * views subscribed to the store then re-render only for real changes, and a
+ * refresh that echoes an already-applied update is a state no-op.
+ */
+export function reconcileById<T extends { id: string }>(current: readonly T[], next: readonly T[]): T[] {
+	const currentById = new Map(current.map((item) => [item.id, item]));
+	const merged = next.map((item) => {
+		const existing = currentById.get(item.id);
+		return existing && deepEqual(existing, item) ? existing : item;
+	});
+	if (merged.length === current.length && merged.every((item, index) => item === current[index])) {
+		return current as T[];
+	}
+	return merged;
+}


### PR DESCRIPTION
## Summary

Every `tasks-updated` broadcast made the web app run `loadAllData()`: a 6-request refetch burst (statuses, config, milestones, archived milestones, search, duplicates) that rebuilt the whole store, per broadcast, twice per drag. BACK-654/665 already kept the loading shell off screen; this PR fixes the data layer underneath by generalizing the single-card reorder path's `onTasksUpdated` surgical store update into the standard refresh path.

### Server
- `broadcastTasksUpdated` becomes `broadcastDataUpdated(scope)`. Store/task events keep the `tasks-updated` wire message; milestone endpoints (update/remove/archive, and create, which previously broadcast nothing) send `milestones-updated`. The existing 75ms debounce merges a pending tasks scope up into milestones.

### Client
- New incremental `refreshTasksData`: fetches only `/api/search` (plus milestone entities when milestone-scoped) and reconciles tasks/docs/decisions into the store via `reconcileById` (new shared helper in `src/web/utils/reconcile.ts`): unchanged records keep their object identity, unchanged lists keep their array identity, so a broadcast that merely echoes an already-applied surgical update is a state no-op and unrelated cards never re-render.
- The duplicate repair plan (a server-side filesystem rescan) is refetched in the background only when the task ID multiset changes (external file arriving, repair renaming IDs) - edits and reorders skip it, and the repair flow still clears its banner.
- Full `loadAllData` remains exactly where incremental cannot work: initial load (unchanged), `config-updated`, cross-branch indexing completion and socket-close reconnect (which can surface cross-branch duplicate findings), and as the fallback when an incremental refresh fails.

## Measured (live server, 6-task board, single-card drop into another column)
| | requests after one drag |
|---|---|
| before (origin/main) | reorder POST + **6-request burst** (statuses, config, milestones, archived, search, duplicates) per broadcast |
| after | reorder POST + **1 background search reconcile** |

External file edit (rename / status change on disk): exactly 1 `/api/search` request, card updates/moves in place. Milestone create: 3 requests (milestones, archived, search).

## Still triggers a full refetch (by design)
- `config-updated` (statuses/labels/config genuinely changed)
- cross-branch indexing `loaded` frames and data-socket reconnect (cross-branch corpus and duplicate findings can change beyond what a search reconcile sees)
- any incremental refresh failure (pinned fallback)
- initial page load (unchanged)

## Tests
- `src/test/web-in-place-refresh.test.tsx`: App-level jsdom tests - external edit, cross-column move, external creation update in place with the request set pinned and no loading shell; echo broadcast is a no-op; milestone-scoped broadcast fetches milestones+archived+search; search failure falls back to the full reload.
- `src/web/utils/reconcile.test.ts`: identity-preservation unit tests.
- `src/test/server-milestone-broadcast.test.ts`: milestone mutations publish `milestones-updated`.
- `src/test/web-task-detail-deeplink.test.tsx`: 4 scenarios updated from the old full-burst expectations to the incremental ones (31/31 pass); live modal sync, deep links, and loading-state protocol flows unchanged.

`bunx tsc --noEmit` clean, `bun run check .` clean, full `bun test`: 2748 pass / 2 fail (mcp-tasks task_search and server-statistics reconcile - known full-suite-concurrency flakes, both pass isolated).

Closes BACK-653.