### PR TITLE
BACK-683 - Render TUI acceptance-criteria progress as a pie glyph

### DIFF
--- a/backlog/tasks/back-683 - Render-TUI-acceptance-criteria-progress-as-a-pie-glyph.md
+++ b/backlog/tasks/back-683 - Render-TUI-acceptance-criteria-progress-as-a-pie-glyph.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-02 21:40'
-updated_date: '2026-09-02 22:38'
+updated_date: '2026-09-02 23:00'
 labels: []
 dependencies: []
 ordinal: 315000
@@ -59,10 +59,24 @@ The reserved column is emitted before the row-level color tags on both surfaces.
 In the task list the status segment is now always the single-cell icon. It previously swapped between the icon and 'icon + status word', which is variable width, so ids could not line up. Flagged in the PR for review since it removes the status word from rows that are not In Progress.
 
 Verified in a real PTY at 150x40 with expect (board and task list): the five glyphs render single-cell and every task id lines up, including a 10/13 row and rows with no criteria. blessed only degrades non-ASCII to '?' when the locale is not UTF-8 (Tput.detectUnicode), which already applies to the shipped ◒ ○ ✔ status icons, so the pies introduce no new exposure. neo-neo-bblessed unicode.strWidth reports 1 for all five, same as the ● already in use, and no Block Elements are used.
+
+Review follow-up (Codex findings on PR #996), both resolved by one change rather than two patches.
+
+Finding 1 (custom statuses): dropping the status word from the task list made every status outside the six getStatusStyle entries render as the same default ○ and color. Reproduced before the fix: 'Ready', 'Waiting', 'Blocked on review' and 'To Do' all rendered the identical row '○         BACK-1 - Title'. The word is load-bearing, so the list shows icon + status word on every row again, unconditionally.
+
+Finding 2 (three-digit counts): the fixed 8-column reserve overflowed for larger checklists. Reproduced before the fix: 10/100 needed 9 cells and 100/100 needed 10, so those ids sat at columns 9 and 10 while every other row sat at 8.
+
+Both come from a fixed constant, so the constant is gone. New src/ui/task-row-prefix.ts builds the prefix per render: a status segment (task list only; board columns already name the status) then the progress cell, each padded to the widest of its kind across the rows actually being rendered. Ids line up, custom statuses keep their label, three-digit counts fit, and a render pays only for columns something on it fills. A board column where no row has criteria now has no gutter at all, and a list with only single-digit counts spends nothing on the three-digit case. Widths are measured with the same neo-neo-bblessed unicode.strWidth the layout uses, not string length, so a non-ASCII status label pads correctly.
+
+acceptance-criteria-progress.ts is back to formatAcceptanceCriteriaProgress(task) returning the bare tagged cell or an empty string; all reservation lives in the prefix builder. The prefix is still emitted before the row-level move/dim tags, so the highlight and cross-branch dim survive the whole row.
+
+The board formatter and the task-list formatter take the prefix builder as a last parameter, defaulting to a single-row builder so standalone calls still render sensibly. The task list rebuilds it wherever filteredTasks is assigned, so the render stays O(n).
+
+Verified: 13 tests in src/test/tui-acceptance-criteria-progress.test.ts, including a render mixing custom statuses, 100/100, 10/100 and rows without progress that asserts one id column for all of them, a test that Ready and Waiting stay distinguishable, a test that an all-queued board column spends zero prefix width, and cell-width checks on the composed prefix. PTY QA at 150x40 on a project configured with To Do / Ready / In Progress / Waiting / Done and a 100-criterion task. bunx tsc --noEmit and bun run check . pass; bun run test is 2860 pass / 8 skip / 1 fail, matching a clean origin/main baseline run (2859 / 8 / 1) that fails the same ContentStore test.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
-Replaced the TUI's ASCII acceptance-criteria bar with a single pie glyph plus the live checked/total count (○ ◔ ◑ ◕ ●, green/yellow/red unchanged), and made the indicator a fixed 8-column field present on every row so task ids line up on the board and in the task list. The wide/compact variants and their availableWidth plumbing are gone. Verified with 12 rewritten unit tests covering each glyph threshold, the color at each threshold, id alignment between rows with and without progress, and single-cell width via neo-neo-bblessed unicode.strWidth; plus real PTY renders of board and task list at 150x40 under a UTF-8 locale. Plain and MCP output are untouched (cli-task-list and mcp-tasks tests pass unchanged). bunx tsc --noEmit and bun run check . pass; bun run test is 2859 pass / 1 fail, the failure being a load-dependent local flake that passes in isolation and lands on a different unrelated test each run. PR #996.
+Replaced the TUI's ASCII acceptance-criteria bar with a single pie glyph plus the live checked/total count (○ ◔ ◑ ◕ ●, green/yellow/red unchanged), and moved column reservation into src/ui/task-row-prefix.ts, which sizes the status and progress columns per render from the rows actually on screen. Task ids line up on the board and in the task list, custom status labels are preserved, counts of any length fit, and a render pays only for columns something on it fills. The prefix is emitted before the row-level move and cross-branch tags so those colors survive the whole row. Verified with 13 unit tests covering the glyph thresholds, the color at each threshold, id alignment across custom statuses / three-digit counts / rows without progress, zero prefix width for an all-queued board column, and cell widths on the composed prefix; plus PTY renders at 150x40 with a five-status workflow and a 100-criterion task. Plain and MCP output untouched. bunx tsc --noEmit and bun run check . pass; bun run test is 2860/8/1, matching a clean origin/main baseline that fails the same ContentStore flake. PR #996.
 <!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-683 - Render-TUI-acceptance-criteria-progress-as-a-pie-glyph.md
+++ b/backlog/tasks/back-683 - Render-TUI-acceptance-criteria-progress-as-a-pie-glyph.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-02 21:40'
-updated_date: '2026-09-02 22:27'
+updated_date: '2026-09-02 22:38'
 labels: []
 dependencies: []
 ordinal: 315000
@@ -21,18 +21,18 @@ Replace the bar with a single pie glyph from the same Unicode block as the shape
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 In Progress rows with criteria show a pie glyph (○ ◔ ◑ ◕ ●) and the checked/total count instead of the ASCII bar, on the board and in the task list
-- [ ] #2 The glyph keeps the existing color semantics: green when all criteria are checked, yellow when underway, red when a third or fewer are checked
-- [ ] #3 Task IDs align across rows because the indicator column is reserved on rows without progress
-- [ ] #4 The glyphs render at the correct width in the TUI, verified with the existing width test infrastructure, and no Block Elements are introduced
-- [ ] #5 Plain and MCP list output are unchanged
+- [x] #1 In Progress rows with criteria show a pie glyph (○ ◔ ◑ ◕ ●) and the checked/total count instead of the ASCII bar, on the board and in the task list
+- [x] #2 The glyph keeps the existing color semantics: green when all criteria are checked, yellow when underway, red when a third or fewer are checked
+- [x] #3 Task IDs align across rows because the indicator column is reserved on rows without progress
+- [x] #4 The glyphs render at the correct width in the TUI, verified with the existing width test infrastructure, and no Block Elements are introduced
+- [x] #5 Plain and MCP list output are unchanged
 <!-- AC:END -->
 
 ## Definition of Done
 <!-- DOD:BEGIN -->
-- [ ] #1 bunx tsc --noEmit passes when TypeScript touched
-- [ ] #2 bun run check . passes when formatting/linting touched
-- [ ] #3 bun test (or scoped test) passes
+- [x] #1 bunx tsc --noEmit passes when TypeScript touched
+- [x] #2 bun run check . passes when formatting/linting touched
+- [x] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
 
 ## Implementation Plan
@@ -60,3 +60,9 @@ In the task list the status segment is now always the single-cell icon. It previ
 
 Verified in a real PTY at 150x40 with expect (board and task list): the five glyphs render single-cell and every task id lines up, including a 10/13 row and rows with no criteria. blessed only degrades non-ASCII to '?' when the locale is not UTF-8 (Tput.detectUnicode), which already applies to the shipped ◒ ○ ✔ status icons, so the pies introduce no new exposure. neo-neo-bblessed unicode.strWidth reports 1 for all five, same as the ● already in use, and no Block Elements are used.
 <!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Replaced the TUI's ASCII acceptance-criteria bar with a single pie glyph plus the live checked/total count (○ ◔ ◑ ◕ ●, green/yellow/red unchanged), and made the indicator a fixed 8-column field present on every row so task ids line up on the board and in the task list. The wide/compact variants and their availableWidth plumbing are gone. Verified with 12 rewritten unit tests covering each glyph threshold, the color at each threshold, id alignment between rows with and without progress, and single-cell width via neo-neo-bblessed unicode.strWidth; plus real PTY renders of board and task list at 150x40 under a UTF-8 locale. Plain and MCP output are untouched (cli-task-list and mcp-tasks tests pass unchanged). bunx tsc --noEmit and bun run check . pass; bun run test is 2859 pass / 1 fail, the failure being a load-dependent local flake that passes in isolation and lands on a different unrelated test each run. PR #996.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/back-683 - Render-TUI-acceptance-criteria-progress-as-a-pie-glyph.md
+++ b/backlog/tasks/back-683 - Render-TUI-acceptance-criteria-progress-as-a-pie-glyph.md
@@ -1,9 +1,11 @@
 ---
 id: BACK-683
 title: Render TUI acceptance-criteria progress as a pie glyph
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-02 21:40'
+updated_date: '2026-09-02 22:27'
 labels: []
 dependencies: []
 ordinal: 315000
@@ -32,3 +34,29 @@ Replace the bar with a single pie glyph from the same Unicode block as the shape
 - [ ] #2 bun run check . passes when formatting/linting touched
 - [ ] #3 bun test (or scoped test) passes
 <!-- DOD:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Replace the ASCII bar in src/ui/acceptance-criteria-progress.ts with a single pie glyph (U+25CB/25D4/25D1/25D5/25CF) plus the checked/total count. Glyph thresholds: nothing checked -> circle, <= 1/3 -> quarter, <= 2/3 -> half, above that but incomplete -> three-quarter, all checked -> full. Keep the existing wrapStatusColor semantics (green complete, yellow underway, red at a third or fewer). No Block Elements.
+2. Turn the formatter into a fixed-width column that every row gets, including the separator before the task id: blanks when a row shows no progress. Drop the wide/compact variants and the now-unused availableWidth plumbing from both row formatters.
+3. Board (src/ui/board.ts formatTaskListItem): prefix every row with the reserved column so ids line up across rows and columns; verify the moving marker and cross-branch dimming still compose.
+4. Task list (src/ui/task-viewer-with-search.ts formatTaskViewerListItem): use the same reserved column; make the status segment a uniform-width icon so ids actually line up (the BACK-551 conditional swapped between icon-only and icon+status-word, which is variable width).
+5. Verify the five glyphs measure one cell in the patched neo-neo-bblessed width table using the same unicode.strWidth infrastructure as src/test/tui-emoji-width.test.ts.
+6. Rewrite src/test/tui-acceptance-criteria-progress.test.ts for the new output: each glyph threshold, the color at each threshold, id alignment between a row with progress and a row without, and cell width. Leave the plain/MCP suffix test untouched.
+7. Gates: bunx tsc --noEmit, bun run check ., bun run test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Replaced the ASCII bar with a single pie glyph plus the live checked/total count, in src/ui/acceptance-criteria-progress.ts. Thresholds: ○ nothing checked, ◔ up to a third, ◑ up to two thirds, ◕ above that, ● only when every criterion is checked. ○ and ● are reserved for the exact counts, which replaces the old rounding clamps. Colors are unchanged (green complete, yellow underway, red at a third or fewer), so ○/◔ are red, ◑/◕ yellow and ● green.
+
+The formatter is now formatAcceptanceCriteriaProgressColumn and returns a fixed 8-column field for every row, blanks included, with the separator before the task id. 8 fits '● 99/99', so ids stay aligned for any checklist length a person would review. The wide/compact variants and the availableWidth plumbing behind them are gone from both row formatters, buildRenderedTaskListItems and getTaskListSummaryWidth.
+
+The reserved column is emitted before the row-level color tags on both surfaces. blessed treats a bare {/} as a full attribute reset (Element.prototype._parseTags), so the glyph's own close tag used to cancel the magenta move highlight and the gray cross-branch dim for the rest of the row; keeping the column outside those tags fixes that and holds the leftmost column still while a task moves.
+
+In the task list the status segment is now always the single-cell icon. It previously swapped between the icon and 'icon + status word', which is variable width, so ids could not line up. Flagged in the PR for review since it removes the status word from rows that are not In Progress.
+
+Verified in a real PTY at 150x40 with expect (board and task list): the five glyphs render single-cell and every task id lines up, including a 10/13 row and rows with no criteria. blessed only degrades non-ASCII to '?' when the locale is not UTF-8 (Tput.detectUnicode), which already applies to the shipped ◒ ○ ✔ status icons, so the pies introduce no new exposure. neo-neo-bblessed unicode.strWidth reports 1 for all five, same as the ● already in use, and no Block Elements are used.
+<!-- SECTION:NOTES:END -->

--- a/src/test/tui-acceptance-criteria-progress.test.ts
+++ b/src/test/tui-acceptance-criteria-progress.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import blessed from "neo-neo-bblessed";
 import type { AcceptanceCriterion, Task } from "../types/index.ts";
-import { formatAcceptanceCriteriaProgressColumn } from "../ui/acceptance-criteria-progress.ts";
+import { formatAcceptanceCriteriaProgress } from "../ui/acceptance-criteria-progress.ts";
 import { formatTaskListItem } from "../ui/board.ts";
+import { createTaskRowPrefix } from "../ui/task-row-prefix.ts";
 import { formatTaskViewerListItem } from "../ui/task-viewer-with-search.ts";
 import { stripBlessedFgTags } from "../ui/utils/strip-tags.ts";
 
@@ -30,24 +31,37 @@ function makeTask(overrides: Partial<Task> = {}): Task {
 	};
 }
 
-const column = (total: number, checked: number) =>
-	formatAcceptanceCriteriaProgressColumn(makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }));
+const withCriteria = (total: number, checked: number, overrides: Partial<Task> = {}) =>
+	makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked), ...overrides });
+
+const cell = (total: number, checked: number) => formatAcceptanceCriteriaProgress(withCriteria(total, checked));
 
 /** What the terminal actually shows once blessed has consumed every tag. */
 const rendered = (row: string) => row.replace(/\{\/?[\w\-,;!#]*\}/g, "");
-const idColumn = (row: string) => rendered(row).indexOf("BACK-");
+/** Cells before the task id, measured the way blessed lays the row out. */
+const idColumn = (row: string) => unicode.strWidth(rendered(row).split("BACK-")[0] ?? "");
+
+function renderList(tasks: Task[]): string[] {
+	const formatPrefix = createTaskRowPrefix(tasks, { showStatus: true });
+	return tasks.map((task) => formatTaskViewerListItem(task, undefined, undefined, formatPrefix));
+}
+
+function renderBoardColumn(tasks: Task[]): string[] {
+	const formatPrefix = createTaskRowPrefix(tasks, { showStatus: false });
+	return tasks.map((task) => formatTaskListItem(task, false, undefined, undefined, formatPrefix));
+}
 
 describe("TUI acceptance-criteria progress", () => {
 	it("renders one pie glyph and the live count from checklist state", () => {
 		const task = makeTask();
 
-		expect(formatAcceptanceCriteriaProgressColumn(task)).toBe("{yellow-fg}◑{/} 4/7   ");
+		expect(formatAcceptanceCriteriaProgress(task)).toBe("{yellow-fg}◑{/} 4/7");
 		if (task.acceptanceCriteriaItems?.[4]) task.acceptanceCriteriaItems[4].checked = true;
-		expect(formatAcceptanceCriteriaProgressColumn(task)).toBe("{yellow-fg}◕{/} 5/7   ");
+		expect(formatAcceptanceCriteriaProgress(task)).toBe("{yellow-fg}◕{/} 5/7");
 	});
 
 	it("fills the pie as the checklist fills", () => {
-		const glyph = (total: number, checked: number) => stripBlessedFgTags(column(total, checked)).trim().split(" ")[0];
+		const glyph = (total: number, checked: number) => stripBlessedFgTags(cell(total, checked)).split(" ")[0];
 
 		expect(glyph(9, 0)).toBe("○");
 		expect(glyph(9, 1)).toBe("◔");
@@ -62,104 +76,127 @@ describe("TUI acceptance-criteria progress", () => {
 	it("reserves the empty and full pies for the exact counts", () => {
 		// One checked criterion out of twenty must not read as untouched, and nineteen must
 		// not read as finished.
-		expect(stripBlessedFgTags(column(20, 1))).toBe("◔ 1/20  ");
-		expect(stripBlessedFgTags(column(20, 19))).toBe("◕ 19/20 ");
+		expect(stripBlessedFgTags(cell(20, 1))).toBe("◔ 1/20");
+		expect(stripBlessedFgTags(cell(20, 19))).toBe("◕ 19/20");
 	});
 
 	it("colors the glyph by completion ratio using the TUI's red/yellow/green semantics", () => {
-		expect(column(4, 0)).toBe("{red-fg}○{/} 0/4   ");
-		expect(column(3, 1)).toBe("{red-fg}◔{/} 1/3   ");
-		expect(column(7, 4)).toBe("{yellow-fg}◑{/} 4/7   ");
-		expect(column(5, 4)).toBe("{yellow-fg}◕{/} 4/5   ");
-		expect(column(2, 2)).toBe("{green-fg}●{/} 2/2   ");
+		expect(cell(4, 0)).toBe("{red-fg}○{/} 0/4");
+		expect(cell(3, 1)).toBe("{red-fg}◔{/} 1/3");
+		expect(cell(7, 4)).toBe("{yellow-fg}◑{/} 4/7");
+		expect(cell(5, 4)).toBe("{yellow-fg}◕{/} 4/5");
+		expect(cell(2, 2)).toBe("{green-fg}●{/} 2/2");
 	});
 
-	it("blanks the column instead of dropping it when a row has no progress to show", () => {
-		const blank = " ".repeat(8);
-
-		expect(formatAcceptanceCriteriaProgressColumn(makeTask({ acceptanceCriteriaItems: [] }))).toBe(blank);
-		expect(formatAcceptanceCriteriaProgressColumn(makeTask({ status: "To Do" }))).toBe(blank);
-		expect(formatAcceptanceCriteriaProgressColumn(makeTask({ status: "Done" }))).toBe(blank);
+	it("shows progress only for In Progress tasks that have criteria", () => {
+		expect(formatAcceptanceCriteriaProgress(makeTask({ acceptanceCriteriaItems: [] }))).toBe("");
+		expect(formatAcceptanceCriteriaProgress(makeTask({ status: "To Do" }))).toBe("");
+		expect(formatAcceptanceCriteriaProgress(makeTask({ status: "Done" }))).toBe("");
 	});
 
-	it("lines task ids up on the board whether or not a row shows progress", () => {
-		const withProgress = formatTaskListItem(makeTask());
-		const noCriteria = formatTaskListItem(makeTask({ id: "BACK-552", acceptanceCriteriaItems: [] }));
-		const otherStatus = formatTaskListItem(makeTask({ id: "BACK-553", status: "To Do" }));
-		const twoDigitCounts = formatTaskListItem(
-			makeTask({ id: "BACK-554", acceptanceCriteriaItems: makeCriteria(13, 10) }),
-		);
+	it("lines every task id up across custom statuses, three-digit counts and rows without progress", () => {
+		const rows = renderList([
+			withCriteria(4, 0, { id: "BACK-1" }),
+			withCriteria(100, 100, { id: "BACK-2" }),
+			withCriteria(100, 10, { id: "BACK-3" }),
+			makeTask({ id: "BACK-4", acceptanceCriteriaItems: [] }),
+			makeTask({ id: "BACK-5", status: "Waiting" }),
+			makeTask({ id: "BACK-6", status: "Ready" }),
+			makeTask({ id: "BACK-7", status: "Done" }),
+		]);
 
-		expect(rendered(withProgress)).toBe("◑ 4/7   BACK-551 - Show progress");
-		expect(rendered(noCriteria)).toBe("        BACK-552 - Show progress");
-		expect(idColumn(withProgress)).toBe(idColumn(noCriteria));
-		expect(idColumn(withProgress)).toBe(idColumn(otherStatus));
-		expect(idColumn(withProgress)).toBe(idColumn(twoDigitCounts));
+		expect(new Set(rows.map(idColumn)).size).toBe(1);
+		expect(rendered(rows[1] ?? "")).toBe("◒ In Progress ● 100/100 BACK-2 - Show progress");
+		expect(rendered(rows[3] ?? "")).toBe("◒ In Progress           BACK-4 - Show progress");
+		expect(rendered(rows[5] ?? "")).toBe("○ Ready                 BACK-6 - Show progress");
 	});
 
-	it("lines task ids up in the task list behind a single-cell status icon", () => {
-		const withProgress = formatTaskViewerListItem(makeTask());
-		const done = formatTaskViewerListItem(makeTask({ id: "BACK-552", status: "Done" }));
+	it("keeps the status word so unmapped custom statuses stay distinguishable", () => {
+		// getStatusStyle maps six statuses; everything else shares the default ○ and color, so
+		// the word is the only thing telling Ready from Waiting.
+		const rows = renderList([
+			makeTask({ id: "BACK-1", status: "Ready", acceptanceCriteriaItems: [] }),
+			makeTask({ id: "BACK-2", status: "Waiting", acceptanceCriteriaItems: [] }),
+		]);
 
-		expect(rendered(withProgress)).toBe("◒ ◑ 4/7   BACK-551 - Show progress");
-		expect(rendered(done)).toBe("✔         BACK-552 - Show progress");
-		expect(idColumn(withProgress)).toBe(idColumn(done));
+		expect(rendered(rows[0] ?? "")).toContain("○ Ready  ");
+		expect(rendered(rows[1] ?? "")).toContain("○ Waiting");
+		expect(rendered(rows[0] ?? "")).not.toBe(rendered(rows[1] ?? ""));
 	});
 
-	it("keeps the moving marker and cross-branch dimming outside the reserved column", () => {
-		const moving = formatTaskListItem(makeTask(), true);
-		const crossBranch = formatTaskListItem(makeTask({ branch: "feature/x" } as Partial<Task>));
+	it("charges a render only for the columns something on it fills", () => {
+		// Board columns already name the status, so a column where no row has criteria spends
+		// nothing on a prefix, and single-digit counts never pay for the three-digit case.
+		const queued = renderBoardColumn([
+			makeTask({ id: "BACK-1", status: "To Do" }),
+			makeTask({ id: "BACK-2", status: "To Do" }),
+		]);
+		expect(queued.map(idColumn)).toEqual([0, 0]);
 
-		// The column precedes the row tags, so its own {/} cannot close the highlight or the
-		// dim, and the column itself never moves.
-		expect(moving).toBe("{yellow-fg}◑{/} 4/7   {magenta-fg}► {bold}BACK-551{/bold} - Show progress{/}");
-		expect(crossBranch.startsWith("{yellow-fg}◑{/} 4/7   {gray-fg}")).toBe(true);
-		expect(formatTaskViewerListItem(makeTask({ branch: "feature/x" } as Partial<Task>))).toContain(
-			"◑{/} 4/7   {gray-fg}",
-		);
+		const active = renderBoardColumn([
+			withCriteria(7, 4, { id: "BACK-1" }),
+			makeTask({ id: "BACK-2", acceptanceCriteriaItems: [] }),
+		]);
+		expect(rendered(active[0] ?? "")).toBe("◑ 4/7 BACK-1 - Show progress");
+		expect(rendered(active[1] ?? "")).toBe("      BACK-2 - Show progress");
+		expect(new Set(active.map(idColumn)).size).toBe(1);
 	});
 
-	it("measures every pie as one cell in the patched blessed width table", () => {
+	it("keeps the move marker and cross-branch dim outside the prefix", () => {
+		const formatPrefix = createTaskRowPrefix([makeTask()], { showStatus: false });
+		const moving = formatTaskListItem(makeTask(), true, undefined, undefined, formatPrefix);
+		const crossBranch = formatTaskViewerListItem(makeTask({ branch: "feature/x" } as Partial<Task>));
+
+		// blessed reads a bare {/} as a full reset, so a prefix inside these tags would cancel
+		// the highlight and the dim for the rest of the row.
+		expect(moving).toBe("{yellow-fg}◑{/} 4/7 {magenta-fg}► {bold}BACK-551{/bold} - Show progress{/}");
+		expect(crossBranch).toContain("{yellow-fg}◑{/} 4/7 {gray-fg}{bold}BACK-551{/bold}");
+	});
+
+	it("measures every composed prefix in whole cells", () => {
 		// Geometric Shapes, the block the TUI already renders (see status-icon.ts). Block
 		// Elements would blank out on fonts without them and blessed cannot ACS-route them.
 		for (const glyph of ["○", "◔", "◑", "◕", "●"]) {
 			expect(unicode.strWidth(glyph)).toBe(1);
 		}
-		for (const [total, checked] of [
-			[4, 0],
-			[7, 4],
-			[13, 10],
-			[3, 3],
-		] as const) {
-			const cells = stripBlessedFgTags(column(total, checked));
-			expect(unicode.strWidth(cells)).toBe(cells.length);
-			expect(cells).toMatch(/^[○◔◑◕●] \d+\/\d+ *$/);
+
+		const rows = renderList([
+			withCriteria(4, 0, { id: "BACK-1" }),
+			withCriteria(100, 100, { id: "BACK-2" }),
+			makeTask({ id: "BACK-3", status: "Waiting", acceptanceCriteriaItems: [] }),
+		]);
+		for (const row of rows) {
+			const prefix = rendered(row).split("BACK-")[0] ?? "";
+			// Every glyph is single-width, so the cells blessed lays out match the characters
+			// the padding counted.
+			expect(unicode.strWidth(prefix)).toBe(prefix.length);
+			expect(prefix).toMatch(/^[○◒✔◆▣●] [\w ]+?(?: [○◔◑◕●] \d+\/\d+)? *$/);
 		}
 	});
 
 	it("keeps fully checked work visibly In Progress without color-dependent meaning", () => {
-		const task = makeTask({ acceptanceCriteriaItems: makeCriteria(2, 2) });
-		const progress = formatAcceptanceCriteriaProgressColumn(task);
+		const task = withCriteria(2, 2);
+		const progress = formatAcceptanceCriteriaProgress(task);
 		const listItem = rendered(formatTaskViewerListItem(task));
 
-		expect(stripBlessedFgTags(progress)).toBe("● 2/2   ");
+		expect(stripBlessedFgTags(progress)).toBe("● 2/2");
 		expect(progress).not.toContain("AC");
 		expect(progress).not.toContain("%");
 		expect(task.status).toBe("In Progress");
-		expect(listItem).toContain("◒ ● 2/2");
+		expect(listItem).toContain("◒ In Progress ● 2/2");
 		expect(listItem).not.toContain("✔");
 	});
 
 	it("normalizes configured status casing before choosing the active-work icon", () => {
 		const listItem = rendered(formatTaskViewerListItem(makeTask({ status: " IN PROGRESS " })));
 
-		expect(listItem).toContain("◑ 4/7   BACK-551");
+		expect(listItem).toContain("◒  IN PROGRESS  ◑ 4/7 BACK-551");
 	});
 
 	it("reuses the same indicator in board cards and task-list summaries", () => {
 		const task = makeTask();
 
-		expect(formatTaskListItem(task)).toContain("{yellow-fg}◑{/} 4/7   {bold}BACK-551{/bold}");
-		expect(formatTaskViewerListItem(task)).toContain("{yellow-fg}◑{/} 4/7   {bold}BACK-551{/bold}");
+		expect(formatTaskListItem(task)).toContain("{yellow-fg}◑{/} 4/7 {bold}BACK-551{/bold}");
+		expect(formatTaskViewerListItem(task)).toContain("{yellow-fg}◑{/} 4/7 {bold}BACK-551{/bold}");
 	});
 });

--- a/src/test/tui-acceptance-criteria-progress.test.ts
+++ b/src/test/tui-acceptance-criteria-progress.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "bun:test";
+import blessed from "neo-neo-bblessed";
 import type { AcceptanceCriterion, Task } from "../types/index.ts";
-import { formatAcceptanceCriteriaProgress } from "../ui/acceptance-criteria-progress.ts";
+import { formatAcceptanceCriteriaProgressColumn } from "../ui/acceptance-criteria-progress.ts";
 import { formatTaskListItem } from "../ui/board.ts";
 import { formatTaskViewerListItem } from "../ui/task-viewer-with-search.ts";
 import { stripBlessedFgTags } from "../ui/utils/strip-tags.ts";
+
+const unicode = (blessed as unknown as { unicode: { strWidth(s: string): number } }).unicode;
 
 function makeCriteria(total: number, checked: number): AcceptanceCriterion[] {
 	return Array.from({ length: total }, (_, index) => ({
@@ -27,88 +30,136 @@ function makeTask(overrides: Partial<Task> = {}): Task {
 	};
 }
 
+const column = (total: number, checked: number) =>
+	formatAcceptanceCriteriaProgressColumn(makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }));
+
+/** What the terminal actually shows once blessed has consumed every tag. */
+const rendered = (row: string) => row.replace(/\{\/?[\w\-,;!#]*\}/g, "");
+const idColumn = (row: string) => rendered(row).indexOf("BACK-");
+
 describe("TUI acceptance-criteria progress", () => {
-	it("renders the exact wide and constrained bars from live checklist state", () => {
+	it("renders one pie glyph and the live count from checklist state", () => {
 		const task = makeTask();
 
-		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[{yellow-fg}###{/}--] 4/7");
-		expect(formatAcceptanceCriteriaProgress(task, 39)).toBe("[{yellow-fg}##{/}-] 4/7");
+		expect(formatAcceptanceCriteriaProgressColumn(task)).toBe("{yellow-fg}◑{/} 4/7   ");
 		if (task.acceptanceCriteriaItems?.[4]) task.acceptanceCriteriaItems[4].checked = true;
-		expect(formatAcceptanceCriteriaProgress(task, 40)).toBe("[{yellow-fg}####{/}-] 5/7");
+		expect(formatAcceptanceCriteriaProgressColumn(task)).toBe("{yellow-fg}◕{/} 5/7   ");
 	});
 
-	it("colors the filled run by completion ratio using the TUI's red/yellow/green semantics", () => {
-		const bar = (total: number, checked: number) =>
-			formatAcceptanceCriteriaProgress(makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }), 40);
+	it("fills the pie as the checklist fills", () => {
+		const glyph = (total: number, checked: number) => stripBlessedFgTags(column(total, checked)).trim().split(" ")[0];
 
-		expect(bar(3, 1)).toBe("[{red-fg}##{/}---] 1/3");
-		expect(bar(7, 4)).toBe("[{yellow-fg}###{/}--] 4/7");
-		expect(bar(2, 2)).toBe("[{green-fg}#####{/}] 2/2");
-		// Nothing checked leaves nothing to color: an all-empty bar carries no tag.
-		expect(bar(4, 0)).toBe("[-----] 0/4");
+		expect(glyph(9, 0)).toBe("○");
+		expect(glyph(9, 1)).toBe("◔");
+		// The thirds are inclusive boundaries: 3/9 is still a quarter pie, 6/9 still a half.
+		expect(glyph(9, 3)).toBe("◔");
+		expect(glyph(9, 4)).toBe("◑");
+		expect(glyph(9, 6)).toBe("◑");
+		expect(glyph(9, 7)).toBe("◕");
+		expect(glyph(9, 9)).toBe("●");
 	});
 
-	it("never rounds progress to an empty bar or unfinished work to a full one", () => {
-		const bar = (total: number, checked: number, width: number) =>
-			formatAcceptanceCriteriaProgress(makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }), width);
-
-		expect(bar(20, 1, 40)).toBe("[{red-fg}#{/}----] 1/20");
-		expect(bar(20, 19, 40)).toBe("[{yellow-fg}####{/}-] 19/20");
-		expect(bar(10, 1, 20)).toBe("[{red-fg}#{/}--] 1/10");
-		expect(bar(10, 9, 20)).toBe("[{yellow-fg}##{/}-] 9/10");
+	it("reserves the empty and full pies for the exact counts", () => {
+		// One checked criterion out of twenty must not read as untouched, and nineteen must
+		// not read as finished.
+		expect(stripBlessedFgTags(column(20, 1))).toBe("◔ 1/20  ");
+		expect(stripBlessedFgTags(column(20, 19))).toBe("◕ 19/20 ");
 	});
 
-	it("emits only ASCII bar characters so terminals without Block Element glyphs stay legible", () => {
-		// blessed only ACS-routes DEC Special Graphics; U+2588/U+2591 would render
-		// as blank cells on fonts without Block Elements and as "?" without UTF-8.
-		for (const [total, checked, width] of [
-			[7, 4, 40],
-			[7, 4, 39],
-			[10, 0, 40],
-			[3, 3, 20],
-		] as const) {
-			const bar = formatAcceptanceCriteriaProgress(
-				makeTask({ acceptanceCriteriaItems: makeCriteria(total, checked) }),
-				width,
-			);
-			expect(stripBlessedFgTags(bar)).toMatch(/^\[[#-]*\] \d+\/\d+$/);
+	it("colors the glyph by completion ratio using the TUI's red/yellow/green semantics", () => {
+		expect(column(4, 0)).toBe("{red-fg}○{/} 0/4   ");
+		expect(column(3, 1)).toBe("{red-fg}◔{/} 1/3   ");
+		expect(column(7, 4)).toBe("{yellow-fg}◑{/} 4/7   ");
+		expect(column(5, 4)).toBe("{yellow-fg}◕{/} 4/5   ");
+		expect(column(2, 2)).toBe("{green-fg}●{/} 2/2   ");
+	});
+
+	it("blanks the column instead of dropping it when a row has no progress to show", () => {
+		const blank = " ".repeat(8);
+
+		expect(formatAcceptanceCriteriaProgressColumn(makeTask({ acceptanceCriteriaItems: [] }))).toBe(blank);
+		expect(formatAcceptanceCriteriaProgressColumn(makeTask({ status: "To Do" }))).toBe(blank);
+		expect(formatAcceptanceCriteriaProgressColumn(makeTask({ status: "Done" }))).toBe(blank);
+	});
+
+	it("lines task ids up on the board whether or not a row shows progress", () => {
+		const withProgress = formatTaskListItem(makeTask());
+		const noCriteria = formatTaskListItem(makeTask({ id: "BACK-552", acceptanceCriteriaItems: [] }));
+		const otherStatus = formatTaskListItem(makeTask({ id: "BACK-553", status: "To Do" }));
+		const twoDigitCounts = formatTaskListItem(
+			makeTask({ id: "BACK-554", acceptanceCriteriaItems: makeCriteria(13, 10) }),
+		);
+
+		expect(rendered(withProgress)).toBe("◑ 4/7   BACK-551 - Show progress");
+		expect(rendered(noCriteria)).toBe("        BACK-552 - Show progress");
+		expect(idColumn(withProgress)).toBe(idColumn(noCriteria));
+		expect(idColumn(withProgress)).toBe(idColumn(otherStatus));
+		expect(idColumn(withProgress)).toBe(idColumn(twoDigitCounts));
+	});
+
+	it("lines task ids up in the task list behind a single-cell status icon", () => {
+		const withProgress = formatTaskViewerListItem(makeTask());
+		const done = formatTaskViewerListItem(makeTask({ id: "BACK-552", status: "Done" }));
+
+		expect(rendered(withProgress)).toBe("◒ ◑ 4/7   BACK-551 - Show progress");
+		expect(rendered(done)).toBe("✔         BACK-552 - Show progress");
+		expect(idColumn(withProgress)).toBe(idColumn(done));
+	});
+
+	it("keeps the moving marker and cross-branch dimming outside the reserved column", () => {
+		const moving = formatTaskListItem(makeTask(), true);
+		const crossBranch = formatTaskListItem(makeTask({ branch: "feature/x" } as Partial<Task>));
+
+		// The column precedes the row tags, so its own {/} cannot close the highlight or the
+		// dim, and the column itself never moves.
+		expect(moving).toBe("{yellow-fg}◑{/} 4/7   {magenta-fg}► {bold}BACK-551{/bold} - Show progress{/}");
+		expect(crossBranch.startsWith("{yellow-fg}◑{/} 4/7   {gray-fg}")).toBe(true);
+		expect(formatTaskViewerListItem(makeTask({ branch: "feature/x" } as Partial<Task>))).toContain(
+			"◑{/} 4/7   {gray-fg}",
+		);
+	});
+
+	it("measures every pie as one cell in the patched blessed width table", () => {
+		// Geometric Shapes, the block the TUI already renders (see status-icon.ts). Block
+		// Elements would blank out on fonts without them and blessed cannot ACS-route them.
+		for (const glyph of ["○", "◔", "◑", "◕", "●"]) {
+			expect(unicode.strWidth(glyph)).toBe(1);
 		}
-	});
-
-	it("omits progress when criteria are absent or the task is not in progress", () => {
-		expect(formatAcceptanceCriteriaProgress(makeTask({ acceptanceCriteriaItems: [] }), 40)).toBe("");
-		expect(formatAcceptanceCriteriaProgress(makeTask({ status: "To Do" }), 40)).toBe("");
-		expect(formatAcceptanceCriteriaProgress(makeTask({ status: "Done" }), 40)).toBe("");
+		for (const [total, checked] of [
+			[4, 0],
+			[7, 4],
+			[13, 10],
+			[3, 3],
+		] as const) {
+			const cells = stripBlessedFgTags(column(total, checked));
+			expect(unicode.strWidth(cells)).toBe(cells.length);
+			expect(cells).toMatch(/^[○◔◑◕●] \d+\/\d+ *$/);
+		}
 	});
 
 	it("keeps fully checked work visibly In Progress without color-dependent meaning", () => {
 		const task = makeTask({ acceptanceCriteriaItems: makeCriteria(2, 2) });
-		const progress = formatAcceptanceCriteriaProgress(task, 40);
-		const listItem = stripBlessedFgTags(formatTaskViewerListItem(task, 40));
+		const progress = formatAcceptanceCriteriaProgressColumn(task);
+		const listItem = rendered(formatTaskViewerListItem(task));
 
-		expect(stripBlessedFgTags(progress)).toBe("[#####] 2/2");
+		expect(stripBlessedFgTags(progress)).toBe("● 2/2   ");
 		expect(progress).not.toContain("AC");
 		expect(progress).not.toContain("%");
 		expect(task.status).toBe("In Progress");
-		expect(listItem).toContain("◒ [#####] 2/2");
+		expect(listItem).toContain("◒ ● 2/2");
 		expect(listItem).not.toContain("✔");
 	});
 
 	it("normalizes configured status casing before choosing the active-work icon", () => {
-		const task = makeTask({ status: " IN PROGRESS " });
-		const listItem = stripBlessedFgTags(formatTaskViewerListItem(task, 40));
+		const listItem = rendered(formatTaskViewerListItem(makeTask({ status: " IN PROGRESS " })));
 
-		expect(listItem).toContain("◒ [###--] 4/7");
+		expect(listItem).toContain("◑ 4/7   BACK-551");
 	});
 
-	it("reuses the same responsive indicator in board cards and task-list summaries", () => {
+	it("reuses the same indicator in board cards and task-list summaries", () => {
 		const task = makeTask();
-		const wideBoardCard = formatTaskListItem(task, false, 40);
-		const compactBoardCard = stripBlessedFgTags(formatTaskListItem(task, false, 20));
-		const compactListItem = stripBlessedFgTags(formatTaskViewerListItem(task, 20));
 
-		expect(wideBoardCard).toContain("[{yellow-fg}###{/}--] 4/7 {bold}BACK-551{/bold}");
-		expect(compactBoardCard).toContain("[##-] 4/7 {bold}BACK-551{/bold}");
-		expect(compactListItem).toContain("◒ [##-] 4/7 {bold}BACK-551{/bold}");
+		expect(formatTaskListItem(task)).toContain("{yellow-fg}◑{/} 4/7   {bold}BACK-551{/bold}");
+		expect(formatTaskViewerListItem(task)).toContain("{yellow-fg}◑{/} 4/7   {bold}BACK-551{/bold}");
 	});
 });

--- a/src/test/tui-task-project.test.ts
+++ b/src/test/tui-task-project.test.ts
@@ -34,8 +34,8 @@ describe("TUI task project display", () => {
 	});
 
 	it("shows the project badge on board task cards", () => {
-		const projected = formatTaskListItem(createTask({ project: "Web" }), false, undefined, undefined, ["Web"]);
-		const unprojected = formatTaskListItem(createTask(), false, undefined, undefined, ["Web"]);
+		const projected = formatTaskListItem(createTask({ project: "Web" }), false, undefined, ["Web"]);
+		const unprojected = formatTaskListItem(createTask(), false, undefined, ["Web"]);
 		const unconfigured = formatTaskListItem(createTask({ project: "Web" }));
 
 		expect(projected).toContain("{blue-fg}[Web]{/}");

--- a/src/ui/acceptance-criteria-progress.ts
+++ b/src/ui/acceptance-criteria-progress.ts
@@ -1,12 +1,6 @@
 import type { Task } from "../types/index.ts";
 import { wrapStatusColor } from "./status-icon.ts";
 
-// Every row reserves this column so task ids line up whether or not the row shows
-// progress. It holds "● 99/99" plus the separator before the id, which covers any
-// checklist a person can review; a longer count pushes its own row right rather than
-// losing a digit.
-const PROGRESS_COLUMN_WIDTH = 8;
-
 function isInProgress(status: string): boolean {
 	return status.trim().toLowerCase() === "in progress";
 }
@@ -48,22 +42,19 @@ export function formatAcceptanceCriteriaSummarySuffix(task: Task): string {
 }
 
 /**
- * Format the acceptance-criteria column that precedes the task id in one-line TUI summaries.
+ * Format live acceptance-criteria completion for one-line TUI task summaries: a pie glyph
+ * and the checked/total count for In Progress tasks with criteria, empty for every other
+ * row. createTaskRowPrefix reserves the column this occupies.
  *
- * In Progress tasks with criteria get a pie glyph and their live checked/total count; every
- * other row gets the same width in blanks so ids stay aligned down the list. The glyph is
- * wrapped in a deliberate blessed color tag and no task-derived text enters the column, so
- * callers can embed the result in tag-parsed content without escaping.
+ * The glyph is wrapped in a deliberate blessed color tag and no task-derived text enters
+ * the cell, so callers can embed the result in tag-parsed content without escaping.
  */
-export function formatAcceptanceCriteriaProgressColumn(task: Task): string {
+export function formatAcceptanceCriteriaProgress(task: Task): string {
 	const criteria = task.acceptanceCriteriaItems ?? [];
-	if (!isInProgress(task.status) || criteria.length === 0) return " ".repeat(PROGRESS_COLUMN_WIDTH);
+	if (!isInProgress(task.status) || criteria.length === 0) return "";
 
 	const checked = criteria.filter((criterion) => criterion.checked).length;
-	const glyph = pieGlyph(checked, criteria.length);
-	const count = `${checked}/${criteria.length}`;
-	// Pad on the rendered text, not the tagged string, and always keep one separator column.
-	const padding = " ".repeat(Math.max(1, PROGRESS_COLUMN_WIDTH - `${glyph} ${count}`.length));
+	const color = completionColor(checked, criteria.length);
 
-	return `${wrapStatusColor(glyph, completionColor(checked, criteria.length))} ${count}${padding}`;
+	return `${wrapStatusColor(pieGlyph(checked, criteria.length), color)} ${checked}/${criteria.length}`;
 }

--- a/src/ui/acceptance-criteria-progress.ts
+++ b/src/ui/acceptance-criteria-progress.ts
@@ -1,18 +1,11 @@
 import type { Task } from "../types/index.ts";
 import { wrapStatusColor } from "./status-icon.ts";
 
-// A compact indicator leaves the task id and title most of the row; the color of the
-// filled run carries the completion signal that the dropped cells used to spell out.
-const WIDE_PROGRESS_MIN_WIDTH = 40;
-const WIDE_PROGRESS_CELLS = 5;
-const COMPACT_PROGRESS_CELLS = 3;
-
-// Plain ASCII on purpose: blessed only guarantees glyph fallback for DEC Special
-// Graphics (box drawing), so Block Elements like U+2588/U+2591 render as blank
-// cells when the terminal font lacks them and as "?" without a UTF-8 locale.
-// ASCII stays below "~" and bypasses every charset translation.
-const FILLED_CELL = "#";
-const EMPTY_CELL = "-";
+// Every row reserves this column so task ids line up whether or not the row shows
+// progress. It holds "● 99/99" plus the separator before the id, which covers any
+// checklist a person can review; a longer count pushes its own row right rather than
+// losing a digit.
+const PROGRESS_COLUMN_WIDTH = 8;
 
 function isInProgress(status: string): boolean {
 	return status.trim().toLowerCase() === "in progress";
@@ -27,6 +20,24 @@ function completionColor(checked: number, total: number): string {
 	return checked / total <= 1 / 3 ? "red" : "yellow";
 }
 
+/**
+ * One pie glyph mirrors the web's progress ring in a single cell, leaving the task id and
+ * title the rest of the row. These live in the Geometric Shapes block the TUI already
+ * renders (● ○ ◒ in status-icon.ts), unlike Block Elements such as U+2588/U+2591, which
+ * blessed cannot ACS-route and which blank out on fonts that lack them.
+ *
+ * The empty and full pies are reserved for the exact counts, so a nearly finished task never
+ * reads as complete and a barely started one never reads as untouched.
+ */
+function pieGlyph(checked: number, total: number): string {
+	if (checked === 0) return "○";
+	if (checked === total) return "●";
+	const ratio = checked / total;
+	if (ratio <= 1 / 3) return "◔";
+	if (ratio <= 2 / 3) return "◑";
+	return "◕";
+}
+
 /** Format a " (ac: checked/total)" suffix for plain and MCP task list lines; empty without criteria. */
 export function formatAcceptanceCriteriaSummarySuffix(task: Task): string {
 	const criteria = task.acceptanceCriteriaItems ?? [];
@@ -37,24 +48,22 @@ export function formatAcceptanceCriteriaSummarySuffix(task: Task): string {
 }
 
 /**
- * Format live acceptance-criteria completion for one-line TUI task summaries.
+ * Format the acceptance-criteria column that precedes the task id in one-line TUI summaries.
  *
- * The filled run is wrapped in a deliberate blessed color tag; no task-derived text
- * enters the bar, so callers embed the result in tag-parsed content without escaping.
+ * In Progress tasks with criteria get a pie glyph and their live checked/total count; every
+ * other row gets the same width in blanks so ids stay aligned down the list. The glyph is
+ * wrapped in a deliberate blessed color tag and no task-derived text enters the column, so
+ * callers can embed the result in tag-parsed content without escaping.
  */
-export function formatAcceptanceCriteriaProgress(task: Task, availableWidth = Number.POSITIVE_INFINITY): string {
+export function formatAcceptanceCriteriaProgressColumn(task: Task): string {
 	const criteria = task.acceptanceCriteriaItems ?? [];
-	if (!isInProgress(task.status) || criteria.length === 0) return "";
+	if (!isInProgress(task.status) || criteria.length === 0) return " ".repeat(PROGRESS_COLUMN_WIDTH);
 
 	const checked = criteria.filter((criterion) => criterion.checked).length;
-	const cells = availableWidth >= WIDE_PROGRESS_MIN_WIDTH ? WIDE_PROGRESS_CELLS : COMPACT_PROGRESS_CELLS;
-	// Clamp rounding so any progress shows at least one cell and unfinished work never fills the bar.
-	let filled = Math.round((checked / criteria.length) * cells);
-	if (checked > 0 && filled === 0) filled = 1;
-	if (checked < criteria.length && filled === cells) filled = cells - 1;
+	const glyph = pieGlyph(checked, criteria.length);
+	const count = `${checked}/${criteria.length}`;
+	// Pad on the rendered text, not the tagged string, and always keep one separator column.
+	const padding = " ".repeat(Math.max(1, PROGRESS_COLUMN_WIDTH - `${glyph} ${count}`.length));
 
-	const filledRun =
-		filled > 0 ? wrapStatusColor(FILLED_CELL.repeat(filled), completionColor(checked, criteria.length)) : "";
-
-	return `[${filledRun}${EMPTY_CELL.repeat(cells - filled)}] ${checked}/${criteria.length}`;
+	return `${wrapStatusColor(glyph, completionColor(checked, criteria.length))} ${count}${padding}`;
 }

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -22,7 +22,7 @@ import { compareTaskIds } from "../utils/task-sorting.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
 import { taskContentSignature } from "../utils/task-watcher.ts";
 import { formatUtcDateForDisplay } from "../utils/utc-date-display.ts";
-import { formatAcceptanceCriteriaProgress } from "./acceptance-criteria-progress.ts";
+import { formatAcceptanceCriteriaProgressColumn } from "./acceptance-criteria-progress.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
 import { createFilterHeader, type FilterHeader, type FilterState } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
@@ -157,7 +157,6 @@ export function prepareBoardColumns(tasks: Task[], statuses: string[]): ColumnDa
 export function formatTaskListItem(
 	task: Task,
 	isMoving = false,
-	availableWidth = Number.POSITIVE_INFINITY,
 	dateFormat?: string,
 	configuredProjects?: string[],
 ): string {
@@ -172,29 +171,29 @@ export function formatTaskListItem(
 	const project = projectBadge ? ` ${projectBadge}` : "";
 	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 	const branch = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
-	const progress = formatAcceptanceCriteriaProgress(task, availableWidth);
-	const progressPrefix = progress ? `${progress} ` : "";
+	// The reserved column stays outside the row-level color tags: its own {/} would close
+	// them, and keeping it there also holds the leftmost column still while a task moves.
+	const progress = formatAcceptanceCriteriaProgressColumn(task);
 
 	// Cross-branch tasks are dimmed to indicate read-only status
-	const content = `${progressPrefix}{bold}${task.id}{/bold}${type}${project}${dueDate} - ${task.title}${assignee}${labels}${branch}`;
+	const content = `{bold}${task.id}{/bold}${type}${project}${dueDate} - ${task.title}${assignee}${labels}${branch}`;
 	if (isMoving) {
-		return `{magenta-fg}► ${content}{/}`;
+		return `${progress}{magenta-fg}► ${content}{/}`;
 	}
 	if (isCrossBranch) {
-		return `{gray-fg}${content}{/}`;
+		return `${progress}{gray-fg}${content}{/}`;
 	}
-	return content;
+	return `${progress}${content}`;
 }
 
 function buildRenderedTaskListItems(
 	tasks: Task[],
 	movingTaskIds?: ReadonlySet<string>,
-	availableWidth = Number.POSITIVE_INFINITY,
 	dateFormat?: string,
 	configuredProjects?: string[],
 ): { rich: string[]; plain: string[] } {
 	const rich = tasks.map((task) =>
-		formatTaskListItem(task, movingTaskIds?.has(task.id) ?? false, availableWidth, dateFormat, configuredProjects),
+		formatTaskListItem(task, movingTaskIds?.has(task.id) ?? false, dateFormat, configuredProjects),
 	);
 	return {
 		rich,
@@ -647,17 +646,13 @@ export async function renderBoardTui(
 			syncColumnSelectionDisplay(column, active);
 		};
 
-		const getFormattedItems = (tasks: Task[]) => {
-			const columnCount = Math.max(1, currentColumnsData.length);
-			const availableWidth = Math.max(1, Math.floor(getTerminalWidth() / columnCount) - 4);
-			return buildRenderedTaskListItems(
+		const getFormattedItems = (tasks: Task[]) =>
+			buildRenderedTaskListItems(
 				tasks,
 				moveOp ? new Set(getMoveSetIds(moveOp)) : undefined,
-				availableWidth,
 				options?.dateFormat,
 				configuredProjects,
 			);
-		};
 
 		const createColumnViews = (data: ColumnData[]) => {
 			clearColumns();

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -22,7 +22,6 @@ import { compareTaskIds } from "../utils/task-sorting.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
 import { taskContentSignature } from "../utils/task-watcher.ts";
 import { formatUtcDateForDisplay } from "../utils/utc-date-display.ts";
-import { formatAcceptanceCriteriaProgressColumn } from "./acceptance-criteria-progress.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
 import { createFilterHeader, type FilterHeader, type FilterState } from "./components/filter-header.ts";
 import { openMultiSelectFilterPopup, openSingleSelectFilterPopup } from "./components/filter-popup.ts";
@@ -37,6 +36,7 @@ import {
 	formatTaskArchivedMessage,
 	formatTaskCompletionBlockedMessage,
 } from "./task-lifecycle.ts";
+import { createTaskRowPrefix, type TaskRowPrefix } from "./task-row-prefix.ts";
 import { formatTaskTypeBadge } from "./task-type.ts";
 import {
 	createTaskPopup,
@@ -159,6 +159,9 @@ export function formatTaskListItem(
 	isMoving = false,
 	dateFormat?: string,
 	configuredProjects?: string[],
+	// Board columns already name the status, so the prefix here is progress alone. Rendering a
+	// lone row aligns it against itself.
+	formatPrefix: TaskRowPrefix = createTaskRowPrefix([task], { showStatus: false }),
 ): string {
 	const assignee = task.assignee?.[0]
 		? ` {cyan-fg}${task.assignee[0].startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
@@ -171,19 +174,19 @@ export function formatTaskListItem(
 	const project = projectBadge ? ` ${projectBadge}` : "";
 	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 	const branch = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
-	// The reserved column stays outside the row-level color tags: its own {/} would close
-	// them, and keeping it there also holds the leftmost column still while a task moves.
-	const progress = formatAcceptanceCriteriaProgressColumn(task);
+	// The prefix stays outside the row-level color tags: its own {/} would close them, and
+	// keeping it there also holds the reserved columns still while a task moves.
+	const prefix = formatPrefix(task);
 
 	// Cross-branch tasks are dimmed to indicate read-only status
 	const content = `{bold}${task.id}{/bold}${type}${project}${dueDate} - ${task.title}${assignee}${labels}${branch}`;
 	if (isMoving) {
-		return `${progress}{magenta-fg}► ${content}{/}`;
+		return `${prefix}{magenta-fg}► ${content}{/}`;
 	}
 	if (isCrossBranch) {
-		return `${progress}{gray-fg}${content}{/}`;
+		return `${prefix}{gray-fg}${content}{/}`;
 	}
-	return `${progress}${content}`;
+	return `${prefix}${content}`;
 }
 
 function buildRenderedTaskListItems(
@@ -192,8 +195,9 @@ function buildRenderedTaskListItems(
 	dateFormat?: string,
 	configuredProjects?: string[],
 ): { rich: string[]; plain: string[] } {
+	const formatPrefix = createTaskRowPrefix(tasks, { showStatus: false });
 	const rich = tasks.map((task) =>
-		formatTaskListItem(task, movingTaskIds?.has(task.id) ?? false, dateFormat, configuredProjects),
+		formatTaskListItem(task, movingTaskIds?.has(task.id) ?? false, dateFormat, configuredProjects, formatPrefix),
 	);
 	return {
 		rich,

--- a/src/ui/task-row-prefix.ts
+++ b/src/ui/task-row-prefix.ts
@@ -1,0 +1,42 @@
+import blessed from "neo-neo-bblessed";
+import type { Task } from "../types/index.ts";
+import { formatAcceptanceCriteriaProgress } from "./acceptance-criteria-progress.ts";
+import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-icon.ts";
+import { stripBlessedFgTags } from "./utils/strip-tags.ts";
+
+const { unicode } = blessed as unknown as { unicode: { strWidth(value: string): number } };
+
+/** Cells a segment occupies once blessed has consumed its color tags. */
+function displayWidth(segment: string): number {
+	return unicode.strWidth(stripBlessedFgTags(segment));
+}
+
+function widestSegment(tasks: Task[], segment: (task: Task) => string): number {
+	return tasks.reduce((widest, task) => Math.max(widest, displayWidth(segment(task))), 0);
+}
+
+/** A column no row fills is dropped entirely, separator included. */
+function pad(segment: string, width: number): string {
+	return width === 0 ? "" : `${segment}${" ".repeat(width - displayWidth(segment) + 1)}`;
+}
+
+export type TaskRowPrefix = (task: Task) => string;
+
+/**
+ * Build the prefix that precedes the task id in one-line TUI summaries: the status, on
+ * surfaces that do not already name it, then the acceptance-criteria progress.
+ *
+ * Each segment is padded to the widest one across `tasks`, so ids line up down the render
+ * while no row pays for width nothing on screen uses -- a list without progress, or with
+ * only single-digit counts, spends nothing on the three-digit case. Both segments carry
+ * their own color tags, so callers must place the prefix outside any row-level tag: a
+ * bare {/} closes the enclosing color, not just its own.
+ */
+export function createTaskRowPrefix(tasks: Task[], options: { showStatus: boolean }): TaskRowPrefix {
+	const status = (task: Task) =>
+		options.showStatus ? wrapStatusColor(formatStatusWithIcon(task.status), getStatusColor(task.status)) : "";
+	const statusWidth = widestSegment(tasks, status);
+	const progressWidth = widestSegment(tasks, formatAcceptanceCriteriaProgress);
+
+	return (task) => pad(status(task), statusWidth) + pad(formatAcceptanceCriteriaProgress(task), progressWidth);
+}

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -37,7 +37,7 @@ import { canonicalTaskId, taskIdsEqual } from "../utils/task-id.ts";
 import { applyTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
-import { formatAcceptanceCriteriaProgress } from "./acceptance-criteria-progress.ts";
+import { formatAcceptanceCriteriaProgressColumn } from "./acceptance-criteria-progress.ts";
 import { formatChecklistItem } from "./checklist.ts";
 import { transformCodePaths } from "./code-path.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
@@ -76,16 +76,12 @@ function getPriorityDisplay(priority?: string): string {
 	}
 }
 
-export function formatTaskViewerListItem(
-	task: Task,
-	availableWidth = Number.POSITIVE_INFINITY,
-	dateFormat?: string,
-	configuredProjects?: string[],
-): string {
-	const progress = formatAcceptanceCriteriaProgress(task, availableWidth);
-	// The compact status icon keeps task identity visible beside the progress indicator. Its
-	// shape still distinguishes active work from the terminal-status checkmark.
-	const status = progress ? getStatusIcon(task.status) : formatStatusWithIcon(task.status);
+export function formatTaskViewerListItem(task: Task, dateFormat?: string, configuredProjects?: string[]): string {
+	const progress = formatAcceptanceCriteriaProgressColumn(task);
+	// The status icon stays a single cell so it and the reserved progress column form a
+	// fixed-width prefix and task ids line up down the list. Its shape still distinguishes
+	// active work from the terminal-status checkmark.
+	const status = getStatusIcon(task.status);
 	const statusColor = getStatusColor(task.status);
 	const assigneeText = task.assignee?.length
 		? ` {cyan-fg}${task.assignee[0]?.startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
@@ -99,10 +95,12 @@ export function formatTaskViewerListItem(
 	const dueDateText = task.dueDate ? ` {gray-fg}(due ${formatDateForDisplay(task.dueDate, { dateFormat })}){/}` : "";
 	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 	const branchText = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
-	const progressText = progress ? ` ${progress}` : "";
 
-	const content = `${wrapStatusColor(status, statusColor)}${progressText} {bold}${task.id}{/bold}${typeText}${projectText}${dueDateText} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
-	return isCrossBranch ? `{gray-fg}${content}{/}` : content;
+	// The status icon and the reserved column keep their own color tags, whose {/} would
+	// close the cross-branch dim, so the dim starts at the task id.
+	const prefix = `${wrapStatusColor(status, statusColor)} ${progress}`;
+	const content = `{bold}${task.id}{/bold}${typeText}${projectText}${dueDateText} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
+	return `${prefix}${isCrossBranch ? `{gray-fg}${content}{/}` : content}`;
 }
 
 export function buildTaskViewerMilestoneFilterModel(
@@ -729,10 +727,6 @@ export async function viewTaskEnhanced(
 		return typeof screen.width === "number" ? screen.width : 80;
 	}
 
-	function getTaskListSummaryWidth(): number {
-		return Math.max(1, Math.floor(getTerminalWidth() * 0.4) - 4);
-	}
-
 	function syncPaneLayout() {
 		const headerHeight = filterHeader.getHeight();
 		const helpHeight = typeof helpBar.height === "number" ? helpBar.height : 1;
@@ -987,8 +981,7 @@ export async function viewTaskEnhanced(
 			left: 1,
 			width: "100%-4",
 			height: "100%-3",
-			itemRenderer: (task: Task) =>
-				formatTaskViewerListItem(task, getTaskListSummaryWidth(), dateFormat, configuredProjects),
+			itemRenderer: (task: Task) => formatTaskViewerListItem(task, dateFormat, configuredProjects),
 			onSelect: (selected: Task | Task[]) => {
 				const selectedTask = Array.isArray(selected) ? selected[0] : selected;
 				void applySelection(selectedTask || null);

--- a/src/ui/task-viewer-with-search.ts
+++ b/src/ui/task-viewer-with-search.ts
@@ -37,7 +37,6 @@ import { canonicalTaskId, taskIdsEqual } from "../utils/task-id.ts";
 import { applyTaskFilters, createTaskSearchIndex } from "../utils/task-search.ts";
 import { attachSubtaskSummaries } from "../utils/task-subtasks.ts";
 import { getTaskTypeValues, resolveTaskTypeValues } from "../utils/task-type-config.ts";
-import { formatAcceptanceCriteriaProgressColumn } from "./acceptance-criteria-progress.ts";
 import { formatChecklistItem } from "./checklist.ts";
 import { transformCodePaths } from "./code-path.ts";
 import { openConfirmPopup } from "./components/confirm-popup.ts";
@@ -54,12 +53,13 @@ import { formatFooterContent, getTaskListFooterContent } from "./footer-content.
 import { formatHeading } from "./heading.ts";
 import { createLoadingScreen } from "./loading.ts";
 import { formatProjectBadge } from "./project.ts";
-import { formatStatusWithIcon, getStatusColor, getStatusIcon, wrapStatusColor } from "./status-icon.ts";
+import { formatStatusWithIcon, getStatusColor, wrapStatusColor } from "./status-icon.ts";
 import {
 	completeTaskFromTui,
 	formatTaskArchivedMessage,
 	formatTaskCompletionBlockedMessage,
 } from "./task-lifecycle.ts";
+import { createTaskRowPrefix, type TaskRowPrefix } from "./task-row-prefix.ts";
 import { formatTaskTypeBadge } from "./task-type.ts";
 import { addScrollKeys, createScreen, formatTuiTitle } from "./tui.ts";
 
@@ -76,13 +76,14 @@ function getPriorityDisplay(priority?: string): string {
 	}
 }
 
-export function formatTaskViewerListItem(task: Task, dateFormat?: string, configuredProjects?: string[]): string {
-	const progress = formatAcceptanceCriteriaProgressColumn(task);
-	// The status icon stays a single cell so it and the reserved progress column form a
-	// fixed-width prefix and task ids line up down the list. Its shape still distinguishes
-	// active work from the terminal-status checkmark.
-	const status = getStatusIcon(task.status);
-	const statusColor = getStatusColor(task.status);
+export function formatTaskViewerListItem(
+	task: Task,
+	dateFormat?: string,
+	configuredProjects?: string[],
+	// The list mixes statuses and nothing else names them, so the prefix carries the status
+	// label. Rendering a lone row aligns it against itself.
+	formatPrefix: TaskRowPrefix = createTaskRowPrefix([task], { showStatus: true }),
+): string {
 	const assigneeText = task.assignee?.length
 		? ` {cyan-fg}${task.assignee[0]?.startsWith("@") ? task.assignee[0] : `@${task.assignee[0]}`}{/}`
 		: "";
@@ -96,9 +97,9 @@ export function formatTaskViewerListItem(task: Task, dateFormat?: string, config
 	const isCrossBranch = Boolean((task as Task & { branch?: string }).branch);
 	const branchText = isCrossBranch ? ` {green-fg}(${(task as Task & { branch?: string }).branch}){/}` : "";
 
-	// The status icon and the reserved column keep their own color tags, whose {/} would
-	// close the cross-branch dim, so the dim starts at the task id.
-	const prefix = `${wrapStatusColor(status, statusColor)} ${progress}`;
+	// The prefix keeps its own color tags, whose {/} would close the cross-branch dim, so the
+	// dim starts at the task id.
+	const prefix = formatPrefix(task);
 	const content = `{bold}${task.id}{/bold}${typeText}${projectText}${dueDateText} - ${task.title}${priorityText}${assigneeText}${labelsText}${branchText}`;
 	return `${prefix}${isCrossBranch ? `{gray-fg}${content}{/}` : content}`;
 }
@@ -401,6 +402,7 @@ export async function viewTaskEnhanced(
 	let labelMatch: LabelMatchMode = options.labelMatch ?? "any";
 	const taskLimit = options.limit;
 	let filteredTasks = [...allTasks];
+	let taskRowPrefix = createTaskRowPrefix(filteredTasks, { showStatus: true });
 
 	if (options.labelFilter && options.labelFilter.length > 0) {
 		const availableSet = new Set(availableLabels.map((label) => label.toLowerCase()));
@@ -827,6 +829,7 @@ export async function viewTaskEnhanced(
 			? withReadiness(nextFilteredTasks, resolveDependencyCorpus()).filter((task) => task.isReady)
 			: nextFilteredTasks;
 		filteredTasks = taskLimit !== undefined ? readyFilteredTasks.slice(0, taskLimit) : readyFilteredTasks;
+		taskRowPrefix = createTaskRowPrefix(filteredTasks, { showStatus: true });
 
 		// Update the task list label
 		if (taskListPane.setLabel) {
@@ -981,7 +984,7 @@ export async function viewTaskEnhanced(
 			left: 1,
 			width: "100%-4",
 			height: "100%-3",
-			itemRenderer: (task: Task) => formatTaskViewerListItem(task, dateFormat, configuredProjects),
+			itemRenderer: (task: Task) => formatTaskViewerListItem(task, dateFormat, configuredProjects, taskRowPrefix),
 			onSelect: (selected: Task | Task[]) => {
 				const selectedTask = Array.isArray(selected) ? selected[0] : selected;
 				void applySelection(selectedTask || null);


### PR DESCRIPTION
## Summary

The TUI showed acceptance-criteria progress as an ASCII bar, `[###--] 3/5`. That caution was
aimed at Block Elements, but it was applied to the whole indicator even though the TUI
already renders Geometric Shapes (`● ○ ◒ ✔`) on every supported terminal. The bar also sat
before the task id on In Progress rows only, so ids never lined up across rows.

- One pie glyph plus the live checked/total count replaces the bar: `○` nothing checked,
  `◔` up to a third, `◑` up to two thirds, `◕` above that, `●` only when every criterion is
  checked. It mirrors the ring the web shows and costs one cell.
- Colors are unchanged: green complete, yellow underway, red at a third or fewer. The glyph
  and the color share the same thirds, so `○`/`◔` are red, `◑`/`◕` yellow, `●` green.
- Column reservation moved to `src/ui/task-row-prefix.ts`, which sizes the prefix **per
  render** from the rows actually on screen: a status segment (task list only — board columns
  already name the status) then the progress cell, each padded to the widest of its kind.
  Ids line up, and a render pays only for columns something on it fills.
- The wide/compact variants collapse into one form, taking the `availableWidth` plumbing
  behind them with it.

Which rows show progress is unchanged: In Progress tasks with criteria. Plain and MCP list
output (`(ac: 1/3)`) is untouched.

## Rendered

Task list — custom statuses keep their labels, `100/100` fits, every id starts at one column:

```
lq Tasks (8) qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqk
x                                                           x
x ◒ In Progress ◔ 2/9     TASK-1 - Render progress as a     x
x ◒ In Progress ○ 0/4     TASK-2 - Fail closed on           x
x ◒ In Progress ● 100/100 TASK-3 - Audit every generated    x
x ◒ In Progress           TASK-4 - In progress without      x
x ○ Waiting               TASK-5 - Waiting on the design    x
x ○ Ready                 TASK-6 - Ready to pick up         x
x ○ To Do                 TASK-7 - A plain queued task      x
x ✔ Done                  TASK-8 - A finished task          x
```

Board — the In Progress column reserves for `● 100/100`; the other four columns have no row
with progress, so they spend no prefix width at all:

```
lq ○ To Do (1) qqqqqqqqqqqqqqklq ○ Ready (1) qqqqqqqqqqqqqqklq ◒ In Progress (4) qqqqqqqqklq ○ Waiting (1) qqqqqqqqqqqqklq ✔ Done (1) qqqqqqqqqqqqqqqk
x                            xx                            xx                            xx                            xx                            x
x TASK-7 - A plain queued    xx TASK-6 - Ready to pick up   xx ◔ 2/9     TASK-1 - Render  xx TASK-5 - Waiting on the    xx TASK-8 - A finished task   x
x                            xx                            xx ○ 0/4     TASK-2 - Fail    xx                            xx                            x
x                            xx                            xx ● 100/100 TASK-3 - Audit   xx                            xx                            x
x                            xx                            xx           TASK-4 - In      xx                            xx                            x
```

## Notes for review

**The status word stays.** An earlier revision of this branch reduced the task list to an
icon-only status to buy a fixed-width prefix. `getStatusStyle` maps six statuses, so every
custom status — `Ready`, `Waiting`, `Blocked on review` — collapsed to the same default `○`
and color, making those rows indistinguishable. Per-render sizing gets the alignment without
that trade, so the list shows icon + word on every row again, unconditionally.

**The prefix is emitted before the row-level color tags.** blessed treats a bare `{/}` as a
full attribute reset (`Element.prototype._parseTags`), so the indicator's own close tag used
to cancel the magenta move highlight and the gray cross-branch dim for the rest of the row.
Keeping the prefix outside those tags fixes that, and holds the reserved columns still while
a task moves — the `►` marker now sits between the prefix and the id.

**Board rows carry no status segment.** The column header already names the status and every
row in a column shares it, so a per-row icon would cost a column for no information. Easy to
add if you'd rather have it.

## Width

The five glyphs are East Asian Width "ambiguous", the same class as the `●` already in use.
`unicode.strWidth` in the patched neo-neo-bblessed reports **1** for each, and none matches
the wide-layout regex, so they occupy one cell exactly like the existing status icons. No
Block Elements are introduced. The prefix builder measures with that same `strWidth` rather
than string length, so a non-ASCII status label still pads to the right number of cells.

blessed degrades non-ASCII to `?` only when the locale is not UTF-8 (`Tput.detectUnicode`
reads `LANG`/`LC_ALL`). That already applies to the shipped `◒ ○ ✔` status icons, so the pies
add no new exposure.

## Testing

- `bunx tsc --noEmit`
- `bun run check .`
- `bun run test` — 2860 pass / 8 skip / 1 fail; a clean `origin/main` worktree run gives
  2859 / 8 / 1, failing the same `ContentStore` test. Local-only flake, green on CI.
- PTY QA with `expect` at 150x40 on `board` and `task list`, against a project configured
  with `To Do / Ready / In Progress / Waiting / Done` and a 100-criterion task
