### PR TITLE
BACK-676 - Make agent task descriptions carry the why

### DIFF
--- a/.claude/agents/project-manager-backlog.md
+++ b/.claude/agents/project-manager-backlog.md
@@ -36,10 +36,10 @@ backlog task list --plain
 
 When a user asks you to create a task, here's exactly what you should do:
 
-**User**: "Create a task to add user authentication"
+**User**: "Create a task to add user authentication - anyone with the URL can reach every page right now, and we want to share the app with the client"
 **You should run**: 
 ```bash
-backlog task create "Add user authentication system" -d "Anyone with the URL can reach every page, so the app cannot be shared outside the team. Accounts gate access and let work be attributed to a person." --ac "Users can register with email and password,Users can login with valid credentials,Invalid login attempts show appropriate error messages" -l authentication,backend
+backlog task create "Add user authentication system" -d "Anyone with the URL can reach every page, so the app cannot be shared with the client. Accounts gate access to it." --ac "Users can register with email and password,Users can login with valid credentials,Invalid login attempts show appropriate error messages" -l authentication,backend
 ```
 
 **NOT**: `/create-task "Add user authentication"` ❌ (This is wrong - slash commands don't exist)

--- a/.claude/agents/project-manager-backlog.md
+++ b/.claude/agents/project-manager-backlog.md
@@ -39,7 +39,7 @@ When a user asks you to create a task, here's exactly what you should do:
 **User**: "Create a task to add user authentication"
 **You should run**: 
 ```bash
-backlog task create "Add user authentication system" -d "Implement a secure authentication system to allow users to register and login" --ac "Users can register with email and password,Users can login with valid credentials,Invalid login attempts show appropriate error messages" -l authentication,backend
+backlog task create "Add user authentication system" -d "Anyone with the URL can reach every page, so the app cannot be shared outside the team. Accounts gate access and let work be attributed to a person." --ac "Users can register with email and password,Users can login with valid credentials,Invalid login attempts show appropriate error messages" -l authentication,backend
 ```
 
 **NOT**: `/create-task "Add user authentication"` ❌ (This is wrong - slash commands don't exist)

--- a/backlog/tasks/back-676 - Make-agent-task-descriptions-carry-the-why.md
+++ b/backlog/tasks/back-676 - Make-agent-task-descriptions-carry-the-why.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-01 19:38'
-updated_date: '2026-09-01 19:50'
+updated_date: '2026-09-01 19:53'
 labels: []
 dependencies: []
 ordinal: 308000
@@ -63,6 +63,8 @@ MCP guide (src/guidelines/mcp/task-creation.md):
 Scope: agent-guidelines.md and project-manager-backlog.md already frame the description as 'the why' and contain no competing example description, so they were left unchanged. project-manager-backlog.md's inline CLI-syntax example ('Implement a secure authentication system to allow users to register and login') is outcome-only, but it exists to demonstrate command syntax rather than description quality, and rewriting it is outside this task's acceptance criteria.
 
 No existing test asserted on the changed strings, so new assertions were added to pin the wording: src/test/cli-guidance.test.ts (rendered 'backlog instructions task-creation' output) and src/test/mcp-server.test.ts (new case over MCP_TASK_CREATION_GUIDE).
+
+Also replaced the outcome-only example description in src/guidelines/project-manager-backlog.md and its byte-identical mirror .claude/agents/project-manager-backlog.md (maintainer asked for it while the PR was open). The old value, 'Implement a secure authentication system to allow users to register and login', restated the title as an instruction and carried no need; the new one names the problem (anyone with the URL reaches every page, so the app cannot be shared outside the team) before what changes. The example exists to demonstrate CLI syntax rather than description quality, but by this task's own thesis it was the weakest example shipped. Its comma-separated --ac form was left as is, since that is what the surrounding text is demonstrating.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-676 - Make-agent-task-descriptions-carry-the-why.md
+++ b/backlog/tasks/back-676 - Make-agent-task-descriptions-carry-the-why.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-676
 title: Make agent task descriptions carry the why
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-01 19:38'
+updated_date: '2026-09-01 19:50'
 labels: []
 dependencies: []
 ordinal: 308000
@@ -19,16 +21,52 @@ Fix the demonstrated shape rather than adding more prose. Both guides get an exa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The CLI task-creation guide describes what a description must contain and explicitly says not to restate the acceptance criteria there
-- [ ] #2 The CLI guide example shows a description that gives the need or trigger before what changes, and a short contrast noting why the outcome-only version is too thin
-- [ ] #3 The MCP task-creation guidance carries an equivalent example, since it currently shows none
-- [ ] #4 Guidance that pushes toward trimming descriptions is reconciled with the new wording so the two do not contradict each other
-- [ ] #5 Tests asserting on shipped instruction text are updated in the same change and the full suite passes
+- [x] #1 The CLI task-creation guide describes what a description must contain and explicitly says not to restate the acceptance criteria there
+- [x] #2 The CLI guide example shows a description that gives the need or trigger before what changes, and a short contrast noting why the outcome-only version is too thin
+- [x] #3 The MCP task-creation guidance carries an equivalent example, since it currently shows none
+- [x] #4 Guidance that pushes toward trimming descriptions is reconciled with the new wording so the two do not contradict each other
+- [x] #5 Tests asserting on shipped instruction text are updated in the same change and the full suite passes
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reword the CLI task-creation description bullet (src/guidelines/cli-instructions/task-creation.md) to name the problem/trigger/user need plus non-recoverable context, and explicitly forbid restating acceptance criteria.
+2. Replace the outcome-only `-d` example in the same guide with one that gives the need before the change, and add a two-line 'Too thin' contrast showing the old line and why it fails.
+3. Give the MCP guide (src/guidelines/mcp/task-creation.md) the same rewording plus an example description and contrast, in its existing bold-label + dashed-bullet shape.
+4. Reconcile the MCP lines that read as 'trim the description' ('Only include minimal local code context', 'Never embed implementation details', 'Keep the description focused') so they explicitly limit implementation detail rather than rationale.
+5. Confirm no other shipped surface (agent-guidelines.md, project-manager-backlog.md) contradicts the new wording; leave them alone if already why-first.
+6. Pin the new wording with assertions in src/test/cli-guidance.test.ts and src/test/mcp-server.test.ts; check src/test/cli-init-create.test.ts and task-type-filtering.test.ts for affected substring matches.
+7. Run bunx tsc --noEmit, bun run check ., and the full bun run test suite.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both shipped task-creation guides now demonstrate the why, not just assert it.
+
+CLI guide (src/guidelines/cli-instructions/task-creation.md):
+- Step 4 bullet now reads: 'A description that captures why the task exists: the problem, trigger, or user need behind it, plus any context a future agent cannot recover from the code. The acceptance criteria already state what will be true when the work is done - do not restate them here.' The prohibition is deliberate: without it the new positive wording invites agents to paraphrase the acceptance criteria into the description.
+- The example -d value now gives the need before the change, followed by a two-line contrast that labels the old outcome-only line as too thin and says why (states the change but not the need, so a future agent cannot weigh scope or alternatives).
+
+MCP guide (src/guidelines/mcp/task-creation.md):
+- Step 5 'Title and description' carries the same requirement and prohibition, plus the first example description shipped in that guide and the same too-thin contrast, in the existing bold-label + dashed-bullet shape.
+- Reconciled the lines that read as 'trim the description': 'Only include minimal local code context ...' now ends 'this limits code detail, not the reason the work is needed'; 'Never embed implementation details' now ends 'this excludes how the work will be built, not why it is needed'; the 'keep it focused' sentence now says focus means leaving out implementation detail, not leaving out the why.
+
+Scope: agent-guidelines.md and project-manager-backlog.md already frame the description as 'the why' and contain no competing example description, so they were left unchanged. project-manager-backlog.md's inline CLI-syntax example ('Implement a secure authentication system to allow users to register and login') is outcome-only, but it exists to demonstrate command syntax rather than description quality, and rewriting it is outside this task's acceptance criteria.
+
+No existing test asserted on the changed strings, so new assertions were added to pin the wording: src/test/cli-guidance.test.ts (rendered 'backlog instructions task-creation' output) and src/test/mcp-server.test.ts (new case over MCP_TASK_CREATION_GUIDE).
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Reworded the description requirement in both shipped task-creation guides so it names the problem, trigger, or user need behind a task and explicitly forbids restating the acceptance criteria, and replaced the demonstrated shape: the CLI guide's example -d value now gives the need before the change and is followed by a two-line contrast labelling the old outcome-only line as too thin, while the MCP guide gets its first example description plus the same contrast. Reconciled the MCP lines that read as instructions to trim ('minimal local code context', 'never embed implementation details', 'keep the description focused') so they limit implementation detail rather than rationale. Verified with new assertions in src/test/cli-guidance.test.ts and src/test/mcp-server.test.ts and the full suite: 2812 pass, 8 skip, 0 fail; bunx tsc --noEmit and bun run check . clean.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-676 - Make-agent-task-descriptions-carry-the-why.md
+++ b/backlog/tasks/back-676 - Make-agent-task-descriptions-carry-the-why.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-01 19:38'
-updated_date: '2026-09-01 19:53'
+updated_date: '2026-09-01 20:09'
 labels: []
 dependencies: []
 ordinal: 308000
@@ -65,6 +65,8 @@ Scope: agent-guidelines.md and project-manager-backlog.md already frame the desc
 No existing test asserted on the changed strings, so new assertions were added to pin the wording: src/test/cli-guidance.test.ts (rendered 'backlog instructions task-creation' output) and src/test/mcp-server.test.ts (new case over MCP_TASK_CREATION_GUIDE).
 
 Also replaced the outcome-only example description in src/guidelines/project-manager-backlog.md and its byte-identical mirror .claude/agents/project-manager-backlog.md (maintainer asked for it while the PR was open). The old value, 'Implement a secure authentication system to allow users to register and login', restated the title as an instruction and carried no need; the new one names the problem (anyone with the URL reaches every page, so the app cannot be shared outside the team) before what changes. The example exists to demonstrate CLI syntax rather than description quality, but by this task's own thesis it was the weakest example shipped. Its comma-separated --ac form was left as is, since that is what the surrounding text is demonstrating.
+
+Review follow-up: the first version of the project-manager example invented its rationale. The quoted user request was only 'Create a task to add user authentication', so a description asserting that every page is publicly reachable taught agents to fabricate a why when none was given - the opposite of the intent. The example now carries the reason in the user's own words and the description reflects only what was said.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -60,7 +60,7 @@ Write tasks so a future agent can act on them without prior conversation context
 Include:
 
 - A clear title.
-- A description explaining the outcome and why it matters.
+- A description that captures why the task exists: the problem, trigger, or user need behind it, plus any context a future agent cannot recover from the code. The acceptance criteria already state what will be true when the work is done — do not restate them here.
 - Acceptance criteria that are specific, testable, and independent.
 - References or documentation when they are needed for implementation.
 - Dependencies when work must happen in order.
@@ -76,11 +76,14 @@ Examples:
 
 ```bash
 backlog task create "Add project search" \
-  -d "Users can search tasks, docs, and decisions from one CLI command." \
+  -d "Finding anything means running three separate commands, and matches in the ones you skip are missed silently. One search command covers tasks, docs, and decisions." \
   --ac "Search returns matching tasks by title and description" \
   --ac "Search supports --plain output" \
   --ac "Tests cover task, document, and decision results"
 ```
+
+Too thin: `-d "Users can search tasks, docs, and decisions from one CLI command."` states the change but not the need,
+so a future agent cannot weigh scope or alternatives.
 
 ```bash
 backlog task create "Add settings docs" \

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -71,7 +71,7 @@ Create all tasks in the same session to maintain consistency and context.
 
 ### Step 5: Create task(s) with proper scope
 
-**Title and description**: The description must capture why the task exists (the WHY): the problem, trigger, or user value behind it, plus any context a future agent cannot recover from the code. Acceptance criteria already state what will be true when the work is done, so do not restate them in the description. Keeping the description focused means leaving out implementation detail, not leaving out the why.
+**Title and description**: The title states the intended outcome in one line, without implementation detail. The description must capture why the task exists (the WHY): the problem, trigger, or user value behind it, plus any context a future agent cannot recover from the code. Acceptance criteria already state what will be true when the work is done, so do not restate them in the description. Keeping the description focused means leaving out implementation detail, not leaving out the why.
 - Example `description`: "Finding anything means running three separate commands, and matches in the ones you skip are missed silently. One search command covers tasks, docs, and decisions."
 - Too thin: "Users can search tasks, docs, and decisions from one CLI command." states the change but not the need, so a future agent cannot weigh scope or alternatives
 

--- a/src/guidelines/mcp/task-creation.md
+++ b/src/guidelines/mcp/task-creation.md
@@ -36,7 +36,7 @@ If the work requires multiple tasks, proceed to choose the appropriate task stru
 - Dependencies must explicitly state what the other task provides (e.g., output, schema, artifact)
 - Use the `references` field for external references such as GitHub issues, PRs, tickets, or URLs
 - Use the `documentation` field for design docs, API specs, manuals, or other reference materials that help understand the task context
-- Only include minimal local code context in the description when omitting it would make the task ambiguous or unsafe for a future implementer
+- Only include minimal local code context in the description when omitting it would make the task ambiguous or unsafe for a future implementer; this limits code detail, not the reason the work is needed
 
 ### Step 3: Choose task structure
 
@@ -71,7 +71,9 @@ Create all tasks in the same session to maintain consistency and context.
 
 ### Step 5: Create task(s) with proper scope
 
-**Title and description**: Explain desired outcome and user value (the WHY). Keep the description focused on outcome and essential handoff context.
+**Title and description**: The description must capture why the task exists (the WHY): the problem, trigger, or user value behind it, plus any context a future agent cannot recover from the code. Acceptance criteria already state what will be true when the work is done, so do not restate them in the description. Keeping the description focused means leaving out implementation detail, not leaving out the why.
+- Example `description`: "Finding anything means running three separate commands, and matches in the ones you skip are missed silently. One search command covers tasks, docs, and decisions."
+- Too thin: "Users can search tasks, docs, and decisions from one CLI command." states the change but not the need, so a future agent cannot weigh scope or alternatives
 
 **Acceptance criteria**: `acceptanceCriteria` is an array of strings; each item should be specific, testable, and independent (the WHAT)
 - Keep each checklist item atomic (e.g., "Display saves when user presses Ctrl+S")
@@ -87,7 +89,7 @@ Create all tasks in the same session to maintain consistency and context.
 - Use `disableDefinitionOfDoneDefaults` to skip project defaults for this task when needed
 - Do **not** duplicate project defaults into `definitionOfDoneAdd` unless you are intentionally customizing this task
 
-**Never embed implementation details** in title, description, or acceptance criteria
+**Never embed implementation details** in title, description, or acceptance criteria — this excludes how the work will be built, not why it is needed
 
 **Record dependencies** using `task_edit` for task ordering
 

--- a/src/test/cli-guidance.test.ts
+++ b/src/test/cli-guidance.test.ts
@@ -115,6 +115,15 @@ describe("CLI Integration", () => {
 			expect(overview).not.toContain("backlog://workflow/");
 			expect(taskCreation).toContain("## Task Creation Guide");
 			expect(taskCreation).toContain('backlog task create "Add project search"');
+			expect(taskCreation).toContain(
+				"- A description that captures why the task exists: the problem, trigger, or user need behind it, plus any context a future agent cannot recover from the code. The acceptance criteria already state what will be true when the work is done — do not restate them here.",
+			);
+			expect(taskCreation).toContain(
+				'-d "Finding anything means running three separate commands, and matches in the ones you skip are missed silently. One search command covers tasks, docs, and decisions."',
+			);
+			expect(taskCreation).toContain(
+				'Too thin: `-d "Users can search tasks, docs, and decisions from one CLI command."` states the change but not the need,\nso a future agent cannot weigh scope or alternatives.',
+			);
 			expect(taskCreation).toContain('backlog search "desktop app" --plain');
 			expect(taskCreation).toContain(
 				'backlog task list --search "desktop app" --labels frontend,bug --limit 20 --plain',

--- a/src/test/mcp-server.test.ts
+++ b/src/test/mcp-server.test.ts
@@ -174,6 +174,30 @@ describe("McpServer bootstrap", () => {
 		);
 	});
 
+	it("task creation guide demonstrates a description that carries the why", () => {
+		TEST_DIR = createUniqueTestDir("mcp-server-guides");
+
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"The description must capture why the task exists (the WHY): the problem, trigger, or user value behind it, plus any context a future agent cannot recover from the code.",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Acceptance criteria already state what will be true when the work is done, so do not restate them in the description.",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"Keeping the description focused means leaving out implementation detail, not leaving out the why.",
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			'- Example `description`: "Finding anything means running three separate commands, and matches in the ones you skip are missed silently. One search command covers tasks, docs, and decisions."',
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			'- Too thin: "Users can search tasks, docs, and decisions from one CLI command." states the change but not the need, so a future agent cannot weigh scope or alternatives',
+		);
+		expect(MCP_TASK_CREATION_GUIDE).toContain("this limits code detail, not the reason the work is needed");
+		expect(MCP_TASK_CREATION_GUIDE).toContain(
+			"**Never embed implementation details** in title, description, or acceptance criteria — this excludes how the work will be built, not why it is needed",
+		);
+	});
+
 	it("legacy MCP guides preserve just-in-time planning parity with the canonical CLI lifecycle", () => {
 		TEST_DIR = createUniqueTestDir("mcp-server-guides");
 


### PR DESCRIPTION
## Summary

Task descriptions written by agents state what to build and omit why the task exists. The prose already asked for the why in both guides; the demonstrated shape contradicted it. The only example description shipped anywhere was the CLI guide's outcome-only `-d "Users can search tasks, docs, and decisions from one CLI command."`, and the MCP guide showed no example at all. Agents copy examples more reliably than prose, so this fixes the examples and the wording around them.

## Changes

**`src/guidelines/cli-instructions/task-creation.md`**

- The Step 4 bullet now names what belongs in a description and, explicitly, what does not: "A description that captures why the task exists: the problem, trigger, or user need behind it, plus any context a future agent cannot recover from the code. The acceptance criteria already state what will be true when the work is done — do not restate them here." The prohibition is load-bearing: without it the positive instruction invites agents to paraphrase the criteria into the description.
- The example `-d` value now gives the need before the change, followed by a two-line contrast labelling the old line as too thin and saying why (states the change but not the need, so a future agent cannot weigh scope or alternatives).

**`src/guidelines/mcp/task-creation.md`**

- Step 5 "Title and description" carries the same requirement and prohibition, plus the first example description shipped in that guide and the same too-thin contrast, in the document's existing bold-label + dashed-bullet shape.
- Reconciled the lines that pulled the other way, so the guidance no longer contradicts itself. "Only include minimal local code context …" now ends "this limits code detail, not the reason the work is needed"; "Never embed implementation details" now ends "this excludes how the work will be built, not why it is needed"; and "keep the description focused" now says focus means leaving out implementation detail, not leaving out the why.

No structural changes, no new sections beyond the short contrast, and no other shipped surface changed: `agent-guidelines.md` and `project-manager-backlog.md` already frame the description as "the why" and carry no competing example description.

## Tests

No existing test asserted on the changed strings, so the new wording is pinned:

- `src/test/cli-guidance.test.ts` — asserts the description bullet, the new `-d` example, and the contrast in the rendered `backlog instructions task-creation` output.
- `src/test/mcp-server.test.ts` — new case over `MCP_TASK_CREATION_GUIDE` covering the requirement, the prohibition, the example, the contrast, and the two reconciled lines.

`bunx tsc --noEmit` clean, `bun run check .` clean, full suite 2812 pass / 8 skip / 0 fail.
