### PR TITLE
BACK-663 - Dependency graph follow-ups from BACK-548 review

### DIFF
--- a/backlog/tasks/back-663 - Dependency-graph-follow-ups-from-BACK-548-review.md
+++ b/backlog/tasks/back-663 - Dependency-graph-follow-ups-from-BACK-548-review.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-08-30 19:38'
-updated_date: '2026-08-31 20:26'
+updated_date: '2026-08-31 20:56'
 labels:
   - cli
   - tui
@@ -66,6 +66,12 @@ Disposition per review item:
 7. ACCEPTED AS BEHAVIOR - Open modal dependents list staleness when another client edits a different task. The modal refetches its detail when the open task's own dependencies change (item 6 keeps that precise); refreshing on every corpus broadcast while a modal is open would cost one detail request per external change for a display-only list that corrects on reopen or on any edit to the open task. Under the no-new-subscription-machinery and simplicity-first rules this stays as designed.
 
 Validation: bunx tsc --noEmit clean, bun run check . clean, bun run test full suite 2811 pass / 0 fail.
+
+Final Summary:
+--------------------------------------------------
+Dispositioned all seven PR #960 follow-ups: fixed items 1-4 and 6 (iterative tree walks in the formatter and tree builder, cursor-based BFS, fail-closed claimant-group merge for the filtered TUI corpus, cross-branch completed records joining the web graph corpus, and a matching-task-ID guard before the web modal sync compares dependency lists), and closed items 5 and 7 as accepted behavior with reasoned notes (the existing task watcher already covers most TUI snapshot staleness; per-broadcast modal refetches are disproportionate for a display-only dependents list). Verified with focused new tests - deep-chain rendering, ambiguous-claimant merge, cross-branch completed resolution, and single-fetch graph-link navigation (the latter two shown to fail without the fixes) - plus bunx tsc --noEmit, bun run check ., and the full bun run test suite (2811 pass, 0 fail).
+
+Review follow-up (Codex P1 on the item-4 fix): joining cross-branch completed records deduplicated by canonical ID, so a branch file claiming a locally-completed ID was dropped and the identity read as resolved instead of ambiguous. Deriving the collision from the merged records is unsound in general - the identity index resolves each identity to at most one record and emits none when its newest record is archived or unparseable - so ambiguity is now taken from the index itself: TaskIdentityIndex.getContestedIds() reports the IDs more than one live identity claims, loadTaskCorpus carries them on TaskCorpus.ambiguousIds, and createTaskRecordIndex seeds those keys as ambiguous, which covers readiness and the dependency graph together. The merge went back to plain ID deduplication. Two tests, each verified to fail without its mechanism: a branch completed file colliding with a local completed record, and a corpus carrying a collision its records cannot show. Full suite 2805 pass, 8 skip, 0 fail.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-663 - Dependency-graph-follow-ups-from-BACK-548-review.md
+++ b/backlog/tasks/back-663 - Dependency-graph-follow-ups-from-BACK-548-review.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-663
 title: Dependency graph follow-ups from BACK-548 review
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-08-30 19:38'
+updated_date: '2026-08-31 20:26'
 labels:
   - cli
   - tui
@@ -21,12 +23,53 @@ Low-severity findings deferred from the PR #960 review triage, none affecting su
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each listed item is fixed or explicitly closed as accepted behavior with a note
+- [x] #1 Each listed item is fixed or explicitly closed as accepted behavior with a note
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Formatter: make appendTreeEntries iterative (explicit stack) so pathological depths cannot exhaust the call stack (dependency-graph-text.ts)
+2. Graph BFS: replace queue.shift() with a cursor index in buildDependencyGraph traverse and findCycleThroughRoot (dependency-graph.ts)
+3. TUI corpus: merge readiness snapshot with live display copies by file identity instead of canonical ID so duplicate identities reach createTaskRecordIndex and fail closed as ambiguous, matching the CLI (task-viewer-with-search.ts resolveDependencyCorpus)
+4. Web corpus: in loadTaskCorpus cross-branch path, add identity-index completed records the local completed corpus does not already hold, so cross-branch completed dependencies resolve as completed instead of missing (task-detail.ts)
+5. TUI readiness staleness on out-of-view external changes: assess; likely accept with note (local TUI reads the working copy at open)
+6. Web sync effect: require matching task IDs before comparing dependency lists so graph-link navigation stops triggering a redundant fetch (App.tsx)
+7. Open modal dependents staleness from other clients: assess; likely accept with note (no new subscription machinery)
+8. Focused tests for 1-4 and 6 where testable; run tsc, biome, full test suite
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Disposition per review item:
+
+1. FIXED - Growing string prefix / recursion in the tree render. appendTreeEntries (src/formatters/dependency-graph-text.ts) and buildDependencyTree (src/utils/dependency-graph.ts) now walk depth-first with explicit stacks, so a pathological dependency chain cannot exhaust the call stack anywhere on the render path. The per-level prefix segment stays: it is the indentation the rendered lines themselves carry, so its cost is proportional to the output. Verified by a 2500-deep chain test asserting line count and deepest-line indentation.
+
+2. FIXED - queue.shift() BFS. Both breadth-first walks (traverse in buildDependencyGraph and findCycleThroughRoot) now advance a cursor index over the queue array instead of shifting, removing the quadratic dequeue. Behavior covered by the existing graph tests plus the new deep-chain test.
+
+3. FIXED - Filtered TUI corpus collapsed duplicate canonical IDs. The snapshot/live merge (now mergeDependencyCorpusTasks in src/ui/task-viewer-with-search.ts) merges claimant groups instead of single records per canonical ID: a uniquely claimed identity is still overlaid by its live display copy (in-session status edits keep counting, and a title rename does not fork the record because the overlay is by identity), while an identity claimed by more than one record keeps every claimant so createTaskRecordIndex reports it ambiguous - the same fail-closed answer the CLI gives. Test drives the merged corpus through the shared graph and asserts the ambiguous node state.
+
+4. FIXED - Cross-branch completed dependencies rendered as missing in the web graph. loadTaskCorpus (src/core/task-detail.ts, cross-branch path only) now adds the identity index's completed records (TaskIdentityIndex.getTasks(true), source === 'completed') that the local completed corpus does not already hold. Identities with any active record anywhere still resolve to that record (the index's lifecycle selection prefers active over completed), so exactly one record per identity joins the corpus. Regression test: a dependency existing only as a completed record on another branch now resolves as completed instead of missing; verified the test fails without the fix.
+
+5. ACCEPTED AS BEHAVIOR - Filtered TUI readiness snapshot staleness on out-of-view external changes. The unified view already watches the working copy's tasks directory and upserts changed or added records into the live list, which the merge from item 3 lets win over the snapshot - so most external edits do reach readiness while the view is open. The residual staleness (a deleted out-of-view record lingering, or changes the watcher cannot attribute) lasts only until the view reopens and matches the CLI's read-at-invocation posture. A second subscription dedicated to the snapshot would duplicate the existing watcher for a marginal window; not worth the machinery.
+
+6. FIXED - Redundant fetch after graph-link navigation. The App.tsx modal sync effect now requires previousRecord.id === updatedTask.id before comparing dependency lists, so navigating between tasks no longer reads two different tasks' lists as an edit. Test opens a task by route, follows a dependency-graph link, and asserts exactly one /api/task fetch for the target; verified the test fails without the guard.
+
+7. ACCEPTED AS BEHAVIOR - Open modal dependents list staleness when another client edits a different task. The modal refetches its detail when the open task's own dependencies change (item 6 keeps that precise); refreshing on every corpus broadcast while a modal is open would cost one detail request per external change for a display-only list that corrects on reopen or on any edit to the open task. Under the no-new-subscription-machinery and simplicity-first rules this stays as designed.
+
+Validation: bunx tsc --noEmit clean, bun run check . clean, bun run test full suite 2811 pass / 0 fail.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Dispositioned all seven PR #960 follow-ups: fixed items 1-4 and 6 (iterative tree walks in the formatter and tree builder, cursor-based BFS, fail-closed claimant-group merge for the filtered TUI corpus, cross-branch completed records joining the web graph corpus, and a matching-task-ID guard before the web modal sync compares dependency lists), and closed items 5 and 7 as accepted behavior with reasoned notes (the existing task watcher already covers most TUI snapshot staleness; per-broadcast modal refetches are disproportionate for a display-only dependents list). Verified with focused new tests - deep-chain rendering, ambiguous-claimant merge, cross-branch completed resolution, and single-fetch graph-link navigation (the latter two shown to fail without the fixes) - plus bunx tsc --noEmit, bun run check ., and the full bun run test suite (2811 pass, 0 fail).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/core/task-detail.ts
+++ b/src/core/task-detail.ts
@@ -40,9 +40,19 @@ export async function loadTaskCorpus(
 
 	const storeTasks = await core.queryTasks({ includeCrossBranch: true });
 	const workingCopyIds = new Set(workingCopyTasks.map((task) => canonicalTaskId(task.id)));
+
+	// The cross-branch store's task list excludes completed records, so an identity that only exists
+	// as a completed record on some branch would otherwise read as missing here. Its identity index
+	// still knows those records; add the ones the local completed corpus does not already hold.
+	const localCompletedIds = new Set(completedTasks.map((task) => canonicalTaskId(task.id)));
+	const identityIndex = (await core.getContentStore()).getTaskCorpusSnapshot().identityIndex;
+	const crossBranchCompleted = (identityIndex?.getTasks(true) ?? []).filter(
+		(task) => task.source === "completed" && !localCompletedIds.has(canonicalTaskId(task.id)),
+	);
+
 	return {
 		tasks: [...workingCopyTasks, ...storeTasks.filter((task) => !workingCopyIds.has(canonicalTaskId(task.id)))],
-		completedTasks,
+		completedTasks: [...completedTasks, ...crossBranchCompleted],
 		statuses,
 	};
 }

--- a/src/core/task-detail.ts
+++ b/src/core/task-detail.ts
@@ -12,6 +12,11 @@ export interface TaskCorpus {
 	tasks: Task[];
 	completedTasks: Task[];
 	statuses: readonly string[] | undefined;
+	/**
+	 * Identities the store knows more than one file claims. Reads fail closed on these whatever the
+	 * merge below kept, so a collision is never answered with whichever record happened to survive.
+	 */
+	ambiguousIds?: ReadonlySet<string>;
 }
 
 /**
@@ -43,9 +48,9 @@ export async function loadTaskCorpus(
 
 	// The cross-branch store's task list excludes completed records, so an identity that only exists
 	// as a completed record on some branch would otherwise read as missing here. Its identity index
-	// still knows those records; add the ones the local completed corpus does not already hold.
-	const localCompletedIds = new Set(completedTasks.map((task) => canonicalTaskId(task.id)));
+	// still knows those records; add the ones the local completed corpus does not already cover.
 	const identityIndex = (await core.getContentStore()).getTaskCorpusSnapshot().identityIndex;
+	const localCompletedIds = new Set(completedTasks.map((task) => canonicalTaskId(task.id)));
 	const crossBranchCompleted = (identityIndex?.getTasks(true) ?? []).filter(
 		(task) => task.source === "completed" && !localCompletedIds.has(canonicalTaskId(task.id)),
 	);
@@ -54,6 +59,11 @@ export async function loadTaskCorpus(
 		tasks: [...workingCopyTasks, ...storeTasks.filter((task) => !workingCopyIds.has(canonicalTaskId(task.id)))],
 		completedTasks: [...completedTasks, ...crossBranchCompleted],
 		statuses,
+		// Both merges above resolve an ID the working copy also holds to the local record, which is
+		// the right answer for an identity only one file claims and a guess for one several do. The
+		// index knows which is which, so the collisions travel with the corpus rather than being
+		// re-derived from the records that survived the merge.
+		ambiguousIds: identityIndex?.getContestedIds(),
 	};
 }
 

--- a/src/core/task-identity-index.ts
+++ b/src/core/task-identity-index.ts
@@ -294,6 +294,21 @@ export class TaskIdentityIndex {
 			.join("\n");
 	}
 
+	/**
+	 * The canonical IDs more than one live identity claims, the same collision `resolveForRead`
+	 * reports. A corpus built from selected records cannot re-derive this: selection keeps one record
+	 * per identity and skips identities whose newest record is archived or failed to parse, so a
+	 * claimant can be missing from the corpus while still contesting the ID here.
+	 */
+	getContestedIds(): Set<string> {
+		const contested = new Set<string>();
+		for (const group of this.groups.values()) {
+			const claimants = [...group.identities.values()].filter((identity) => liveRecords(identity).length > 0);
+			if (claimants.length > 1) contested.add(group.id);
+		}
+		return contested;
+	}
+
 	getOccupiedIds(): string[] {
 		const ids = new Set<string>();
 		for (const group of this.groups.values()) {

--- a/src/formatters/dependency-graph-text.ts
+++ b/src/formatters/dependency-graph-text.ts
@@ -52,18 +52,35 @@ export type DependencyGraphEntry = {
 	node: DependencyGraphNode | null;
 };
 
+type TreeFrame = { children: DependencyTreeNode[]; position: number; prefix: string };
+
 function appendTreeEntries(
 	children: DependencyTreeNode[],
-	prefix: string,
 	entries: DependencyGraphEntry[],
 	formatLabel: (node: DependencyGraphNode) => string,
 ): void {
-	children.forEach((child, position) => {
-		const last = position === children.length - 1;
+	// Depth-first with an explicit stack, so a pathological dependency chain cannot exhaust the call
+	// stack. Each level still extends the parent prefix by one fixed segment, which is the same
+	// per-line indentation the rendered output itself carries.
+	const stack: TreeFrame[] = [{ children, position: 0, prefix: "" }];
+	while (stack.length > 0) {
+		const frame = stack[stack.length - 1];
+		const child = frame?.children[frame.position];
+		if (!frame || !child) {
+			stack.pop();
+			continue;
+		}
+		frame.position += 1;
+		const last = frame.position === frame.children.length;
 		const suffix = child.repeat ? REPEAT_SUFFIXES[child.repeat] : "";
-		entries.push({ text: `${prefix}${last ? "└─ " : "├─ "}${formatLabel(child.node)}${suffix}`, node: child.node });
-		appendTreeEntries(child.children, `${prefix}${last ? "   " : "│  "}`, entries, formatLabel);
-	});
+		entries.push({
+			text: `${frame.prefix}${last ? "└─ " : "├─ "}${formatLabel(child.node)}${suffix}`,
+			node: child.node,
+		});
+		if (child.children.length > 0) {
+			stack.push({ children: child.children, position: 0, prefix: `${frame.prefix}${last ? "   " : "│  "}` });
+		}
+	}
 }
 
 function formatSectionEntries(
@@ -78,12 +95,7 @@ function formatSectionEntries(
 	const entries: DependencyGraphEntry[] = [
 		{ text: `${DIRECTION_HEADINGS[direction]} (${direct} direct, ${reached.length} total):`, node: null },
 	];
-	appendTreeEntries(
-		buildDependencyTree(graph, direction),
-		"",
-		entries,
-		options.formatLabel ?? formatDependencyNodeLabel,
-	);
+	appendTreeEntries(buildDependencyTree(graph, direction), entries, options.formatLabel ?? formatDependencyNodeLabel);
 	return entries;
 }
 

--- a/src/test/core-task-corpus-regressions.test.ts
+++ b/src/test/core-task-corpus-regressions.test.ts
@@ -3,8 +3,10 @@ import { mkdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
+import { loadTaskCorpus } from "../core/task-detail.ts";
 import { serializeTask } from "../markdown/serializer.ts";
 import type { Task } from "../types/index.ts";
+import { buildDependencyGraph } from "../utils/dependency-graph.ts";
 import { createUniqueTestDir, getPlatformTimeout, safeCleanup, waitUntil } from "./test-utils.ts";
 
 let testDir: string;
@@ -137,6 +139,32 @@ describe("Core shared task corpus regressions", () => {
 				.getTaskCorpusSnapshot()
 				.branchStateEntries?.find((entry) => entry.id === "TASK-1" && entry.type === "completed")?.task?.title,
 		).toBe("After ref move");
+	});
+
+	it("resolves a dependency completed only on another branch as completed in the cross-branch corpus", async () => {
+		await writeTask(core.filesystem.tasksDir, "task-2 - Root.md", {
+			...task("TASK-2", "Root task"),
+			dependencies: ["TASK-1"],
+		});
+		await commit("Add root task", recentCommitDate(2));
+		await $`git switch -c feature-completed-dependency`.cwd(testDir).quiet();
+		await writeTask(
+			core.filesystem.completedDir,
+			"task-1 - Completed elsewhere.md",
+			task("TASK-1", "Completed elsewhere", "Done"),
+		);
+		await commit("Complete dependency on branch", recentCommitDate(1));
+		await $`git switch main`.cwd(testDir).quiet();
+
+		const corpus = await loadTaskCorpus(core, { includeCrossBranch: true });
+		expect(corpus.completedTasks.some((candidate) => candidate.id === "TASK-1")).toBe(true);
+
+		const root = corpus.tasks.find((candidate) => candidate.id === "TASK-2");
+		expect(root).toBeDefined();
+		const graph = buildDependencyGraph(root as Task, corpus);
+		const dependency = graph.nodes.find((candidate) => candidate.id === "TASK-1");
+		expect(dependency?.state).toBe("resolved");
+		expect(dependency?.completed).toBe(true);
 	});
 
 	it("refreshes warm cross-branch duplicate findings after branch addition and deletion", async () => {

--- a/src/test/core-task-corpus-regressions.test.ts
+++ b/src/test/core-task-corpus-regressions.test.ts
@@ -167,6 +167,30 @@ describe("Core shared task corpus regressions", () => {
 		expect(dependency?.completed).toBe(true);
 	});
 
+	it("keeps a branch completed file claiming a local completed ID ambiguous", async () => {
+		await writeTask(core.filesystem.tasksDir, "task-2 - Root.md", {
+			...task("TASK-2", "Root task"),
+			dependencies: ["TASK-1"],
+		});
+		await writeTask(core.filesystem.completedDir, "task-1 - Completed here.md", task("TASK-1", "Local", "Done"));
+		await commit("Add root task and local completed dependency", recentCommitDate(2));
+		await $`git switch -c feature-colliding-completed`.cwd(testDir).quiet();
+		await writeTask(
+			core.filesystem.completedDir,
+			"task-1 - Completed elsewhere.md",
+			task("TASK-1", "Branch claimant", "Done"),
+		);
+		await commit("Claim the same completed ID with another file", recentCommitDate(1));
+		await $`git switch main`.cwd(testDir).quiet();
+
+		const corpus = await loadTaskCorpus(core, { includeCrossBranch: true });
+		const root = corpus.tasks.find((candidate) => candidate.id === "TASK-2");
+		expect(root).toBeDefined();
+		const graph = buildDependencyGraph(root as Task, corpus);
+		const dependency = graph.nodes.find((candidate) => candidate.id === "TASK-1");
+		expect(dependency?.state).toBe("ambiguous");
+	});
+
 	it("refreshes warm cross-branch duplicate findings after branch addition and deletion", async () => {
 		const mainTaskPath = await writeTask(core.filesystem.tasksDir, "task-1 - Main.md", task("TASK-1", "Main task"));
 		await commit("Add main task", recentCommitDate(2));

--- a/src/test/dependency-graph-surfaces.test.tsx
+++ b/src/test/dependency-graph-surfaces.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Task } from "../types/index.ts";
 import { withDependencyGraph } from "../core/task-detail.ts";
-import { generateDetailContent } from "../ui/task-viewer-with-search.ts";
+import { generateDetailContent, mergeDependencyCorpusTasks } from "../ui/task-viewer-with-search.ts";
 
 const STATUSES = ["To Do", "In Progress", "Done"] as const;
 
@@ -75,5 +75,37 @@ describe("TUI dependency graph section", () => {
 		const detail = withDependencyGraph(isolated, { tasks: [isolated], completedTasks: [], statuses: STATUSES });
 
 		expect(generateDetailContent(detail).bodyContent.join("\n")).not.toContain("Dependency Graph");
+	});
+});
+
+describe("filtered TUI dependency corpus merge", () => {
+	it("lets a live display copy win over the snapshot for a uniquely claimed identity", () => {
+		const snapshotTask = makeTask("BACK-1", "Foundation", [], "To Do");
+		const outOfView = makeTask("BACK-2", "Elsewhere", ["BACK-1"]);
+		const liveEdit = makeTask("BACK-1", "Foundation", [], "Done");
+
+		const merged = mergeDependencyCorpusTasks([snapshotTask, outOfView], [liveEdit]);
+
+		expect(merged).toHaveLength(2);
+		expect(merged.find((task) => task.id === "BACK-1")?.status).toBe("Done");
+		expect(merged.find((task) => task.id === "BACK-2")).toBe(outOfView);
+	});
+
+	it("keeps every claimant of a contested identity so the graph fails closed like the CLI", () => {
+		const claimantA = makeTask("BACK-1", "First claimant", [], "Done");
+		const claimantB = makeTask("BACK-1", "Second claimant");
+		const root = makeTask("BACK-2", "Selected", ["BACK-1"]);
+
+		const merged = mergeDependencyCorpusTasks([claimantA, claimantB, root], [root, claimantA]);
+		expect(merged.filter((task) => task.id === "BACK-1")).toHaveLength(2);
+
+		// The exact corpus the filtered viewer resolves, run through the shared graph: the contested
+		// identity must be reported ambiguous, never silently collapsed to one claimant.
+		const graph = withDependencyGraph(root, {
+			tasks: merged,
+			completedTasks: [],
+			statuses: STATUSES,
+		}).dependencyGraph;
+		expect(graph.nodes.find((node) => node.id === "BACK-1")?.state).toBe("ambiguous");
 	});
 });

--- a/src/test/dependency-graph.test.ts
+++ b/src/test/dependency-graph.test.ts
@@ -137,6 +137,20 @@ describe("buildDependencyGraph", () => {
 		expect(nodeIds(graph, "dependencies")).toEqual(["TASK-2"]);
 	});
 
+	it("reports a collision the corpus carries but cannot show in its records", () => {
+		// A loader that resolves each identity to one record hands over a corpus where a contested ID
+		// looks singly claimed. The collision travels beside the records, and the read fails closed on
+		// it rather than on how many claimants survived the loader.
+		const graph = buildDependencyGraph(task("task-1", ["task-2"]), {
+			tasks: [task("task-1", ["task-2"]), task("task-2", ["task-3"]), task("task-3")],
+			statuses: STATUSES,
+			ambiguousIds: new Set(["TASK-2"]),
+		});
+
+		expect(graph.nodes.find((node) => node.id === "TASK-2")?.state).toBe("ambiguous");
+		expect(nodeIds(graph, "dependencies")).toEqual(["TASK-2"]);
+	});
+
 	it("keeps an ambiguous identity a leaf even when reverse edges leave it", () => {
 		// One duplicate record behind the ambiguous identity declares a dependency on task-3, which is
 		// itself a dependent of the root, so the shared edge set carries an edge leaving the ambiguous

--- a/src/test/dependency-graph.test.ts
+++ b/src/test/dependency-graph.test.ts
@@ -307,4 +307,19 @@ describe("dependency graph text", () => {
 	it("renders nothing for a task with no dependencies and no dependents", () => {
 		expect(formatDependencyGraphLines(graphFor("task-1", [task("task-1")]))).toEqual([]);
 	});
+
+	it("renders a pathologically deep dependency chain without recursing", () => {
+		// Deep enough that a recursive tree walk or formatter would be at risk on a small stack,
+		// while the quadratic indentation the rendered lines inherently carry stays affordable.
+		const depth = 2500;
+		const chain = Array.from({ length: depth }, (_, position) =>
+			task(`task-${position + 1}`, position === 0 ? [] : [`task-${position}`]),
+		);
+
+		const lines = formatDependencyGraphSection(graphFor(`task-${depth}`, chain), "dependencies");
+		expect(lines.length).toBe(depth);
+		expect(lines[0]).toBe(`Depends on (1 direct, ${depth - 1} total):`);
+		expect(lines[1]).toBe(`└─ task-${depth - 1} - Title task-${depth - 1} [To Do]`);
+		expect(lines[depth - 1]).toBe(`${"   ".repeat(depth - 2)}└─ task-1 - Title task-1 [To Do]`);
+	});
 });

--- a/src/test/web-task-detail-deeplink.test.tsx
+++ b/src/test/web-task-detail-deeplink.test.tsx
@@ -4,6 +4,7 @@ import { StrictMode, act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import type { DuplicateRepairPlan } from "../core/duplicate-task-repair.ts";
 import type { SearchResult, Task } from "../types/index.ts";
+import { buildDependencyGraph } from "../utils/dependency-graph.ts";
 import { isValidTaskId, resolveTaskById } from "../utils/task-id.ts";
 import App from "../web/App.tsx";
 import { HealthCheckProvider } from "../web/contexts/HealthCheckContext.tsx";
@@ -962,6 +963,68 @@ describe("task detail routes", () => {
 			() => window.location.pathname === "/board" && container.querySelector("[role='dialog']") === null,
 			"Back to the canonical board",
 		);
+	});
+
+	it("fetches a graph-linked task exactly once, without a redundant sync refetch", async () => {
+		const foundation: Task = {
+			id: "BACK-201",
+			title: "Graph foundation",
+			status: "To Do",
+			assignee: [],
+			labels: [],
+			dependencies: [],
+			createdDate: "2026-07-10",
+		};
+		const follower: Task = {
+			id: "BACK-202",
+			title: "Graph follower",
+			status: "To Do",
+			assignee: [],
+			labels: [],
+			dependencies: ["BACK-201"],
+			createdDate: "2026-07-10",
+		};
+		const corpus = { tasks: [foundation, follower], completedTasks: [], statuses: defaultConfig.statuses };
+		// The /api/task fixtures are details carrying their graphs; the search results stay plain
+		// list records, exactly as the real endpoints answer.
+		const detailFoundation = Object.assign({}, foundation, {
+			dependencyGraph: buildDependencyGraph(foundation, corpus),
+		});
+		const detailFollower = Object.assign({}, follower, { dependencyGraph: buildDependencyGraph(follower, corpus) });
+		tasks.push(detailFoundation, detailFollower);
+		const addedResults: SearchResult[] = [
+			{ type: "task", task: foundation, score: 1 },
+			{ type: "task", task: follower, score: 1 },
+		];
+		searchResults.push(...addedResults);
+
+		try {
+			const container = await renderApp("/board/BACK-201");
+			const link = container.querySelector('a[aria-label="Open BACK-202 - Graph follower"]');
+			expect(link).toBeTruthy();
+
+			const operation = new FetchOperation("graph link navigation", [
+				expectFetch("linked task", "/api/task/BACK-202"),
+			]);
+			await act(async () => {
+				(link as HTMLElement).dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+				await Promise.resolve();
+			});
+			await act(async () => operation.settle("linked task"));
+			// Give a redundant modal-sync refetch every chance to fire before counting requests. The
+			// sync effect compares the previous task's record against the newly opened one; only
+			// matching task IDs may trigger a follow-up detail read.
+			await act(async () => {
+				await new Promise((resolve) => setTimeout(resolve, 25));
+			});
+			operation.finish();
+			const detailFetches = operation.calls.filter((call) => call.url.startsWith("/api/task/"));
+			expect(detailFetches.map((call) => call.url)).toEqual(["/api/task/BACK-202"]);
+		} finally {
+			tasks.splice(tasks.indexOf(detailFoundation), 1);
+			tasks.splice(tasks.indexOf(detailFollower), 1);
+			for (const result of addedResults) searchResults.splice(searchResults.indexOf(result), 1);
+		}
 	});
 
 	it("preserves a type filter through board task Back, Forward, and close navigation", async () => {

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -192,6 +192,38 @@ export function resolveTaskListSelection<T>(
 }
 
 /**
+ * Merge the unfiltered readiness snapshot with the live display copies into the corpus the
+ * dependency graph and readiness resolve against.
+ *
+ * Live copies win over the snapshot so status edits made in this session count. The merge works on
+ * claimant groups rather than single records: an identity that either side holds more than once
+ * keeps every claimant, so the shared record index still reports it ambiguous exactly as the CLI
+ * does, instead of this merge quietly electing a winner.
+ */
+export function mergeDependencyCorpusTasks(snapshot: Task[], liveTasks: Task[]): Task[] {
+	const groupById = (tasks: Task[]) => {
+		const groups = new Map<string, Task[]>();
+		for (const task of tasks) {
+			const key = canonicalTaskId(task.id);
+			const group = groups.get(key);
+			if (group) group.push(task);
+			else groups.set(key, [task]);
+		}
+		return groups;
+	};
+
+	const groups = groupById(snapshot);
+	for (const [key, liveClaimants] of groupById(liveTasks)) {
+		const snapshotClaimants = groups.get(key);
+		// A live copy cannot be attributed to either claimant of a contested identity, so the
+		// snapshot's ambiguity stands until the view reloads.
+		if (snapshotClaimants && snapshotClaimants.length > 1) continue;
+		groups.set(key, liveClaimants);
+	}
+	return [...groups.values()].flat();
+}
+
+/**
  * Display task details with search/filter header UI
  */
 /**
@@ -339,10 +371,7 @@ export async function viewTaskEnhanced(
 	const resolveDependencyCorpus = () => {
 		let tasks = allTasks;
 		if (readinessSnapshot) {
-			// Live display copies win over the snapshot so status edits in this session count.
-			const byId = new Map(readinessSnapshot.map((task) => [canonicalTaskId(task.id), task]));
-			for (const task of allTasks) byId.set(canonicalTaskId(task.id), task);
-			tasks = [...byId.values()];
+			tasks = mergeDependencyCorpusTasks(readinessSnapshot, allTasks);
 		}
 		return { tasks, completedTasks: readinessCompletedTasks, statuses };
 	};

--- a/src/utils/dependency-graph.ts
+++ b/src/utils/dependency-graph.ts
@@ -160,8 +160,8 @@ export function buildDependencyGraph(
 		neighbours: (key: string) => Array<{ key: string; reference: string }>,
 	) => {
 		const queue: Array<{ key: string; depth: number }> = [{ key: rootKey, depth: 0 }];
-		while (queue.length > 0) {
-			const current = queue.shift();
+		for (let cursor = 0; cursor < queue.length; cursor++) {
+			const current = queue[cursor];
 			if (!current) break;
 			const entry = entries.get(current.key);
 			// Unresolved identities are never walked through: their edges cannot be attributed.
@@ -225,8 +225,8 @@ export function findCycleThroughRoot(graph: DependencyGraph): string[] | null {
 	// the root closes the shortest cycle and the parent chain names its path.
 	const parents = new Map<string, string>();
 	const queue = [graph.rootId];
-	while (queue.length > 0) {
-		const currentId = queue.shift();
+	for (let cursor = 0; cursor < queue.length; cursor++) {
+		const currentId = queue[cursor];
 		if (currentId === undefined) break;
 		if (nodesById.get(currentId)?.state !== "resolved") continue;
 		for (const nextId of dependenciesById.get(currentId) ?? []) {
@@ -280,33 +280,43 @@ export function buildDependencyTree(graph: DependencyGraph, direction: Dependenc
 	const expanded = new Set<string>([graph.rootId]);
 	const branch = new Set<string>([graph.rootId]);
 
-	const expand = (id: string): DependencyTreeNode[] => {
-		const result: DependencyTreeNode[] = [];
-		for (const childId of children.get(id) ?? []) {
-			const node = nodesById.get(childId);
-			if (!node) continue;
-			if (branch.has(childId)) {
-				result.push({ node, children: [], repeat: "cycle" });
-				continue;
-			}
-			if (expanded.has(childId)) {
-				result.push({ node, children: [], repeat: "repeat" });
-				continue;
-			}
-			expanded.add(childId);
-			// An unresolved identity is reported, never traversed through. The reverse traversal can
-			// contribute edges leaving an ambiguous identity to the shared edge set, so the tree must
-			// refuse to follow them rather than trust the traversals to have kept them out.
-			if (node.state !== "resolved") {
-				result.push({ node, children: [], repeat: null });
-				continue;
-			}
-			branch.add(childId);
-			result.push({ node, children: expand(childId), repeat: null });
-			branch.delete(childId);
+	// Depth-first with an explicit stack, so a pathological dependency chain cannot exhaust the call
+	// stack. Each frame expands one node's children into that node's `children` array.
+	const roots: DependencyTreeNode[] = [];
+	const stack: Array<{ id: string; childIds: string[]; position: number; into: DependencyTreeNode[] }> = [
+		{ id: graph.rootId, childIds: children.get(graph.rootId) ?? [], position: 0, into: roots },
+	];
+	while (stack.length > 0) {
+		const frame = stack[stack.length - 1];
+		const childId = frame?.childIds[frame.position];
+		if (!frame || childId === undefined) {
+			stack.pop();
+			if (frame) branch.delete(frame.id);
+			continue;
 		}
-		return result;
-	};
-
-	return expand(graph.rootId);
+		frame.position += 1;
+		const node = nodesById.get(childId);
+		if (!node) continue;
+		if (branch.has(childId)) {
+			frame.into.push({ node, children: [], repeat: "cycle" });
+			continue;
+		}
+		if (expanded.has(childId)) {
+			frame.into.push({ node, children: [], repeat: "repeat" });
+			continue;
+		}
+		expanded.add(childId);
+		// An unresolved identity is reported, never traversed through. The reverse traversal can
+		// contribute edges leaving an ambiguous identity to the shared edge set, so the tree must
+		// refuse to follow them rather than trust the traversals to have kept them out.
+		if (node.state !== "resolved") {
+			frame.into.push({ node, children: [], repeat: null });
+			continue;
+		}
+		branch.add(childId);
+		const treeNode: DependencyTreeNode = { node, children: [], repeat: null };
+		frame.into.push(treeNode);
+		stack.push({ id: childId, childIds: children.get(childId) ?? [], position: 0, into: treeNode.children });
+	}
+	return roots;
 }

--- a/src/utils/dependency-graph.ts
+++ b/src/utils/dependency-graph.ts
@@ -80,7 +80,12 @@ export function nodesInDirection(graph: DependencyGraph, direction: DependencyDi
  */
 export function buildDependencyGraph(
 	root: Task,
-	options: { tasks: Task[]; completedTasks?: Task[]; statuses?: readonly string[] },
+	options: {
+		tasks: Task[];
+		completedTasks?: Task[];
+		statuses?: readonly string[];
+		ambiguousIds?: ReadonlySet<string>;
+	},
 ): DependencyGraph {
 	const index = createTaskRecordIndex(options);
 	const rootKey = canonicalTaskId(root.id);

--- a/src/utils/readiness.ts
+++ b/src/utils/readiness.ts
@@ -46,6 +46,7 @@ export function createReadinessGraph(options: {
 	tasks: Task[];
 	completedTasks?: Task[];
 	statuses?: readonly string[];
+	ambiguousIds?: ReadonlySet<string>;
 }): ReadinessGraph {
 	const index = createTaskRecordIndex(options);
 

--- a/src/utils/task-record-index.ts
+++ b/src/utils/task-record-index.ts
@@ -42,10 +42,15 @@ export function createTaskRecordIndex(options: {
 	tasks: Task[];
 	completedTasks?: Task[];
 	statuses?: readonly string[];
+	ambiguousIds?: ReadonlySet<string>;
 }): TaskRecordIndex {
 	const statuses = options.statuses?.length ? options.statuses : DEFAULT_STATUSES;
 	const records: TaskRecord[] = [];
 	const byIdentity = new Map<string, TaskRecord | "ambiguous">();
+	// A corpus can be handed collisions it cannot show: a loader that resolves each identity to one
+	// record leaves a contested ID looking singly claimed here. Seeding those keys keeps the read
+	// failing closed on the collision its source saw rather than on the records that reached us.
+	for (const id of options.ambiguousIds ?? []) byIdentity.set(canonicalTaskId(id), "ambiguous");
 
 	const add = (task: Task, completedRecord: boolean) => {
 		const key = canonicalTaskId(task.id);

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -735,8 +735,14 @@ function AppContent() {
     const derived = taskDependencyGraph(editingTask);
     setEditingTask(derived ? { ...updatedTask, dependencyGraph: derived } : updatedTask);
     // Editing this task's own dependencies moves the graph, so read the detail again for a fresh
-    // one. Nothing else changes it, so nothing else pays for a request.
-    if (previousRecord && previousRecord.dependencies.join(',') !== updatedTask.dependencies.join(',')) {
+    // one. Nothing else changes it, so nothing else pays for a request. The previous record must
+    // describe the same task: after graph-link navigation it names the task the modal came from,
+    // and comparing dependency lists across different tasks would trigger a redundant fetch.
+    if (
+      previousRecord &&
+      previousRecord.id === updatedTask.id &&
+      previousRecord.dependencies.join(',') !== updatedTask.dependencies.join(',')
+    ) {
       void apiClient
         .fetchTask(updatedTask.id)
         .then(detail => setEditingTask(current => (current && current.id === detail.id ? detail : current)))


### PR DESCRIPTION
## Summary

Dispositions all seven low-severity follow-ups deferred from the PR #960 review triage (task BACK-663). Five are fixed; two are closed as accepted behavior with reasoned notes in the task record.

### Fixed

1. **Tree rendering recursion** — `appendTreeEntries` (`src/formatters/dependency-graph-text.ts`) and `buildDependencyTree` (`src/utils/dependency-graph.ts`) now walk depth-first with explicit stacks, so a pathological dependency chain cannot exhaust the call stack anywhere on the render path. The per-level prefix segment stays: it is the indentation the rendered lines themselves carry.
2. **`queue.shift()` BFS** — both breadth-first walks (`buildDependencyGraph`'s `traverse` and `findCycleThroughRoot`) advance a cursor index over the queue array instead of shifting.
3. **Filtered TUI corpus collapsed duplicate canonical IDs** — the snapshot/live merge (now `mergeDependencyCorpusTasks` in `src/ui/task-viewer-with-search.ts`) merges claimant groups instead of single records: uniquely claimed identities are still overlaid by their live display copies (in-session status edits keep counting), while an identity claimed by more than one record keeps every claimant so the shared record index reports it **ambiguous** — the same fail-closed answer the CLI gives.
4. **Cross-branch completed dependencies rendered as missing in the web graph** — `loadTaskCorpus` (cross-branch path only) now adds the identity index's completed records that the local completed corpus does not already hold, so a dependency that exists only as a completed record on another branch resolves as completed instead of "unknown task ID".
6. **Redundant fetch after graph-link navigation** — the `App.tsx` modal sync effect requires matching task IDs before comparing dependency lists, so navigating between tasks no longer reads two different tasks' lists as an edit.

### Accepted with note (details in the task record)

5. **Filtered TUI readiness staleness on out-of-view external changes** — the unified view's task watcher already upserts external working-copy changes into the live list, which the item-3 merge lets win over the snapshot; the residual window lasts only until reopen and matches the CLI's read-at-invocation posture. A second snapshot-dedicated subscription would duplicate the watcher.
7. **Open modal dependents list staleness from another client's edits** — refreshing on every corpus broadcast would cost one detail request per external change for a display-only list that corrects on reopen or on any edit to the open task; kept as designed under the simplicity-first rules.

## Testing

- New: 2500-deep chain rendering test; ambiguous-claimant merge tests driven through the shared graph; cross-branch completed dependency resolution test; single-fetch graph-link navigation test. The latter two were verified to fail without their fixes.
- `bunx tsc --noEmit` clean, `bun run check .` clean, `bun run test` full suite: 2811 pass / 0 fail.