### PR TITLE
fix(mcp): filter schema placeholder echoes and preserve task metadata in task_edit

### DIFF
--- a/src/mcp/utils/schema-generators.ts
+++ b/src/mcp/utils/schema-generators.ts
@@ -19,12 +19,27 @@ export function getStatusFieldEnumValues(config: Pick<BacklogConfig, "statuses">
 /**
  * Generates a status field schema with dynamic enum values sourced from config.
  */
-export function generateStatusFieldSchema(config: BacklogConfig): JsonSchema {
+export function generateStatusFieldSchema(
+	config: BacklogConfig,
+	includeDefault = true,
+	allowSchemaPlaceholder = false,
+	includeConfiguredDefaultInEnum = includeDefault,
+): JsonSchema {
 	const configuredStatuses =
 		config.statuses && config.statuses.length > 0 ? [...config.statuses] : [...DEFAULT_STATUSES];
 	const normalizedStatuses = configuredStatuses.map((status) => status.trim());
 	const enumStatuses = getStatusFieldEnumValues(config);
-	const defaultStatus = normalizedStatuses[0] ?? DEFAULT_STATUSES[0];
+	// Creation uses the configured defaultStatus, which may intentionally differ
+	// from the first entry in the display/validation status list.
+	const configuredDefault = config.defaultStatus?.trim();
+	if (
+		includeConfiguredDefaultInEnum &&
+		configuredDefault &&
+		!enumStatuses.some((status) => status.toLowerCase() === configuredDefault.toLowerCase())
+	) {
+		enumStatuses.push(configuredDefault);
+	}
+	const defaultStatus = configuredDefault || normalizedStatuses[0] || DEFAULT_STATUSES[0];
 
 	return {
 		type: "string",
@@ -32,7 +47,8 @@ export function generateStatusFieldSchema(config: BacklogConfig): JsonSchema {
 		enum: enumStatuses,
 		enumCaseInsensitive: true,
 		enumNormalizeWhitespace: true,
-		default: defaultStatus,
+		...(allowSchemaPlaceholder ? { allowSchemaPlaceholder: true, schemaPlaceholderField: "status" } : {}),
+		...(includeDefault ? { default: defaultStatus } : {}),
 		description: `Status value (case-insensitive). Valid values: ${enumStatuses.join(", ")}`,
 	};
 }
@@ -119,7 +135,10 @@ export function generateTaskListSchema(config: Pick<BacklogConfig, "types" | "pr
 /**
  * Generates a priority field schema with dynamic enum values sourced from config.
  */
-function generatePriorityFieldSchema(config: Pick<BacklogConfig, "priorities">): JsonSchema {
+function generatePriorityFieldSchema(
+	config: Pick<BacklogConfig, "priorities">,
+	allowSchemaPlaceholder = false,
+): JsonSchema {
 	const priorities = getPriorityLabels(config);
 
 	return {
@@ -127,6 +146,7 @@ function generatePriorityFieldSchema(config: Pick<BacklogConfig, "priorities">):
 		maxLength: 50,
 		enum: priorities,
 		enumCaseInsensitive: true,
+		...(allowSchemaPlaceholder ? { allowSchemaPlaceholder: true, schemaPlaceholderField: "priority" } : {}),
 		description: `Optional task priority (case-insensitive). Valid values: ${priorities.join(", ")}`,
 	};
 }
@@ -136,7 +156,10 @@ function generatePriorityFieldSchema(config: Pick<BacklogConfig, "priorities">):
  * Unlike priority and type, projects has no default set, so callers must omit this
  * field from generated tool schemas entirely when no projects are configured.
  */
-function generateProjectFieldSchema(config: Pick<BacklogConfig, "projects">): JsonSchema {
+function generateProjectFieldSchema(
+	config: Pick<BacklogConfig, "projects">,
+	allowSchemaPlaceholder = false,
+): JsonSchema {
 	const projects = getProjectValues(config);
 
 	return {
@@ -144,6 +167,7 @@ function generateProjectFieldSchema(config: Pick<BacklogConfig, "projects">): Js
 		maxLength: 50,
 		enum: projects,
 		enumCaseInsensitive: true,
+		...(allowSchemaPlaceholder ? { allowSchemaPlaceholder: true, schemaPlaceholderField: "project" } : {}),
 		description: `Optional task project (case-insensitive). Valid values: ${projects.join(", ")}`,
 	};
 }
@@ -293,11 +317,11 @@ export function generateTaskEditSchema(config: BacklogConfig): JsonSchema {
 				type: "string",
 				maxLength: 10000,
 			},
-			status: generateStatusFieldSchema(config),
+			status: generateStatusFieldSchema(config, false, true, false),
 			dueDate: generateDueDateFieldSchema("Set the task due date, or pass null to clear it.", true),
-			priority: generatePriorityFieldSchema(config),
-			type: generateTypeFieldSchema(config),
-			...(getProjectValues(config).length > 0 ? { project: generateProjectFieldSchema(config) } : {}),
+			priority: generatePriorityFieldSchema(config, true),
+			type: { ...generateTypeFieldSchema(config), allowSchemaPlaceholder: true, schemaPlaceholderField: "type" },
+			...(getProjectValues(config).length > 0 ? { project: generateProjectFieldSchema(config, true) } : {}),
 			ordinal: {
 				type: "number",
 				minimum: 0,

--- a/src/mcp/validation/validators.ts
+++ b/src/mcp/validation/validators.ts
@@ -18,6 +18,9 @@ export interface JsonSchema {
 	preserveWhitespace?: boolean;
 	description?: string;
 	default?: unknown;
+	/** Treat TypeScript-style schema echoes as omitted for this field. */
+	allowSchemaPlaceholder?: boolean;
+	schemaPlaceholderField?: string;
 }
 
 /**
@@ -119,6 +122,13 @@ function validateField(
 			const sanitizedString = shouldPreserveWhitespace
 				? sanitizeStringPreserveWhitespace(value)
 				: sanitizeString(value);
+			if (
+				schema.allowSchemaPlaceholder &&
+				schema.schemaPlaceholderField === fieldName &&
+				isEnumSchemaPlaceholder(sanitizedString, fieldName)
+			) {
+				return { isValid: true, errors: [] };
+			}
 			let sanitizedResult = sanitizedString;
 
 			// Length validation
@@ -215,6 +225,11 @@ function validateField(
 	}
 
 	return { isValid: errors.length === 0, errors, sanitizedValue: value };
+}
+
+function isEnumSchemaPlaceholder(value: string, fieldName: string): boolean {
+	const escapedField = fieldName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(`^${escapedField}\\?(?::\\s*.*)?$`, "u").test(value);
 }
 
 /**

--- a/src/test/mcp-tasks.test.ts
+++ b/src/test/mcp-tasks.test.ts
@@ -5,7 +5,7 @@ import { DEFAULT_STATUSES, DEFAULT_TASK_TYPES } from "../constants/index.ts";
 import { serializeTask } from "../markdown/serializer.ts";
 import { McpServer } from "../mcp/server.ts";
 import { registerTaskTools } from "../mcp/tools/tasks/index.ts";
-import type { JsonSchema } from "../mcp/validation/validators.ts";
+import { type JsonSchema, validateInput } from "../mcp/validation/validators.ts";
 import type { Task } from "../types/index.ts";
 import {
 	commitSamePathBranchTaskVariant,
@@ -836,9 +836,48 @@ describe("MCP task tools (MVP)", () => {
 		expect(createStatusSchema?.enumNormalizeWhitespace).toBe(true);
 
 		expect(editStatusSchema?.enum).toEqual(expectedStatuses);
-		expect(editStatusSchema?.default).toBe(normalizedStatuses[0] ?? DEFAULT_STATUSES[0]);
+		expect(editStatusSchema?.default).toBeUndefined();
 		expect(editStatusSchema?.enumCaseInsensitive).toBe(true);
 		expect(editStatusSchema?.enumNormalizeWhitespace).toBe(true);
+	});
+
+	it("advertises and applies a configured create default outside editable statuses", async () => {
+		const config = await loadConfig(mcpServer);
+		config.statuses = ["To Do", "Done"];
+		config.defaultStatus = "Custom Status";
+		await mcpServer.filesystem.saveConfig(config);
+		const customServer = new McpServer(TEST_DIR, "Test instructions");
+		registerTaskTools(customServer, config);
+
+		const tools = await customServer.testInterface.listTools();
+		const toolByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+		const createSchema = toolByName.get("task_create")?.inputSchema as JsonSchema;
+		const editSchema = toolByName.get("task_edit")?.inputSchema as JsonSchema;
+		const createStatus = createSchema.properties?.status;
+		expect(createStatus?.default).toBe("Custom Status");
+		expect(createStatus?.enum).toContain("Custom Status");
+		expect(validateInput({ title: "custom default" }, createSchema).isValid).toBe(true);
+		expect(validateInput({ id: "TASK-1", status: "Custom Status" }, editSchema).isValid).toBe(false);
+
+		const createResult = await customServer.testInterface.callTool({
+			params: { name: "task_create", arguments: { title: "Uses custom default" } },
+		});
+		expect(createResult.isError).not.toBe(true);
+		const created = await customServer.filesystem.loadTask("task-1");
+		expect(created?.status).toBe("Custom Status");
+	});
+
+	it("treats task_edit enum placeholders as omitted without accepting invalid values", async () => {
+		const tools = await mcpServer.testInterface.listTools();
+		const editSchema = tools.tools.find((tool) => tool.name === "task_edit")?.inputSchema as JsonSchema;
+		const placeholderResult = validateInput(
+			{ id: "TASK-1", status: "status?", priority: "priority?", type: "type?" },
+			editSchema,
+		);
+		expect(placeholderResult.isValid).toBe(true);
+		expect(placeholderResult.sanitizedData).toEqual({ id: "TASK-1" });
+		const invalidResult = validateInput({ id: "TASK-1", status: "not-a-status" }, editSchema);
+		expect(invalidResult.isValid).toBe(false);
 	});
 
 	it("exposes configured priority enums and accepts custom priority values", async () => {
@@ -1720,5 +1759,139 @@ describe("MCP task tools (MVP)", () => {
 		}
 		if (primaryError !== undefined) throw primaryError;
 		if (cleanupError !== undefined) throw cleanupError;
+	});
+
+	it("filters schema placeholders and preserves all task sections during comment-only task_edit", async () => {
+		// 1. Create a task with full metadata and body sections
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: {
+					title: "Task with rich sections",
+					modifiedFiles: ["src/initial.ts", "src/secondary.ts"],
+					description: "Original detailed description",
+					status: "In Progress",
+					priority: "high",
+					assignee: ["@souljedi"],
+					labels: ["backend", "mcp"],
+					acceptanceCriteria: ["Criterion 1", "Criterion 2"],
+					finalSummary: "Initial summary draft",
+				},
+			},
+		});
+
+		const preExistingComment = await mcpServer.testInterface.callTool({
+			params: { name: "task_edit", arguments: { id: "task-1", commentsAppend: ["Existing review note"] } },
+		});
+		expect(preExistingComment.isError).toBeFalsy();
+
+		// Add implementation plan and notes
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					planSet: "Step 1: Planning\nStep 2: Execution",
+					notesSet: "Important implementation note",
+				},
+			},
+		});
+
+		// 2. Perform a comment-only edit simulating an AI agent passing TypeScript schema placeholders
+		const editResult = await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_edit",
+				arguments: {
+					id: "task-1",
+					commentsAppend: [
+						"planSet?: string",
+						"acceptanceCriteriaSet?[]",
+						"commentsAppend?[]: string[]",
+						"commentAuthor?:",
+						"Actual review comment: LGTM!",
+					],
+					commentAuthor: "commentAuthor?:",
+					status: "status?",
+					priority: "priority?",
+					type: "type?",
+					planSet: "planSet?",
+					notesSet: "notesSet?",
+					description: "description?",
+					modifiedFiles: [],
+				},
+			},
+		});
+
+		expect(editResult.isError).toBeFalsy();
+		const editText = getText(editResult.content);
+
+		// AC #1: Exactly one comment with no malformed field-name entries
+		expect(editText).toContain("Comments:");
+		expect(editText).toContain("Actual review comment: LGTM!");
+		expect(editText).not.toContain("planSet?: string");
+		expect(editText).not.toContain("acceptanceCriteriaSet?[]");
+		expect(editText).not.toContain("commentsAppend?[]: string[]");
+		expect(editText).not.toContain("commentAuthor?:");
+
+		// AC #2: Comment-only updates preserve description, plan, notes, acceptance criteria, status, and final summary
+		const loadedTask = await mcpServer.filesystem.loadTask("task-1");
+		expect(loadedTask).not.toBeNull();
+		expect(loadedTask?.title).toBe("Task with rich sections");
+		expect(loadedTask?.description).toBe("Original detailed description");
+		expect(loadedTask?.status).toBe("In Progress");
+		expect(loadedTask?.priority).toBe("high");
+		expect(loadedTask?.assignee).toEqual(["@souljedi"]);
+		expect(loadedTask?.labels).toEqual(["backend", "mcp"]);
+		expect(loadedTask?.implementationPlan).toBe("Step 1: Planning\nStep 2: Execution");
+		expect(loadedTask?.implementationNotes).toBe("Important implementation note");
+		expect(loadedTask?.finalSummary).toBe("Initial summary draft");
+		expect(loadedTask?.acceptanceCriteriaItems?.map((ac) => ac.text)).toEqual(["Criterion 1", "Criterion 2"]);
+
+		// The pre-existing comment remains and exactly one real comment is appended.
+		expect(loadedTask?.comments?.length).toBe(2);
+		expect(loadedTask?.comments?.[0]?.body).toBe("Existing review note");
+		expect(loadedTask?.comments?.[1]?.body).toBe("Actual review comment: LGTM!");
+		expect(loadedTask?.comments?.[1]?.author).toBeUndefined();
+		expect(loadedTask?.modifiedFiles).toEqual([]);
+
+		// AC #4: Verify task markdown remains structurally valid
+		const taskPath = loadedTask?.filePath;
+		expect(taskPath).toBeDefined();
+		if (taskPath) {
+			const rawContent = await Bun.file(taskPath).text();
+			expect(rawContent).toContain(
+				"## Description\n\n<!-- SECTION:DESCRIPTION:BEGIN -->\nOriginal detailed description\n<!-- SECTION:DESCRIPTION:END -->",
+			);
+			expect(rawContent).toContain(
+				"## Acceptance Criteria\n<!-- AC:BEGIN -->\n- [ ] #1 Criterion 1\n- [ ] #2 Criterion 2\n<!-- AC:END -->",
+			);
+			expect(rawContent).toContain(
+				"## Implementation Plan\n\n<!-- SECTION:PLAN:BEGIN -->\nStep 1: Planning\nStep 2: Execution\n<!-- SECTION:PLAN:END -->",
+			);
+			expect(rawContent).toContain(
+				"## Implementation Notes\n\n<!-- SECTION:NOTES:BEGIN -->\nImportant implementation note\n<!-- SECTION:NOTES:END -->",
+			);
+			expect(rawContent).toContain(
+				"## Final Summary\n\n<!-- SECTION:FINAL_SUMMARY:BEGIN -->\nInitial summary draft\n<!-- SECTION:FINAL_SUMMARY:END -->",
+			);
+			expect(rawContent).toContain("## Comments\n\n<!-- COMMENTS:BEGIN -->");
+			expect(rawContent).toContain("Actual review comment: LGTM!");
+			expect(rawContent).not.toContain("planSet?: string");
+		}
+	});
+
+	it("treats blank-only modifiedFiles as a no-op", async () => {
+		await mcpServer.testInterface.callTool({
+			params: {
+				name: "task_create",
+				arguments: { title: "Modified files blank input", modifiedFiles: ["src/kept.ts"] },
+			},
+		});
+		const result = await mcpServer.testInterface.callTool({
+			params: { name: "task_edit", arguments: { id: "task-1", modifiedFiles: [" ", "\t"] } },
+		});
+		expect(result.isError).toBeFalsy();
+		const task = await mcpServer.filesystem.loadTask("task-1");
+		expect(task?.modifiedFiles).toEqual(["src/kept.ts"]);
 	});
 });

--- a/src/test/task-edit-builder.test.ts
+++ b/src/test/task-edit-builder.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "bun:test";
+import { buildTaskUpdateInput, isSchemaPlaceholder } from "../utils/task-edit-builder.ts";
+
+describe("isSchemaPlaceholder", () => {
+	it("identifies TypeScript schema placeholder echoes", () => {
+		// Question mark suffixes
+		expect(isSchemaPlaceholder("planSet?")).toBe(true);
+		expect(isSchemaPlaceholder("notesSet?")).toBe(true);
+		expect(isSchemaPlaceholder("description?")).toBe(true);
+		expect(isSchemaPlaceholder("status?")).toBe(true);
+		expect(isSchemaPlaceholder("title?")).toBe(true);
+		expect(isSchemaPlaceholder("dueDate?")).toBe(true);
+		expect(isSchemaPlaceholder("priority?")).toBe(true);
+		expect(isSchemaPlaceholder("type?")).toBe(true);
+
+		// Array question mark suffixes
+		expect(isSchemaPlaceholder("acceptanceCriteriaSet?[]")).toBe(true);
+		expect(isSchemaPlaceholder("commentsAppend?[]")).toBe(true);
+		expect(isSchemaPlaceholder("labels?[]")).toBe(true);
+		expect(isSchemaPlaceholder("planAppend?[]")).toBe(true);
+		expect(isSchemaPlaceholder("notesAppend?[]")).toBe(true);
+		expect(isSchemaPlaceholder("assignee?[]")).toBe(true);
+		expect(isSchemaPlaceholder("dependencies?[]")).toBe(true);
+
+		// Optional property with colon and types
+		expect(isSchemaPlaceholder("commentAuthor?:")).toBe(true);
+		expect(isSchemaPlaceholder("commentAuthor?: string")).toBe(true);
+		expect(isSchemaPlaceholder("planSet?: string")).toBe(true);
+		expect(isSchemaPlaceholder("finalSummaryClear?: boolean")).toBe(true);
+		expect(isSchemaPlaceholder("ordinal?: number")).toBe(true);
+		expect(isSchemaPlaceholder("acceptanceCriteriaSet?: string[]")).toBe(true);
+		expect(isSchemaPlaceholder("commentsAppend?[]: string[]")).toBe(true);
+
+		// Explicit type signatures
+		expect(isSchemaPlaceholder("id: string")).toBe(true);
+		expect(isSchemaPlaceholder("title: string")).toBe(true);
+		expect(isSchemaPlaceholder("ordinal: number")).toBe(true);
+		expect(isSchemaPlaceholder("planAppend: string[]")).toBe(true);
+	});
+
+	it("does not flag legitimate user comments or queries", () => {
+		expect(isSchemaPlaceholder("Why?")).toBe(false);
+		expect(isSchemaPlaceholder("Done?")).toBe(false);
+		expect(isSchemaPlaceholder("Ready?")).toBe(false);
+		expect(isSchemaPlaceholder("Fixed?")).toBe(false);
+		expect(isSchemaPlaceholder("LGTM!")).toBe(false);
+		expect(isSchemaPlaceholder("Can we check planSet before merging?")).toBe(false);
+		expect(isSchemaPlaceholder("Review approved - ready for QA.")).toBe(false);
+		expect(isSchemaPlaceholder("Note: this is important.")).toBe(false);
+		expect(isSchemaPlaceholder("")).toBe(false);
+	});
+});
+
+describe("buildTaskUpdateInput", () => {
+	it("filters schema placeholders from commentsAppend and commentAuthor", () => {
+		const result = buildTaskUpdateInput({
+			commentsAppend: [
+				"planSet?: string",
+				"acceptanceCriteriaSet?[]",
+				"commentAuthor?:",
+				"commentAuthor?: string",
+				"Actual review comment",
+			],
+			commentAuthor: "commentAuthor?:",
+		});
+
+		expect(result.appendComments).toEqual([{ body: "Actual review comment" }]);
+	});
+
+	it("ignores comment-only update if only placeholders were provided", () => {
+		const result = buildTaskUpdateInput({
+			commentsAppend: ["planSet?: string", "acceptanceCriteriaSet?[]"],
+		});
+
+		expect(result.appendComments).toBeUndefined();
+	});
+
+	it("ignores placeholder string and array fields", () => {
+		const result = buildTaskUpdateInput({
+			title: "title?",
+			description: "description?",
+			status: "status?",
+			priority: "priority?",
+			type: "type?",
+			project: "project?",
+			milestone: "milestone?",
+			planSet: "planSet?",
+			notesSet: "notesSet?",
+			finalSummary: "finalSummary?",
+			assignee: ["assignee?[]"],
+			dependencies: ["dependencies?[]"],
+			references: ["references?[]"],
+			documentation: ["documentation?[]"],
+			modifiedFiles: ["modifiedFiles?[]"],
+			commentsAppend: ["Clean comment"],
+			commentAuthor: "@reviewer",
+		});
+
+		expect(result.title).toBeUndefined();
+		expect(result.description).toBeUndefined();
+		expect(result.status).toBeUndefined();
+		expect(result.priority).toBeUndefined();
+		expect(result.type).toBeUndefined();
+		expect(result.project).toBeUndefined();
+		expect(result.milestone).toBeUndefined();
+		expect(result.implementationPlan).toBeUndefined();
+		expect(result.implementationNotes).toBeUndefined();
+		expect(result.finalSummary).toBeUndefined();
+		expect(result.assignee).toBeUndefined();
+		expect(result.dependencies).toBeUndefined();
+		expect(result.references).toBeUndefined();
+		expect(result.documentation).toBeUndefined();
+		expect(result.modifiedFiles).toBeUndefined();
+		expect(result.appendComments).toEqual([{ body: "Clean comment", author: "@reviewer" }]);
+	});
+
+	it("preserves explicit empty clear operations for clearable lists", () => {
+		const result = buildTaskUpdateInput({
+			assignee: [],
+			dependencies: [],
+			references: [],
+			documentation: [],
+			modifiedFiles: [],
+			labels: [],
+			dueDate: null,
+			milestone: null,
+			planClear: true,
+			notesClear: true,
+			finalSummaryClear: true,
+		});
+
+		expect(result.assignee).toEqual([]);
+		expect(result.dependencies).toEqual([]);
+		expect(result.references).toEqual([]);
+		expect(result.documentation).toEqual([]);
+		expect(result.modifiedFiles).toEqual([]);
+		expect(result.labels).toEqual([]);
+		expect(result.dueDate).toBeNull();
+		expect(result.milestone).toBeNull();
+		expect(result.clearImplementationPlan).toBe(true);
+		expect(result.clearImplementationNotes).toBe(true);
+		expect(result.clearFinalSummary).toBe(true);
+	});
+
+	it("preserves legitimate property-shaped comment bodies", () => {
+		const result = buildTaskUpdateInput({ commentsAppend: ["status?", "title?"] });
+		expect(result.appendComments?.map((comment) => (typeof comment === "string" ? comment : comment.body))).toEqual([
+			"status?",
+			"title?",
+		]);
+	});
+
+	it("omits a placeholder-only comment payload", () => {
+		const result = buildTaskUpdateInput({ commentsAppend: ["planSet?: string", "commentAuthor?: string"] });
+		expect(result.appendComments).toBeUndefined();
+	});
+
+	it("filters combined array/type schema echoes while preserving exact property comments", () => {
+		const result = buildTaskUpdateInput({
+			commentsAppend: ["commentsAppend?[]: string[]", "commentsAppend?", "Actual comment"],
+		});
+		expect(result.appendComments).toEqual([{ body: "commentsAppend?" }, { body: "Actual comment" }]);
+	});
+});

--- a/src/utils/task-edit-builder.ts
+++ b/src/utils/task-edit-builder.ts
@@ -1,10 +1,112 @@
 import type { TaskUpdateInput } from "../types/index.ts";
 import type { TaskEditArgs } from "../types/task-edit-args.ts";
-import { normalizeStringList } from "./task-builders.ts";
+
+const SCHEMA_PROPERTY_NAMES = new Set([
+	"id",
+	"title",
+	"description",
+	"duedate",
+	"status",
+	"priority",
+	"type",
+	"project",
+	"milestone",
+	"ordinal",
+	"labels",
+	"addlabels",
+	"removelabels",
+	"assignee",
+	"dependencies",
+	"adddependencies",
+	"removedependencies",
+	"references",
+	"addreferences",
+	"removereferences",
+	"documentation",
+	"adddocumentation",
+	"removedocumentation",
+	"modifiedfiles",
+	"implementationplan",
+	"planset",
+	"planappend",
+	"planclear",
+	"implementationnotes",
+	"notesset",
+	"notesappend",
+	"notesclear",
+	"commentsappend",
+	"commentauthor",
+	"finalsummary",
+	"finalsummaryappend",
+	"finalsummaryclear",
+	"acceptancecriteria",
+	"acceptancecriteriaset",
+	"acceptancecriteriaadd",
+	"acceptancecriteriaremove",
+	"acceptancecriteriacheck",
+	"acceptancecriteriauncheck",
+	"definitionofdoneadd",
+	"definitionofdoneremove",
+	"definitionofdonecheck",
+	"definitionofdoneuncheck",
+	"parenttaskid",
+	"disabledefinitionofdonedefaults",
+]);
+
+// These are valid, human-written short comments (for example, a reviewer may
+// literally ask "status?").  They must not be confused with an echoed field
+// declaration merely because the declaration happens to resemble a comment.
+
+/**
+ * Identify schema property signatures or TypeScript syntax placeholders that AI agents
+ * sometimes echo when serializing tool call payloads (e.g., "planSet?", "acceptanceCriteriaSet?[]", "commentAuthor?:").
+ */
+export function isSchemaPlaceholder(value: string): boolean {
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return false;
+
+	// Matches TypeScript optional field syntax e.g. "foo?:", "foo?: string", "foo?[]", "foo?[]: string[]"
+	if (/^[a-zA-Z][a-zA-Z0-9_]*\s*(?:\?\[\](?:\s*:\s*.*)?|\?:\s*.*)$/.test(trimmed)) {
+		return true;
+	}
+
+	// Matches explicit type annotations e.g. "foo: string", "foo: number", "foo: boolean[]"
+	if (
+		/^[a-zA-Z][a-zA-Z0-9_]*\s*:\s*(?:string|number|boolean|null|undefined|any|unknown|void|never|object|Array<[^>]+>|(?:string|number|boolean|null|undefined)\[\])(?:\s*\|\s*(?:string|number|boolean|null|undefined|any|unknown|void|never|object|Array<[^>]+>|(?:string|number|boolean|null|undefined)\[\]))*$/i.test(
+			trimmed,
+		)
+	) {
+		return true;
+	}
+
+	// Matches known schema property names with TypeScript modifiers (e.g. "planSet?", "commentsAppend?[]", "notesSet?")
+	const match = trimmed.match(/^([a-zA-Z][a-zA-Z0-9_]*)(?:(\?)|(\[\])|(:\s*.*)|(\?:\s*.*))?$/);
+	if (match?.[1]) {
+		const propName = match[1].toLowerCase();
+		if (SCHEMA_PROPERTY_NAMES.has(propName)) {
+			if (match[2] || match[3] || match[4] || match[5]) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+function isCommentPlaceholder(value: string): boolean {
+	if (!isSchemaPlaceholder(value)) return false;
+	const name = value
+		.trim()
+		.match(/^([a-zA-Z][a-zA-Z0-9_]*)\?$/u)?.[1]
+		?.toLowerCase();
+	return !(name && SCHEMA_PROPERTY_NAMES.has(name));
+}
 
 function sanitizeStringArray(values: string[] | undefined): string[] | undefined {
 	if (!values) return undefined;
-	const trimmed = values.map((value) => String(value).trim()).filter((value) => value.length > 0);
+	const trimmed = values
+		.map((value) => String(value).trim())
+		.filter((value) => value.length > 0 && !isSchemaPlaceholder(value));
 	return trimmed.length > 0 ? trimmed : undefined;
 }
 
@@ -26,48 +128,58 @@ function sanitizeAppend(values: string[] | undefined): string[] | undefined {
 
 function toAcceptanceCriteriaEntries(values: string[] | undefined) {
 	if (values === undefined) return undefined;
-	const trimmed = values.map((value) => String(value).trim()).filter((value) => value.length > 0);
-	return trimmed.map((text, index) => ({ text, checked: false, index: index + 1 }));
+	const trimmed = values
+		.map((value) => String(value).trim())
+		.filter((value) => value.length > 0 && !isSchemaPlaceholder(value));
+	return trimmed.length > 0
+		? trimmed.map((text, index) => ({ text, checked: false, index: index + 1 }))
+		: values.length === 0
+			? []
+			: undefined;
 }
 
 export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	const updateInput: TaskUpdateInput = {};
 
-	if (typeof args.title === "string") {
+	if (typeof args.title === "string" && !isSchemaPlaceholder(args.title)) {
 		updateInput.title = args.title;
 	}
 
 	if (args.dueDate === null) {
 		updateInput.dueDate = null;
 	} else if (typeof args.dueDate === "string") {
-		updateInput.dueDate = args.dueDate.trim().length > 0 ? args.dueDate : null;
+		if (!isSchemaPlaceholder(args.dueDate)) {
+			updateInput.dueDate = args.dueDate.trim().length > 0 ? args.dueDate : null;
+		}
 	}
 
-	if (typeof args.description === "string") {
+	if (typeof args.description === "string" && !isSchemaPlaceholder(args.description)) {
 		updateInput.description = args.description;
 	}
 
-	if (typeof args.status === "string") {
+	if (typeof args.status === "string" && !isSchemaPlaceholder(args.status)) {
 		updateInput.status = args.status;
 	}
 
-	if (typeof args.priority === "string") {
+	if (typeof args.priority === "string" && !isSchemaPlaceholder(args.priority)) {
 		updateInput.priority = args.priority;
 	}
 
-	if (typeof args.type === "string") {
+	if (typeof args.type === "string" && !isSchemaPlaceholder(args.type)) {
 		updateInput.type = args.type;
 	}
 
-	if (typeof args.project === "string") {
+	if (typeof args.project === "string" && !isSchemaPlaceholder(args.project)) {
 		updateInput.project = args.project;
 	}
 
 	if (args.milestone === null) {
 		updateInput.milestone = null;
 	} else if (typeof args.milestone === "string") {
-		const trimmed = args.milestone.trim();
-		updateInput.milestone = trimmed.length > 0 ? trimmed : null;
+		if (!isSchemaPlaceholder(args.milestone)) {
+			const trimmed = args.milestone.trim();
+			updateInput.milestone = trimmed.length > 0 ? trimmed : null;
+		}
 	}
 
 	if (typeof args.ordinal === "number") {
@@ -75,7 +187,7 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	}
 
 	if (args.labels !== undefined) {
-		const labels = normalizeStringList(args.labels);
+		const labels = sanitizeStringArray(args.labels);
 		if (labels) {
 			updateInput.labels = labels;
 		} else if (args.labels.length === 0) {
@@ -83,12 +195,12 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		}
 	}
 
-	const addLabels = normalizeStringList(args.addLabels);
+	const addLabels = sanitizeStringArray(args.addLabels);
 	if (addLabels) {
 		updateInput.addLabels = addLabels;
 	}
 
-	const removeLabels = normalizeStringList(args.removeLabels);
+	const removeLabels = sanitizeStringArray(args.removeLabels);
 	if (removeLabels) {
 		updateInput.removeLabels = removeLabels;
 	}
@@ -134,12 +246,12 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	}
 
 	const modifiedFiles = sanitizeStringArray(args.modifiedFiles);
-	if (modifiedFiles) {
-		updateInput.modifiedFiles = modifiedFiles;
+	if (modifiedFiles || args.modifiedFiles?.length === 0) {
+		updateInput.modifiedFiles = modifiedFiles ?? [];
 	}
 
 	const planSet = args.planSet ?? args.implementationPlan;
-	if (typeof planSet === "string") {
+	if (typeof planSet === "string" && !isSchemaPlaceholder(planSet)) {
 		updateInput.implementationPlan = planSet;
 	}
 
@@ -153,7 +265,7 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	}
 
 	const notesSet = args.notesSet ?? args.implementationNotes;
-	if (typeof notesSet === "string") {
+	if (typeof notesSet === "string" && !isSchemaPlaceholder(notesSet)) {
 		updateInput.implementationNotes = notesSet;
 	}
 
@@ -166,10 +278,14 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		updateInput.clearImplementationNotes = true;
 	}
 
-	const commentsAppends = sanitizeAppend(args.commentsAppend);
-	if (commentsAppends) {
+	const commentsAppends = args.commentsAppend
+		?.map((value) => String(value).trim())
+		.filter((value) => value.length > 0 && !isCommentPlaceholder(value));
+	if (commentsAppends && commentsAppends.length > 0) {
 		const author =
-			typeof args.commentAuthor === "string" && args.commentAuthor.trim().length > 0
+			typeof args.commentAuthor === "string" &&
+			args.commentAuthor.trim().length > 0 &&
+			!isSchemaPlaceholder(args.commentAuthor)
 				? args.commentAuthor.trim()
 				: undefined;
 		updateInput.appendComments = commentsAppends.map((body) => ({
@@ -178,7 +294,7 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 		}));
 	}
 
-	if (typeof args.finalSummary === "string") {
+	if (typeof args.finalSummary === "string" && !isSchemaPlaceholder(args.finalSummary)) {
 		updateInput.finalSummary = args.finalSummary;
 	}
 
@@ -199,7 +315,7 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	if (Array.isArray(args.acceptanceCriteriaAdd) && args.acceptanceCriteriaAdd.length > 0) {
 		const additions = args.acceptanceCriteriaAdd
 			.map((text) => String(text).trim())
-			.filter((text) => text.length > 0)
+			.filter((text) => text.length > 0 && !isSchemaPlaceholder(text))
 			.map((text) => ({ text, checked: false }));
 		if (additions.length > 0) {
 			updateInput.addAcceptanceCriteria = additions;
@@ -221,7 +337,7 @@ export function buildTaskUpdateInput(args: TaskEditArgs): TaskUpdateInput {
 	if (Array.isArray(args.definitionOfDoneAdd) && args.definitionOfDoneAdd.length > 0) {
 		const additions = args.definitionOfDoneAdd
 			.map((text) => String(text).trim())
-			.filter((text) => text.length > 0)
+			.filter((text) => text.length > 0 && !isSchemaPlaceholder(text))
 			.map((text) => ({ text, checked: false }));
 		if (additions.length > 0) {
 			updateInput.addDefinitionOfDone = additions;


### PR DESCRIPTION
Fixes #1006

## Summary

When LLM clients call `task_edit` over MCP to append review comments or update specific fields, some models populate omitted parameters with literal TypeScript schema signatures (e.g. `planSet?: string`, `acceptanceCriteriaSet?[]`, `commentAuthor?: string`, `commentsAppend?[]: string[]`).

Previously, `task_edit` accepted these strings directly into comment arrays and update fields, cluttering task history with schema type strings. In addition, comment-only updates risked clearing other task metadata if empty arrays or no-op fields were passed.

## What changed

- `src/utils/task-edit-builder.ts`:
  - Added `isSchemaPlaceholder` to filter echoed TypeScript parameter signatures and type declarations out of string and array update fields.
  - Added `isCommentPlaceholder` so legitimate short user comments (like `status?` or `title?`) are preserved, while signatures like `status?: TaskStatus` or `planSet?: string` are discarded.
  - Preserved explicit clear semantics for `modifiedFiles: []` while treating whitespace-only arrays as no-ops.
- `src/mcp/validation/validators.ts`:
  - Handled enum-backed schema placeholder echoes at the MCP boundary so they are treated as omitted without weakening validation of actual enum values.
- `src/mcp/utils/schema-generators.ts`:
  - Updated `task_create` schema generation to advertise the configured `defaultStatus`.
- `src/test/task-edit-builder.test.ts` & `src/test/mcp-tasks.test.ts`:
  - Added 9 unit tests for builder placeholder filtering and edge cases.
  - Added full MCP integration tests verifying comment-only updates, metadata preservation, modified-file clearing, and markdown structural validity.

## Verification

- `bunx tsc --noEmit` — clean
- `bun run check .` — clean (426 files)
- `bun test src/test/task-edit-builder.test.ts src/test/mcp-tasks.test.ts` — 52 pass / 0 fail (343 assertions)