### PR TITLE
Bind carriage return alongside enter on the TUI board

### DIFF
--- a/src/test/board-ui.test.ts
+++ b/src/test/board-ui.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Task } from "../types/index.ts";
 import type { ColumnData } from "../ui/board.ts";
-import { hasMoveBlockingBoardFilters, shouldRebuildColumns } from "../ui/board.ts";
+import { BOARD_ENTER_KEYS, hasMoveBlockingBoardFilters, shouldRebuildColumns } from "../ui/board.ts";
 
 // Helper to create a minimal valid Task for testing
 const createTestTask = (id: string, title: string, status: string): Task => ({
@@ -76,6 +76,14 @@ describe("Board TUI Logic", () => {
 			expect(hasMoveBlockingBoardFilters({ ...baseFilters, typeFilter: ["bug"] })).toBe(true);
 			expect(hasMoveBlockingBoardFilters({ ...baseFilters, projectFilter: ["web"] })).toBe(true);
 			expect(hasMoveBlockingBoardFilters({ ...baseFilters, labelFilter: ["bug"] })).toBe(true);
+		});
+	});
+
+	describe("BOARD_ENTER_KEYS", () => {
+		it("binds both blessed names for the Enter key", () => {
+			// Terminals sending a carriage return are named "return"; only a linefeed is named "enter".
+			expect(BOARD_ENTER_KEYS).toContain("enter");
+			expect(BOARD_ENTER_KEYS).toContain("return");
 		});
 	});
 });

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -51,6 +51,9 @@ export type ColumnData = {
 	tasks: Task[];
 };
 
+// blessed names a carriage return "return" and only a linefeed "enter", so both must be bound.
+export const BOARD_ENTER_KEYS = ["enter", "return"];
+
 type BoardSharedFilters = {
 	searchQuery: string;
 	excludeStatus?: string[];
@@ -1659,7 +1662,7 @@ export async function renderBoardTui(
 			await syncOpenPopup();
 		};
 
-		screen.key(["enter"], async () => {
+		screen.key(BOARD_ENTER_KEYS, async () => {
 			if (popupOpen || filterPopupOpen || modalOpen || currentFocus === "filters") return;
 
 			// In move mode, Enter confirms the move


### PR DESCRIPTION
Fixes #1003

The board registers its Enter handler as `screen.key(["enter"], ...)` (`src/ui/board.ts`). In the vendored blessed fork (`neo-neo-bblessed/lib/keys.ts`), a carriage return is named `return` and only a linefeed is named `enter`:

```js
if (s === '\r') {
  // carriage return
  key.name = 'return';
} else if (s === '\n') {
  // enter, should have been called linefeed
  key.name = 'enter';
}
```

Terminals that send CR for the Enter key — kitty on Linux among them — therefore reach no handler at all.

That handler does double duty: in move mode it confirms a pending move, and outside move mode it opens the task popup. On an affected terminal **both silently do nothing**.

The move case is especially opaque because `performTaskMove` swallows every error unless `DEBUG` is set, so a move that never fired is indistinguishable from one that failed. `m` still works as a confirm key, which makes the Enter path look selectively broken rather than unbound.

### Fix

Bind both names. Added as an exported `BOARD_ENTER_KEYS` constant so it can be asserted in a test — the board needs a tty to instantiate, and the file already exports `hasMoveBlockingBoardFilters` / `shouldRebuildColumns` for the same reason.

`screen.key(["enter"])` is the only such registration under `src/ui/`, and nothing registers `"return"` anywhere, so this is a single-site change.

### Verification

- Reproduced and confirmed fixed on kitty / Ubuntu: Enter now both opens the task popup and confirms a pending move.
- `bunx tsc --noEmit` clean
- `biome check` clean on both files
- `bun test src/test/board-ui.test.ts` — 8 pass / 0 fail

