### PR TITLE
Prevent archived and demoted task ID reuse

### DIFF
--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -393,3 +393,10 @@ Archived tasks remain outside active views, but their task IDs stay reserved. Ne
 tasks and promoted drafts allocate beyond archived IDs; archiving a child also
 reserves its subtask number. This prevents a historical task link from silently
 referring to a different task later. Existing duplicate IDs are not renumbered.
+
+Demoting a task also preserves its original record in `archive/tasks` while
+creating a separately numbered draft. Editing into Draft through supported
+interfaces uses the same behavior. The old task ID stays reserved through later
+draft edits, promotion, and archival. Duplicate repair allocates from the same
+reserved-ID set. IDs lost to demotion before this behavior was installed cannot
+be reconstructed safely from draft numbers alone.

--- a/CLI-INSTRUCTIONS.md
+++ b/CLI-INSTRUCTIONS.md
@@ -388,3 +388,8 @@ backlog completion install --shell pwsh
 - Context-aware suggestions for priorities, labels, and assignees
 
 Full documentation: See [completions/README.md](completions/README.md) for detailed installation instructions, troubleshooting, and examples.
+
+Archived tasks remain outside active views, but their task IDs stay reserved. New
+tasks and promoted drafts allocate beyond archived IDs; archiving a child also
+reserves its subtask number. This prevents a historical task link from silently
+referring to a different task later. Existing duplicate IDs are not renumbered.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3902,6 +3902,7 @@ addHelpSchema(taskCmd.command("complete <taskId>"), {
 taskCmd
 	.command("demote <taskId>")
 	.description("move task back to drafts")
+	.addHelpText("after", "\nThe original task is preserved in archive/tasks so its ID remains reserved.\n")
 	.action(async (taskId: string) => {
 		const cwd = await requireProjectRoot();
 		const core = new Core(cwd);

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1597,16 +1597,21 @@ export class Core {
 		return entries;
 	}
 
-	private async getOccupiedTaskIds(): Promise<string[]> {
-		const snapshot = await this.loadTasksWithStableBranchSnapshot({
-			includeCompleted: false,
-			visibleCompleted: false,
-			forceRemoteRefresh: true,
-		});
-		const completedTasks = snapshot.completedTasks;
-		const config = snapshot.config;
+	/** Shared identity reservations for normal allocation and duplicate-repair allocation. */
+	async getOccupiedTaskIds(snapshot?: TaskCorpusSnapshot): Promise<string[]> {
+		// A repair preview must allocate against the same corpus that supplied its duplicate
+		// groups. Applying that preview rebuilds it under the create lock with fresh branch refs.
+		const corpus =
+			snapshot ??
+			(await this.loadTasksWithStableBranchSnapshot({
+				includeCompleted: false,
+				visibleCompleted: false,
+				forceRemoteRefresh: true,
+			}));
+		const completedTasks = corpus.completedTasks;
+		const config = corpus.config;
 		const taskPrefix = config?.prefixes?.task ?? "task";
-		if (!snapshot.identityIndex) throw new Error("Task corpus identity index was not initialized");
+		if (!corpus.identityIndex) throw new Error("Task corpus identity index was not initialized");
 
 		// Same-repository worktrees share the task ID namespace even before their
 		// task files are committed, so include their filesystem state for allocation.
@@ -1614,12 +1619,12 @@ export class Core {
 			this.loadWorktreeTaskStateEntries(taskPrefix),
 			this.fs.listOccupiedArchivedTaskIds(),
 		]);
-		const occupiedIds = new Set(snapshot.identityIndex.getOccupiedIds());
+		const occupiedIds = new Set(corpus.identityIndex.getOccupiedIds());
 		for (const task of completedTasks) occupiedIds.add(task.id);
 		for (const id of archivedIds) occupiedIds.add(id);
 		// Reserve archived branch identities without changing which records are
 		// visible or how historical lifecycle states resolve in normal task reads.
-		for (const entry of snapshot.branchStateEntries ?? []) {
+		for (const entry of corpus.branchStateEntries ?? []) {
 			occupiedIds.add(entry.id);
 			if (entry.task) occupiedIds.add(entry.task.id);
 		}
@@ -2784,8 +2789,7 @@ export class Core {
 		autoCommit?: boolean,
 		options: TaskReadOptions = {},
 	): Promise<TaskEditResult> {
-		// Editing a task into the Draft status vacates its ID just as `task demote` does, so it
-		// runs the same cleanup rather than leaving dependents pointing at the freed ID.
+		// Editing into Draft uses the same history preservation and dependency cleanup as demote.
 		return await this.withVacatedIdCleanup(task, task.id, async (cleanup) => {
 			const current = await this.loadTaskForMutation(task.id, options);
 			if (!current) {
@@ -2799,17 +2803,14 @@ export class Core {
 				return this.requireCanonicalStatus(status);
 			});
 
-			// The record keeps its own links under the new draft identity, so a link naming the task
-			// ID it is vacating would rebind to whatever task is allocated that ID next.
+			// Preserve existing cleanup of links to the original identity as it leaves active work.
 			const vacating = withoutVacatedTaskLinks(current, current.id) ?? current;
 
-			const { demotedDraft, savedPath } = await this.withCreateLock(async () => {
+			const { demotedDraft, savedPath, archivedPath } = await this.withCreateLock(async () => {
 				const newDraftId = await this.generateNextId(EntityType.Draft);
 				// Mirrors promotion: the allocated draft ID can be named by a stored dangling
 				// reference, so the demoted record must not materialize a cycle through it.
 				await validateDependencies(vacating.dependencies ?? [], this, { ...vacating, id: newDraftId });
-				const taskPath = current.filePath;
-
 				const demotedDraft: Task = {
 					...vacating,
 					id: newDraftId,
@@ -2821,13 +2822,8 @@ export class Core {
 				};
 
 				normalizeAssignee(demotedDraft);
-				const savedPath = await this.fs.saveDraft(demotedDraft);
-
-				if (taskPath) {
-					await unlink(taskPath);
-				}
-
-				return { demotedDraft, savedPath };
+				const { savedPath, archivedPath } = await this.fs.saveDemotedTask(current, demotedDraft);
+				return { demotedDraft, savedPath, archivedPath };
 			});
 
 			// The draft is written and the task file is gone, so anything failing from here reports
@@ -2849,7 +2845,7 @@ export class Core {
 						`backlog: Demote task ${normalizeTaskId(current.id)}`,
 						previousPaths,
 						savedPath,
-						cleanedPaths,
+						[archivedPath, ...cleanedPaths],
 					);
 				}
 			} catch (error) {
@@ -3578,16 +3574,16 @@ export class Core {
 		// vacates its task ID, so the dependents are locked and cleaned in the same span.
 		const demotion = {
 			success: false,
-			moved: undefined as { previousPath: string; savedPath: string } | undefined,
+			moved: undefined as { previousPath: string; savedPath: string; archivedPath: string } | undefined,
 			cleanedTaskIds: [] as string[],
 			cleanedPaths: [] as string[],
 		};
 		let result: typeof demotion;
 		try {
 			result = await this.withVacatedIdCleanup(task, task.id, async (cleanup) => {
-				const movedPaths: Array<{ previousPath: string; savedPath: string }> = [];
-				const success = await this.fs.demoteTask(task.id, (previousPath, savedPath) => {
-					movedPaths.push({ previousPath, savedPath });
+				const movedPaths: Array<{ previousPath: string; savedPath: string; archivedPath: string }> = [];
+				const success = await this.fs.demoteTask(task.id, (previousPath, savedPath, archivedPath) => {
+					movedPaths.push({ previousPath, savedPath, archivedPath });
 				});
 				// Record the move before anything that can fail after it. A cleanup write that
 				// throws must still report the demotion as "moved", or a client is told the task
@@ -3619,12 +3615,10 @@ export class Core {
 		if (success && moved) {
 			try {
 				if (await this.shouldAutoCommit(autoCommit)) {
-					await this.commitWrittenFile(
-						`backlog: Demote task ${task.id}`,
-						[moved.previousPath],
-						moved.savedPath,
-						cleanedPaths,
-					);
+					await this.commitWrittenFile(`backlog: Demote task ${task.id}`, [moved.previousPath], moved.savedPath, [
+						moved.archivedPath,
+						...cleanedPaths,
+					]);
 				}
 			} catch (error) {
 				throw markRecordAlreadyMoved(error, "demotionState", "commit");

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1566,17 +1566,19 @@ export class Core {
 
 			for (const file of files) {
 				const match = file.match(idRegex);
-				if (!match?.[1]) continue;
+				if (!match?.[1] && type !== "archived") continue;
 
 				const filePath = join(path, file);
 				const stats = await stat(filePath).catch(() => null);
-				entries.push({
-					id: normalizeId(match[1], taskPrefix),
-					type,
-					branch: `worktree:${worktreeRoot}`,
-					path: filePath,
-					lastModified: stats?.mtime ?? new Date(0),
-				});
+				if (match?.[1]) {
+					entries.push({
+						id: normalizeId(match[1], taskPrefix),
+						type,
+						branch: `worktree:${worktreeRoot}`,
+						path: filePath,
+						lastModified: stats?.mtime ?? new Date(0),
+					});
+				}
 				if (type === "archived") {
 					const content = await Bun.file(filePath).text();
 					try {
@@ -1608,6 +1610,11 @@ export class Core {
 				visibleCompleted: false,
 				forceRemoteRefresh: true,
 			}));
+		if (corpus.branchLoadComplete === false) {
+			throw new Error(
+				"Cannot allocate a task ID while branch identity reservations are incomplete; retry after restoring branch reads",
+			);
+		}
 		const completedTasks = corpus.completedTasks;
 		const config = corpus.config;
 		const taskPrefix = config?.prefixes?.task ?? "task";
@@ -1622,6 +1629,7 @@ export class Core {
 		const occupiedIds = new Set(corpus.identityIndex.getOccupiedIds());
 		for (const task of completedTasks) occupiedIds.add(task.id);
 		for (const id of archivedIds) occupiedIds.add(id);
+		for (const id of corpus.archivedBranchIds ?? []) occupiedIds.add(id);
 		// Reserve archived branch identities without changing which records are
 		// visible or how historical lifecycle states resolve in normal task reads.
 		for (const entry of corpus.branchStateEntries ?? []) {
@@ -3918,13 +3926,20 @@ export class Core {
 		git = this.git,
 	): Promise<Array<Task & { lastModified?: Date; branch?: string }>> {
 		const tasks = await filesystem.listTasks();
-		return await Promise.all(
+		const withMetadata = await Promise.all(
 			tasks.map(async (task) => {
 				const filePath = task.filePath ?? (await getTaskPath(task.id, { filesystem }));
 
 				if (filePath) {
 					const bunFile = Bun.file(filePath);
-					const stats = await bunFile.stat();
+					const stats = await bunFile.stat().catch((error: NodeJS.ErrnoException) => {
+						// A concurrent archive/demotion may remove a task after listTasks
+						// captured its content. Omit that vanished active record; other
+						// filesystem failures must still abort the read.
+						if (error.code === "ENOENT") return null;
+						throw error;
+					});
+					if (!stats) return null;
 					return {
 						...task,
 						lastModified: new Date(stats.mtime),
@@ -3937,6 +3952,7 @@ export class Core {
 				return task;
 			}),
 		);
+		return withMetadata.filter((task) => task !== null);
 	}
 
 	/**
@@ -4340,6 +4356,7 @@ export class Core {
 		// Load tasks from remote branches and other local branches in parallel
 		// Skip entirely when cross-branch scanning is disabled
 		const branchStateEntries: BranchTaskStateEntry[] = [];
+		const archivedBranchIds: string[] = [];
 		let branchLoadComplete = true;
 
 		let backlogDir: string | null = null;
@@ -4356,6 +4373,7 @@ export class Core {
 				snapshotBefore.currentBranch,
 			);
 			branchStateEntries.push(...branchLoad.entries);
+			archivedBranchIds.push(...branchLoad.archivedIds);
 			branchLoadComplete = branchLoad.complete;
 			if (projectChanged()) return await retryForCurrentProject();
 		}
@@ -4418,6 +4436,8 @@ export class Core {
 			completedTasks,
 			identityIndex,
 			branchStateEntries,
+			archivedBranchIds,
+			branchLoadComplete,
 			config,
 		};
 	}

--- a/src/core/backlog.ts
+++ b/src/core/backlog.ts
@@ -1492,7 +1492,7 @@ export class Core {
 	 * @returns The next available ID (e.g., "task-42", "draft-5", "doc-3")
 	 *
 	 * Folder scanning by type:
-	 * - Task: /tasks, /completed, cross-branch (if enabled), remote (if enabled)
+	 * - Task: /tasks, /completed, /archive/tasks, cross-branch (if enabled), remote (if enabled)
 	 * - Draft: /drafts only
 	 * - Document: /documents only
 	 * - Decision: /decisions only
@@ -1514,10 +1514,8 @@ export class Core {
 	}
 
 	/**
-	 * Gets all task IDs that are in use (active or completed) across all branches.
-	 * Respects cross-branch config settings. Archived IDs are excluded (can be reused).
-	 *
-	 * This is used for ID generation to determine the next available ID.
+	 * Reads task identity reservations from other worktrees, including archives.
+	 * Uncommitted records share the same namespace as the current checkout.
 	 */
 	private async loadWorktreeTaskStateEntries(taskPrefix: string): Promise<BranchTaskStateEntry[]> {
 		const [repoRoot, worktreeRoots] = await Promise.all([this.git.getRepositoryRoot(), this.git.listWorktreePaths()]);
@@ -1548,17 +1546,21 @@ export class Core {
 	): Promise<BranchTaskStateEntry[]> {
 		const idRegex = buildIdRegex(taskPrefix);
 		const globPattern = buildGlobPattern(taskPrefix.toLowerCase());
-		const directories: Array<{ path: string; type: "task" | "completed" }> = [
+		const directories: Array<{ path: string; type: "task" | "completed" | "archived" }> = [
 			{ path: join(projectRoot, backlogDir, DEFAULT_DIRECTORIES.TASKS), type: "task" },
 			{ path: join(projectRoot, backlogDir, DEFAULT_DIRECTORIES.COMPLETED), type: "completed" },
+			{ path: join(projectRoot, backlogDir, DEFAULT_DIRECTORIES.ARCHIVE_TASKS), type: "archived" },
 		];
 		const entries: BranchTaskStateEntry[] = [];
 
 		for (const { path, type } of directories) {
 			let files: string[];
 			try {
-				files = await Array.fromAsync(new Bun.Glob(globPattern).scan({ cwd: path, followSymlinks: true }));
-			} catch {
+				files = await Array.fromAsync(
+					new Bun.Glob(type === "archived" ? "*.md" : globPattern).scan({ cwd: path, followSymlinks: true }),
+				);
+			} catch (error) {
+				if (type === "archived" && (error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
 				continue;
 			}
 
@@ -1575,13 +1577,27 @@ export class Core {
 					path: filePath,
 					lastModified: stats?.mtime ?? new Date(0),
 				});
+				if (type === "archived") {
+					const content = await Bun.file(filePath).text();
+					try {
+						entries.push({
+							id: parseTask(content).id,
+							type,
+							branch: `worktree:${worktreeRoot}`,
+							path: filePath,
+							lastModified: stats?.mtime ?? new Date(0),
+						});
+					} catch {
+						// The filename still reserves the identity of an unparsable archive.
+					}
+				}
 			}
 		}
 
 		return entries;
 	}
 
-	private async getActiveAndCompletedTaskIds(): Promise<string[]> {
+	private async getOccupiedTaskIds(): Promise<string[]> {
 		const snapshot = await this.loadTasksWithStableBranchSnapshot({
 			includeCompleted: false,
 			visibleCompleted: false,
@@ -1594,12 +1610,20 @@ export class Core {
 
 		// Same-repository worktrees share the task ID namespace even before their
 		// task files are committed, so include their filesystem state for allocation.
-		const worktreeEntries = await this.loadWorktreeTaskStateEntries(taskPrefix);
+		const [worktreeEntries, archivedIds] = await Promise.all([
+			this.loadWorktreeTaskStateEntries(taskPrefix),
+			this.fs.listOccupiedArchivedTaskIds(),
+		]);
 		const occupiedIds = new Set(snapshot.identityIndex.getOccupiedIds());
 		for (const task of completedTasks) occupiedIds.add(task.id);
-		for (const entry of worktreeEntries) {
-			if (entry.type === "task" || entry.type === "completed") occupiedIds.add(entry.id);
+		for (const id of archivedIds) occupiedIds.add(id);
+		// Reserve archived branch identities without changing which records are
+		// visible or how historical lifecycle states resolve in normal task reads.
+		for (const entry of snapshot.branchStateEntries ?? []) {
+			occupiedIds.add(entry.id);
+			if (entry.task) occupiedIds.add(entry.task.id);
 		}
+		for (const entry of worktreeEntries) occupiedIds.add(entry.id);
 		return [...occupiedIds];
 	}
 
@@ -1607,15 +1631,14 @@ export class Core {
 	 * Gets all existing IDs for a given entity type.
 	 * Used internally by generateNextId to determine the next available ID.
 	 *
-	 * Note: Archived tasks are intentionally excluded - archived IDs can be reused.
-	 * This makes archive act as a soft delete for ID purposes.
+	 * Archived task IDs remain occupied: archiving hides a task from active
+	 * views, but must not make historical references identify a new task.
 	 */
 	private async getExistingIdsForType(type: EntityType): Promise<string[]> {
 		switch (type) {
 			case EntityType.Task: {
-				// Get active + completed task IDs from all branches (respects config)
-				// Archived IDs are excluded - they can be reused (soft delete behavior)
-				return this.getActiveAndCompletedTaskIds();
+				// Preserve active, completed, and archived task identities (respects config).
+				return this.getOccupiedTaskIds();
 			}
 			case EntityType.Draft: {
 				// Occupancy includes filename-derived ids: an unparsable file still reserves its

--- a/src/core/content-store.ts
+++ b/src/core/content-store.ts
@@ -26,6 +26,9 @@ export interface TaskCorpusSnapshot {
 	completedTasks: Task[];
 	identityIndex?: TaskIdentityIndex;
 	branchStateEntries?: BranchTaskStateEntry[];
+	/** False means branch reservations are incomplete and cannot justify ID allocation. */
+	branchLoadComplete?: boolean;
+	archivedBranchIds?: string[];
 	config?: BacklogConfig | null;
 }
 
@@ -119,6 +122,8 @@ export class ContentStore {
 	private taskIdentityIndex?: TaskIdentityIndex;
 	private branchTaskStateEntries: BranchTaskStateEntry[] = [];
 	private taskCorpusConfig: BacklogConfig | null | undefined;
+	private branchLoadComplete: boolean | undefined;
+	private archivedBranchIds: string[] = [];
 	private cachedDocuments: Document[] = [];
 	private cachedDecisions: Decision[] = [];
 
@@ -344,6 +349,8 @@ export class ContentStore {
 			completedTasks: this.completedTasks.slice(),
 			identityIndex: this.taskIdentityIndex,
 			branchStateEntries: this.branchTaskStateEntries.slice(),
+			branchLoadComplete: this.branchLoadComplete,
+			archivedBranchIds: this.archivedBranchIds.slice(),
 			config: this.taskCorpusConfig,
 		};
 	}
@@ -1359,6 +1366,8 @@ export class ContentStore {
 		this.taskIdentityIndex = corpus.identityIndex;
 		this.branchTaskStateEntries = corpus.branchStateEntries?.slice() ?? [];
 		this.taskCorpusConfig = corpus.config;
+		this.branchLoadComplete = corpus.branchLoadComplete;
+		this.archivedBranchIds = corpus.archivedBranchIds?.slice() ?? [];
 		this.replaceVisibleTasks(visibleTasks);
 	}
 
@@ -1638,6 +1647,8 @@ export class ContentStore {
 				this.hasTaskListChanged(this.activeTasks, reconciledCorpus.activeTasks) ||
 				this.hasTaskListChanged(this.completedTasks, reconciledCorpus.completedTasks) ||
 				this.hasBranchTaskStateChanged(reconciledCorpus.branchStateEntries ?? []) ||
+				this.branchLoadComplete !== reconciledCorpus.branchLoadComplete ||
+				JSON.stringify(this.archivedBranchIds) !== JSON.stringify(reconciledCorpus.archivedBranchIds ?? []) ||
 				JSON.stringify(this.taskCorpusConfig) !== JSON.stringify(reconciledCorpus.config);
 			if (!visibleChanged && !identityChanged && !corpusChanged) return false;
 			this.installTaskCorpus(reconciledCorpus, merged);

--- a/src/core/duplicate-task-repair.ts
+++ b/src/core/duplicate-task-repair.ts
@@ -378,12 +378,13 @@ export async function previewDuplicateTaskIdRepair(
 	const crossBranchFindings = options.includeBranches ? await findCrossBranchDuplicateTaskIds(core, snapshot) : [];
 	const blockedReasons: string[] = [];
 	const changes: DuplicateRepairChange[] = [];
-	const [activeTasks, completedTasks, config] = await Promise.all([
+	const [activeTasks, completedTasks, config, occupiedIds] = await Promise.all([
 		snapshot ? Promise.resolve(snapshot.activeTasks) : core.filesystem.listTasks(),
 		snapshot ? Promise.resolve(snapshot.completedTasks) : core.filesystem.listCompletedTasks(),
 		core.filesystem.loadConfig(),
+		groups.length > 0 ? core.getOccupiedTaskIds(snapshot) : Promise.resolve([]),
 	]);
-	const existingIds = [...activeTasks, ...completedTasks].map((task) => task.id);
+	const existingIds = [...activeTasks, ...completedTasks].map((task) => task.id).concat(occupiedIds);
 	const plannedIds: string[] = [];
 
 	for (const group of groups) {

--- a/src/core/task-loader.ts
+++ b/src/core/task-loader.ts
@@ -13,6 +13,7 @@ import type { GitBranchTip, GitOperations } from "../git/operations.ts";
 import { parseTask } from "../markdown/parser.ts";
 import type { BacklogConfig, Task } from "../types/index.ts";
 import { extractAnyPrefix } from "../utils/prefix-config.ts";
+import { isValidTaskId } from "../utils/task-id.ts";
 import {
 	canonicalTaskId,
 	extractTaskIdFromFilename,
@@ -44,6 +45,8 @@ export interface BranchTaskStateEntry {
 
 export interface BranchTaskLoadResult {
 	entries: BranchTaskStateEntry[];
+	/** Allocation reservations only; do not participate in lifecycle winner selection. */
+	archivedIds: string[];
 	/** False when at least one branch index or selected task payload could not be read. */
 	complete: boolean;
 }
@@ -101,7 +104,8 @@ interface HydrationCandidate {
 }
 
 interface CachedTaskTreeEntry {
-	id: string;
+	id: string | null;
+	archivedId?: string;
 	path: string;
 	type: TaskDirectoryType | null;
 	lastModified: number;
@@ -367,7 +371,7 @@ export class BranchTaskLoader {
 		currentBranch?: string,
 	): Promise<BranchTaskLoadResult> {
 		const branchRefs = await this.getPinnedBranchRefs(tips, userConfig, currentBranch);
-		if (branchRefs.length === 0) return { entries: [], complete: true };
+		if (branchRefs.length === 0) return { entries: [], archivedIds: [], complete: true };
 
 		const remoteCount = branchRefs.filter((branch) => branch.source === "remote").length;
 		const localCount = branchRefs.length - remoteCount;
@@ -377,6 +381,7 @@ export class BranchTaskLoader {
 		const prefix = userConfig?.prefixes?.task ?? DEFAULT_TASK_PREFIX;
 		const historyCutoff = getBranchHistoryCutoff(userConfig?.activeBranchDays ?? 30);
 		const stateEntries: BranchTaskStateEntry[] = [];
+		const archivedIds = new Set<string>();
 		const remoteIndex = new Map<string, RemoteIndexEntry[]>();
 		const localIndex = new Map<string, RemoteIndexEntry[]>();
 		const queue = [...branchRefs];
@@ -391,6 +396,8 @@ export class BranchTaskLoader {
 					const tree = await this.loadCommitIndex(branchRef.commit, backlogDir, prefix, historyCutoff);
 					const index = branchRef.source === "remote" ? remoteIndex : localIndex;
 					for (const cached of tree) {
+						if (cached.archivedId) archivedIds.add(cached.archivedId);
+						if (!cached.id) continue;
 						const lastModified = new Date(cached.lastModified);
 						const entry: RemoteIndexEntry = {
 							id: cached.id,
@@ -467,6 +474,7 @@ export class BranchTaskLoader {
 		]);
 		return {
 			entries: stateEntries,
+			archivedIds: [...archivedIds].sort(),
 			complete: complete && hydrationResults.every(Boolean),
 		};
 	}
@@ -525,18 +533,30 @@ export class BranchTaskLoader {
 			const files = await this.git.listFilesInTree(commit, backlogDir);
 			if (files.length === 0) return [];
 			const lastModified = await this.git.getBranchLastModifiedMap(commit, backlogDir, historyCutoff);
-			return files.flatMap((path) => {
-				const id = extractConfiguredTaskId(path, prefix);
-				if (!id) return [];
-				return [
-					{
-						id,
-						path,
-						type: getTaskTypeFromPath(path, backlogDir),
-						lastModified: (lastModified.get(path) ?? new Date(0)).getTime(),
-					},
-				];
-			});
+			const entries: CachedTaskTreeEntry[] = [];
+			for (const path of files) {
+				const type = getTaskTypeFromPath(path, backlogDir);
+				const filenameId = extractConfiguredTaskId(path, prefix);
+				let archivedId: string | undefined;
+				if (type === "archived" && path.endsWith(".md")) {
+					// Archive identity also survives a renamed file or frontmatter/filename
+					// disagreement. Reuse the immutable blob cache; read errors invalidate
+					// this branch index, while malformed Markdown keeps its filename ID.
+					const task = await this.loadCachedTask(commit, path);
+					if (task && isValidTaskId(task.id) && extractAnyPrefix(task.id)?.toLowerCase() === prefix.toLowerCase()) {
+						archivedId = task.id;
+					}
+				}
+				if (!filenameId && !archivedId) continue;
+				entries.push({
+					id: filenameId,
+					archivedId,
+					path,
+					type,
+					lastModified: (lastModified.get(path) ?? new Date(0)).getTime(),
+				});
+			}
+			return entries;
 		})();
 		this.commitIndexCache.set(key, promise);
 		try {

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1086,9 +1086,9 @@ export class FileSystem {
 		const ids = new Set<string>();
 		for (const file of files) {
 			const match = file.match(idRegex);
-			if (!match?.[1]) continue;
-			ids.add(normalizeId(match[1], prefix));
-			// Parsing failure cannot release the ID already claimed by the filename.
+			if (match?.[1]) ids.add(normalizeId(match[1], prefix));
+			// A renamed file may still carry an ID. Parse independently of its filename;
+			// parsing failure cannot release an ID already claimed by the filename.
 			const content = await Bun.file(join(archiveTasksDir, file)).text();
 			try {
 				ids.add(parseTask(content).id);

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -20,6 +20,7 @@ import type { DraftIdentityFindings } from "../utils/duplicate-detection.ts";
 import { AmbiguousIdError, isAmbiguousIdError } from "../utils/entity-id.ts";
 import {
 	buildGlobPattern,
+	buildIdRegex,
 	extractAnyPrefix,
 	filenameMatchesId,
 	generateNextId,
@@ -1068,6 +1069,35 @@ export class FileSystem {
 		return sortByTaskId(tasks);
 	}
 
+	/** Archived filenames and parsed IDs both remain reserved, even if a file is malformed. */
+	async listOccupiedArchivedTaskIds(): Promise<string[]> {
+		const archiveTasksDir = await this.getArchiveTasksDir();
+		const config = await this.loadConfig();
+		const prefix = config?.prefixes?.task ?? "task";
+		const idRegex = buildIdRegex(prefix);
+		let files: string[];
+		try {
+			files = await Array.fromAsync(new Bun.Glob("*.md").scan({ cwd: archiveTasksDir, followSymlinks: true }));
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+			throw error;
+		}
+		const ids = new Set<string>();
+		for (const file of files) {
+			const match = file.match(idRegex);
+			if (!match?.[1]) continue;
+			ids.add(normalizeId(match[1], prefix));
+			// Parsing failure cannot release the ID already claimed by the filename.
+			const content = await Bun.file(join(archiveTasksDir, file)).text();
+			try {
+				ids.add(parseTask(content).id);
+			} catch {
+				// Retain the filename reservation for malformed archived records.
+			}
+		}
+		return [...ids];
+	}
+
 	async archiveTask(taskId: string): Promise<boolean> {
 		try {
 			const tasksDir = await this.getTasksDir();
@@ -1171,10 +1201,12 @@ export class FileSystem {
 				const taskPrefix = config?.prefixes?.task ?? "task";
 
 				// Get existing task IDs to generate next ID
-				// Include both active and completed tasks to prevent ID collisions
-				const existingTasks = await this.listTasks();
-				const completedTasks = await this.listCompletedTasks();
-				const existingIds = [...existingTasks, ...completedTasks].map((t) => t.id);
+				const [existingTasks, completedTasks, archivedIds] = await Promise.all([
+					this.listTasks(),
+					this.listCompletedTasks(),
+					this.listOccupiedArchivedTaskIds(),
+				]);
+				const existingIds = [...existingTasks, ...completedTasks].map((t) => t.id).concat(archivedIds);
 
 				// Generate new task ID
 				const newTaskId = generateNextId(existingIds, taskPrefix, config?.zeroPaddedIds);

--- a/src/file-system/operations.ts
+++ b/src/file-system/operations.ts
@@ -1,4 +1,5 @@
-import { mkdir, rename, stat, unlink } from "node:fs/promises";
+import { constants } from "node:fs";
+import { copyFile, mkdir, rename, stat, unlink } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import lockfile from "proper-lockfile";
 import { DEFAULT_DIRECTORIES, DEFAULT_FILES, DEFAULT_STATUSES, FALLBACK_STATUS } from "../constants/index.ts";
@@ -1239,7 +1240,55 @@ export class FileSystem {
 		}
 	}
 
-	async demoteTask(taskId: string, onMoved?: (fromPath: string, toPath: string) => void): Promise<boolean> {
+	/** Persist a draft while retaining the original task as a durable ID reservation.
+	 * Callers hold the task and creation locks across this operation.
+	 */
+	async saveDemotedTask(task: Task, demotedDraft: Task): Promise<{ savedPath: string; archivedPath: string }> {
+		if (!task.filePath) throw new Error(`Task ${task.id} has no source path to preserve.`);
+		const config = await this.loadConfig();
+		const prefix = config?.prefixes?.task ?? "task";
+		const filenameId = basename(task.filePath).match(buildIdRegex(prefix))?.[1];
+		const identities = [task.id, ...(filenameId ? [normalizeId(filenameId, prefix)] : [])];
+		const occupiedArchiveIds = await this.listOccupiedArchivedTaskIds();
+		if (occupiedArchiveIds.some((id) => identities.some((identity) => taskIdsEqual(id, identity)))) {
+			throw new Error(`Cannot demote ${task.id}: its task identity is already present in the archive.`);
+		}
+
+		const archivedPath = join(await this.getArchiveTasksDir(), basename(task.filePath));
+		await this.ensureDirectoryExists(dirname(archivedPath));
+		const savedPath = await this.saveDraft(demotedDraft);
+		let archiveWritten = false;
+		try {
+			// Reserve the original bytes before removing the task. Exclusive creation must never
+			// overwrite historical evidence, including a destination created after the scan.
+			await copyFile(task.filePath, archivedPath, constants.COPYFILE_EXCL);
+			archiveWritten = true;
+			await unlink(task.filePath);
+		} catch (error) {
+			// The original task has not been removed. Roll back only files written by this call.
+			let cleanupFailure: unknown;
+			for (const path of [savedPath, ...(archiveWritten ? [archivedPath] : [])]) {
+				try {
+					await unlink(path);
+				} catch (cleanupError) {
+					if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") cleanupFailure ??= cleanupError;
+				}
+			}
+			if (cleanupFailure) {
+				const failure = error instanceof Error ? error : new Error(String(error));
+				(failure as Error & { demotionState?: string }).demotionState = "partial";
+				failure.cause = cleanupFailure;
+				throw failure;
+			}
+			throw error;
+		}
+		return { savedPath, archivedPath };
+	}
+
+	async demoteTask(
+		taskId: string,
+		onMoved?: (fromPath: string, toPath: string, archivedPath: string) => void,
+	): Promise<boolean> {
 		return await this.withCreateLock(async () => {
 			// Load the task. A missing task is the only false result; filesystem failures must reach
 			// callers so the Web API can distinguish an operational failure from a 404.
@@ -1256,33 +1305,15 @@ export class FileSystem {
 			const config = await this.loadConfig();
 			const newDraftId = generateNextId(existingIds, "draft", config?.zeroPaddedIds);
 
-			// Update task with new draft ID and save as draft. The record's own links are cleaned of
-			// the task ID it vacates here: carried into the draft, such a link would rebind to
-			// whatever task is allocated that ID next.
+			// Keep the existing dependency-cleanup behavior as the task leaves the active corpus.
 			const demotedDraft: Task = {
 				...(withoutVacatedTaskLinks(task, task.id) ?? task),
 				id: newDraftId,
 				filePath: undefined, // Will be set by saveDraft
 			};
 
-			const savedPath = await this.saveDraft(demotedDraft);
-
-			// Delete old task file. If that fails, remove the newly written draft so a retry cannot
-			// encounter two copies of the task.
-			try {
-				await unlink(task.filePath);
-			} catch (error) {
-				try {
-					await unlink(savedPath);
-				} catch (cleanupError) {
-					const failure = error instanceof Error ? error : new Error(String(error));
-					(failure as Error & { demotionState?: string }).demotionState = "partial";
-					failure.cause = cleanupError;
-					throw failure;
-				}
-				throw error;
-			}
-			onMoved?.(task.filePath, savedPath);
+			const { savedPath, archivedPath } = await this.saveDemotedTask(task, demotedDraft);
+			onMoved?.(task.filePath, savedPath, archivedPath);
 
 			return true;
 		});

--- a/src/guidelines/cli-instructions/task-creation.md
+++ b/src/guidelines/cli-instructions/task-creation.md
@@ -19,6 +19,10 @@ Avoid broad unfiltered listing when the project may have many tasks. Use `--stat
 
 Use `backlog task view {{TASK_ID:123}} --plain` to read full context for likely matches.
 
+Archived task and subtask IDs remain reserved. Demoting a task preserves the
+original record in `archive/tasks` and creates a separately numbered draft;
+later draft edits, promotion, or archival do not release the old task ID.
+
 ### Step 2: Assess Scope Before Creating Tasks
 
 Decide whether the request is:

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -67,7 +67,7 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 - DoD is not acceptance criteria: acceptance criteria define scope/behavior, while DoD tracks completion hygiene
 - Comments are for discussion and review notes; Implementation Notes are for execution progress; Final Summary is the PR-style completion summary. Comment bodies may contain Markdown, but standalone `---` lines are reserved as comment delimiters.
 - `task_complete` — move a Done task to the completed folder (periodic cleanup, not immediate)
-- `task_archive` — archive a task that should not be completed (duplicate, canceled, invalid). Note: archived task IDs can be reused by new tasks (soft delete behavior).
+- `task_archive` — archive a task that should not be completed (duplicate, canceled, invalid). Archived task IDs remain reserved and are not reused by new tasks.
 
 **Document path rules:** document paths are relative to the docs directory. Use `path` values like `guides/setup`; absolute paths and `..` traversal are rejected.
 

--- a/src/guidelines/mcp/overview.md
+++ b/src/guidelines/mcp/overview.md
@@ -69,6 +69,10 @@ Backlog tracks **commitments** (what will be built). Use your judgment to distin
 - `task_complete` — move a Done task to the completed folder (periodic cleanup, not immediate)
 - `task_archive` — archive a task that should not be completed (duplicate, canceled, invalid). Archived task IDs remain reserved and are not reused by new tasks.
 
+Demoting a task into Draft preserves its original record in `archive/tasks`.
+The separately numbered draft may be edited, promoted, or archived without
+releasing the original task ID.
+
 **Document path rules:** document paths are relative to the docs directory. Use `path` values like `guides/setup`; absolute paths and `..` traversal are rejected.
 
 **Always operate through MCP tools. Never edit markdown files directly so relationships, metadata, and history stay consistent.**

--- a/src/test/archived-task-id-allocation.test.ts
+++ b/src/test/archived-task-id-allocation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdir } from "node:fs/promises";
+import { chmod, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { $ } from "bun";
 import { Core } from "../core/backlog.ts";
@@ -168,5 +168,207 @@ describe("archived task IDs remain reserved", () => {
 		const next = await mainCore.createTaskFromInput({ title: "Main task" }, false);
 
 		expect(next.task.id).toBe("TASK-2");
+	});
+
+	for (const git of [false, true]) {
+		it(`reserves noncanonical archived frontmatter through the CLI (${git ? "Git" : "filesystem-only"})`, async () => {
+			const core = await createProject(git);
+			const config = await core.fs.loadConfig();
+			if (!config) throw new Error("Expected initialized config");
+			config.prefixes = { task: "MATH" };
+			config.zeroPaddedIds = 3;
+			await core.fs.saveConfig(config);
+			const archivePath = join(core.fs.archiveTasksDir, "history.md");
+			const content = "---\nid: mAtH-050\ntitle: Renamed history\n---\nPreserved bytes\n";
+			await Bun.write(archivePath, content);
+
+			await $`bun ${CLI_PATH} task create "After renamed history"`.cwd(core.fs.rootDir).quiet();
+
+			expect((await core.fs.listTasks()).map((task) => task.id)).toEqual(["MATH-051"]);
+			expect(await Bun.file(archivePath).text()).toBe(content);
+		});
+	}
+
+	it("reserves a noncanonical padded child archive", async () => {
+		const core = await createProject();
+		const config = await core.fs.loadConfig();
+		if (!config) throw new Error("Expected initialized config");
+		config.prefixes = { task: "MATH" };
+		config.zeroPaddedIds = 3;
+		await core.fs.saveConfig(config);
+		const parent = await core.createTaskFromInput({ title: "Parent" }, false);
+		const archivePath = join(core.fs.archiveTasksDir, "child-history.md");
+		const content = "---\nid: math-001.09\ntitle: Renamed child\n---\nPreserved bytes\n";
+		await Bun.write(archivePath, content);
+
+		const next = await core.createTaskFromInput({ title: "Next child", parentTaskId: parent.task.id }, false);
+
+		expect(next.task.id).toBe("MATH-001.10");
+		expect(await Bun.file(archivePath).text()).toBe(content);
+	});
+
+	it("reserves noncanonical archived frontmatter in an uncommitted sibling worktree", async () => {
+		const core = await createProject(true);
+		const sibling = join(testDir, "sibling");
+		await $`git worktree add ${sibling} -b sibling-renamed-history`.cwd(core.fs.rootDir).quiet();
+		const siblingCore = new Core(sibling);
+		const archivePath = join(siblingCore.fs.archiveTasksDir, "history.md");
+		const content = "---\nid: TASK-050\ntitle: Renamed history\n---\nPreserved bytes\n";
+		await Bun.write(archivePath, content);
+
+		const next = await core.createTaskFromInput({ title: "Main task" }, false);
+
+		expect(next.task.id).toBe("TASK-51");
+		expect(await Bun.file(archivePath).text()).toBe(content);
+	});
+
+	it("reserves noncanonical archived frontmatter committed only on another branch", async () => {
+		const core = await createProject(true);
+		const root = core.fs.rootDir;
+		await $`git switch -c renamed-archive-branch`.cwd(root).quiet();
+		const archivePath = join(core.fs.archiveTasksDir, "history.md");
+		const content = "---\nid: TASK-050\ntitle: Renamed history\n---\nPreserved bytes\n";
+		await Bun.write(archivePath, content);
+		await $`git add backlog`.cwd(root).quiet();
+		await $`git commit -m "Retain renamed history"`.cwd(root).quiet();
+		await $`git switch main`.cwd(root).quiet();
+
+		const next = await new Core(root).createTaskFromInput({ title: "Main task" }, false);
+
+		expect(next.task.id).toBe("TASK-51");
+		expect(await $`git show renamed-archive-branch:backlog/archive/tasks/history.md`.cwd(root).text()).toBe(content);
+	});
+
+	it("allocates distinct IDs above noncanonical archives in simultaneous sibling CLI processes", async () => {
+		const core = await createProject(true);
+		const sibling = join(testDir, "sibling");
+		await $`git worktree add ${sibling} -b concurrent-renamed-history`.cwd(core.fs.rootDir).quiet();
+		const siblingCore = new Core(sibling);
+		const archivePath = join(siblingCore.fs.archiveTasksDir, "history.md");
+		const content = "---\nid: TASK-050\ntitle: Renamed history\n---\nPreserved bytes\n";
+		await Bun.write(archivePath, content);
+
+		await Promise.all([
+			$`bun ${CLI_PATH} task create "Concurrent main"`.cwd(core.fs.rootDir).quiet(),
+			$`bun ${CLI_PATH} task create "Concurrent sibling"`.cwd(sibling).quiet(),
+		]);
+
+		const ids = [...(await core.fs.listTasks()), ...(await siblingCore.fs.listTasks())].map((task) => task.id);
+		expect(ids.sort()).toEqual(["TASK-51", "TASK-52"]);
+		expect(await Bun.file(archivePath).text()).toBe(content);
+	});
+
+	it("reserves both archived branch identities and reuses their immutable blob cache", async () => {
+		const core = await createProject(true);
+		const root = core.fs.rootDir;
+		await $`git switch -c conflicting-archive-branch`.cwd(root).quiet();
+		const history = [
+			["TASK-005 - Content identity.md", "---\nid: task-017\ntitle: Content identity\n---\nHistory\n"],
+			["task-025 - Filename identity.md", "---\nid: TASK-003\ntitle: Filename identity\n---\nHistory\n"],
+			["task-030 - Malformed.md", "---\nid: [unclosed\n---\nHistory\n"],
+		] as const;
+		for (const [filename, content] of history) await Bun.write(join(core.fs.archiveTasksDir, filename), content);
+		await $`git add backlog`.cwd(root).quiet();
+		await $`git commit -m "Preserve conflicting archive identities"`.cwd(root).quiet();
+		await $`git switch main`.cwd(root).quiet();
+		// The added frontmatter reservation must not become a lifecycle winner:
+		// this live record remains visible under the pre-existing branch rules.
+		await Bun.write(
+			join(core.fs.tasksDir, "task-017 - Current record.md"),
+			"---\nid: TASK-017\ntitle: Current record\nstatus: To Do\n---\nCurrent evidence\n",
+		);
+		const mainCore = new Core(root);
+		const showFile = mainCore.gitOps.showFile.bind(mainCore.gitOps);
+		let archiveReads = 0;
+		mainCore.gitOps.showFile = async (commit, path) => {
+			if (path.includes("/archive/tasks/")) archiveReads += 1;
+			return showFile(commit, path);
+		};
+		try {
+			const first = await mainCore.getOccupiedTaskIds();
+			expect(first).toEqual(expect.arrayContaining(["TASK-005", "TASK-017", "TASK-025", "TASK-003", "TASK-030"]));
+			expect(await mainCore.getOccupiedTaskIds()).toEqual(first);
+			expect((await mainCore.queryTasks()).map((task) => task.id)).toEqual(["TASK-017"]);
+			expect(archiveReads).toBe(history.length);
+			const next = await mainCore.createTaskFromInput({ title: "After conflicting history" }, false);
+			expect(next.task.id).toBe("TASK-31");
+			expect(archiveReads).toBe(history.length);
+		} finally {
+			mainCore.gitOps.showFile = showFile;
+			mainCore.disposeSearchService();
+			mainCore.disposeContentStore();
+		}
+		for (const [filename, content] of history) {
+			expect(await $`git show ${`conflicting-archive-branch:backlog/archive/tasks/${filename}`}`.cwd(root).text()).toBe(
+				content,
+			);
+		}
+	});
+
+	for (const siblingArchive of [false, true]) {
+		it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+			`fails closed when a noncanonical ${siblingArchive ? "sibling" : "local"} archive cannot be read`,
+			async () => {
+				const core = await createProject(siblingArchive);
+				let archiveCore = core;
+				if (siblingArchive) {
+					const sibling = join(testDir, "sibling");
+					await $`git worktree add ${sibling} -b unreadable-archive`.cwd(core.fs.rootDir).quiet();
+					archiveCore = new Core(sibling);
+				}
+				const path = join(archiveCore.fs.archiveTasksDir, "history.md");
+				const content = "---\nid: TASK-050\ntitle: Preserved history\n---\nHistory\n";
+				await Bun.write(path, content);
+				await chmod(path, 0o000);
+				try {
+					await expect(core.createTaskFromInput({ title: "Must not be allocated" }, false)).rejects.toThrow();
+					expect(await core.fs.listTasks()).toHaveLength(0);
+				} finally {
+					await chmod(path, 0o644);
+				}
+				expect(await Bun.file(path).text()).toBe(content);
+			},
+		);
+	}
+
+	it("refuses partial branch reservations after an archive read error and retries safely", async () => {
+		const core = await createProject(true);
+		const root = core.fs.rootDir;
+		await $`git switch -c unreadable-archive-branch`.cwd(root).quiet();
+		const path = join(core.fs.archiveTasksDir, "history.md");
+		await Bun.write(path, "---\nid: TASK-050\ntitle: Preserved history\n---\nHistory\n");
+		await $`git add backlog`.cwd(root).quiet();
+		await $`git commit -m "Preserve archive identity"`.cwd(root).quiet();
+		await $`git switch main`.cwd(root).quiet();
+		const mainCore = new Core(root);
+		const showFile = mainCore.gitOps.showFile.bind(mainCore.gitOps);
+		mainCore.gitOps.showFile = async (commit, filename) => {
+			if (filename.endsWith("archive/tasks/history.md")) throw new Error("injected archive blob read failure");
+			return showFile(commit, filename);
+		};
+		try {
+			await expect(mainCore.createTaskFromInput({ title: "Must not be allocated" }, false)).rejects.toThrow(
+				"incomplete",
+			);
+			expect(await mainCore.fs.listTasks()).toHaveLength(0);
+			for (const title of ["Alpha", "Beta"]) {
+				await Bun.write(
+					join(mainCore.fs.tasksDir, `task-1 - ${title}.md`),
+					`---\nid: TASK-1\ntitle: ${title}\nstatus: To Do\n---\n${title} body\n`,
+				);
+			}
+			await expect(mainCore.previewDuplicateTaskIdRepair({ includeBranches: true })).rejects.toThrow("incomplete");
+		} finally {
+			mainCore.gitOps.showFile = showFile;
+		}
+		try {
+			const recovered = await mainCore.previewDuplicateTaskIdRepair({ includeBranches: true });
+			expect(recovered.changes.map((change) => change.newId)).toEqual(["TASK-51"]);
+			const next = await mainCore.createTaskFromInput({ title: "After recovered read" }, false);
+			expect(next.task.id).toBe("TASK-51");
+		} finally {
+			mainCore.disposeSearchService();
+			mainCore.disposeContentStore();
+		}
 	});
 });

--- a/src/test/archived-task-id-allocation.test.ts
+++ b/src/test/archived-task-id-allocation.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import {
+	createUniqueTestDir,
+	initializeFilesystemTestProject,
+	initializeTestProject,
+	safeCleanup,
+} from "./test-utils.ts";
+
+const CLI_PATH = getTestCliPath();
+
+describe("archived task IDs remain reserved", () => {
+	let testDir: string;
+
+	afterEach(async () => {
+		if (testDir) await safeCleanup(testDir);
+	});
+
+	async function createProject(git = false): Promise<Core> {
+		testDir = createUniqueTestDir("archived-task-id-allocation");
+		const root = join(testDir, "repo");
+		await mkdir(root, { recursive: true });
+		const core = new Core(root);
+		if (git) {
+			await $`git init -b main`.cwd(root).quiet();
+			await initializeTestProject(core, "Archived ID Test", true);
+		} else {
+			await initializeFilesystemTestProject(core, "Archived ID Test");
+		}
+		return core;
+	}
+
+	for (const git of [false, true]) {
+		it(`the CLI increments after archiving every task (${git ? "Git" : "filesystem-only"})`, async () => {
+			const core = await createProject(git);
+			const root = core.fs.rootDir;
+			await $`bun ${CLI_PATH} task create "Original task"`.cwd(root).quiet();
+			await $`bun ${CLI_PATH} task archive TASK-1`.cwd(root).quiet();
+			expect(await core.fs.listTasks()).toHaveLength(0);
+
+			await $`bun ${CLI_PATH} task create "Next task"`.cwd(root).quiet();
+
+			expect((await core.fs.loadTask("TASK-2"))?.title).toBe("Next task");
+			expect((await core.fs.listArchivedTasks()).map((task) => task.id)).toEqual(["TASK-1"]);
+		});
+	}
+
+	it("preserves custom prefixes and padding after archiving the highest task", async () => {
+		const core = await createProject();
+		const config = await core.fs.loadConfig();
+		if (!config) throw new Error("Expected initialized config");
+		config.prefixes = { task: "MATH" };
+		config.zeroPaddedIds = 3;
+		await core.fs.saveConfig(config);
+
+		await core.createTaskFromInput({ title: "First" }, false);
+		const highest = await core.createTaskFromInput({ title: "Highest" }, false);
+		expect(highest.task.id).toBe("MATH-002");
+		expect((await core.archiveTask(highest.task.id, false)).success).toBe(true);
+
+		const next = await core.createTaskFromInput({ title: "Next" }, false);
+		expect(next.task.id).toBe("MATH-003");
+	});
+
+	it("increments padded child IDs after archiving the highest child", async () => {
+		const core = await createProject();
+		const config = await core.fs.loadConfig();
+		if (!config) throw new Error("Expected initialized config");
+		config.prefixes = { task: "MATH" };
+		config.zeroPaddedIds = 3;
+		await core.fs.saveConfig(config);
+		const parent = await core.createTaskFromInput({ title: "Parent" }, false);
+		const child = await core.createTaskFromInput({ title: "First child", parentTaskId: parent.task.id }, false);
+		expect(child.task.id).toBe("MATH-001.01");
+		expect((await core.archiveTask(child.task.id, false)).success).toBe(true);
+
+		const next = await core.createTaskFromInput({ title: "Next child", parentTaskId: "1" }, false);
+		expect(next.task.id).toBe("MATH-001.02");
+		expect(next.task.parentTaskId).toBe(parent.task.id);
+	});
+
+	it("promotes a draft using the next task ID after the archive", async () => {
+		const core = await createProject();
+		const original = await core.createTaskFromInput({ title: "Archived task" }, false);
+		expect((await core.archiveTask(original.task.id, false)).success).toBe(true);
+		const draft = await core.createTaskFromInput({ title: "Promoted task", status: "Draft" }, false);
+
+		expect(await core.promoteDraft(draft.task.id, false)).toBe(true);
+		expect((await core.fs.loadTask("TASK-2"))?.title).toBe("Promoted task");
+		expect(await core.fs.loadDraft(draft.task.id)).toBeNull();
+	});
+
+	it("reserves an archived filename even when its Markdown cannot be parsed", async () => {
+		const core = await createProject();
+		const archivedPath = join(core.fs.archiveTasksDir, "task-009 - Malformed.md");
+		await Bun.write(archivedPath, "---\nid: [unclosed\n---\nMalformed archived task\n");
+
+		const next = await core.createTaskFromInput({ title: "After malformed archive" }, false);
+
+		expect(next.task.id).toBe("TASK-10");
+		expect(await Bun.file(archivedPath).text()).toContain("id: [unclosed");
+	});
+
+	it("reserves both identities when archived filenames and frontmatter disagree", async () => {
+		const core = await createProject();
+		const contentPath = join(core.fs.archiveTasksDir, "task-005 - Content identity.md");
+		const content = "---\nid: TASK-017\ntitle: Content identity\n---\nPreserved history\n";
+		await Bun.write(contentPath, content);
+		const afterContent = await core.createTaskFromInput({ title: "After content identity" }, false);
+		expect(afterContent.task.id).toBe("TASK-18");
+
+		const filenamePath = join(core.fs.archiveTasksDir, "task-025 - Filename identity.md");
+		const filenameContent = "---\nid: TASK-003\ntitle: Filename identity\n---\nPreserved history\n";
+		await Bun.write(filenamePath, filenameContent);
+		const afterFilename = await core.createTaskFromInput({ title: "After filename identity" }, false);
+		expect(afterFilename.task.id).toBe("TASK-26");
+		expect(await Bun.file(contentPath).text()).toBe(content);
+		expect(await Bun.file(filenamePath).text()).toBe(filenameContent);
+	});
+
+	it("reserves an uncommitted archived task in a sibling worktree", async () => {
+		const core = await createProject(true);
+		const sibling = join(testDir, "sibling");
+		await $`git worktree add ${sibling} -b sibling-archive`.cwd(core.fs.rootDir).quiet();
+		const siblingCore = new Core(sibling);
+		const archived = await siblingCore.createTaskFromInput({ title: "Sibling task" }, false);
+		expect((await siblingCore.archiveTask(archived.task.id, false)).success).toBe(true);
+		expect(await siblingCore.fs.listTasks()).toHaveLength(0);
+
+		const next = await core.createTaskFromInput({ title: "Main task" }, false);
+
+		expect(next.task.id).toBe("TASK-2");
+	});
+
+	it("reserves uppercase filenames and differing archive IDs in a sibling worktree", async () => {
+		const core = await createProject(true);
+		const sibling = join(testDir, "sibling");
+		await $`git worktree add ${sibling} -b sibling-archive-drift`.cwd(core.fs.rootDir).quiet();
+		const siblingCore = new Core(sibling);
+		const archivedPath = join(siblingCore.fs.archiveTasksDir, "TASK-005 - Archive drift.md");
+		const content = "---\nid: TASK-017\ntitle: Archive drift\n---\nPreserved history\n";
+		await Bun.write(archivedPath, content);
+
+		const next = await core.createTaskFromInput({ title: "Main task" }, false);
+
+		expect(next.task.id).toBe("TASK-18");
+		expect(await Bun.file(archivedPath).text()).toBe(content);
+	});
+
+	it("reserves an archived task committed only on another branch", async () => {
+		const core = await createProject(true);
+		const root = core.fs.rootDir;
+		await $`git switch -c branch-archive`.cwd(root).quiet();
+		const branchCore = new Core(root);
+		const archived = await branchCore.createTaskFromInput({ title: "Branch task" }, false);
+		expect((await branchCore.archiveTask(archived.task.id, false)).success).toBe(true);
+		await $`git add backlog`.cwd(root).quiet();
+		await $`git commit -m "Archive branch task"`.cwd(root).quiet();
+		await $`git switch main`.cwd(root).quiet();
+		const mainCore = new Core(root);
+		expect(await mainCore.fs.listTasks()).toHaveLength(0);
+		expect(await mainCore.fs.listArchivedTasks()).toHaveLength(0);
+
+		const next = await mainCore.createTaskFromInput({ title: "Main task" }, false);
+
+		expect(next.task.id).toBe("TASK-2");
+	});
+});

--- a/src/test/atomic-task-create.test.ts
+++ b/src/test/atomic-task-create.test.ts
@@ -215,6 +215,30 @@ describe("atomic task creation", () => {
 		expect(drafts.map((draft) => draft.title)).toEqual(["Task A", "Task B"]);
 	});
 
+	it("omits a task demoted after the task snapshot but before metadata is read", async () => {
+		const writer = new Core(testDir);
+		await writer.createTaskFromInput({ title: "Task A" }, false);
+		await writer.createTaskFromInput({ title: "Task B" }, false);
+		const reader = new Core(testDir);
+		const listTasks = reader.fs.listTasks.bind(reader.fs);
+		reader.fs.listTasks = async (...args) => {
+			const snapshot = await listTasks(...args);
+			reader.fs.listTasks = listTasks;
+			expect((await writer.demoteTask("TASK-1", false)).success).toBe(true);
+			return snapshot;
+		};
+		try {
+			const tasks = await reader.listTasksWithMetadata();
+			expect(tasks.map((task) => task.id)).toEqual(["TASK-2"]);
+			expect((await writer.fs.listDrafts()).map((draft) => draft.id)).toEqual(["DRAFT-1"]);
+			expect((await writer.fs.listArchivedTasks()).map((task) => task.id)).toEqual(["TASK-1"]);
+		} finally {
+			reader.fs.listTasks = listTasks;
+			reader.disposeContentStore();
+			writer.disposeContentStore();
+		}
+	});
+
 	it("assigns unique ids when two milestone creations race", async () => {
 		const first = new Core(testDir);
 		const second = new Core(testDir);

--- a/src/test/branch-task-loader-resilience.test.ts
+++ b/src/test/branch-task-loader-resilience.test.ts
@@ -124,7 +124,7 @@ Loaded after retrying the failed history query.`;
 			{ name: "origin/feature/retry", commit: featureCommit, current: false },
 		];
 
-		expect(await loader.load(tips, config, [], false)).toEqual({ entries: [], complete: false });
+		expect(await loader.load(tips, config, [], false)).toEqual({ entries: [], archivedIds: [], complete: false });
 		const result = await loader.load(tips, config, [], false);
 		const entries = result.entries;
 

--- a/src/test/demoted-task-id-allocation.test.ts
+++ b/src/test/demoted-task-id-allocation.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { getTestCliPath } from "./test-cli.ts";
+import {
+	createUniqueTestDir,
+	initializeFilesystemTestProject,
+	initializeTestProject,
+	safeCleanup,
+} from "./test-utils.ts";
+
+const CLI_PATH = getTestCliPath();
+
+describe("demoted task IDs remain reserved", () => {
+	let testDir: string;
+
+	afterEach(async () => {
+		if (testDir) await safeCleanup(testDir);
+	});
+
+	async function createProject(git = false): Promise<Core> {
+		testDir = createUniqueTestDir("demoted-task-id-allocation");
+		const root = join(testDir, "repo");
+		await mkdir(root, { recursive: true });
+		const core = new Core(root);
+		if (git) {
+			await $`git init -b main`.cwd(root).quiet();
+			await initializeTestProject(core, "Demoted ID Test", true);
+		} else {
+			await initializeFilesystemTestProject(core, "Demoted ID Test");
+		}
+		return core;
+	}
+
+	async function originalRecord(core: Core, id: string) {
+		const task = await core.fs.loadTask(id);
+		if (!task?.filePath) throw new Error(`Missing task file: ${id}`);
+		return {
+			path: task.filePath,
+			archivedPath: join(core.fs.archiveTasksDir, basename(task.filePath)),
+			content: await Bun.file(task.filePath).text(),
+		};
+	}
+
+	for (const git of [false, true]) {
+		it(`the CLI allocates TASK-4 after demoting TASK-3 (${git ? "Git" : "filesystem-only"})`, async () => {
+			const core = await createProject(git);
+			const root = core.fs.rootDir;
+			for (const title of ["First", "Second", "Third"]) {
+				await $`bun ${CLI_PATH} task create ${title}`.cwd(root).quiet();
+			}
+			const original = await originalRecord(core, "TASK-3");
+
+			await $`bun ${CLI_PATH} task demote TASK-3`.cwd(root).quiet();
+			await $`bun ${CLI_PATH} task create "After demotion"`.cwd(root).quiet();
+
+			expect((await core.fs.loadTask("TASK-4"))?.title).toBe("After demotion");
+			expect(await core.fs.loadTask("TASK-3")).toBeNull();
+			expect((await core.fs.listDrafts()).map((draft) => draft.title)).toEqual(["Third"]);
+			expect(await Bun.file(original.archivedPath).text()).toBe(original.content);
+		});
+	}
+
+	it("editing a task into Draft preserves its original bytes while applying updates only to the draft", async () => {
+		const core = await createProject();
+		const { task } = await core.createTaskFromInput(
+			{ title: "Original title", description: "Original description", status: "In Progress" },
+			false,
+		);
+		const original = await originalRecord(core, task.id);
+
+		await core.editTaskOrDraft(
+			task.id,
+			{ status: "Draft", title: "Revised draft title", description: "Revised draft description" },
+			false,
+		);
+
+		expect(await Bun.file(original.archivedPath).text()).toBe(original.content);
+		expect(await Bun.file(original.path).exists()).toBe(false);
+		const drafts = await core.fs.listDrafts();
+		expect(drafts).toHaveLength(1);
+		expect(drafts[0]?.title).toBe("Revised draft title");
+		expect(drafts[0]?.description).toBe("Revised draft description");
+		expect(drafts[0]?.status).toBe("Draft");
+		expect((await core.createTaskFromInput({ title: "Next" }, false)).task.id).toBe("TASK-2");
+	});
+
+	it("increments custom-prefix padded child IDs after demotion", async () => {
+		const core = await createProject();
+		const config = await core.fs.loadConfig();
+		if (!config) throw new Error("Expected initialized config");
+		config.prefixes = { task: "MATH" };
+		config.zeroPaddedIds = 3;
+		await core.fs.saveConfig(config);
+		const { task: parent } = await core.createTaskFromInput({ title: "Parent" }, false);
+		const { task: child } = await core.createTaskFromInput({ title: "Child", parentTaskId: parent.id }, false);
+		expect(child.id).toBe("MATH-001.01");
+
+		expect((await core.demoteTask(child.id, false)).success).toBe(true);
+		const next = await core.createTaskFromInput({ title: "Next child", parentTaskId: "1" }, false);
+
+		expect(next.task.id).toBe("MATH-001.02");
+		expect((await core.fs.listArchivedTasks()).map((task) => task.id)).toEqual([child.id]);
+	});
+
+	for (const editStatus of [false, true]) {
+		it(`preserves retired IDs after demotion and ${editStatus ? "edit-status" : "direct"} promotion`, async () => {
+			const core = await createProject();
+			const { task } = await core.createTaskFromInput({ title: "Round trip" }, false);
+			const original = await originalRecord(core, task.id);
+			expect((await core.demoteTask(task.id, false)).success).toBe(true);
+			const [draft] = await core.fs.listDrafts();
+			if (!draft) throw new Error("Expected demoted draft");
+
+			if (editStatus) {
+				const result = await core.editTaskOrDraft(draft.id, { status: "To Do" }, false);
+				expect(result.task.id).toBe("TASK-2");
+			} else {
+				expect(await core.promoteDraft(draft.id, false)).toBe(true);
+			}
+
+			expect((await core.fs.loadTask("TASK-2"))?.title).toBe("Round trip");
+			expect(await core.fs.listDrafts()).toHaveLength(0);
+			expect(await Bun.file(original.archivedPath).text()).toBe(original.content);
+			expect((await core.createTaskFromInput({ title: "Next" }, false)).task.id).toBe("TASK-3");
+		});
+	}
+
+	it("keeps the old task ID reserved after the resulting draft is archived", async () => {
+		const core = await createProject();
+		const { task } = await core.createTaskFromInput({ title: "Retired task" }, false);
+		const original = await originalRecord(core, task.id);
+		expect((await core.demoteTask(task.id, false)).success).toBe(true);
+		const [draft] = await core.fs.listDrafts();
+		if (!draft) throw new Error("Expected demoted draft");
+
+		expect(await core.archiveDraft(draft.id, false)).toBe(true);
+
+		expect(await core.fs.listTasks()).toHaveLength(0);
+		expect(await core.fs.listDrafts()).toHaveLength(0);
+		expect((await core.createTaskFromInput({ title: "Next" }, false)).task.id).toBe("TASK-2");
+		expect(await Bun.file(original.archivedPath).text()).toBe(original.content);
+	});
+
+	it("the filesystem demote and promote paths retain the retired task identity", async () => {
+		const core = await createProject();
+		const { task } = await core.createTaskFromInput({ title: "Filesystem round trip" }, false);
+		const original = await originalRecord(core, task.id);
+
+		expect(await core.fs.demoteTask(task.id)).toBe(true);
+		const [draft] = await core.fs.listDrafts();
+		if (!draft) throw new Error("Expected demoted draft");
+		expect(await core.fs.promoteDraft(draft.id)).toBe(true);
+
+		expect((await core.fs.loadTask("TASK-2"))?.title).toBe("Filesystem round trip");
+		expect(await Bun.file(original.archivedPath).text()).toBe(original.content);
+	});
+
+	it("reserves an uncommitted demoted task in a sibling worktree", async () => {
+		const core = await createProject(true);
+		const sibling = join(testDir, "sibling");
+		await $`git worktree add ${sibling} -b sibling-demotion`.cwd(core.fs.rootDir).quiet();
+		const siblingCore = new Core(sibling);
+		const { task } = await siblingCore.createTaskFromInput({ title: "Sibling task" }, false);
+		expect((await siblingCore.demoteTask(task.id, false)).success).toBe(true);
+
+		expect((await core.createTaskFromInput({ title: "Main task" }, false)).task.id).toBe("TASK-2");
+	});
+
+	for (const editStatus of [false, true]) {
+		it(`auto-commits the retired task so a fresh clone reserves its ID (${editStatus ? "edit-status" : "direct"})`, async () => {
+			const core = await createProject(true);
+			const { task } = await core.createTaskFromInput({ title: "Committed task" }, true);
+			const original = await originalRecord(core, task.id);
+			if (editStatus) {
+				await core.editTaskOrDraft(task.id, { status: "Draft", title: "Committed draft" }, true);
+			} else {
+				expect((await core.demoteTask(task.id, true)).success).toBe(true);
+			}
+
+			const clone = join(testDir, "clone");
+			await $`git clone --no-local ${core.fs.rootDir} ${clone}`.quiet();
+			const cloneCore = new Core(clone);
+
+			expect((await cloneCore.createTaskFromInput({ title: "Clone task" }, false)).task.id).toBe("TASK-2");
+			expect(await Bun.file(join(cloneCore.fs.archiveTasksDir, basename(original.path))).text()).toBe(original.content);
+		});
+	}
+});

--- a/src/test/demotion-archive-safety.test.ts
+++ b/src/test/demotion-archive-safety.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmod, mkdir, rm } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { $ } from "bun";
+import { Core } from "../core/backlog.ts";
+import { serializeTask } from "../markdown/serializer.ts";
+import type { Task } from "../types/index.ts";
+import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
+
+describe("demotion archive safety", () => {
+	let testDir: string;
+	let core: Core;
+
+	beforeEach(async () => {
+		testDir = createUniqueTestDir("demotion-archive-safety");
+		await mkdir(testDir, { recursive: true });
+		core = new Core(testDir);
+		await initializeFilesystemTestProject(core, "Demotion archive safety");
+	});
+
+	afterEach(async () => {
+		core.disposeSearchService();
+		core.disposeContentStore();
+		await safeCleanup(testDir);
+	});
+
+	async function createTarget(): Promise<Task & { filePath: string }> {
+		const { task } = await core.createTaskFromInput(
+			{ title: "Demotion target", description: "Original evidence" },
+			false,
+		);
+		if (!task.filePath) throw new Error("Expected a saved task path");
+		return { ...task, filePath: task.filePath };
+	}
+
+	const archivedPath = (task: Task & { filePath: string }) => join(core.fs.archiveTasksDir, basename(task.filePath));
+
+	async function expectOriginalAndNoDraft(task: Task & { filePath: string }, original: string): Promise<void> {
+		expect(await Bun.file(task.filePath).text()).toBe(original);
+		expect(await core.fs.listDrafts()).toHaveLength(0);
+	}
+
+	it("refuses an occupied archive destination without overwriting history or creating a draft", async () => {
+		const task = await createTarget();
+		const original = await Bun.file(task.filePath).text();
+		const existing = serializeTask({ ...task, id: "TASK-99", title: "Older history" });
+		await Bun.write(archivedPath(task), existing);
+
+		await expect(core.demoteTask(task.id, false)).rejects.toThrow();
+
+		await expectOriginalAndNoDraft(task, original);
+		expect(await Bun.file(archivedPath(task)).text()).toBe(existing);
+	});
+
+	it("refuses an archived frontmatter identity claimed under a different filename", async () => {
+		const task = await createTarget();
+		const original = await Bun.file(task.filePath).text();
+		const existingPath = join(core.fs.archiveTasksDir, "task-099 - Earlier identity.md");
+		const existing = serializeTask({ ...task, title: "Earlier identity" });
+		await Bun.write(existingPath, existing);
+
+		await expect(core.editTaskOrDraft(task.id, { status: "Draft", title: "Reconsidered" }, false)).rejects.toThrow();
+
+		await expectOriginalAndNoDraft(task, original);
+		expect(await Bun.file(existingPath).text()).toBe(existing);
+		expect(await Bun.file(archivedPath(task)).exists()).toBe(false);
+	});
+
+	it("preserves an archive destination created by another writer after the identity scan", async () => {
+		const task = await createTarget();
+		const original = await Bun.file(task.filePath).text();
+		const concurrentHistory = serializeTask({ ...task, title: "Concurrent archived history" });
+		const saveDraft = core.fs.saveDraft.bind(core.fs);
+		core.fs.saveDraft = async (draft) => {
+			const path = await saveDraft(draft);
+			await Bun.write(archivedPath(task), concurrentHistory);
+			return path;
+		};
+		try {
+			await expect(core.demoteTask(task.id, false)).rejects.toThrow();
+		} finally {
+			core.fs.saveDraft = saveDraft;
+		}
+
+		await expectOriginalAndNoDraft(task, original);
+		expect(await Bun.file(archivedPath(task)).text()).toBe(concurrentHistory);
+	});
+
+	it("preserves the task when archive storage is not a directory", async () => {
+		const task = await createTarget();
+		const original = await Bun.file(task.filePath).text();
+		await rm(core.fs.archiveTasksDir, { recursive: true, force: true });
+		await Bun.write(core.fs.archiveTasksDir, "Archive storage is blocked\n");
+
+		await expect(core.demoteTask(task.id, false)).rejects.toThrow();
+
+		await expectOriginalAndNoDraft(task, original);
+		expect(await Bun.file(core.fs.archiveTasksDir).text()).toBe("Archive storage is blocked\n");
+	});
+
+	it("does not leave an archive reservation when saving the new draft fails", async () => {
+		const task = await createTarget();
+		const original = await Bun.file(task.filePath).text();
+		const saveDraft = core.fs.saveDraft.bind(core.fs);
+		core.fs.saveDraft = async () => {
+			throw new Error("Draft storage failure");
+		};
+		try {
+			await expect(core.editTaskOrDraft(task.id, { status: "Draft" }, false)).rejects.toThrow("Draft storage failure");
+		} finally {
+			core.fs.saveDraft = saveDraft;
+		}
+
+		await expectOriginalAndNoDraft(task, original);
+		expect(await Bun.file(archivedPath(task)).exists()).toBe(false);
+	});
+
+	it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+		"rolls back the draft and new archive if the original task cannot be removed",
+		async () => {
+			const task = await createTarget();
+			const original = await Bun.file(task.filePath).text();
+			const saveDraft = core.fs.saveDraft.bind(core.fs);
+			core.fs.saveDraft = async (draft) => {
+				const path = await saveDraft(draft);
+				// The original is still readable, and archive/draft storage remains writable;
+				// only removing its directory entry is forbidden.
+				await chmod(core.fs.tasksDir, 0o555);
+				return path;
+			};
+			try {
+				await expect(core.demoteTask(task.id, false)).rejects.toThrow();
+			} finally {
+				core.fs.saveDraft = saveDraft;
+				await chmod(core.fs.tasksDir, 0o755);
+			}
+
+			await expectOriginalAndNoDraft(task, original);
+			expect(await Bun.file(archivedPath(task)).exists()).toBe(false);
+		},
+	);
+
+	for (const edit of [false, true]) {
+		it(`retains the retired ID after dependency cleanup fails (${edit ? "edit into Draft" : "demote"})`, async () => {
+			const { task: dependent } = await core.createTaskFromInput({ title: "Dependent" }, false);
+			const task = await createTarget();
+			const original = await Bun.file(task.filePath).text();
+			await core.updateTaskFromInput(dependent.id, { dependencies: [task.id] }, false);
+			const saveTask = core.fs.saveTask.bind(core.fs);
+			core.fs.saveTask = async (record) => {
+				if (record.id === dependent.id) throw new Error("Dependency cleanup failure");
+				return await saveTask(record);
+			};
+			let failure: unknown;
+			try {
+				if (edit) await core.editTaskOrDraft(task.id, { status: "Draft" }, false);
+				else await core.demoteTask(task.id, false);
+			} catch (error) {
+				failure = error;
+			} finally {
+				core.fs.saveTask = saveTask;
+			}
+
+			expect((failure as { demotionState?: string } | undefined)?.demotionState).toBe("moved");
+			expect((failure as { demotionFailureCause?: string } | undefined)?.demotionFailureCause).toBe("cleanup");
+			expect(await Bun.file(archivedPath(task)).text()).toBe(original);
+			expect(await core.fs.loadTask(task.id)).toBeNull();
+			expect(await core.fs.listDrafts()).toHaveLength(1);
+			expect((await core.createTaskFromInput({ title: "After cleanup failure" }, false)).task.id).toBe("TASK-3");
+		});
+	}
+
+	it("retains the retired ID and reports a completed move when its commit fails", async () => {
+		await $`git init -b main`.cwd(testDir).quiet();
+		const config = await core.fs.loadConfig();
+		if (!config) throw new Error("Expected initialized config");
+		await core.fs.saveConfig({ ...config, filesystemOnly: false });
+		const task = await createTarget();
+		const original = await Bun.file(task.filePath).text();
+		const git = await core.getGitOps();
+		const commitFiles = git.commitFiles.bind(git);
+		git.commitFiles = async () => {
+			throw new Error("Commit failure");
+		};
+		let failure: unknown;
+		try {
+			await core.demoteTask(task.id, true);
+		} catch (error) {
+			failure = error;
+		} finally {
+			git.commitFiles = commitFiles;
+		}
+
+		expect((failure as { demotionState?: string } | undefined)?.demotionState).toBe("moved");
+		expect((failure as { demotionFailureCause?: string } | undefined)?.demotionFailureCause).toBe("commit");
+		expect(await Bun.file(archivedPath(task)).text()).toBe(original);
+		expect(await core.fs.loadTask(task.id)).toBeNull();
+		expect(await core.fs.listDrafts()).toHaveLength(1);
+		expect((await core.createTaskFromInput({ title: "After commit failure" }, false)).task.id).toBe("TASK-2");
+	});
+
+	it("keeps retired IDs reserved when doctor allocates a duplicate repair", async () => {
+		const task = await createTarget();
+		await Bun.write(
+			join(core.fs.tasksDir, "task-01 - Duplicate.md"),
+			serializeTask({ ...task, id: "TASK-01", title: "Duplicate" }),
+		);
+		const historyPath = join(core.fs.archiveTasksDir, "task-2 - Retired.md");
+		const history = serializeTask({ ...task, id: "TASK-2", title: "Retired" });
+		await Bun.write(historyPath, history);
+
+		const plan = await core.previewDuplicateTaskIdRepair();
+
+		expect(plan.repairable).toBe(true);
+		expect(plan.changes).toHaveLength(1);
+		expect(plan.changes[0]?.newId).toBe("TASK-3");
+		await core.repairDuplicateTaskIds(plan.fingerprint);
+		expect((await core.fs.loadTask("TASK-3"))?.title).toBe("Duplicate");
+		expect(await Bun.file(historyPath).text()).toBe(history);
+	});
+});

--- a/src/test/duplicate-task-repair.test.ts
+++ b/src/test/duplicate-task-repair.test.ts
@@ -168,6 +168,31 @@ describe("duplicate task diagnosis", () => {
 });
 
 describe("duplicate task repair", () => {
+	it("rechecks branch reservations before applying a preview made from a cached corpus", async () => {
+		await $`git init -b main`.cwd(testDir).quiet();
+		const config = await core.filesystem.loadConfig();
+		if (!config) throw new Error("Missing test config");
+		await core.filesystem.saveConfig({ ...config, checkActiveBranches: true });
+		const alphaPath = await writeTask(core.filesystem.tasksDir, "task-1 - Alpha.md", makeTask("TASK-1", "Alpha"));
+		const betaPath = await writeTask(core.filesystem.tasksDir, "task-01 - Beta.md", makeTask("TASK-01", "Beta"));
+		await $`git add .`.cwd(testDir).quiet();
+		await $`git commit -m "Duplicate tasks before branch reservation"`.cwd(testDir).quiet();
+		const originals = await Promise.all([alphaPath, betaPath].map((path) => Bun.file(path).text()));
+		const plan = await core.previewDuplicateTaskIdRepair();
+		expect(plan.changes[0]?.newId).toBe("TASK-2");
+
+		await $`git switch -c retired-history`.cwd(testDir).quiet();
+		await writeTask(core.filesystem.archiveTasksDir, "task-2 - Retired.md", makeTask("TASK-2", "Retired"));
+		await $`git add .`.cwd(testDir).quiet();
+		await $`git commit -m "Reserve the proposed repair ID on another branch"`.cwd(testDir).quiet();
+		await $`git switch main`.cwd(testDir).quiet();
+
+		await expect(core.repairDuplicateTaskIds(plan.fingerprint)).rejects.toThrow("changed after the preview");
+		expect(await Promise.all([alphaPath, betaPath].map((path) => Bun.file(path).text()))).toEqual(originals);
+		const refreshed = await core.previewDuplicateTaskIdRepair({ includeBranches: true });
+		expect(refreshed.changes[0]?.newId).toBe("TASK-3");
+	});
+
 	it("preserves dotted subtask identity with parent-aware allocation", async () => {
 		await writeTask(core.filesystem.tasksDir, "task-1 - Parent.md", makeTask("TASK-1", "Parent"));
 		await writeTask(core.filesystem.tasksDir, "task-1.1 - Plain.md", {

--- a/src/test/filesystem.test.ts
+++ b/src/test/filesystem.test.ts
@@ -424,8 +424,8 @@ Invalid content`,
 			const promoted = await filesystem.promoteDraft("draft-1");
 			expect(promoted).toBe(true);
 
-			const promotedTask = await filesystem.loadTask("task-1");
-			expect(promotedTask?.id).toBe("TASK-1");
+			const promotedTask = await filesystem.loadTask("task-2");
+			expect(promotedTask?.id).toBe("TASK-2");
 			expect(promotedTask?.status).toBe("In Progress");
 		});
 

--- a/src/test/id-generation.test.ts
+++ b/src/test/id-generation.test.ts
@@ -22,7 +22,7 @@ describe("Task ID Generation with Archives", () => {
 		await rm(testDir, { recursive: true, force: true });
 	});
 
-	it("should reuse IDs from archived tasks (soft delete behavior)", async () => {
+	it("preserves IDs when all tasks are archived", async () => {
 		// Create tasks 1-5
 		await core.createTaskFromInput({ title: "Task 1" }, false);
 		await core.createTaskFromInput({ title: "Task 2" }, false);
@@ -41,23 +41,23 @@ describe("Task ID Generation with Archives", () => {
 		const activeTasks = await core.fs.listTasks();
 		expect(activeTasks.length).toBe(0);
 
-		// Create new task - should be TASK-1 (archived IDs can be reused)
+		// A new task advances beyond the archived high-water mark.
 		const result = await core.createTaskFromInput({ title: "Task After Archive" }, false);
-		expect(result.task.id).toBe("TASK-1");
+		expect(result.task.id).toBe("TASK-6");
 
 		// Verify the task was created with correct ID
-		const newTask = await core.getTask("task-1");
+		const newTask = await core.getTask("task-6");
 		expect(newTask).not.toBeNull();
 		expect(newTask?.title).toBe("Task After Archive");
 	});
 
-	it("should consider completed tasks but not archived tasks for ID generation", async () => {
+	it("considers active, completed, and archived tasks for ID generation", async () => {
 		// Create tasks 1-3
 		await core.createTaskFromInput({ title: "Task 1", status: "Todo" }, false);
 		await core.createTaskFromInput({ title: "Task 2", status: "Done" }, false);
 		await core.createTaskFromInput({ title: "Task 3", status: "Todo" }, false);
 
-		// Archive task-1 (its ID can be reused)
+		// Archive task-1 (its ID remains reserved)
 		await core.archiveTask("task-1", false);
 
 		// Complete task-2 (moves to completed directory, ID cannot be reused)
@@ -69,7 +69,7 @@ describe("Task ID Generation with Archives", () => {
 		expect(activeTasks[0]?.id).toBe("TASK-3");
 
 		// Create new task - should be TASK-4 (max of active 3 + completed 2 is 3, so next is 4)
-		// Note: archived TASK-1 is NOT considered, so its ID could be reused if 2 and 3 weren't taken
+		// Archived TASK-1 also remains reserved.
 		const result = await core.createTaskFromInput({ title: "Task 4" }, false);
 		expect(result.task.id).toBe("TASK-4");
 
@@ -98,16 +98,16 @@ describe("Task ID Generation with Archives", () => {
 		await core.archiveTask("task-1.1", false);
 		await core.archiveTask("task-1.2", false);
 
-		// Create new parent task - should be TASK-1 (reusing archived parent ID)
+		// The new parent has a distinct ID from the archived family.
 		const newParent = await core.createTaskFromInput({ title: "New Parent" }, false);
-		expect(newParent.task.id).toBe("TASK-1");
+		expect(newParent.task.id).toBe("TASK-2");
 
-		// Create subtask of new parent (TASK-1) - should be TASK-1.1 (reusing archived subtask ID)
-		const newSubtask = await core.createTaskFromInput({ title: "New Subtask", parentTaskId: "task-1" }, false);
-		expect(newSubtask.task.id).toBe("TASK-1.1");
+		// The new child belongs to the new parent, not the archived family.
+		const newSubtask = await core.createTaskFromInput({ title: "New Subtask", parentTaskId: newParent.task.id }, false);
+		expect(newSubtask.task.id).toBe("TASK-2.1");
 	});
 
-	it("should work with zero-padded IDs and reuse archived IDs", async () => {
+	it("preserves zero padding while advancing beyond archived IDs", async () => {
 		// Update config to use zero-padded IDs
 		const config = await core.fs.loadConfig();
 		if (config) {
@@ -122,9 +122,9 @@ describe("Task ID Generation with Archives", () => {
 
 		await core.archiveTask("task-001", false);
 
-		// Create new task - should reuse archived ID (TASK-001)
+		// The next padded task ID remains distinct from the archive.
 		const result = await core.createTaskFromInput({ title: "Task 2" }, false);
-		expect(result.task.id).toBe("TASK-001");
+		expect(result.task.id).toBe("TASK-002");
 	});
 
 	it("should detect existing subtasks with different casing (legacy data)", async () => {

--- a/src/test/vacated-task-references.test.ts
+++ b/src/test/vacated-task-references.test.ts
@@ -11,10 +11,9 @@ import { getTestCliPath } from "./test-cli.ts";
 import { createUniqueTestDir, initializeFilesystemTestProject, safeCleanup } from "./test-utils.ts";
 
 /**
- * Archiving and demoting both hand a task ID back to the allocator. A reference left behind stops
- * meaning what it said the moment the next created task is given that ID: it resolves to an
- * unrelated task instead of failing closed. Completion is the deliberate exception - a completed
- * dependency is exactly what readiness reads.
+ * Archiving and demoting preserve task IDs while removing tasks from active work. Keep their
+ * dependency-cleanup behavior so active dependents do not retain obsolete workflow blockers.
+ * Completion is the deliberate exception: a completed dependency is exactly what readiness reads.
  */
 describe("references to a vacated task ID", () => {
 	const cliPath = getTestCliPath();
@@ -94,7 +93,7 @@ describe("references to a vacated task ID", () => {
 		expect(demotion.cleanedTaskIds).toEqual([dependent.id]);
 
 		const { task: unrelated } = await core.createTaskFromInput({ title: "Totally unrelated new task" });
-		expect(taskIdsEqual(unrelated.id, target.id)).toBe(true);
+		expect(taskIdsEqual(unrelated.id, target.id)).toBe(false);
 
 		// The reference is removed, not rewritten to the draft the record became.
 		const drafts = await core.filesystem.listDrafts();
@@ -266,9 +265,9 @@ describe("references to a vacated task ID", () => {
 		expect(drafts).toHaveLength(1);
 		expect(drafts[0]?.references ?? []).toEqual(["docs/notes.md"]);
 
-		// The freed ID goes to the next task, which the draft must not have started naming.
+		// The original identity stays reserved after the draft's own references are cleaned.
 		const { task: unrelated } = await core.createTaskFromInput({ title: "Totally unrelated new task" });
-		expect(taskIdsEqual(unrelated.id, target.id)).toBe(true);
+		expect(taskIdsEqual(unrelated.id, target.id)).toBe(false);
 	});
 
 	it("removes the vacated ID from a record demoted by an edit into the Draft status", async () => {
@@ -280,7 +279,7 @@ describe("references to a vacated task ID", () => {
 		expect(demoted.references ?? []).toEqual(["docs/notes.md"]);
 	});
 
-	it("cleans a zero-padded reference and does not let it rebind to the reissued ID", async () => {
+	it("cleans a zero-padded reference while keeping the original ID reserved", async () => {
 		const { task: dependent } = await core.createTaskFromInput({ title: "Padded reference holder" });
 		const { task: target } = await core.createTaskFromInput({ title: "Demote target" });
 		// One identity, spelled with padding. Everything else in the product treats TASK-01 and
@@ -293,9 +292,9 @@ describe("references to a vacated task ID", () => {
 		expect(demotion.success).toBe(true);
 		expect(demotion.cleanedTaskIds).toEqual([dependent.id]);
 
-		// The freed ID goes to the next task created, which the padded reference must not name.
+		// Padding does not release the original identity to the next created task.
 		const { task: unrelated } = await core.createTaskFromInput({ title: "Totally unrelated new task" });
-		expect(taskIdsEqual(unrelated.id, target.id)).toBe(true);
+		expect(taskIdsEqual(unrelated.id, target.id)).toBe(false);
 
 		const updated = await core.filesystem.loadTask(dependent.id);
 		expect(updated?.references ?? []).toEqual([]);

--- a/src/test/vacated-task-references.test.ts
+++ b/src/test/vacated-task-references.test.ts
@@ -75,9 +75,9 @@ describe("references to a vacated task ID", () => {
 		expect(archived.success).toBe(true);
 		expect(archived.cleanedTaskIds).toEqual([dependent.id]);
 
-		// The archived ID is free again, so the next task is allocated exactly the vacated slot.
+		// The archived identity stays reserved even after its live dependency edges are cleaned.
 		const { task: unrelated } = await core.createTaskFromInput({ title: "Totally unrelated new task" });
-		expect(taskIdsEqual(unrelated.id, target.id)).toBe(true);
+		expect(taskIdsEqual(unrelated.id, target.id)).toBe(false);
 
 		const completedDependent = await loadCompleted(dependent.id);
 		expect(completedDependent?.dependencies ?? []).toEqual([]);
@@ -194,7 +194,7 @@ describe("references to a vacated task ID", () => {
 		}
 
 		const { task: unrelated } = await core.createTaskFromInput({ title: "Totally unrelated new task" });
-		expect(taskIdsEqual(unrelated.id, target.id)).toBe(true);
+		expect(taskIdsEqual(unrelated.id, target.id)).toBe(false);
 
 		const updated = await core.filesystem.loadTask(late.id);
 		expect(updated?.dependencies ?? []).toEqual([]);


### PR DESCRIPTION
Archiving or demoting the highest task allows a later task to reuse its identity. Demoting `TASK-3` to `DRAFT-1` now preserves the original task in the archive, so the next task is `TASK-4`. Archive frontmatter also reserves IDs when a file is renamed: `archive/tasks/history.md` containing `TASK-50` makes the next task `TASK-51`.

Fixes #997, including the [additional demotion reproduction](https://github.com/MrLesk/Backlog.md/issues/997#issuecomment-5547951552).

Allocation reserves archived task and child IDs from local files, configured branch scans, and sibling worktrees, including custom prefixes and padding. Filename and frontmatter IDs both remain reserved when they disagree; a malformed archive still reserves its recognizable filename ID. Branch frontmatter reservations use the immutable blob cache and travel separately from lifecycle entries. Unreadable archives or incomplete branch reads prevent allocation and recover on a later successful read.

Both demotion paths preserve the original bytes through exclusive archive creation before removing the active task. Failures before removal roll back new files; later cleanup or commit failures retain the reservation and report the completed move. Automatic commits include the archive, so fresh clones retain the identity. A concurrent archive/demotion that removes an active file between listing and metadata lookup now omits that vanished record; other filesystem errors propagate.

Duplicate repair uses the same reservation set, reuses the existing preview corpus, and refreshes reservations under the creation lock before applying. Live visibility, duplicate-winner policy, and reference-review rules remain unchanged. Existing collisions are not automatically renumbered; identities already lost through old demotions require reliable historical evidence to recover.

Validation:

- **2,903 passed, 8 skipped, 0 failed** in the full upstream isolated CI profile on macOS with Bun 1.3.14 and a freshly built CLI bundle.
- **109 targeted tests / 434 assertions** cover archive allocation, worktrees, demotion and rollback, duplicate repair, branch-read failures, and concurrent creation. The archive file has 20 passing regressions, including renamed frontmatter-only files and simultaneous sibling CLI processes allocating `TASK-51` / `TASK-52`.
- An additional deterministic regression reproduces a task disappearing between list and stat. The corrected concurrency checks pass **40 consecutive runs**.
- Biome, TypeScript checks, and the compiled CLI build pass. The repository-local Bun 1.3.8 binary is built from the exact cumulative patch and verified by source-tree and binary receipts.
- CLI help and agent guidance describe reserved identities and demotion semantics. No maintenance task is added to Backlog.

Full-suite reproduction, using Bun 1.3.14:

```sh
BACKLOG_BUILD_OUTDIR=/tmp/backlog-test-cli bun scripts/build.ts
BACKLOG_TEST_CLI_BUNDLE=/tmp/backlog-test-cli/cli.js bun scripts/run-ci-tests.ts --profile=full --parallel=2 --isolate --timeout=10000 --max-concurrency=2
```
