### PR TITLE
BACK-677 - Show local time in the web UI with the UTC value on hover

### DIFF
--- a/backlog/tasks/back-677 - Show-local-time-in-the-web-UI-with-the-UTC-value-on-hover.md
+++ b/backlog/tasks/back-677 - Show-local-time-in-the-web-UI-with-the-UTC-value-on-hover.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-02 17:01'
-updated_date: '2026-09-02 17:26'
+updated_date: '2026-09-02 17:31'
 labels: []
 dependencies: []
 ordinal: 309000
@@ -71,6 +71,8 @@ Tests: src/web/utils/date-display.test.ts now passes an explicit timeZone to eve
 Validation: bunx tsc --noEmit and bun run check . pass. Full bun run test on this branch: 2852 pass, 8 skip, 1 fail. The single failure is in src/test/content-store.test.ts, which also fails on an unmodified origin/main worktree (2849 pass, 8 skip, 1 fail, different test in the same suite, same 'Unhandled error between tests' with a git posix_spawn ENOENT); both pass when that file runs on its own, so it is a pre-existing flake in that suite and not caused by this change. CI on the PR: lint-and-unit-test passes on macOS and Windows (confirming process.env.TZ pinning works on Windows too), compile-and-smoke-test passes on all three platforms, CodeQL and nix-package pass. The four date-related test files were also rerun under TZ=UTC, TZ=America/Los_Angeles and TZ=Pacific/Kiritimati and pass unchanged.
 
 Manual verification in the running web UI with the browser in Europe/Vienna: BACK-677's stored '2026-09-02 17:01' rendered as '2026-09-02 19:01' with title '2026-09-02 17:01 (UTC)'; the task list's compact column rendered 'today'/'yesterday' with the canonical UTC value on hover; BACK-208's date-only created_date '2025-07-26' rendered unchanged with no title. CLI plain output for the same tasks still prints 'Created: 2025-07-26 (UTC)' and 'Created: 2026-09-02 17:01 (UTC)', and the diff against origin/main touches no file under src/utils/utc-date-display.ts, src/cli.ts, src/ui, src/formatters or src/mcp.
+
+All 10 CI checks on PR 992 pass, including lint-and-unit-test (ubuntu-latest), which runs the full behavioural profile plus the interactive TUI pass. The content-store failure seen locally does not reproduce there, confirming it as a local environment flake.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-677 - Show-local-time-in-the-web-UI-with-the-UTC-value-on-hover.md
+++ b/backlog/tasks/back-677 - Show-local-time-in-the-web-UI-with-the-UTC-value-on-hover.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-02 17:01'
-updated_date: '2026-09-02 17:31'
+updated_date: '2026-09-02 17:47'
 labels: []
 dependencies: []
 ordinal: 309000
@@ -73,6 +73,16 @@ Validation: bunx tsc --noEmit and bun run check . pass. Full bun run test on thi
 Manual verification in the running web UI with the browser in Europe/Vienna: BACK-677's stored '2026-09-02 17:01' rendered as '2026-09-02 19:01' with title '2026-09-02 17:01 (UTC)'; the task list's compact column rendered 'today'/'yesterday' with the canonical UTC value on hover; BACK-208's date-only created_date '2025-07-26' rendered unchanged with no title. CLI plain output for the same tasks still prints 'Created: 2025-07-26 (UTC)' and 'Created: 2026-09-02 17:01 (UTC)', and the diff against origin/main touches no file under src/utils/utc-date-display.ts, src/cli.ts, src/ui, src/formatters or src/mcp.
 
 All 10 CI checks on PR 992 pass, including lint-and-unit-test (ubuntu-latest), which runs the full behavioural profile plus the interactive TUI pass. The content-store failure seen locally does not reproduce there, confirming it as a local environment flake.
+
+Review fixes from PR 992 (Codex findings):
+
+1. Pinned the timezone in src/test/web-board-filters.test.tsx, the one remaining test asserting a rendered stored date without a pin. Pre-fix evidence: TZ=Asia/Tokyo bun test src/test/web-board-filters.test.tsx failed with 'Timed out after 4000ms waiting for () => (container.textContent ?? "").includes("09/02/2026 06:01")' because the cleanup preview now renders 15:01 locally. It now pins Asia/Tokyo and asserts both the local text '09/02/2026 15:01' and the title '09/02/2026 06:01 (UTC)'. Swept every test file for assertions on rendered stored dates, relative labels and date-only renders; this was the only unpinned one, the other three were already pinned.
+
+2. Cached the Intl.DateTimeFormat instances in a module-level Map instead of constructing one per StoredDate render. The key is the resolved zone (timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone), so a cached formatter is never reused after the runtime zone changes, which is what pinTimeZone does mid-process. Measured: constructing per call was 30.2us/op, reusing a cached formatter is 0.75us/op, and resolving the default zone first costs 1.3us/op; a full formatStoredDateForDisplay render is now 2.42us. Verified the cache follows a runtime zone change: UTC 06:01, Tokyo 15:01, Los Angeles 08 22:01, back to UTC 06:01.
+
+3. The compact label now compares calendar days in the viewer's timezone instead of elapsed hours. Pre-fix evidence: at now=2026-02-21T01:00Z in America/Los_Angeles a stored '2026-02-20 06:00' is locally Feb 19 against a local today of Feb 20, and the 19-hour gap returned 'today' instead of 'yesterday'; the same slip made a Feb 18 stamp read '2d ago' instead of '3d ago'. Both are covered by new tests that failed before the change, alongside a Tokyo case crossing local midnight the other way and a UTC case, since the elapsed-hours bug was not limited to non-UTC viewers.
+
+Gates after the fixes: bunx tsc --noEmit and bun run check . clean; full bun run test 2854 pass, 8 skip, 1 fail (the same pre-existing content-store flake, which still passes in isolation at 67/67). The five date-related test files pass under TZ=UTC, Asia/Tokyo, America/Los_Angeles, Pacific/Kiritimati and Europe/Vienna.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/back-677 - Show-local-time-in-the-web-UI-with-the-UTC-value-on-hover.md
+++ b/backlog/tasks/back-677 - Show-local-time-in-the-web-UI-with-the-UTC-value-on-hover.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-02 17:01'
-updated_date: '2026-09-02 17:17'
+updated_date: '2026-09-02 17:26'
 labels: []
 dependencies: []
 ordinal: 309000
@@ -23,20 +23,20 @@ One correctness trap: many stored dates are date-only, such as created_date '202
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Web timestamps that carry a time render in the viewer's local timezone
-- [ ] #2 Each converted timestamp carries the canonical UTC value in its title attribute, so hovering shows the stored value with a UTC marker
-- [ ] #3 Date-only values render unchanged, with no timezone conversion and no UTC hover claiming a time the record does not have
-- [ ] #4 The configured dateFormat still governs how the displayed value is arranged
-- [ ] #5 CLI, TUI and plain output are unchanged and still display UTC
-- [ ] #6 Every web surface showing a stored date goes through one shared helper rather than converting per component
-- [ ] #7 Tests cover a timestamp in a non-UTC timezone, a date-only value, and the dateFormat interaction
+- [x] #1 Web timestamps that carry a time render in the viewer's local timezone
+- [x] #2 Each converted timestamp carries the canonical UTC value in its title attribute, so hovering shows the stored value with a UTC marker
+- [x] #3 Date-only values render unchanged, with no timezone conversion and no UTC hover claiming a time the record does not have
+- [x] #4 The configured dateFormat still governs how the displayed value is arranged
+- [x] #5 CLI, TUI and plain output are unchanged and still display UTC
+- [x] #6 Every web surface showing a stored date goes through one shared helper rather than converting per component
+- [x] #7 Tests cover a timestamp in a non-UTC timezone, a date-only value, and the dateFormat interaction
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -67,4 +67,18 @@ Deliberate label change: the visible 'Due (UTC):' labels became 'Due:' because t
 Not changed: src/utils/utc-date-display.ts and every CLI, TUI, MCP and plain-output caller still pass appendUtcLabel and print UTC. TaskCard's relative age label ('3w ago') is timezone-independent and was left alone.
 
 Tests: src/web/utils/date-display.test.ts now passes an explicit timeZone to every case (Asia/Tokyo, America/Los_Angeles, UTC), so nothing depends on the runner's timezone; it covers a non-UTC timestamp, the local-midnight rollover, a date-only value left unconverted with no title, and dateFormat applied to both the local value and the UTC hover. Component tests that assert rendered timestamps pin the timezone through the new src/test/pin-timezone.ts helper (beforeAll/afterAll, restoring the previously resolved zone because bun shares one process across test files): web-task-list-table-width, web-milestones-page-search and web-task-types now render under Asia/Tokyo and assert both the local text and the UTC title, plus a date-only created_date that must not shift. Verified the suite is timezone-independent by rerunning those files under TZ=UTC, America/Los_Angeles and Pacific/Kiritimati.
+
+Validation: bunx tsc --noEmit and bun run check . pass. Full bun run test on this branch: 2852 pass, 8 skip, 1 fail. The single failure is in src/test/content-store.test.ts, which also fails on an unmodified origin/main worktree (2849 pass, 8 skip, 1 fail, different test in the same suite, same 'Unhandled error between tests' with a git posix_spawn ENOENT); both pass when that file runs on its own, so it is a pre-existing flake in that suite and not caused by this change. CI on the PR: lint-and-unit-test passes on macOS and Windows (confirming process.env.TZ pinning works on Windows too), compile-and-smoke-test passes on all three platforms, CodeQL and nix-package pass. The four date-related test files were also rerun under TZ=UTC, TZ=America/Los_Angeles and TZ=Pacific/Kiritimati and pass unchanged.
+
+Manual verification in the running web UI with the browser in Europe/Vienna: BACK-677's stored '2026-09-02 17:01' rendered as '2026-09-02 19:01' with title '2026-09-02 17:01 (UTC)'; the task list's compact column rendered 'today'/'yesterday' with the canonical UTC value on hover; BACK-208's date-only created_date '2025-07-26' rendered unchanged with no title. CLI plain output for the same tasks still prints 'Created: 2025-07-26 (UTC)' and 'Created: 2026-09-02 17:01 (UTC)', and the diff against origin/main touches no file under src/utils/utc-date-display.ts, src/cli.ts, src/ui, src/formatters or src/mcp.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+The browser now shows stored timestamps as local time with the canonical UTC value on hover, while the CLI, TUI, MCP and plain output keep printing UTC.
+
+One shared web helper does the work: formatStoredDateForDisplay (and its compact variant) in src/web/utils/date-display.ts returns { text, title }, where text is the stored instant in the viewer's timezone and title is the canonical value marked (UTC). Parsing is explicit UTC rather than Date's local parsing, conversion goes through Intl.DateTimeFormat, and the resulting local wall-clock value is arranged by the existing formatUtcDateForDisplay so the configured dateFormat still governs the output. Date-only values such as created_date '2025-07-26' never reach the conversion, so they render unchanged and carry no hover claiming a time the record does not have. A one-line StoredDate component renders <span title={utc}>{local}</span>, and every web stored-date render was routed through it, removing the per-component formatting in CleanupModal and Statistics. The visible 'Due (UTC):' labels became 'Due:' because the shown value is no longer UTC; the due-date input labels stay 'Due (UTC)' since entry semantics are unchanged.
+
+Verified with tests that pass an explicit timezone (Asia/Tokyo, America/Los_Angeles, UTC) rather than relying on the runner, covering a non-UTC timestamp, the local-midnight rollover, a date-only value with no hover and the dateFormat interaction; with component tests pinned to Asia/Tokyo through the new pinTimeZone helper that assert both the local text and the UTC title; with those files rerun under three more timezones; and by exercising the running web UI from a Europe/Vienna browser, where 17:01 UTC rendered as 19:01 titled '2026-09-02 17:01 (UTC)' and a date-only created_date rendered unchanged. tsc, biome and the test suite pass, apart from a pre-existing content-store flake that fails on origin/main too. PR https://github.com/MrLesk/Backlog.md/pull/992 fixes issue #991.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-677 - Show-local-time-in-the-web-UI-with-the-UTC-value-on-hover.md
+++ b/backlog/tasks/back-677 - Show-local-time-in-the-web-UI-with-the-UTC-value-on-hover.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-677
 title: Show local time in the web UI with the UTC value on hover
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-02 17:01'
+updated_date: '2026-09-02 17:17'
 labels: []
 dependencies: []
 ordinal: 309000
@@ -36,3 +38,33 @@ One correctness trap: many stored dates are date-only, such as created_date '202
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add one shared web helper in src/web/utils/date-display.ts: formatStoredDateForDisplay(value, { dateFormat, timeZone }) returning { text, title? }. It parses the stored value explicitly as UTC (parseStoredUtcDate), converts to the viewer timezone via Intl.DateTimeFormat with an optional explicit timeZone, then reuses formatUtcDateForDisplay to arrange the local wall-clock value with the configured dateFormat. title is the canonical UTC value with the (UTC) marker.
+2. Date-only stored values (yyyy-mm-dd) and unparsable values are returned unchanged with no title, so no day shift and no misleading hover.
+3. Add a tiny StoredDate component so every web call site renders <span title={utc}>{local}</span> identically instead of converting per component.
+4. Route every web stored-date render through it: TaskDetailsModal (Created/Updated/Due/comment dates), TaskList (compact created + Due), TaskCard (Due), DraftsList, Statistics, MilestonesPage (Due), DocumentationDetail, DecisionDetail, CleanupModal.
+5. Make the compact list label share the same helper so its absolute fallback and hover match.
+6. Rename the visible 'Due (UTC):' display labels to 'Due:' since the value is no longer UTC; the due-date input labels stay 'Due (UTC)' because entry semantics are unchanged.
+7. Leave src/utils/utc-date-display.ts callers for CLI, TUI, MCP and plain output untouched, so those surfaces keep appendUtcLabel UTC output.
+8. Tests: extend src/web/utils/date-display.test.ts with an explicit timeZone argument (no reliance on the runner timezone) covering a non-UTC timestamp, a date-only value, and the dateFormat interaction; set process.env.TZ explicitly in any component test that asserts a rendered timestamp.
+9. Gates: bunx tsc --noEmit, bun run check ., bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added one shared web helper in src/web/utils/date-display.ts. formatStoredDateForDisplay(value, { dateFormat, timeZone }) returns { text, title? }: text is the stored instant rendered in the viewer's timezone, title is the canonical stored value with the (UTC) marker for the title attribute. formatStoredDateForCompactDisplay returns the same shape for dense lists. Conversion goes through parseStoredUtcDate (explicit UTC parsing, never Date's local parsing of '2026-07-16 21:49') and Intl.DateTimeFormat with hourCycle h23; the resulting local wall-clock string is then arranged by the existing formatUtcDateForDisplay, so the configured dateFormat still governs both the visible value and the hover.
+
+Date-only stored values such as created_date '2025-07-26' never reach the conversion: localCanonicalOf returns null when the canonical value has no time, so the value renders unchanged and carries no title that would claim a time the record does not have. Unparsable values fall back to the previous passthrough behaviour.
+
+Added src/web/components/StoredDate.tsx, a one-line component rendering <span title={utc}>{local}</span>, and routed every web stored-date render through it: TaskDetailsModal (Created, Updated, Due, comment dates), TaskList (compact Created column and Due), TaskCard (Due), DraftsList (Created, Updated), Statistics, MilestonesPage (Due), DocumentationDetail (Created), DecisionDetail (Date), CleanupModal (preview dates). No component converts on its own any more; CleanupModal's and Statistics' local formatDate helpers were deleted.
+
+Deliberate label change: the visible 'Due (UTC):' labels became 'Due:' because the displayed value is no longer UTC and the UTC value is on hover. The due-date entry fields keep their 'Due (UTC)' labels: entry semantics are unchanged, the input still takes and stores a UTC value.
+
+Not changed: src/utils/utc-date-display.ts and every CLI, TUI, MCP and plain-output caller still pass appendUtcLabel and print UTC. TaskCard's relative age label ('3w ago') is timezone-independent and was left alone.
+
+Tests: src/web/utils/date-display.test.ts now passes an explicit timeZone to every case (Asia/Tokyo, America/Los_Angeles, UTC), so nothing depends on the runner's timezone; it covers a non-UTC timestamp, the local-midnight rollover, a date-only value left unconverted with no title, and dateFormat applied to both the local value and the UTC hover. Component tests that assert rendered timestamps pin the timezone through the new src/test/pin-timezone.ts helper (beforeAll/afterAll, restoring the previously resolved zone because bun shares one process across test files): web-task-list-table-width, web-milestones-page-search and web-task-types now render under Asia/Tokyo and assert both the local text and the UTC title, plus a date-only created_date that must not shift. Verified the suite is timezone-independent by rerunning those files under TZ=UTC, America/Los_Angeles and Pacific/Kiritimati.
+<!-- SECTION:NOTES:END -->

--- a/src/test/pin-timezone.ts
+++ b/src/test/pin-timezone.ts
@@ -1,0 +1,19 @@
+import { afterAll, beforeAll } from "bun:test";
+
+/**
+ * Pins the process timezone for one test file so assertions on rendered local timestamps
+ * never depend on the machine running the tests. The previous value is restored afterwards
+ * because bun runs test files in a shared process.
+ */
+export function pinTimeZone(timeZone: string): void {
+	// Deleting TZ again would not restore the resolved zone, so capture the effective one.
+	const previous = process.env.TZ ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+	beforeAll(() => {
+		process.env.TZ = timeZone;
+	});
+
+	afterAll(() => {
+		process.env.TZ = previous;
+	});
+}

--- a/src/test/web-board-filters.test.tsx
+++ b/src/test/web-board-filters.test.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter } from "react-router-dom";
 import type { Task } from "../types/index.ts";
 import BoardPage from "../web/components/BoardPage.tsx";
 import { apiClient } from "../web/lib/api.ts";
+import { pinTimeZone } from "./pin-timezone.ts";
 
 const createTask = (overrides: Partial<Task>): Task => ({
 	id: "task-1",
@@ -264,6 +265,9 @@ afterEach(() => {
 });
 
 describe("Web board filters", () => {
+	// The cleanup preview renders stored timestamps in the viewer's timezone, so pin one.
+	pinTimeZone("Asia/Tokyo");
+
 	it("publishes every returned reorder task without a foreground refresh", async () => {
 		const originalReorderTask = apiClient.reorderTask.bind(apiClient);
 		const sourceTask = tasks[0];
@@ -540,8 +544,12 @@ describe("Web board filters", () => {
 			expect(oneDayButton).toBeTruthy();
 			await clickElement(oneDayButton as Element);
 
-			await waitFor(() => (container.textContent ?? "").includes("09/02/2026 06:01"));
+			await waitFor(() => (container.textContent ?? "").includes("09/02/2026 15:01"));
 			expect(container.textContent).not.toContain("2026-02-09 06:01");
+			const renderedDate = Array.from(container.querySelectorAll("span[title]")).find(
+				(element) => element.textContent === "09/02/2026 15:01",
+			);
+			expect(renderedDate?.getAttribute("title")).toBe("09/02/2026 06:01 (UTC)");
 		} finally {
 			apiClient.getCleanupPreview = originalGetCleanupPreview;
 		}

--- a/src/test/web-milestones-page-search.test.tsx
+++ b/src/test/web-milestones-page-search.test.tsx
@@ -7,6 +7,7 @@ import type { Milestone, Task } from "../types/index.ts";
 import { createTaskSearchIndex } from "../utils/task-search.ts";
 import MilestonesPage from "../web/components/MilestonesPage.tsx";
 import { apiClient } from "../web/lib/api.ts";
+import { pinTimeZone } from "./pin-timezone.ts";
 import { setNativeInputValue } from "./react-dom-input.ts";
 
 const createTask = (overrides: Partial<Task>): Task => ({
@@ -161,6 +162,9 @@ afterEach(() => {
 });
 
 describe("Web milestones page search", () => {
+	// The browser renders stored timestamps in the viewer's timezone, so pin one.
+	pinTimeZone("Asia/Tokyo");
+
 	it("renders a keyboard-focusable search input near the header", () => {
 		const container = renderPage();
 		expect(container.textContent).toContain("Milestones");
@@ -177,12 +181,16 @@ describe("Web milestones page search", () => {
 		const text = container.textContent ?? "";
 
 		expect(text.indexOf("Release 1")).toBeLessThan(text.indexOf("Release 2"));
-		expect(text).toContain("Due (UTC):");
+		expect(text).toContain("Due:");
 	});
 
-	it("uses the configured date format for milestone due dates", () => {
+	it("uses the configured date format for milestone due dates and keeps UTC on hover", () => {
 		const container = renderPage(baseTasks, { dateFormat: "dd/mm/yyyy hh:mm" });
-		expect(container.textContent).toContain("Due (UTC): 01/09/2026 12:00");
+		expect(container.textContent).toContain("Due: 01/09/2026 21:00");
+		const renderedDue = Array.from(container.querySelectorAll("span[title]")).find(
+			(element) => element.textContent === "01/09/2026 21:00",
+		);
+		expect(renderedDue?.getAttribute("title")).toBe("01/09/2026 12:00 (UTC)");
 	});
 
 	it("searching one milestone still renders other milestone sections", () => {

--- a/src/test/web-task-list-table-width.test.tsx
+++ b/src/test/web-task-list-table-width.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import type { Task } from "../types/index.ts";
 import TaskList from "../web/components/TaskList.tsx";
+import { pinTimeZone } from "./pin-timezone.ts";
 
 // jsdom performs no layout, so these tests cannot show that the rendered table fits a
 // viewport or that no scrollbar appears. They pin the width budget the browser then has
@@ -103,6 +104,9 @@ afterEach(() => {
 });
 
 describe("TaskList table width budget", () => {
+	// The browser renders stored timestamps in the viewer's timezone, so pin one.
+	pinTimeZone("Asia/Tokyo");
+
 	it("renders every column", () => {
 		const container = renderTaskList();
 		const headers = Array.from(container.querySelectorAll("thead th")).map(
@@ -111,7 +115,11 @@ describe("TaskList table width budget", () => {
 
 		expect(headers).toEqual(EXPECTED_HEADERS);
 		expect(container.querySelectorAll("tbody tr td")).toHaveLength(EXPECTED_HEADERS.length);
-		expect(container.textContent).toContain("Due (UTC): 2026-08-10 14:30");
+		expect(container.textContent).toContain("Due: 2026-08-10 23:30");
+		const renderedDue = Array.from(container.querySelectorAll("span[title]")).find(
+			(element) => element.textContent === "2026-08-10 23:30",
+		);
+		expect(renderedDue?.getAttribute("title")).toBe("2026-08-10 14:30 (UTC)");
 	});
 
 	it("leaves Title as the only flexible column", () => {

--- a/src/test/web-task-types.test.tsx
+++ b/src/test/web-task-types.test.tsx
@@ -8,6 +8,7 @@ import TaskCard from "../web/components/TaskCard.tsx";
 import { TaskDetailsModal } from "../web/components/TaskDetailsModal.tsx";
 import { ThemeProvider } from "../web/contexts/ThemeContext.tsx";
 import { apiClient, type TaskUpdateRequest } from "../web/lib/api.ts";
+import { pinTimeZone } from "./pin-timezone.ts";
 import { setNativeInputValue } from "./react-dom-input.ts";
 
 const createTask = (overrides: Partial<Task> = {}): Task => ({
@@ -112,6 +113,9 @@ afterEach(() => {
 });
 
 describe("Web task type UI", () => {
+	// The browser renders stored timestamps in the viewer's timezone, so pin one.
+	pinTimeZone("Asia/Tokyo");
+
 	it("displays and clears a task due date through the edit form", async () => {
 		const container = setupDom();
 		const task = createTask({ dueDate: "2026-08-10 14:30" });
@@ -130,7 +134,9 @@ describe("Web task type UI", () => {
 			);
 			await Promise.resolve();
 		});
-		expect(container.textContent).toContain("Due (UTC):");
+		expect(container.textContent).toContain("Due: 2026-08-10 23:30");
+		// The stored created_date is date-only: it has no time to convert and must not shift a day.
+		expect(container.textContent).toContain("Created: 2026-07-09");
 
 		const editButton = Array.from(container.querySelectorAll("button")).find(
 			(button) => button.textContent?.trim() === "Edit",
@@ -196,8 +202,8 @@ describe("Web task type UI", () => {
 		expect(customHtml).toContain("bg-blue-100");
 		expect(docsHtml).toContain("bg-cyan-100");
 		expect(untypedHtml).not.toContain("data-task-type");
-		expect(datedHtml).toContain("Due (UTC):");
-		expect(datedHtml).toContain("10/08/2026 14:30");
+		expect(datedHtml).toContain("Due: ");
+		expect(datedHtml).toContain('title="10/08/2026 14:30 (UTC)">10/08/2026 23:30<');
 	});
 
 	it("creates a task with a configured custom type and defaults to untyped", async () => {

--- a/src/web/components/CleanupModal.tsx
+++ b/src/web/components/CleanupModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Modal from './Modal';
 import { apiClient } from '../lib/api';
-import { formatStoredUtcDateForDisplay } from '../utils/date-display';
+import StoredDate from './StoredDate';
 
 interface CleanupModalProps {
 	isOpen: boolean;
@@ -86,11 +86,6 @@ const CleanupModal: React.FC<CleanupModalProps> = ({ isOpen, onClose, onSuccess,
 		onClose();
 	};
 
-	const formatDate = (dateStr?: string) => {
-		if (!dateStr) return '';
-		return formatStoredUtcDateForDisplay(dateStr, dateFormat);
-	};
-
 	return (
 		<Modal isOpen={isOpen} onClose={handleClose} title="Clean Up Completed Tasks" maxWidthClass="max-w-3xl">
 			<div className="space-y-6">
@@ -156,7 +151,7 @@ const CleanupModal: React.FC<CleanupModalProps> = ({ isOpen, onClose, onSuccess,
 															{task.title}
 														</p>
 														<p className="text-xs text-gray-500 dark:text-gray-400">
-															{task.id} • {formatDate(task.updatedDate || task.createdDate)}
+															{task.id} • <StoredDate value={task.updatedDate || task.createdDate} dateFormat={dateFormat} />
 														</p>
 													</div>
 												</div>

--- a/src/web/components/DecisionDetail.tsx
+++ b/src/web/components/DecisionDetail.tsx
@@ -9,7 +9,7 @@ import ErrorBoundary from '../components/ErrorBoundary';
 import { SuccessToast } from './SuccessToast';
 import { useTheme } from '../contexts/ThemeContext';
 import { sanitizeUrlTitle } from '../utils/urlHelpers';
-import { formatStoredUtcDateForDisplay } from '../utils/date-display';
+import StoredDate from './StoredDate';
 
 // Utility function for ID transformations
 const stripIdPrefix = (id: string): string => {
@@ -301,7 +301,7 @@ export default function DecisionDetail({ decisions, onRefreshData, dateFormat }:
 										<svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 											<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
 										</svg>
-										<span>Date: {formatStoredUtcDateForDisplay(decision.date, dateFormat)}</span>
+										<span>Date: <StoredDate value={decision.date} dateFormat={dateFormat} /></span>
 									</div>
 								)}
 								{decision?.status && (

--- a/src/web/components/DocumentationDetail.tsx
+++ b/src/web/components/DocumentationDetail.tsx
@@ -9,7 +9,7 @@ import ErrorBoundary from '../components/ErrorBoundary';
 import {SuccessToast} from './SuccessToast';
 import { useTheme } from '../contexts/ThemeContext';
 import { sanitizeUrlTitle } from '../utils/urlHelpers';
-import { formatStoredUtcDateForDisplay } from '../utils/date-display';
+import StoredDate from './StoredDate';
 
 // Custom MDEditor wrapper for proper height handling
 const MarkdownEditor = memo(function MarkdownEditor({
@@ -363,7 +363,7 @@ export default function DocumentationDetail({docs, onRefreshData, dateFormat}: D
                                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                                                       d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
                                             </svg>
-                                            <span>Created: {formatStoredUtcDateForDisplay(document.createdDate, dateFormat)}</span>
+                                            <span>Created: <StoredDate value={document.createdDate} dateFormat={dateFormat} /></span>
                                         </div>
                                     )}
                                 </div>

--- a/src/web/components/DraftsList.tsx
+++ b/src/web/components/DraftsList.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { type Task } from '../../types';
-import { formatStoredUtcDateForDisplay } from '../utils/date-display';
+import StoredDate from './StoredDate';
 import { formatPriorityLabel } from '../../utils/priority-config';
 
 interface DraftsListProps {
@@ -148,9 +148,9 @@ const DraftsList: React.FC<DraftsListProps> = ({ onEditTask, onNewDraft, dateFor
                     </div>
                     <div className="flex items-center space-x-4 text-sm text-gray-500 dark:text-gray-400 mb-2">
                       <span>{draft.id}</span>
-                      <span>Created: {formatStoredUtcDateForDisplay(draft.createdDate, dateFormat)}</span>
+                      <span>Created: <StoredDate value={draft.createdDate} dateFormat={dateFormat} /></span>
                       {draft.updatedDate && (
-                        <span>Updated: {formatStoredUtcDateForDisplay(draft.updatedDate, dateFormat)}</span>
+                        <span>Updated: <StoredDate value={draft.updatedDate} dateFormat={dateFormat} /></span>
                       )}
                     </div>
                     {draft.assignee && draft.assignee.length > 0 && (

--- a/src/web/components/MilestonesPage.tsx
+++ b/src/web/components/MilestonesPage.tsx
@@ -6,7 +6,7 @@ import { type Milestone, type MilestoneBucket, type Task } from "../../types";
 import { createTaskSearchIndex } from "../../utils/task-search";
 import MilestoneTaskRow from "./MilestoneTaskRow";
 import Modal from "./Modal";
-import { formatStoredUtcDateForDisplay } from "../utils/date-display";
+import StoredDate from "./StoredDate";
 
 type RemoveTaskHandling = "clear" | "reassign";
 
@@ -503,7 +503,7 @@ const MilestonesPage: React.FC<MilestonesPageProps> = ({
 							<h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">{bucket.label}</h3>
 							{milestoneEntity?.dueDate && (
 								<p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-									Due (UTC): {formatStoredUtcDateForDisplay(milestoneEntity.dueDate, dateFormat)}
+									Due: <StoredDate value={milestoneEntity.dueDate} dateFormat={dateFormat} />
 								</p>
 							)}
 						</div>

--- a/src/web/components/Statistics.tsx
+++ b/src/web/components/Statistics.tsx
@@ -4,7 +4,7 @@ import type { TaskStatistics } from '../../core/statistics';
 import type { Task } from '../../types';
 import { formatPriorityLabel } from '../../utils/priority-config';
 import LoadingSpinner from './LoadingSpinner';
-import { formatStoredUtcDateForDisplay } from '../utils/date-display';
+import StoredDate from './StoredDate';
 
 interface StatisticsData extends Omit<TaskStatistics, 'statusCounts' | 'priorityCounts'> {
 	statusCounts: Record<string, number>;
@@ -136,8 +136,6 @@ const Statistics: React.FC<StatisticsProps> = ({
 	}
 
 	const TaskPreview = ({ task, showDate, onClick }: { task: Task; showDate: 'created' | 'updated'; onClick?: () => void }) => {
-		const formatDate = (dateStr: string) => formatStoredUtcDateForDisplay(dateStr, dateFormat);
-
 		const displayDate = showDate === 'created' ? task.createdDate : task.updatedDate || task.createdDate;
 
 		return (
@@ -152,7 +150,7 @@ const Statistics: React.FC<StatisticsProps> = ({
 				<div className="flex-1 min-w-0">
 					<p className="font-medium text-gray-900 dark:text-gray-100 truncate">{task.title}</p>
 					<p className="text-sm text-gray-500 dark:text-gray-400">
-						{task.id} • {showDate === 'created' ? 'Created' : 'Updated'} {formatDate(displayDate)}
+						{task.id} • {showDate === 'created' ? 'Created' : 'Updated'} <StoredDate value={displayDate} dateFormat={dateFormat} />
 					</p>
 				</div>
 			</div>

--- a/src/web/components/StoredDate.tsx
+++ b/src/web/components/StoredDate.tsx
@@ -1,0 +1,28 @@
+import type React from "react";
+import { formatStoredDateForCompactDisplay, formatStoredDateForDisplay } from "../utils/date-display";
+
+interface StoredDateProps {
+	value?: string;
+	dateFormat?: string;
+	/** Dense lists render recent values relatively ("today", "3d ago"). */
+	compact?: boolean;
+	className?: string;
+}
+
+/**
+ * Renders a stored UTC date as local time with the canonical UTC value on hover.
+ * Every web surface showing a stored date goes through this, so no component converts on its own.
+ */
+const StoredDate: React.FC<StoredDateProps> = ({ value, dateFormat, compact = false, className }) => {
+	const { text, title } = compact
+		? formatStoredDateForCompactDisplay(value, { dateFormat })
+		: formatStoredDateForDisplay(value, { dateFormat });
+
+	return (
+		<span className={className} title={title}>
+			{text}
+		</span>
+	);
+};
+
+export default StoredDate;

--- a/src/web/components/TaskCard.tsx
+++ b/src/web/components/TaskCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { type Task } from '../../types';
 import { formatPriorityLabel } from '../../utils/priority-config';
 import AcceptanceCriteriaProgress, { getAcceptanceCriteriaProgressCounts } from './AcceptanceCriteriaProgress';
-import { formatStoredUtcDateForDisplay } from '../utils/date-display';
+import StoredDate from './StoredDate';
 import ProjectBadge from './ProjectBadge';
 import TaskTypeBadge from './TaskTypeBadge';
 
@@ -291,7 +291,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
         {/* Footer with date */}
         <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 text-[10px] text-gray-400 dark:text-gray-500 mt-2 pt-1.5 border-t border-gray-100 dark:border-gray-600/50 transition-colors duration-200">
           <span>{formatRelativeDate(task.createdDate)}</span>
-          {task.dueDate && <span>Due (UTC): {formatStoredUtcDateForDisplay(task.dueDate, dateFormat)}</span>}
+          {task.dueDate && <span>Due: <StoredDate value={task.dueDate} dateFormat={dateFormat} /></span>}
           {task.assignee.length > 0 && (
             <span className="truncate max-w-[80px]" title={task.assignee.join(', ')}>
               {task.assignee[0]}

--- a/src/web/components/TaskDetailsModal.tsx
+++ b/src/web/components/TaskDetailsModal.tsx
@@ -10,7 +10,7 @@ import MermaidMarkdown from './MermaidMarkdown';
 import ChipInput from "./ChipInput";
 import DependencyInput from "./DependencyInput";
 import { DependencyGraphSection } from "./DependencyGraphSection";
-import { formatStoredUtcDateForDisplay } from "../utils/date-display";
+import StoredDate from "./StoredDate";
 import { getPriorityOptions } from "../../utils/priority-config";
 import { getProjectValues, resolveProjectValue } from "../../utils/project-config";
 import { getTaskTypeValues, resolveTaskTypeValue } from "../../utils/task-type-config";
@@ -1655,7 +1655,7 @@ export const TaskDetailsModal: React.FC<Props> = ({
                       <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
                         <span className="font-semibold text-gray-700 dark:text-gray-200">#{comment.index}</span>
                         {comment.author ? <span>{comment.author}</span> : null}
-                        {comment.createdDate ? <span>{formatStoredUtcDateForDisplay(comment.createdDate, dateFormat)}</span> : null}
+                        {comment.createdDate ? <StoredDate value={comment.createdDate} dateFormat={dateFormat} /> : null}
                       </div>
                       <div className="prose prose-sm !max-w-none wmde-markdown" data-color-mode={theme}>
                         <MermaidMarkdown source={comment.body} />
@@ -1728,12 +1728,12 @@ export const TaskDetailsModal: React.FC<Props> = ({
           {/* Dates */}
 	          {task && (
 	            <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 text-xs text-gray-600 dark:text-gray-300 space-y-1">
-	              <div><span className="font-semibold text-gray-800 dark:text-gray-100">Created:</span> <span className="text-gray-700 dark:text-gray-200">{formatStoredUtcDateForDisplay(task.createdDate, dateFormat)}</span></div>
+	              <div><span className="font-semibold text-gray-800 dark:text-gray-100">Created:</span> <StoredDate value={task.createdDate} dateFormat={dateFormat} className="text-gray-700 dark:text-gray-200" /></div>
 	              {task.updatedDate && (
-	                <div><span className="font-semibold text-gray-800 dark:text-gray-100">Updated:</span> <span className="text-gray-700 dark:text-gray-200">{formatStoredUtcDateForDisplay(task.updatedDate, dateFormat)}</span></div>
+	                <div><span className="font-semibold text-gray-800 dark:text-gray-100">Updated:</span> <StoredDate value={task.updatedDate} dateFormat={dateFormat} className="text-gray-700 dark:text-gray-200" /></div>
 	              )}
 	              {task.dueDate && mode === "preview" && (
-	                <div><span className="font-semibold text-gray-800 dark:text-gray-100">Due (UTC):</span> <span className="text-gray-700 dark:text-gray-200">{formatStoredUtcDateForDisplay(task.dueDate, dateFormat)}</span></div>
+	                <div><span className="font-semibold text-gray-800 dark:text-gray-100">Due:</span> <StoredDate value={task.dueDate} dateFormat={dateFormat} className="text-gray-700 dark:text-gray-200" /></div>
 	              )}
 	            </div>
 	          )}

--- a/src/web/components/TaskList.tsx
+++ b/src/web/components/TaskList.tsx
@@ -11,11 +11,7 @@ import { collectAvailableLabels } from "../../utils/label-filter.ts";
 import { compareTaskIds, compareTaskIdsDescending } from "../../utils/task-sorting.ts";
 import { isTerminalStatus } from "../../utils/terminal-status.ts";
 import { collectArchivedMilestoneKeys, getMilestoneLabel, milestoneKey } from "../utils/milestones";
-import {
-	formatStoredUtcDateForCompactDisplay,
-	formatStoredUtcDateForDisplay,
-	parseStoredUtcDate,
-} from "../utils/date-display";
+import { parseStoredUtcDate } from "../utils/date-display";
 import {
 	formatPriorityLabel,
 	getPriorityOptions,
@@ -23,6 +19,7 @@ import {
 	resolvePriorityValue,
 } from "../../utils/priority-config.ts";
 import CleanupModal from "./CleanupModal";
+import StoredDate from "./StoredDate";
 import AcceptanceCriteriaProgress from "./AcceptanceCriteriaProgress";
 import LabelFilterDropdown from "./LabelFilterDropdown";
 import { SuccessToast } from "./SuccessToast";
@@ -868,7 +865,6 @@ const TaskList: React.FC<TaskListProps> = ({
 									const visibleAssignees = task.assignee.slice(0, 2);
 									const assigneeOverflow = Math.max(task.assignee.length - visibleAssignees.length, 0);
 									const milestoneLabel = task.milestone ? getMilestoneLabel(task.milestone, milestoneEntities) : "—";
-									const createdLabel = formatStoredUtcDateForCompactDisplay(task.createdDate ?? "", dateFormat);
 
 									return (
 										<tr
@@ -913,7 +909,7 @@ const TaskList: React.FC<TaskListProps> = ({
 												<AcceptanceCriteriaProgress task={task} density="list" className="mt-1" />
 												{task.dueDate && (
 													<div className="mt-1 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-														Due (UTC): {formatStoredUtcDateForDisplay(task.dueDate, dateFormat)}
+														Due: <StoredDate value={task.dueDate} dateFormat={dateFormat} />
 													</div>
 												)}
 											</td>
@@ -980,7 +976,7 @@ const TaskList: React.FC<TaskListProps> = ({
 												{milestoneLabel}
 											</td>
 											<td className="px-3 py-2.5 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-												{createdLabel}
+												<StoredDate value={task.createdDate} dateFormat={dateFormat} compact />
 											</td>
 										</tr>
 									);

--- a/src/web/utils/date-display.test.ts
+++ b/src/web/utils/date-display.test.ts
@@ -121,6 +121,33 @@ describe("formatStoredDateForCompactDisplay", () => {
 		).toBe("11/02/2026");
 	});
 
+	it("names the day by the viewer's calendar, not by elapsed hours", () => {
+		// 17:00 on Feb 20 in Los Angeles. The stored value is 19 hours old but fell on Feb 19 locally.
+		const lateEvening = new Date(Date.UTC(2026, 1, 21, 1, 0, 0));
+		expect(formatStoredDateForCompactDisplay("2026-02-20 06:00", { timeZone: LOS_ANGELES }, lateEvening).text).toBe(
+			"yesterday",
+		);
+
+		// The same trap the other way round the globe: 01:00 on Feb 22 in Tokyo, 6 hours after a Feb 21 stamp.
+		const pastMidnight = new Date(Date.UTC(2026, 1, 21, 16, 0, 0));
+		expect(formatStoredDateForCompactDisplay("2026-02-21 10:00", { timeZone: TOKYO }, pastMidnight).text).toBe(
+			"yesterday",
+		);
+
+		// A UTC viewer reads calendar days too: 19 hours earlier is still the previous day.
+		expect(formatStoredDateForCompactDisplay("2026-02-20 06:00", { timeZone: "UTC" }, lateEvening).text).toBe(
+			"yesterday",
+		);
+	});
+
+	it("counts older values in whole local days", () => {
+		const lateEvening = new Date(Date.UTC(2026, 1, 21, 1, 0, 0));
+		// Locally Feb 17 against a local today of Feb 20.
+		expect(formatStoredDateForCompactDisplay("2026-02-18 06:00", { timeZone: LOS_ANGELES }, lateEvening).text).toBe(
+			"3d ago",
+		);
+	});
+
 	it("handles missing and invalid values gracefully", () => {
 		expect(formatStoredDateForCompactDisplay("", { timeZone: TOKYO }, now)).toEqual({ text: "—" });
 		expect(formatStoredDateForCompactDisplay("not-a-date", { timeZone: TOKYO }, now)).toEqual({ text: "not-a-date" });

--- a/src/web/utils/date-display.test.ts
+++ b/src/web/utils/date-display.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import {
-	formatStoredUtcDateForCompactDisplay,
-	formatStoredUtcDateForDisplay,
-	parseStoredUtcDate,
-} from "./date-display";
+import { formatStoredDateForCompactDisplay, formatStoredDateForDisplay, parseStoredUtcDate } from "./date-display";
+
+// Every case passes an explicit timeZone so results never depend on the machine running the tests.
+const TOKYO = "Asia/Tokyo"; // UTC+9, no DST
+const LOS_ANGELES = "America/Los_Angeles"; // UTC-8/-7
 
 describe("parseStoredUtcDate", () => {
 	it("parses stored UTC datetime strings", () => {
@@ -24,51 +24,105 @@ describe("parseStoredUtcDate", () => {
 	});
 });
 
-describe("formatStoredUtcDateForDisplay", () => {
-	it("renders datetime values as stored (UTC), not in the browser locale", () => {
-		expect(formatStoredUtcDateForDisplay("2026-02-09 06:01")).toBe("2026-02-09 06:01");
+describe("formatStoredDateForDisplay", () => {
+	it("renders stored timestamps in the viewer's timezone", () => {
+		expect(formatStoredDateForDisplay("2026-02-09 06:01", { timeZone: TOKYO })).toEqual({
+			text: "2026-02-09 15:01",
+			title: "2026-02-09 06:01 (UTC)",
+		});
+		expect(formatStoredDateForDisplay("2026-02-09 06:01", { timeZone: LOS_ANGELES })).toEqual({
+			text: "2026-02-08 22:01",
+			title: "2026-02-09 06:01 (UTC)",
+		});
 	});
 
-	it("renders date-only values as stored", () => {
-		expect(formatStoredUtcDateForDisplay("2026-02-09")).toBe("2026-02-09");
+	it("keeps the same instant when the viewer is in UTC", () => {
+		expect(formatStoredDateForDisplay("2026-02-09 06:01", { timeZone: "UTC" })).toEqual({
+			text: "2026-02-09 06:01",
+			title: "2026-02-09 06:01 (UTC)",
+		});
 	});
 
-	it("applies a custom display format when provided", () => {
-		expect(formatStoredUtcDateForDisplay("2026-02-09 06:01", "dd/mm/yyyy")).toBe("09/02/2026 06:01");
-		expect(formatStoredUtcDateForDisplay("2026-02-09", "mm/dd/yyyy")).toBe("02/09/2026");
+	it("renders midnight without rolling the local hour to 24", () => {
+		expect(formatStoredDateForDisplay("2026-02-09 15:00", { timeZone: TOKYO })).toEqual({
+			text: "2026-02-10 00:00",
+			title: "2026-02-09 15:00 (UTC)",
+		});
+	});
+
+	it("leaves date-only values unconverted and without a misleading hover", () => {
+		expect(formatStoredDateForDisplay("2026-02-09", { timeZone: TOKYO })).toEqual({ text: "2026-02-09" });
+		expect(formatStoredDateForDisplay("2026-02-09", { timeZone: LOS_ANGELES })).toEqual({ text: "2026-02-09" });
+	});
+
+	it("applies the configured date format to both the local value and the UTC hover", () => {
+		expect(formatStoredDateForDisplay("2026-02-09 06:01", { dateFormat: "dd/mm/yyyy", timeZone: TOKYO })).toEqual({
+			text: "09/02/2026 15:01",
+			title: "09/02/2026 06:01 (UTC)",
+		});
+		expect(
+			formatStoredDateForDisplay("2026-02-09 06:01", { dateFormat: "mm/dd/yyyy hh:mm", timeZone: LOS_ANGELES }),
+		).toEqual({
+			text: "02/08/2026 22:01",
+			title: "02/09/2026 06:01 (UTC)",
+		});
+		expect(formatStoredDateForDisplay("2026-02-09", { dateFormat: "mm/dd/yyyy", timeZone: LOS_ANGELES })).toEqual({
+			text: "02/09/2026",
+		});
 	});
 
 	it("falls back to canonical output for invalid formats", () => {
-		expect(formatStoredUtcDateForDisplay("2026-02-09 06:01", "banana")).toBe("2026-02-09 06:01");
+		expect(formatStoredDateForDisplay("2026-02-09 06:01", { dateFormat: "banana", timeZone: "UTC" })).toEqual({
+			text: "2026-02-09 06:01",
+			title: "2026-02-09 06:01 (UTC)",
+		});
 	});
 
-	it("falls back to original value when parsing fails", () => {
-		expect(formatStoredUtcDateForDisplay("not-a-date")).toBe("not-a-date");
-		expect(formatStoredUtcDateForDisplay("not-a-date", "dd/mm/yyyy")).toBe("not-a-date");
+	it("falls back to the original value when parsing fails", () => {
+		expect(formatStoredDateForDisplay("not-a-date", { timeZone: TOKYO })).toEqual({ text: "not-a-date" });
+		expect(formatStoredDateForDisplay("not-a-date", { dateFormat: "dd/mm/yyyy", timeZone: TOKYO })).toEqual({
+			text: "not-a-date",
+		});
+		expect(formatStoredDateForDisplay(undefined, { timeZone: TOKYO })).toEqual({ text: "" });
 	});
 });
 
-describe("formatStoredUtcDateForCompactDisplay", () => {
+describe("formatStoredDateForCompactDisplay", () => {
 	const now = new Date(Date.UTC(2026, 1, 21, 12, 0, 0));
 
 	it("formats recent values as relative days", () => {
-		expect(formatStoredUtcDateForCompactDisplay("2026-02-21", undefined, now)).toBe("today");
-		expect(formatStoredUtcDateForCompactDisplay("2026-02-20", undefined, now)).toBe("yesterday");
-		expect(formatStoredUtcDateForCompactDisplay("2026-02-18", undefined, now)).toBe("3d ago");
+		expect(formatStoredDateForCompactDisplay("2026-02-21", { timeZone: TOKYO }, now).text).toBe("today");
+		expect(formatStoredDateForCompactDisplay("2026-02-20", { timeZone: TOKYO }, now).text).toBe("yesterday");
+		expect(formatStoredDateForCompactDisplay("2026-02-18", { timeZone: TOKYO }, now).text).toBe("3d ago");
 	});
 
-	it("formats older values as a compact date", () => {
-		expect(formatStoredUtcDateForCompactDisplay("2026-02-10", undefined, now)).toBe("2026-02-10");
-		expect(formatStoredUtcDateForCompactDisplay("2026-02-10 06:01", undefined, now)).toBe("2026-02-10");
+	it("keeps the canonical UTC value on hover for relative timestamps", () => {
+		expect(formatStoredDateForCompactDisplay("2026-02-21 06:01", { timeZone: TOKYO }, now)).toEqual({
+			text: "today",
+			title: "2026-02-21 06:01 (UTC)",
+		});
+		expect(formatStoredDateForCompactDisplay("2026-02-21", { timeZone: TOKYO }, now).title).toBeUndefined();
+	});
+
+	it("formats older values as a compact date in the viewer's timezone", () => {
+		expect(formatStoredDateForCompactDisplay("2026-02-10", { timeZone: LOS_ANGELES }, now).text).toBe("2026-02-10");
+		expect(formatStoredDateForCompactDisplay("2026-02-10 06:01", { timeZone: LOS_ANGELES }, now).text).toBe(
+			"2026-02-09",
+		);
+		expect(formatStoredDateForCompactDisplay("2026-02-10 06:01", { timeZone: TOKYO }, now).text).toBe("2026-02-10");
 	});
 
 	it("applies a custom display format to the compact date fallback", () => {
-		expect(formatStoredUtcDateForCompactDisplay("2026-02-10", "dd/mm/yyyy", now)).toBe("10/02/2026");
-		expect(formatStoredUtcDateForCompactDisplay("2026-02-10 06:01", "dd/mm/yyyy", now)).toBe("10/02/2026");
+		expect(
+			formatStoredDateForCompactDisplay("2026-02-10", { dateFormat: "dd/mm/yyyy", timeZone: TOKYO }, now).text,
+		).toBe("10/02/2026");
+		expect(
+			formatStoredDateForCompactDisplay("2026-02-10 20:01", { dateFormat: "dd/mm/yyyy", timeZone: TOKYO }, now).text,
+		).toBe("11/02/2026");
 	});
 
 	it("handles missing and invalid values gracefully", () => {
-		expect(formatStoredUtcDateForCompactDisplay("", undefined, now)).toBe("—");
-		expect(formatStoredUtcDateForCompactDisplay("not-a-date", undefined, now)).toBe("not-a-date");
+		expect(formatStoredDateForCompactDisplay("", { timeZone: TOKYO }, now)).toEqual({ text: "—" });
+		expect(formatStoredDateForCompactDisplay("not-a-date", { timeZone: TOKYO }, now)).toEqual({ text: "not-a-date" });
 	});
 });

--- a/src/web/utils/date-display.ts
+++ b/src/web/utils/date-display.ts
@@ -3,6 +3,25 @@ import { formatUtcDateForDisplay } from "../../utils/utc-date-display.ts";
 const DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
 const DATE_TIME_REGEX = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})$/;
 
+export type StoredDateDisplayOptions = {
+	dateFormat?: string;
+	/**
+	 * IANA timezone used to render the local value. Defaults to the runtime timezone;
+	 * tests pass it explicitly so results never depend on the machine's timezone.
+	 */
+	timeZone?: string;
+};
+
+export type StoredDateDisplay = {
+	/** Value to render: local time for stored timestamps, unchanged for date-only values. */
+	text: string;
+	/**
+	 * Canonical stored value with the (UTC) marker, for the title attribute.
+	 * Absent when nothing was converted, so a date-only value never claims a time it does not have.
+	 */
+	title?: string;
+};
+
 function parseIntStrict(value: string): number {
 	return Number.parseInt(value, 10);
 }
@@ -60,30 +79,89 @@ export function parseStoredUtcDate(dateStr: string): Date | null {
 	return null;
 }
 
-export function formatStoredUtcDateForDisplay(dateStr: string, dateFormat?: string): string {
-	return formatUtcDateForDisplay(dateStr, { dateFormat });
+/** Renders an instant as `yyyy-mm-dd hh:mm` wall-clock time in the given (or runtime) timezone. */
+function toLocalCanonical(date: Date, timeZone?: string): string | null {
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		hourCycle: "h23",
+	}).formatToParts(date);
+
+	const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((candidate) => candidate.type === type)?.value;
+	const year = part("year");
+	const month = part("month");
+	const day = part("day");
+	const hours = part("hour");
+	const minutes = part("minute");
+	if (!year || !month || !day || !hours || !minutes) return null;
+
+	return `${year.padStart(4, "0")}-${month}-${day} ${hours}:${minutes}`;
 }
 
-export function formatStoredUtcDateForCompactDisplay(
-	dateStr: string,
-	dateFormat?: string,
+/**
+ * Web-only display of a stored UTC date.
+ *
+ * The browser is the one surface that knows the viewer's timezone, so a stored timestamp
+ * renders as local time with the canonical UTC value on hover. Date-only values carry no
+ * time to convert: they render unchanged and get no hover.
+ */
+export function formatStoredDateForDisplay(
+	dateStr: string | undefined,
+	options: StoredDateDisplayOptions = {},
+): StoredDateDisplay {
+	const canonicalUtc = formatUtcDateForDisplay(dateStr);
+	if (!canonicalUtc) return { text: "" };
+
+	const local = localCanonicalOf(canonicalUtc, options.timeZone);
+	if (!local) return { text: formatUtcDateForDisplay(canonicalUtc, { dateFormat: options.dateFormat }) };
+
+	return {
+		text: formatUtcDateForDisplay(local, { dateFormat: options.dateFormat }),
+		title: formatUtcDateForDisplay(canonicalUtc, { dateFormat: options.dateFormat, appendUtcLabel: true }),
+	};
+}
+
+/** Local rendering of a canonical UTC value, or null when there is no time to convert. */
+function localCanonicalOf(canonicalUtc: string, timeZone?: string): string | null {
+	if (!DATE_TIME_REGEX.test(canonicalUtc)) return null;
+	const parsed = parseStoredUtcDate(canonicalUtc);
+	return parsed ? toLocalCanonical(parsed, timeZone) : null;
+}
+
+/**
+ * Compact variant for dense lists: recent values render relatively, older ones fall back
+ * to the local date. Both keep the canonical UTC value on hover when there is a time.
+ */
+export function formatStoredDateForCompactDisplay(
+	dateStr: string | undefined,
+	options: StoredDateDisplayOptions = {},
 	now: Date = new Date(),
-): string {
-	const normalized = dateStr.trim();
-	if (!normalized) return "—";
+): StoredDateDisplay {
+	const canonicalUtc = formatUtcDateForDisplay(dateStr);
+	if (!canonicalUtc) return { text: "—" };
 
-	const parsed = parseStoredUtcDate(normalized);
-	if (!parsed) return normalized;
+	const parsed = parseStoredUtcDate(canonicalUtc);
+	if (!parsed) return { text: canonicalUtc };
 
-	const diffMs = now.getTime() - parsed.getTime();
-	const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+	const local = localCanonicalOf(canonicalUtc, options.timeZone);
+	const title = local
+		? formatUtcDateForDisplay(canonicalUtc, { dateFormat: options.dateFormat, appendUtcLabel: true })
+		: undefined;
 
-	if (diffDays >= 0) {
-		if (diffDays === 0) return "today";
-		if (diffDays === 1) return "yesterday";
-		if (diffDays < 7) return `${diffDays}d ago`;
+	const diffDays = Math.floor((now.getTime() - parsed.getTime()) / (1000 * 60 * 60 * 24));
+	if (diffDays >= 0 && diffDays < 7) {
+		if (diffDays === 0) return { text: "today", title };
+		if (diffDays === 1) return { text: "yesterday", title };
+		return { text: `${diffDays}d ago`, title };
 	}
 
-	// Absolute fallback stays compact: format only the date portion of the stored value.
-	return formatUtcDateForDisplay(normalized.slice(0, 10), { dateFormat });
+	// Absolute fallback stays compact: the date portion only, in the viewer's timezone.
+	return {
+		text: formatUtcDateForDisplay((local ?? canonicalUtc).slice(0, 10), { dateFormat: options.dateFormat }),
+		title,
+	};
 }

--- a/src/web/utils/date-display.ts
+++ b/src/web/utils/date-display.ts
@@ -79,17 +79,31 @@ export function parseStoredUtcDate(dateStr: string): Date | null {
 	return null;
 }
 
-/** Renders an instant as `yyyy-mm-dd hh:mm` wall-clock time in the given (or runtime) timezone. */
-function toLocalCanonical(date: Date, timeZone?: string): string | null {
-	const parts = new Intl.DateTimeFormat("en-US", {
-		timeZone,
+// Building a formatter costs far more than using one, and a task list renders a date per row.
+// Keyed by the resolved zone, so a cached formatter is never reused after the runtime zone changes.
+const localFormatters = new Map<string, Intl.DateTimeFormat>();
+
+function localFormatterFor(timeZone: string | undefined): Intl.DateTimeFormat {
+	const zone = timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+	const cached = localFormatters.get(zone);
+	if (cached) return cached;
+
+	const formatter = new Intl.DateTimeFormat("en-US", {
+		timeZone: zone,
 		year: "numeric",
 		month: "2-digit",
 		day: "2-digit",
 		hour: "2-digit",
 		minute: "2-digit",
 		hourCycle: "h23",
-	}).formatToParts(date);
+	});
+	localFormatters.set(zone, formatter);
+	return formatter;
+}
+
+/** Renders an instant as `yyyy-mm-dd hh:mm` wall-clock time in the given (or runtime) timezone. */
+function toLocalCanonical(date: Date, timeZone?: string): string | null {
+	const parts = localFormatterFor(timeZone).formatToParts(date);
 
 	const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((candidate) => candidate.type === type)?.value;
 	const year = part("year");
@@ -148,23 +162,31 @@ export function formatStoredDateForCompactDisplay(
 ): StoredDateDisplay {
 	const canonicalUtc = formatUtcDateForDisplay(dateStr);
 	if (!canonicalUtc) return { text: "—" };
-
-	const parsed = parseStoredUtcDate(canonicalUtc);
-	if (!parsed) return { text: canonicalUtc };
+	if (!parseStoredUtcDate(canonicalUtc)) return { text: canonicalUtc };
 
 	const local = localCanonicalOf(canonicalUtc, options.timeZone);
 	const title = local ? utcTitleOf(canonicalUtc, options.dateFormat) : undefined;
 
-	const diffDays = Math.floor((now.getTime() - parsed.getTime()) / (1000 * 60 * 60 * 24));
-	if (diffDays >= 0 && diffDays < 7) {
+	// "today" and "yesterday" name calendar days, so compare the days the viewer actually reads:
+	// a value less than 24 hours old can still belong to the previous local day.
+	const localDate = (local ?? canonicalUtc).slice(0, 10);
+	const todayLocal = toLocalCanonical(now, options.timeZone)?.slice(0, 10);
+	const diffDays = todayLocal ? calendarDaysBetween(localDate, todayLocal) : null;
+
+	if (diffDays !== null && diffDays >= 0 && diffDays < 7) {
 		if (diffDays === 0) return { text: "today", title };
 		if (diffDays === 1) return { text: "yesterday", title };
 		return { text: `${diffDays}d ago`, title };
 	}
 
 	// Absolute fallback stays compact: the date portion only, in the viewer's timezone.
-	return {
-		text: formatUtcDateForDisplay((local ?? canonicalUtc).slice(0, 10), { dateFormat: options.dateFormat }),
-		title,
-	};
+	return { text: formatUtcDateForDisplay(localDate, { dateFormat: options.dateFormat }), title };
+}
+
+/** Whole calendar days from `earlier` to `later`, both `yyyy-mm-dd` read in the same timezone. */
+function calendarDaysBetween(earlier: string, later: string): number | null {
+	const from = parseStoredUtcDate(earlier);
+	const to = parseStoredUtcDate(later);
+	if (!from || !to) return null;
+	return Math.round((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24));
 }

--- a/src/web/utils/date-display.ts
+++ b/src/web/utils/date-display.ts
@@ -121,8 +121,13 @@ export function formatStoredDateForDisplay(
 
 	return {
 		text: formatUtcDateForDisplay(local, { dateFormat: options.dateFormat }),
-		title: formatUtcDateForDisplay(canonicalUtc, { dateFormat: options.dateFormat, appendUtcLabel: true }),
+		title: utcTitleOf(canonicalUtc, options.dateFormat),
 	};
+}
+
+/** The hover value: the canonical stored value, arranged by the configured format, marked UTC. */
+function utcTitleOf(canonicalUtc: string, dateFormat?: string): string {
+	return formatUtcDateForDisplay(canonicalUtc, { dateFormat, appendUtcLabel: true });
 }
 
 /** Local rendering of a canonical UTC value, or null when there is no time to convert. */
@@ -148,9 +153,7 @@ export function formatStoredDateForCompactDisplay(
 	if (!parsed) return { text: canonicalUtc };
 
 	const local = localCanonicalOf(canonicalUtc, options.timeZone);
-	const title = local
-		? formatUtcDateForDisplay(canonicalUtc, { dateFormat: options.dateFormat, appendUtcLabel: true })
-		: undefined;
+	const title = local ? utcTitleOf(canonicalUtc, options.dateFormat) : undefined;
 
 	const diffDays = Math.floor((now.getTime() - parsed.getTime()) / (1000 * 60 * 60 * 24));
 	if (diffDays >= 0 && diffDays < 7) {


### PR DESCRIPTION
Fixes #991

The browser rendered stored timestamps in UTC without saying so, so a viewer outside UTC read a time that was not theirs. The CLI, TUI, MCP and plain output all pass `appendUtcLabel`, so their readers see `(UTC)`; the browser called the same helper without the label, so the value looked local and was not.

The browser is the one surface that knows the viewer's timezone and can show more on hover, so it is now the friendly one: the visible value is local time, and the canonical stored value sits in the `title` attribute, e.g. hovering `2026-08-30 21:38` shows `2026-08-30 19:38 (UTC)`.

## What changed

**One shared helper** (`src/web/utils/date-display.ts`)

```ts
formatStoredDateForDisplay(value, { dateFormat, timeZone }) -> { text, title? }
formatStoredDateForCompactDisplay(value, { dateFormat, timeZone }, now) -> { text, title? }
```

`text` is the value to render, `title` the canonical UTC value with the marker. Parsing goes through `parseStoredUtcDate` rather than `Date`'s parsing, because `new Date("2026-07-16 21:49")` is parsed as *local* in V8; conversion uses `Intl.DateTimeFormat` with `hourCycle: "h23"`, and the resulting local wall-clock string is arranged by the existing `formatUtcDateForDisplay`, so the configured `dateFormat` still governs the output.

**Date-only values are never converted.** `created_date: '2025-07-26'` has no time component, so converting it can move it a day. Those values render unchanged and get no `title`, so the hover never claims a time the record does not have.

**One component, no per-component conversion.** `src/web/components/StoredDate.tsx` renders `<span title={utc}>{local}</span>`, and every web stored-date render goes through it: TaskDetailsModal (Created / Updated / Due / comment dates), TaskList (compact Created column and Due), TaskCard (Due), DraftsList, Statistics, MilestonesPage, DocumentationDetail, DecisionDetail, CleanupModal. The ad-hoc `formatDate` closures in CleanupModal and Statistics are gone.

**CLI, TUI, MCP and plain output are untouched** and still print UTC with the `(UTC)` marker.

## One decision worth a look

The visible `Due (UTC):` labels became `Due:`, because the displayed value is no longer UTC and the UTC value is now on hover. The due-date **entry** fields keep their `Due (UTC)` labels: entry semantics are unchanged, the input still takes and stores a UTC value. That means you type `14:30` into a field labelled `Due (UTC)` and the card then shows your local `16:30`, with `14:30 (UTC)` on hover. Converting the inputs too would be a write-path change and is out of scope here — happy to follow up if you would rather have that.

## Tests

`src/web/utils/date-display.test.ts` passes an explicit `timeZone` to every case, so nothing depends on the machine running the tests. It covers a timestamp rendered in a non-UTC timezone, the local-midnight rollover, a date-only value left unconverted with no hover, and `dateFormat` applied to both the local value and the UTC hover.

Component tests that assert a rendered timestamp pin the timezone through the new `src/test/pin-timezone.ts` helper (`beforeAll`/`afterAll`, restoring the previously *resolved* zone because bun shares one process across test files). `web-task-list-table-width`, `web-milestones-page-search` and `web-task-types` now render under `Asia/Tokyo` and assert both the local text and the UTC title, plus a date-only `created_date` that must not shift. Those files were rerun under `TZ=UTC`, `America/Los_Angeles` and `Pacific/Kiritimati` to confirm.

Also verified in the running web UI (browser timezone Europe/Vienna): a task stored as `2026-09-02 17:01` renders `2026-09-02 19:01` titled `2026-09-02 17:01 (UTC)`, and BACK-208's date-only `2025-07-26` renders unchanged with no title.
