### PR TITLE
BACK-675 - Fix Windows TUI keyboard input after Tab view switch

### DIFF
--- a/backlog/tasks/back-675 - Fix-Windows-TUI-keyboard-input-after-Tab-view-switch.md
+++ b/backlog/tasks/back-675 - Fix-Windows-TUI-keyboard-input-after-Tab-view-switch.md
@@ -1,0 +1,70 @@
+---
+id: BACK-675
+title: Fix Windows TUI keyboard input after Tab view switch
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-01 17:42'
+updated_date: '2026-09-01 18:09'
+labels: []
+dependencies: []
+references:
+  - 'https://github.com/MrLesk/Backlog.md/issues/936'
+type: bug
+ordinal: 307000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+On Windows standalone builds, switching between the board and task list with Tab renders the destination view but stops all keyboard input, including Ctrl+C. Restore reliable input across both view-switch directions without changing documented TUI behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 On Windows, switching from board to task list preserves keyboard input
+- [x] #2 On Windows, switching from task list to board preserves keyboard input
+- [x] #3 Existing quit, navigation, search, and Tab bindings continue to work after a switch
+- [x] #4 Automated tests cover the view handoff regression
+<!-- AC:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [ ] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
+<!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Hold a lightweight blessed program lease for the lifetime of runUnifiedView so destroying an individual screen never drops stdin ownership to zero during Tab handoff.
+2. Release the lease on both ordinary cleanup and process exit so raw mode and stdin are restored exactly once.
+3. Add focused lifecycle tests that prove a screen replacement does not pause stdin mid-session and final cleanup still restores it.
+4. Run the scoped TUI tests, type-check, Biome checks, and repeat the Windows PTY board-to-list interaction.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced before the fix on Windows with a live PTY: board -> Tab rendered the task list, then q and Ctrl+C produced no input; the Bun process required external termination.
+
+Kept one lightweight blessed program alive for the whole unified-view session. Individual screen destruction therefore never drops blessed's shared stdin owner count to zero between views, while the idempotent session release still restores raw mode and pauses stdin on final cleanup/process exit.
+
+Verification:
+- bunx tsc --noEmit passed.
+- Biome passed for all four changed TypeScript files.
+- bun test --timeout=10000 src/test/tui-input-lifecycle.test.ts src/test/tab-switching.test.ts passed (4 tests, 41 assertions).
+- bun run build passed.
+- The freshly compiled dist/backlog.exe completed board -> list -> board, accepted j/right navigation, opened and exited / search, and quit with q (exit 0).
+
+Repository-wide caveats unrelated to this change:
+- bun run check . reports 326 existing CRLF formatting diagnostics across untouched files on this Windows checkout; changed-file checks pass.
+- The full test suite was stopped after unrelated Windows baseline failures cascaded through missing Unix tools, existing file locks/timeouts, and dependency patch expectations; the scoped regression suite remains green.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Prevented Windows stdin from being paused between unified TUI screens by retaining a blessed program lease for the session and releasing it exactly once on cleanup. Added lifecycle regression coverage and verified the compiled Windows binary across repeated Tab switches, navigation, search, and quit.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/src/test/tui-input-lifecycle.test.ts
+++ b/src/test/tui-input-lifecycle.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { ProgramInterface } from "neo-neo-bblessed";
+import { program as createProgram } from "neo-neo-bblessed";
+import { keepTuiInputAlive } from "../ui/tui.ts";
+
+class TestInput extends EventEmitter {
+	isRaw = true;
+	destroyed = false;
+	pauseCalls = 0;
+	rawModes: boolean[] = [];
+
+	setRawMode(enabled: boolean): this {
+		this.isRaw = enabled;
+		this.rawModes.push(enabled);
+		return this;
+	}
+
+	pause(): this {
+		this.pauseCalls += 1;
+		return this;
+	}
+
+	resume(): this {
+		return this;
+	}
+}
+
+class TestOutput extends EventEmitter {
+	isTTY = true;
+	columns = 80;
+	rows = 24;
+
+	write(): boolean {
+		return true;
+	}
+}
+
+describe("TUI input lifecycle", () => {
+	it("keeps stdin active between screen programs and restores it after the session", () => {
+		const input = new TestInput();
+		const output = new TestOutput();
+		const release = keepTuiInputAlive(input as unknown as NodeJS.ReadStream, output as unknown as NodeJS.WriteStream);
+		const screenProgram: ProgramInterface = createProgram({ tput: false, input, output });
+
+		screenProgram.destroy();
+
+		expect(input.pauseCalls).toBe(0);
+		expect(input.rawModes).toEqual([]);
+
+		release();
+
+		expect(input.pauseCalls).toBe(1);
+		expect(input.rawModes).toEqual([false]);
+
+		release();
+		expect(input.pauseCalls).toBe(1);
+	});
+});

--- a/src/types/neo-neo-bblessed.d.ts
+++ b/src/types/neo-neo-bblessed.d.ts
@@ -1,5 +1,6 @@
 declare module "neo-neo-bblessed" {
 	export interface ProgramInterface {
+		destroy(): void;
 		disableMouse(): void;
 		enableMouse(): void;
 		hideCursor(): void;

--- a/src/ui/tui.ts
+++ b/src/ui/tui.ts
@@ -134,6 +134,34 @@ function writeTerminalControl(program: ProgramInterface, sequence: string): void
 	program.write(program.tmux ? `\x1bPtmux;\x1b${sequence.replaceAll("\x1b\\", "\x07")}\x1b\\` : sequence);
 }
 
+/**
+ * Keep blessed's shared stdin listeners alive while a TUI session replaces one screen with another.
+ *
+ * Destroying the last program pauses stdin. Bun on Windows cannot reliably resume delivery after
+ * that transition, so unified views retain one otherwise idle program until the whole session exits.
+ */
+export function keepTuiInputAlive(
+	sessionInput: NodeJS.ReadStream = input,
+	sessionOutput: NodeJS.WriteStream = output,
+): () => void {
+	const program: ProgramInterface = createProgram({
+		tput: false,
+		input: sessionInput,
+		output: sessionOutput,
+	});
+	let released = false;
+
+	const release = () => {
+		if (released) return;
+		released = true;
+		process.removeListener("exit", release);
+		program.destroy();
+	};
+
+	process.once("exit", release);
+	return release;
+}
+
 export function createScreen(options: Partial<ScreenOptions> = {}): ScreenInterface {
 	const program: ProgramInterface = createProgram({ tput: false });
 

--- a/src/ui/unified-view.ts
+++ b/src/ui/unified-view.ts
@@ -14,6 +14,7 @@ import { type TaskWatcherCallbacks, watchTasks } from "../utils/task-watcher.ts"
 import { renderBoardTui } from "./board.ts";
 import { createLoadingScreen } from "./loading.ts";
 import { buildTaskViewerMilestoneFilterModel, viewTaskEnhanced } from "./task-viewer-with-search.ts";
+import { keepTuiInputAlive } from "./tui.ts";
 import { type ViewState, ViewSwitcher, type ViewType } from "./view-switcher.ts";
 
 export interface UnifiedViewOptions {
@@ -291,6 +292,7 @@ export async function createTaskFromBoard(
  * Main unified view controller that handles Tab switching between views
  */
 export async function runUnifiedView(options: UnifiedViewOptions): Promise<void> {
+	const releaseTuiInput = keepTuiInputAlive();
 	try {
 		const {
 			tasks: loadedTasks,
@@ -391,7 +393,6 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 		});
 
 		process.on("exit", () => configWatcher.stop());
-
 		// Function to show task view
 		const showTaskView = async (): Promise<ViewResult> => {
 			const availableTasks = tasks.filter((t) => t.id && t.id.trim() !== "" && hasAnyPrefix(t.id));
@@ -580,5 +581,7 @@ export async function runUnifiedView(options: UnifiedViewOptions): Promise<void>
 	} catch (error) {
 		console.error(error instanceof Error ? error.message : error);
 		process.exit(1);
+	} finally {
+		releaseTuiInput();
 	}
 }


### PR DESCRIPTION
## Summary

- keep a lightweight blessed program lease alive for the unified TUI session
- prevent destroying an individual screen from pausing stdin during Tab view handoffs on Windows/Bun
- release the lease idempotently during normal cleanup or process exit
- add regression coverage for the shared input lifecycle

Fixes #936

## Verification

- `bunx tsc --noEmit`
- `bunx biome check src/types/neo-neo-bblessed.d.ts src/ui/tui.ts src/ui/unified-view.ts src/test/tui-input-lifecycle.test.ts`
- `bun test --timeout=10000 src/test/tui-input-lifecycle.test.ts src/test/tab-switching.test.ts` (4 tests, 41 assertions)
- `bun run build`
- manually verified the freshly compiled Windows executable across board -> list -> board switches, navigation, search, and clean `q` exit

## Repository baseline notes

- `bun run check .` reports existing CRLF formatting diagnostics in untouched files on this Windows checkout; all changed files pass Biome.
- The full suite was stopped after unrelated Windows baseline failures involving missing Unix tools, file locks/timeouts, and dependency patch expectations; the scoped regression tests pass.
