### PR TITLE
BACK-669 - Close residual self-dependency gaps from the BACK-656 review

### DIFF
--- a/backlog/tasks/back-669 - Close-residual-self-dependency-gaps-from-the-BACK-656-review.md
+++ b/backlog/tasks/back-669 - Close-residual-self-dependency-gaps-from-the-BACK-656-review.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@Claude'
 created_date: '2026-08-31 00:26'
-updated_date: '2026-08-31 00:43'
+updated_date: '2026-08-31 01:16'
 labels:
   - cli
   - bug
@@ -48,6 +48,8 @@ Two residual defects deferred at PR #978 merge, both small: (1) a legacy draft c
 Moved the self-dependency check in validateDependencies ahead of corpus resolution, comparing the raw input to target.id with taskIdsEqual (the same predicate the corpus filter uses, so it subsumes the removed post-resolution check). doctor --fix now re-runs findDependencyDefects after repairDuplicateTaskIds and gates the final dependency message/exit on the repaired corpus. Tests: promotion and demotion with a dangling ref equal to the allocated ID are rejected and write nothing; doctor --fix exits 0 when the rename resolves the self-dependency. tsc, biome, and the two touched test files are green; full suite running.
 
 Full suite: only pre-existing tui-emoji-width failures remain locally; they fail identically on unmodified origin/main and the diff does not touch src/tui. PR: https://github.com/MrLesk/Backlog.md/pull/982
+
+Review round (Codex on PR #982): reordered validateDependencies so unique corpus resolution runs before the raw-target self check, restoring bare-number resolution to existing records (bare 1 -> DRAFT-1 during TASK-1 creation) while still rejecting dangling refs equal to the allocated ID; doctor --fix now prints the post-repair defects report before the findings-remain line. New tests for both; tsc/biome green, dependency+doctor suites 52/52, adjacent dependency suites 76/76. Head 50772df2.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-669 - Close-residual-self-dependency-gaps-from-the-BACK-656-review.md
+++ b/backlog/tasks/back-669 - Close-residual-self-dependency-gaps-from-the-BACK-656-review.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@Claude'
 created_date: '2026-08-31 00:26'
-updated_date: '2026-08-31 00:32'
+updated_date: '2026-08-31 00:43'
 labels:
   - cli
   - bug
@@ -21,16 +21,16 @@ Two residual defects deferred at PR #978 merge, both small: (1) a legacy draft c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Promoting or demoting a record with a dangling reference equal to the allocated ID is rejected; no self-dependency can be written
-- [ ] #2 doctor --fix exit status reflects the post-repair corpus
-- [ ] #3 Tests cover both scenarios
+- [x] #1 Promoting or demoting a record with a dangling reference equal to the allocated ID is rejected; no self-dependency can be written
+- [x] #2 doctor --fix exit status reflects the post-repair corpus
+- [x] #3 Tests cover both scenarios
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -46,4 +46,12 @@ Two residual defects deferred at PR #978 merge, both small: (1) a legacy draft c
 
 <!-- SECTION:NOTES:BEGIN -->
 Moved the self-dependency check in validateDependencies ahead of corpus resolution, comparing the raw input to target.id with taskIdsEqual (the same predicate the corpus filter uses, so it subsumes the removed post-resolution check). doctor --fix now re-runs findDependencyDefects after repairDuplicateTaskIds and gates the final dependency message/exit on the repaired corpus. Tests: promotion and demotion with a dangling ref equal to the allocated ID are rejected and write nothing; doctor --fix exits 0 when the rename resolves the self-dependency. tsc, biome, and the two touched test files are green; full suite running.
+
+Full suite: only pre-existing tui-emoji-width failures remain locally; they fail identically on unmodified origin/main and the diff does not touch src/tui. PR: https://github.com/MrLesk/Backlog.md/pull/982
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved the self-dependency check in validateDependencies ahead of corpus resolution (raw input vs target via taskIdsEqual, subsuming the old post-resolution check), so promotion/demotion of a record carrying a dangling reference equal to the freshly allocated ID now fails closed instead of writing a self-dependency. doctor --fix re-runs findDependencyDefects after repairDuplicateTaskIds so its exit reflects the repaired corpus. Verified with new tests (promotion and demotion rejection cases in src/test/dependency.test.ts; doctor --fix exit-0 case in src/test/cli-doctor.test.ts), bunx tsc --noEmit, bun run check ., and bun test. Delivered as PR #982 (unmerged).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-669 - Close-residual-self-dependency-gaps-from-the-BACK-656-review.md
+++ b/backlog/tasks/back-669 - Close-residual-self-dependency-gaps-from-the-BACK-656-review.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-669
 title: Close residual self-dependency gaps from the BACK-656 review
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@Claude'
 created_date: '2026-08-31 00:26'
+updated_date: '2026-08-31 00:32'
 labels:
   - cli
   - bug
@@ -30,3 +32,18 @@ Two residual defects deferred at PR #978 merge, both small: (1) a legacy draft c
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. In validateDependencies (src/utils/task-builders.ts), move the target self-check before resolveUniqueDependency and compare the raw dependency spelling to target.id with taskIdsEqual, replacing the post-resolution check it subsumes; dangling refs equal to the allocated promotion/demotion ID then fail closed.
+2. In doctor --fix (src/cli.ts), re-run findDependencyDefects after repairDuplicateTaskIds and gate the final dependency-findings message and exit code on the repaired corpus.
+3. Tests: promotion and demotion with a dangling reference equal to the next allocated ID are rejected; doctor --fix exits 0 when the duplicate-ID repair resolves the self-dependency finding.
+4. Proof: bunx tsc --noEmit, bun run check ., bun test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Moved the self-dependency check in validateDependencies ahead of corpus resolution, comparing the raw input to target.id with taskIdsEqual (the same predicate the corpus filter uses, so it subsumes the removed post-resolution check). doctor --fix now re-runs findDependencyDefects after repairDuplicateTaskIds and gates the final dependency message/exit on the repaired corpus. Tests: promotion and demotion with a dangling ref equal to the allocated ID are rejected and write nothing; doctor --fix exits 0 when the rename resolves the self-dependency. tsc, biome, and the two touched test files are green; full suite running.
+<!-- SECTION:NOTES:END -->

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5535,10 +5535,12 @@ addHelpSchema(program.command("doctor"), {
 				console.log("Draft identity findings remain diagnostic-only and still require manual review.");
 				process.exitCode = 1;
 			}
-			// Diagnosed again after the repair: renaming a duplicate can itself resolve a dependency
-			// finding, so the final status must reflect the repaired corpus, not the preview snapshot.
+			// Diagnosed again after the repair: renaming a duplicate can resolve a dependency finding
+			// or materialize a new one from a dangling reference, so the report and final status must
+			// reflect the repaired corpus, not the preview snapshot.
 			const remainingDependencyDefects = await findDependencyDefects(core);
 			if (remainingDependencyDefects.selfDependencies.length > 0 || remainingDependencyDefects.cycles.length > 0) {
+				printDependencyDefectsReport(remainingDependencyDefects);
 				console.log("Dependency findings remain diagnostic-only and still require manual repair.");
 				process.exitCode = 1;
 			}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5535,7 +5535,10 @@ addHelpSchema(program.command("doctor"), {
 				console.log("Draft identity findings remain diagnostic-only and still require manual review.");
 				process.exitCode = 1;
 			}
-			if (dependenciesBroken) {
+			// Diagnosed again after the repair: renaming a duplicate can itself resolve a dependency
+			// finding, so the final status must reflect the repaired corpus, not the preview snapshot.
+			const remainingDependencyDefects = await findDependencyDefects(core);
+			if (remainingDependencyDefects.selfDependencies.length > 0 || remainingDependencyDefects.cycles.length > 0) {
 				console.log("Dependency findings remain diagnostic-only and still require manual repair.");
 				process.exitCode = 1;
 			}

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -397,6 +397,22 @@ describe("dependency defects", () => {
 		expect((await core.filesystem.loadTask("TASK-7"))?.dependencies).toEqual(["TASK-7"]);
 	});
 
+	it("exits zero when the duplicate repair itself resolves the dependency finding", async () => {
+		await writeDuplicateTasks();
+		// Beta depends on its own duplicate ID; renaming Beta re-points the reference at Alpha.
+		await Bun.write(
+			join(core.filesystem.tasksDir, "task-01 - Beta.md"),
+			serializeTask({ ...makeTask("TASK-01", "Beta"), dependencies: ["TASK-01"] }),
+		);
+
+		const result = await $`bun ${cliPath} doctor --fix --yes`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(0);
+		expect(output).toContain("Repaired 2 duplicate task files");
+		expect(output).toContain("TASK-01 depends on itself");
+		expect(output).not.toContain("Dependency findings remain diagnostic-only");
+	});
+
 	it("refuses --fix for dependency findings instead of repairing them", async () => {
 		await Bun.write(
 			join(core.filesystem.tasksDir, "task-2 - Selfy.md"),

--- a/src/test/cli-doctor.test.ts
+++ b/src/test/cli-doctor.test.ts
@@ -413,6 +413,23 @@ describe("dependency defects", () => {
 		expect(output).not.toContain("Dependency findings remain diagnostic-only");
 	});
 
+	it("prints the dependency defect the repair itself materializes", async () => {
+		await writeDuplicateTasks();
+		// Beta's dangling reference names the ID the repair allocates to Beta, so the defect exists
+		// only in the repaired corpus; the post-repair report must name it.
+		await Bun.write(
+			join(core.filesystem.tasksDir, "task-01 - Beta.md"),
+			serializeTask({ ...makeTask("TASK-01", "Beta"), dependencies: ["TASK-2"] }),
+		);
+
+		const result = await $`bun ${cliPath} doctor --fix --yes`.cwd(testDir).quiet().nothrow();
+		const output = `${result.stdout}${result.stderr}`;
+		expect(result.exitCode).toBe(1);
+		expect(output).toContain("Repaired 2 duplicate task files");
+		expect(output).toContain("TASK-2 depends on itself");
+		expect(output).toContain("Dependency findings remain diagnostic-only and still require manual repair.");
+	});
+
 	it("refuses --fix for dependency findings instead of repairing them", async () => {
 		await Bun.write(
 			join(core.filesystem.tasksDir, "task-2 - Selfy.md"),

--- a/src/test/dependency.test.ts
+++ b/src/test/dependency.test.ts
@@ -609,6 +609,45 @@ describe("Self-referential and cyclic dependencies", () => {
 		expect(await core.filesystem.loadDraft("draft-2")).toBeNull();
 	});
 
+	test("rejects a promotion whose dangling reference equals the allocated task ID", async () => {
+		// The reference resolves to nothing, so only the pre-resolution target check can catch it;
+		// writing the record under the allocated ID would store a direct self-dependency.
+		await core.filesystem.saveDraft({
+			id: "draft-1",
+			title: "Dangling reference to the next task ID",
+			status: "Draft",
+			assignee: [],
+			createdDate: "2024-01-01",
+			labels: [],
+			dependencies: ["task-1"],
+		});
+
+		await expect(core.editTaskOrDraft("draft-1", { status: "To Do" })).rejects.toThrow("cannot depend on itself");
+		expect(await core.filesystem.loadDraft("draft-1")).not.toBeNull();
+		expect(await core.filesystem.loadTask("task-1")).toBeNull();
+	});
+
+	test("rejects a demotion whose dangling reference equals the allocated draft ID", async () => {
+		await core.createTask(
+			{
+				id: "task-1",
+				title: "Dangling reference to the next draft ID",
+				status: "To Do",
+				assignee: [],
+				createdDate: "2024-01-01",
+				labels: [],
+				dependencies: ["draft-1"],
+			},
+			false,
+		);
+
+		await expect(core.updateTaskFromInput("task-1", { status: "Draft" }, false)).rejects.toThrow(
+			"cannot depend on itself",
+		);
+		expect(await core.filesystem.loadTask("task-1")).not.toBeNull();
+		expect(await core.filesystem.loadDraft("draft-1")).toBeNull();
+	});
+
 	test("a stored self-dependency does not block adding an unrelated dependency", async () => {
 		const { task: other } = await core.createTaskFromInput({ title: "Other" });
 		const legacy: Task = {

--- a/src/test/dependency.test.ts
+++ b/src/test/dependency.test.ts
@@ -609,6 +609,15 @@ describe("Self-referential and cyclic dependencies", () => {
 		expect(await core.filesystem.loadDraft("draft-2")).toBeNull();
 	});
 
+	test("a bare-number dependency resolves to the existing draft, not the allocated task ID", async () => {
+		const { task: draft } = await core.createTaskFromInput({ title: "Existing draft", status: "Draft" }, false);
+
+		// With no tasks yet, creation allocates task-1; bare 1 must keep naming the record that
+		// already claims it instead of being rejected as a self-dependency on the allocated ID.
+		const { task } = await core.createTaskFromInput({ title: "Depends on the draft", dependencies: ["1"] }, false);
+		expect(task.dependencies).toEqual([draft.id]);
+	});
+
 	test("rejects a promotion whose dangling reference equals the allocated task ID", async () => {
 		// The reference resolves to nothing, so only the pre-resolution target check can catch it;
 		// writing the record under the allocated ID would store a direct self-dependency.

--- a/src/utils/task-builders.ts
+++ b/src/utils/task-builders.ts
@@ -53,12 +53,14 @@ function resolveUniqueDependency(dependency: string, matches: Task[]): string | 
  * branch would name a task no task command can show, and reaching for branches here would put a
  * remote fetch inside the task lock.
  *
- * When `target` names the task being created or edited, a dependency naming the target's identity
- * is rejected in any spelling, and a dependency that would close a cycle through the existing
- * graph is rejected with the cycle path. The self check compares the raw input against the target
- * before corpus resolution: creation, promotion, and demotion pass the identity they just
- * allocated, inside the create lock, so a stored dangling reference to exactly that ID resolves
- * to nothing yet would become a self-dependency the moment the record is written under it.
+ * When `target` names the task being created or edited, a dependency resolving to the target
+ * itself is rejected in any spelling, and a dependency that would close a cycle through the
+ * existing graph is rejected with the cycle path. An unresolved input is also checked against the
+ * target before being reported as missing: creation, promotion, and demotion validate against an
+ * identity allocated moments ago, which no corpus record claims, so a dangling reference to
+ * exactly that ID would become a self-dependency the moment the record is written under it.
+ * Resolution runs first so an input that names an existing record keeps naming it - a bare number
+ * resolves to the draft or task that already claims it, not to the identity being allocated.
  *
  * Returns the matched canonical IDs, deduplicated, plus the inputs that matched nothing.
  */
@@ -75,19 +77,21 @@ export async function validateDependencies(
 	const corpus = await loadDependencyCorpus(core);
 	const known = [...corpus.tasks, ...corpus.drafts, ...corpus.completed, ...corpus.archived];
 	for (const dependency of dependencies) {
-		// The corpus filter matches candidates with this same predicate, so checking the raw input
-		// first covers every spelling a resolved match could, plus references the corpus cannot
-		// resolve because the target's ID was allocated moments ago.
-		if (target && taskIdsEqual(dependency, target.id)) {
-			throw new Error(`Task ${target.id} cannot depend on itself ("${dependency.trim()}" names this task).`);
-		}
 		const resolved = resolveUniqueDependency(
 			dependency,
 			known.filter((candidate) => taskIdsEqual(dependency, candidate.id)),
 		);
 		if (resolved === null) {
+			// The corpus cannot resolve a reference to the target's freshly allocated ID, so the raw
+			// input is checked against the target before the reference is reported as missing.
+			if (target && taskIdsEqual(dependency, target.id)) {
+				throw new Error(`Task ${target.id} cannot depend on itself ("${dependency.trim()}" names this task).`);
+			}
 			invalid.push(dependency);
 			continue;
+		}
+		if (target && taskIdsEqual(resolved, target.id)) {
+			throw new Error(`Task ${target.id} cannot depend on itself ("${dependency.trim()}" names this task).`);
 		}
 		// Called for its ambiguity check: it raises AmbiguousTaskIdError when several working-copy
 		// files (active or completed) claim this ID. Drafts and archived tasks resolve to null here

--- a/src/utils/task-builders.ts
+++ b/src/utils/task-builders.ts
@@ -53,11 +53,12 @@ function resolveUniqueDependency(dependency: string, matches: Task[]): string | 
  * branch would name a task no task command can show, and reaching for branches here would put a
  * remote fetch inside the task lock.
  *
- * When `target` names the task being created or edited, a dependency resolving to the target
- * itself is rejected in any spelling, and a dependency that would close a cycle through the
- * existing graph is rejected with the cycle path. Creation passes the identity it just allocated,
- * inside the create lock: no record can claim that ID, so the self check cannot fire, but a
- * stored dangling reference to exactly that ID can close a cycle the moment it materializes.
+ * When `target` names the task being created or edited, a dependency naming the target's identity
+ * is rejected in any spelling, and a dependency that would close a cycle through the existing
+ * graph is rejected with the cycle path. The self check compares the raw input against the target
+ * before corpus resolution: creation, promotion, and demotion pass the identity they just
+ * allocated, inside the create lock, so a stored dangling reference to exactly that ID resolves
+ * to nothing yet would become a self-dependency the moment the record is written under it.
  *
  * Returns the matched canonical IDs, deduplicated, plus the inputs that matched nothing.
  */
@@ -74,6 +75,12 @@ export async function validateDependencies(
 	const corpus = await loadDependencyCorpus(core);
 	const known = [...corpus.tasks, ...corpus.drafts, ...corpus.completed, ...corpus.archived];
 	for (const dependency of dependencies) {
+		// The corpus filter matches candidates with this same predicate, so checking the raw input
+		// first covers every spelling a resolved match could, plus references the corpus cannot
+		// resolve because the target's ID was allocated moments ago.
+		if (target && taskIdsEqual(dependency, target.id)) {
+			throw new Error(`Task ${target.id} cannot depend on itself ("${dependency.trim()}" names this task).`);
+		}
 		const resolved = resolveUniqueDependency(
 			dependency,
 			known.filter((candidate) => taskIdsEqual(dependency, candidate.id)),
@@ -81,9 +88,6 @@ export async function validateDependencies(
 		if (resolved === null) {
 			invalid.push(dependency);
 			continue;
-		}
-		if (target && taskIdsEqual(resolved, target.id)) {
-			throw new Error(`Task ${target.id} cannot depend on itself ("${dependency.trim()}" names this task).`);
 		}
 		// Called for its ambiguity check: it raises AmbiguousTaskIdError when several working-copy
 		// files (active or completed) claim this ID. Drafts and archived tasks resolve to null here


### PR DESCRIPTION
Closes the two residual defects deferred at the merge of #978 (BACK-656).

## What changed

**1. Dangling references equal to a freshly allocated ID no longer become self-dependencies** (`src/utils/task-builders.ts`)

`validateDependencies` now checks the raw dependency input against the target identity **before** corpus resolution. Previously the self check ran only on a resolved match, so on promotion/demotion a stored dangling reference naming exactly the ID being allocated resolved to `null`, landed in the ignored `invalid` list, and was written unchanged under the new ID as a direct self-dependency. The pre-resolution check uses `taskIdsEqual` — the same predicate the corpus filter uses — so it subsumes the removed post-resolution check for every resolvable spelling and additionally covers unresolvable ones.

**2. `doctor --fix` exit status reflects the repaired corpus** (`src/cli.ts`)

The final dependency-findings status was computed from the pre-repair snapshot, so a self-dependency that the duplicate-ID rename itself resolves still reported remaining findings and exited 1. `findDependencyDefects` is now re-run after `repairDuplicateTaskIds` and the final message/exit derive from the post-repair corpus.

## Tests

- Promotion of a draft whose stored dangling reference equals the next allocated task ID is rejected with `cannot depend on itself`; the draft survives and no task file is written.
- Demotion mirror case with the next allocated draft ID.
- `doctor --fix --yes` exits 0 when renaming the duplicate re-points the self-referential dependency at the surviving task.

## Proof

- `bunx tsc --noEmit` clean
- `bun run check .` clean
- `bun test` — the two touched suites pass (50/50); the only full-suite failures are the pre-existing `tui-emoji-width` tests, which fail identically on unmodified origin/main in this local environment and are untouched by this diff.