### PR TITLE
BACK-674 - Sort the TUI list view through the shared task ID comparator

### DIFF
--- a/backlog/tasks/back-674 - Sort-the-TUI-list-view-through-the-shared-task-ID-comparator.md
+++ b/backlog/tasks/back-674 - Sort-the-TUI-list-view-through-the-shared-task-ID-comparator.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-01 17:16'
-updated_date: '2026-09-01 17:40'
+updated_date: '2026-09-01 17:44'
 labels: []
 dependencies: []
 ordinal: 306000
@@ -71,6 +71,8 @@ Validation: bunx tsc --noEmit clean, bun run check . clean, bun run test green a
 Also observed: backlog board export reads the same corpus, so exported markdown boards now list subtasks numerically too. Verified on the reproduction project.
 
 PR: https://github.com/MrLesk/Backlog.md/pull/985
+
+Accepted behavior (maintainer decision, 2026-09-01): a task created while the TUI list view is open still appends to the bottom rather than landing in sort position. The view is deliberately ignorant of ordering — callers hand it an already-sorted corpus, so honoring the active order on insert would mean threading sort state into the view and risks clobbering --sort and the priority default. The placement corrects itself when the view is reopened. Do not 'fix' this without an explicit decision.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-674 - Sort-the-TUI-list-view-through-the-shared-task-ID-comparator.md
+++ b/backlog/tasks/back-674 - Sort-the-TUI-list-view-through-the-shared-task-ID-comparator.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-01 17:16'
-updated_date: '2026-09-01 17:28'
+updated_date: '2026-09-01 17:40'
 labels: []
 dependencies: []
 ordinal: 306000
@@ -25,17 +25,17 @@ The reporter also asked for a configurable and persisted sort order. That is out
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The TUI list view orders tasks by the shared task ID comparator, so TASK-1.9 precedes TASK-1.10 and subtask ordering matches the board
-- [ ] #2 Ordering comes from the existing shared comparator with no new sorting implementation added
-- [ ] #3 Board, TUI list, CLI plain and JSON, and the web task list all agree on subtask ordering for the same corpus
-- [ ] #4 A regression test covers double-digit subtask ordering (at least 1.2 through 1.11) on the affected surface
+- [x] #1 The TUI list view orders tasks by the shared task ID comparator, so TASK-1.9 precedes TASK-1.10 and subtask ordering matches the board
+- [x] #2 Ordering comes from the existing shared comparator with no new sorting implementation added
+- [x] #3 Board, TUI list, CLI plain and JSON, and the web task list all agree on subtask ordering for the same corpus
+- [x] #4 A regression test covers double-digit subtask ordering (at least 1.2 through 1.11) on the affected surface
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -65,4 +65,16 @@ Change: getTasks() now sorts groups with the shared compareTaskIds, so the dupli
 Tests: new src/test/subtask-ordering-consistency.test.ts builds TASK-1 with subtasks 1.1-1.11 (created in reverse) plus TASK-2 and TASK-11, and asserts the board corpus, every corpus reader, the TUI board columns, the comparator the web list sorts by, and CLI plain and JSON all produce one identical ID order. Added a TaskIdentityIndex unit test for the changed line. Both fail on the pre-fix comparator (verified by reverting it) and pass after. src/ui/board.ts exports prepareBoardColumns so the board assertion reads real board columns instead of re-deriving them.
 
 Out of scope as directed: no configurable or persisted sort order (task list --sort already exists).
+
+Validation: bunx tsc --noEmit clean, bun run check . clean, bun run test green at 2810 pass / 8 skip / 0 fail across 281 files. An earlier run of the same commit reported one failure while three agents' suites ran concurrently on this machine; re-running the full suite on the same tree was green, and the eight files that could be sensitive to corpus ordering (core, board-loading, core-task-corpus-regressions, shared-branch-task-loader, content-store, readme-board, board, no-remote-preflight) pass on their own, so it was a timing flake rather than this change.
+
+Also observed: backlog board export reads the same corpus, so exported markdown boards now list subtasks numerically too. Verified on the reproduction project.
+
+PR: https://github.com/MrLesk/Backlog.md/pull/985
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Fixed the alphabetical subtask ordering reported in issue #953. The divergence was not in the TUI list view itself but in TaskIdentityIndex.getTasks(), which ordered identity groups with left.id.localeCompare(right.id); ContentStore masked it by re-sorting, while Core.loadTasks() (the corpus 'backlog board' hands to the unified view) returned that alphabetical order straight into the TUI task list, which renders its array as given. getTasks() now uses the shared compareTaskIds, removing the duplicate comparator instead of adding a sort, and leaving board ordinal ordering, task list --sort and its priority default, and the web list's descending default untouched. Verified by reproducing on a scratch project across every surface, by src/test/subtask-ordering-consistency.test.ts (subtasks 1.1-1.11 plus two-digit top-level ids; board corpus, corpus readers, TUI board columns, the web list comparator, and CLI plain and JSON all assert one identical order) and a TaskIdentityIndex unit test, both confirmed to fail against the old comparator, with tsc, biome, and the full suite green.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-674 - Sort-the-TUI-list-view-through-the-shared-task-ID-comparator.md
+++ b/backlog/tasks/back-674 - Sort-the-TUI-list-view-through-the-shared-task-ID-comparator.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-674
 title: Sort the TUI list view through the shared task ID comparator
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-01 17:16'
+updated_date: '2026-09-01 17:28'
 labels: []
 dependencies: []
 ordinal: 306000
@@ -35,3 +37,32 @@ The reporter also asked for a configurable and persisted sort order. That is out
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce on a scratch project (custom prefix, parent + 11 subtasks) and compare every surface: CLI plain/JSON, TUI board, TUI list, web list.
+2. Confirmed root cause: TaskIdentityIndex.getTasks() (src/core/task-identity-index.ts) orders identity groups with left.id.localeCompare(right.id), an ad-hoc alphabetical ID comparator. ContentStore masks it by re-sorting with sortByTaskId, but Core.loadTasks() returns getTasks() order verbatim, and backlog board feeds that corpus straight into the TUI list, which renders it in array order.
+3. Replace the localeCompare with the shared compareTaskIds from src/utils/task-sorting.ts so the one comparator decides, removing the duplicate implementation instead of adding one.
+4. Leave every deliberate ordering untouched: board ordinal ordering and parent/subtask grouping, task list --sort and its priority default, web list descending default.
+5. Regression tests: assert Core.loadTasks() and TaskIdentityIndex.getTasks() put 1.2 before 1.11 for a 1.1-1.11 subtask corpus, and assert the board corpus, TUI list corpus, CLI list, and web comparator agree on the same corpus.
+6. Gates: bunx tsc --noEmit, bun run check ., bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced #953 on a scratch project (custom ABC prefix, parent + 11 subtasks created with -p) and compared every surface before changing anything.
+
+Findings, which move the defect off the surface the task description named:
+- CLI plain and JSON, the web task list, the TUI board, filesystem.listTasks() and Core.queryTasks() were all already correct (ABC-1.9 before ABC-1.10).
+- Core.loadTasks() returned ABC-1.1, ABC-1.10, ABC-1.11, ABC-1.2, ... That is the corpus 'backlog board' hands to the unified view, and the TUI list renders its array as given, so pressing Tab from the board showed the alphabetical order the reporter screenshotted. That matches the issue title, 'Sort order in task view of the backlog board'.
+- The TUI list view itself is not the defect. Every other entry point into it (task list, draft list, search, task view) already hands it a deliberately sorted array, and task list --sort / its priority default live there, so sorting inside the view would have overridden intentional orderings.
+- Root cause: TaskIdentityIndex.getTasks() ordered identity groups with left.id.localeCompare(right.id), a second ad-hoc ID comparator. ContentStore hid it by re-sorting with sortByTaskId; Core.loadTasks() returns getTasks() order verbatim.
+
+Change: getTasks() now sorts groups with the shared compareTaskIds, so the duplicate comparator is removed rather than another sort added. One line plus the import. No deliberate ordering was touched: the board still orders by ordinal with parent/subtask grouping, task list keeps --sort and its priority default, and the web list keeps its descending default.
+
+Tests: new src/test/subtask-ordering-consistency.test.ts builds TASK-1 with subtasks 1.1-1.11 (created in reverse) plus TASK-2 and TASK-11, and asserts the board corpus, every corpus reader, the TUI board columns, the comparator the web list sorts by, and CLI plain and JSON all produce one identical ID order. Added a TaskIdentityIndex unit test for the changed line. Both fail on the pre-fix comparator (verified by reverting it) and pass after. src/ui/board.ts exports prepareBoardColumns so the board assertion reads real board columns instead of re-deriving them.
+
+Out of scope as directed: no configurable or persisted sort order (task list --sort already exists).
+<!-- SECTION:NOTES:END -->

--- a/src/core/task-identity-index.ts
+++ b/src/core/task-identity-index.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, relative } from "node:path";
 import type { Task } from "../types/index.ts";
 import { canonicalTaskId, taskIdsEqual } from "../utils/task-path.ts";
+import { compareTaskIds } from "../utils/task-sorting.ts";
 import type { TaskDirectoryType } from "./cross-branch-tasks.ts";
 
 export interface TaskIdentityRecord {
@@ -235,7 +236,10 @@ export class TaskIdentityIndex {
 
 	getTasks(includeCompleted = false): Task[] {
 		const tasks: Task[] = [];
-		const groups = [...this.groups.values()].sort((left, right) => left.id.localeCompare(right.id));
+		// Task ids are hierarchical numbers, so the shared comparator decides their order here.
+		// Comparing them as strings puts task-1.10 before task-1.2 for every consumer that
+		// renders this corpus without re-sorting it, which is what the board's task list does.
+		const groups = [...this.groups.values()].sort((left, right) => compareTaskIds(left.id, right.id));
 		for (const group of groups) {
 			const identities = [...group.identities.values()].sort((left, right) => left.path.localeCompare(right.path));
 			for (const identity of identities) {

--- a/src/test/subtask-ordering-consistency.test.ts
+++ b/src/test/subtask-ordering-consistency.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { $ } from "bun";
+import { Core } from "../index.ts";
+import type { Task } from "../types/index.ts";
+import { prepareBoardColumns } from "../ui/board.ts";
+import { compareTaskIds } from "../utils/task-sorting.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+
+const cliPath = getTestCliPath();
+
+// One parent with more than nine subtasks, plus two-digit top-level ids, so any surface that
+// compares ids as plain strings puts TASK-1.10 in front of TASK-1.2 (github.com/MrLesk/Backlog.md/issues/953).
+const SUBTASK_IDS = Array.from({ length: 11 }, (_, index) => `TASK-1.${index + 1}`);
+const EXPECTED_ORDER = ["TASK-1", ...SUBTASK_IDS.slice().sort(compareTaskIds), "TASK-2", "TASK-11"];
+
+let TEST_DIR: string;
+let core: Core;
+
+const createTask = (id: string, overrides: Partial<Task> = {}): Task => ({
+	id,
+	title: `Task ${id}`,
+	status: "To Do",
+	assignee: [],
+	labels: [],
+	dependencies: [],
+	createdDate: "2026-01-01",
+	...overrides,
+});
+
+function idsFromPlainOutput(output: string): string[] {
+	return [...output.matchAll(/^\s*(TASK-[\d.]+)\s+-/gm)].map(([, id]) => id ?? "");
+}
+
+describe("subtask ordering consistency", () => {
+	beforeEach(async () => {
+		TEST_DIR = createUniqueTestDir("test-subtask-ordering");
+		await mkdir(TEST_DIR, { recursive: true });
+
+		core = new Core(TEST_DIR);
+		await initializeFilesystemTestProject(core, "Subtask Ordering Test");
+
+		await core.createTask(createTask("TASK-1", { title: "Parent" }), false);
+		// Created out of numeric order so no surface can pass by echoing creation order.
+		for (const id of [...SUBTASK_IDS].reverse()) {
+			await core.createTask(createTask(id, { parentTaskId: "TASK-1" }), false);
+		}
+		await core.createTask(createTask("TASK-11"), false);
+		await core.createTask(createTask("TASK-2"), false);
+	});
+
+	afterEach(async () => {
+		core.disposeContentStore();
+		await safeCleanup(TEST_DIR);
+	});
+
+	it("orders the board's task corpus numerically, so TASK-1.9 precedes TASK-1.10", async () => {
+		// The corpus `backlog board` hands to the unified view. Its task list renders this array
+		// as-is, so this order is what the TUI list shows after Tab.
+		const ids = (await core.loadTasks()).map((task) => task.id);
+
+		expect(ids).toEqual(EXPECTED_ORDER);
+		expect(ids.indexOf("TASK-1.9")).toBeLessThan(ids.indexOf("TASK-1.10"));
+		expect(ids.indexOf("TASK-1.2")).toBeLessThan(ids.indexOf("TASK-1.11"));
+	});
+
+	it("agrees across every corpus reader", async () => {
+		expect((await core.loadTasks()).map((task) => task.id)).toEqual(EXPECTED_ORDER);
+		expect((await core.queryTasks()).map((task) => task.id)).toEqual(EXPECTED_ORDER);
+		expect((await core.queryTasks({ includeCrossBranch: false })).map((task) => task.id)).toEqual(EXPECTED_ORDER);
+		expect((await core.filesystem.listTasks()).map((task) => task.id)).toEqual(EXPECTED_ORDER);
+	});
+
+	it("agrees with the board columns and with the comparator the web list sorts by", async () => {
+		const tasks = await core.loadTasks();
+		const [column] = prepareBoardColumns(tasks, ["To Do"]);
+
+		expect(column?.tasks.map((task) => task.id)).toEqual(EXPECTED_ORDER);
+		// The web task list sorts with this same comparator, so a corpus already in its order
+		// cannot disagree with it.
+		expect(tasks.map((task) => task.id)).toEqual(
+			[...tasks].sort((left, right) => compareTaskIds(left.id, right.id)).map((task) => task.id),
+		);
+	});
+
+	it("agrees with the CLI plain and JSON task lists", async () => {
+		const plain = await $`bun ${cliPath} task list --plain`.cwd(TEST_DIR).quiet();
+		expect(plain.exitCode).toBe(0);
+		expect(idsFromPlainOutput(plain.stdout.toString())).toEqual(EXPECTED_ORDER);
+
+		const json = await $`bun ${cliPath} task list --json`.cwd(TEST_DIR).quiet();
+		expect(json.exitCode).toBe(0);
+		const payload = JSON.parse(json.stdout.toString()) as { tasks: Array<{ id: string }> };
+		expect(payload.tasks.map((task) => task.id)).toEqual(EXPECTED_ORDER);
+	});
+});

--- a/src/test/task-identity-index.test.ts
+++ b/src/test/task-identity-index.test.ts
@@ -8,9 +8,9 @@ const context = {
 	backlogDirectory: "backlog",
 };
 
-function task(title: string): Task {
+function task(title: string, id = "BACK-1"): Task {
 	return {
-		id: "BACK-1",
+		id,
 		title,
 		status: "To Do",
 		assignee: [],
@@ -92,6 +92,22 @@ describe("TaskIdentityIndex", () => {
 
 		expect(index([branchA, branchB]).getTasks()[0]?.title).toBe("Branch A");
 		expect(index([branchB, branchA]).getTasks()[0]?.title).toBe("Branch A");
+	});
+
+	it("orders tasks by numeric id segments so BACK-1.2 precedes BACK-1.11", () => {
+		const ids = Array.from({ length: 11 }, (_, position) => `BACK-1.${position + 1}`);
+		const records: TaskIdentityRecord[] = [...ids].reverse().map((id) => ({
+			id,
+			type: "task",
+			branch: "local",
+			path: `backlog/tasks/${id.toLowerCase()} - Subtask.md`,
+			lastModified: new Date("2026-08-01T10:00:00Z"),
+			task: task(`Subtask ${id}`, id),
+		}));
+
+		const ordered = index(records).getTasks();
+
+		expect(ordered.map((entry) => entry.id)).toEqual(ids);
 	});
 
 	it("hides and frees an identity when every record is archived", () => {

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -139,7 +139,7 @@ function buildColumnTasks(status: string, items: Task[], byId: Map<string, Task>
 	return ordered;
 }
 
-function prepareBoardColumns(tasks: Task[], statuses: string[]): ColumnData[] {
+export function prepareBoardColumns(tasks: Task[], statuses: string[]): ColumnData[] {
 	const { orderedStatuses, groupedTasks } = buildKanbanStatusGroups(tasks, statuses);
 	const byId = new Map<string, Task>(tasks.map((task) => [task.id, task]));
 


### PR DESCRIPTION
Fixes #953

## The report

With more than nine subtasks, the board orders them numerically (1.9 then 1.10) while the task list orders them alphabetically (1.10 before 1.2).

## What was actually wrong

Reproduced on a scratch project (custom `ABC` prefix, one parent, eleven subtasks created with `-p`) and compared every surface before changing anything:

| surface | order |
| --- | --- |
| `task list --plain` / `--json` | correct |
| web task list | correct |
| TUI board columns | correct |
| `filesystem.listTasks()`, `Core.queryTasks()` | correct |
| `Core.loadTasks()` | **`ABC-1.1, ABC-1.10, ABC-1.11, ABC-1.2, …`** |

`Core.loadTasks()` is the corpus `backlog board` hands to the unified view. The board re-sorts it into columns, but the TUI task list renders the array as given, so pressing Tab from the board showed the alphabetical order in the reporter's screenshot. That matches the issue title, "Sort order in task view of the backlog board".

The TUI list view itself is not the defect. Every other entry point into it (`task list`, `draft list`, `search`, `task view`) already hands it a deliberately sorted array, and `task list --sort` and its priority default live there — sorting inside the view would have overridden those intentional orderings.

Root cause: `TaskIdentityIndex.getTasks()` ordered identity groups with `left.id.localeCompare(right.id)`, a second ad-hoc ID comparator. `ContentStore` masked it by re-sorting with `sortByTaskId`; `Core.loadTasks()` returns `getTasks()` order verbatim.

## The change

`getTasks()` now sorts groups with the shared `compareTaskIds`, so the duplicate comparator is removed rather than another sort added. One line plus the import.

No deliberate ordering was touched: the board still orders by ordinal with parent/subtask grouping, `task list` keeps `--sort` and its priority default, and the web list keeps its descending default. `backlog board export` reads the same corpus, so its subtask rows come out numeric now too.

## Tests

`src/test/subtask-ordering-consistency.test.ts` builds `TASK-1` with subtasks `1.1`–`1.11` (created in reverse) plus `TASK-2` and `TASK-11`, then asserts the board corpus, every corpus reader, the TUI board columns, the comparator the web list sorts by, and CLI plain and JSON all produce one identical ID order. A `TaskIdentityIndex` unit test guards the changed line directly. Both fail against the old comparator and pass after. `src/ui/board.ts` exports `prepareBoardColumns` so the board assertion reads real board columns instead of re-deriving them.

## Out of scope

The report also asked for a configurable and persisted sort order. Not built: `backlog task list --sort` already exists, and the defect here is consistency.

## Visible output change

`backlog board export` reads the same corpus, so exported markdown boards now list subtasks numerically (1.9 before 1.10) instead of alphabetically. Maintainer-confirmed as correct.
